### PR TITLE
[firmware] Preserve climate intent hardening worktree

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -133,6 +133,17 @@ In chronological order:
 - **Web/Data:** The 2026-05-20 lab-site feedback is tracked in `docs/backlog/lab-site-refactor-2026-05-20.md`: initial site/content refactor tasks (`CODEX-001` through `CODEX-012`), later visual/resource/architecture follow-ups (`CODEX-013` through `CODEX-018`), and Grafana/time-series research tasks (`RP-001` through `RP-007`).
 - **Web:** Image cleanup removed broken/public backup assets and documented current photo fit. The manual image catalog now has a machine-readable manifest checked by `site-doctor`; crop-specific photos for basil/cucumbers/tomatoes remain a content acquisition issue, not a rendering blocker.
 - **Web:** Raw ASCII/Mermaid diagrams were removed from hand-authored public pages. Forecast, daily-plan, plans-index, crop, and zone generated outputs now use web components instead of generated Markdown tables.
+- **Firmware:** `docs/backlog/firmware.md` now tracks `F-CLIMATE-INTENT`,
+  implementing
+  [`docs/firmware-climate-intent-controller-final-design-2026-05-24.md`](firmware-climate-intent-controller-final-design-2026-05-24.md).
+  The design keeps the ESP32 as relay authority, selects safe candidate actions
+  by strict priority order (safety, temperature compliance, VPD compliance,
+  resource use), and gives AI a compact climate-intent surface instead of more
+  planner-facing relay knobs. The 2026-05-25 operator decision is no shadow
+  mode: one controller, one production path, with replay, invariant, compile,
+  and live health evidence as the proof. Closeout is tracked in GitHub issue
+  #8 until the planner PR, dirty worktrees, stale PR wording, and warning-class
+  live alerts are resolved.
 
 ## Sprint numbering
 
@@ -227,6 +238,11 @@ The "fix-it-forward" spiral (sprint-15 regressions → 86°F whipsaw incident on
 ## Phase 3 architecture decision (2026-04-23)
 
 **Supersedes** the original plan.md Phase 3 ("9-mode → 6-mode consolidation"). User proposed **per-zone voting machines + central coordinator**. Five research agents dispatched to validate; all returned. Architecture validated, plan below.
+
+**Historical status:** superseded for implementation by the 2026-05-25
+`F-CLIMATE-INTENT` direction above. Keep this section as research context, but
+do not implement its shadow-mode rollout or broad per-zone tunable expansion as
+the current controller plan.
 
 ### The problem (data-backed)
 

--- a/docs/backlog/firmware.md
+++ b/docs/backlog/firmware.md
@@ -6,6 +6,28 @@ Owned by the [`firmware`](../agents/firmware.md) agent. Sprint counter is agent-
 
 - [ ] **48-hour v2 bake + reboot forensics follow-through.** Behavior-changing OTA for `2026.4.27.2009.2b5f2a5` began at `2026-04-28 02:12:25 UTC`; a wrapper-only main redeploy later put `2026.4.27.2040.c1a6403` live at `2026-04-28 02:41:54 UTC`. Sensor-health is `PASS 27 / FAIL 0 / WARN 0`, open critical/high alerts are `0`, and there are no post-OTA `Guru/Panic` / `Task WDT` resets in the sampled window. Keep OTA freeze intact during the bake. Current evidence reframes the old "midday crash-loop" as broader JSON/API/crash-forensics work; see [`docs/firmware-v2-postdeploy-forensics-2026-04-27.md`](../firmware-v2-postdeploy-forensics-2026-04-27.md).
 - [ ] **Contract + alert drift guard PR.** `firmware/contracts-alert-drift` makes `vpd_low` explicitly dispatcher/band-owned, adds expected-firmware-version mismatch alerting, and adds static drift guards for firmware override tags, `sw_mister_closes_vent` routing, and MCP Tier 1 validation.
+- [ ] **F-CLIMATE-INTENT first-principles controller implementation.**
+  Implement
+  [`docs/firmware-climate-intent-controller-final-design-2026-05-24.md`](../firmware-climate-intent-controller-final-design-2026-05-24.md).
+  The controller objective is strict priority order: safety rails first,
+  temperature-band compliance second, VPD-band compliance third, and resource
+  minimization fourth. Firmware remains the relay authority and selects among
+  safe candidate actions lexicographically; AI emits a compact `ClimateIntent`
+  overlay instead of raw relay commands or dozens of low-level relay knobs.
+  Real climate relay groups are `heat1`/`heat2`, `vent` plus `fan1`/`fan2`,
+  `fog`, clean climate misters (`mister_south`, `mister_west`,
+  `mister_center`), and DLI lights. Drip/fert relays remain owned by
+  irrigation/fertigation and appear to climate logic only as locks. Breakout:
+  `F-CI-1` single production controller path and action model; `F-CI-2`
+  `ClimateIntent` schema/registry ownership; `F-CI-3` firmware candidate action
+  structs and strict-priority tests; `F-CI-4` observability fields for action,
+  priority axis, block reasons, target error, band error, and timers; `F-CI-5`
+  planner/dispatcher intent wiring; `F-CI-6` replay, invariant, compile,
+  service-health, and post-OTA audit gates; `F-CI-7` deployment only with
+  explicit operator approval and rollback path. The 2026-05-25 operator
+  decision is no shadow mode: one controller, one production path, with replay
+  and health evidence as the proof. Global closeout blockers are tracked in
+  platform issue #8. No OTA is authorized by this backlog item alone.
 
 **Project recovery intake from `PROJECT_STATE.md`** (2026-05-22; coordinated
 through [`project-recovery-2026-05-22.md`](project-recovery-2026-05-22.md)).

--- a/docs/firmware-ai-tunable-control-design-2026-05-24.md
+++ b/docs/firmware-ai-tunable-control-design-2026-05-24.md
@@ -1,5 +1,12 @@
 # Firmware AI-Tunable Control Design - 2026-05-24
 
+> Status update: this note is retained as evidence and historical audit context.
+> The implementation target is now the stricter
+> [`Firmware Climate-Intent Controller Final Design`](firmware-climate-intent-controller-final-design-2026-05-24.md),
+> which uses a compact `ClimateIntent` surface and a deterministic
+> safety/temp/VPD/resource priority selector instead of expanding the
+> planner-facing relay-tunable surface.
+
 ## Purpose
 
 This note captures the firmware and planner changes that would make Verdify less

--- a/docs/firmware-climate-intent-controller-final-design-2026-05-24.md
+++ b/docs/firmware-climate-intent-controller-final-design-2026-05-24.md
@@ -1,0 +1,363 @@
+# Firmware Climate-Intent Controller Final Design - 2026-05-24
+
+## Status
+
+Final architecture direction for the next controller simplification. This
+supersedes any plan whose main effect is to add more planner-facing relay
+knobs. The earlier AI-tunable audit/design work remains useful evidence, but
+the implementation target is now a smaller climate-intent surface plus a
+deterministic firmware action selector.
+
+This document is design-only. It does not authorize an OTA. Any implementation
+must follow firmware freeze rules, replay/invariant gates, service restart
+documentation, and explicit operator approval before behavior changes.
+
+2026-05-25 operator decision: do not create a second shadow controller path.
+The implementation target is one production controller path. Replay,
+invariants, unit tests, compile output, and live post-deploy health checks are
+the rollout proof; diagnostic-only observability is allowed, but a parallel
+shadow decision engine is not.
+
+## Objective
+
+Optimize greenhouse operation in this strict priority order:
+
+1. Safety rails.
+2. Maximum temperature-band compliance.
+3. Maximum VPD-band compliance.
+4. Minimum resource use.
+
+The controller should be understandable from first principles. If temperature
+and VPD are both out of band, the system should explain which priority is
+active, which safe actions were eligible, and why an actuator was served,
+paused, or blocked.
+
+## Core Decision
+
+Use a lexicographic controller:
+
+1. Reject candidates that violate safety rails or hard interlocks.
+2. Among safe candidates, choose the best projected temperature-band outcome.
+3. If temperature outcomes are effectively tied, choose the best projected
+   VPD-band outcome.
+4. If temperature and VPD outcomes are effectively tied, choose the lowest
+   resource and relay-churn cost.
+
+This is intentionally not a weighted sum. A cheap action that sacrifices
+temperature compliance cannot beat a safe action that protects temperature.
+Likewise, a VPD improvement cannot close the vent while temperature is actively
+above band unless the projection says temperature compliance remains at least
+equivalent.
+
+## Control Boundary
+
+Firmware owns:
+
+- Safety rails and sensor-fault behavior.
+- Relay truth, relay min-on/min-off, interlocks, and sequencing.
+- Candidate action generation and lexicographic selection every 5 seconds.
+- Water/fog/vent/heat/fan invariants.
+- Observability for chosen action, rejected candidates, timers, and blocks.
+
+AI/planner owns:
+
+- Bounded climate intent for upcoming forecast periods.
+- Forecast-aware preconditioning and resource posture.
+- Historical-response priors used by dispatcher-side planning and post-hoc
+  scorecard learning.
+- Plan-level explanations and post-hoc scorecard learning.
+
+AI must not own:
+
+- Raw relay commands.
+- Safety rail bypasses.
+- Leak, occupancy, fertigation, or irrigation interlock bypasses.
+- Per-relay min-on/min-off mechanics.
+- Fert/drip relay control from climate logic.
+
+## Evidence Behind The Change
+
+The current 2026-05-24 live example exposed the ambiguity:
+
+- Temp was above band: about `75.7-76.2F` vs `temp_high=72.9F`.
+- VPD hovered near the upper edge: about `1.07-1.10 kPa` vs
+  `vpd_high=1.07 kPa`.
+- Firmware chose `VENTILATE` with `mode_reason=temp_high`.
+- `vent_mist_assist` pulsed center mister, then paused on pulse gap or when VPD
+  fell back to the edge.
+- Fog stayed off because current VPD was below the fog escalation trigger and
+  normal fog time window had ended.
+
+That behavior was mostly consistent with current code, but the telemetry made
+it look irrational: generic `VENTILATE`, stale `mister_any`, and
+`fog_block_reason=none` did not expose the actual state:
+`VENT_COOL with moisture assist recently served or waiting`.
+
+Historical evidence points the same way:
+
+- Hot/dry May 11-16 windows drove repeated temp and VPD misses.
+- Cool/cloudy May 18-20 performed well with much less actuation pressure.
+- Last-7-day evidence showed the dominant climate paths were
+  `vent_mist_assist`, `summer_vent`, heat, vent/fans, fog, and center mister.
+- Drip and fert relays are not climate actuators and should remain outside the
+  climate controller except as locks.
+
+## Physical Action Set
+
+Firmware should generate these candidate actions every loop:
+
+| Candidate | Purpose | Typical relays |
+|---|---|---|
+| `SENSOR_FAULT` | Sensor/plausibility failure | all climate relays off |
+| `SAFETY_HEAT` | Hard low-temp rail | heat1, heat2, optional circulation |
+| `SAFETY_COOL` | Hard high-temp rail | vent, fans, optional fog if safe |
+| `HEAT` | Temperature below band | heat1/heat2 by stage |
+| `IDLE` | Band satisfied | all climate relays off except holds |
+| `VENT_COOL` | Temperature above band | vent, fan1/fan2 |
+| `VENT_COOL_MIST_ASSIST` | Temp priority plus dry recovery | vent, fans, pulsed misters |
+| `VENT_COOL_FOG_ASSIST` | Temp priority plus severe dry recovery | vent, fans, fog if safe |
+| `SEALED_HUMIDIFY` | VPD recovery when temp is safe | vent closed, pulsed misters |
+| `SEALED_FOG` | Severe VPD recovery when temp is safe | vent closed, fog |
+| `DEHUM_VENT` | VPD too low / humidity too high | vent and fan staging |
+
+The action name should be the primary published controller state. Pulse stage,
+zone, timers, and relay truth are separate diagnostics, not hidden sub-modes.
+
+## Candidate Evaluation
+
+Each candidate gets a projection record:
+
+```text
+CandidateProjection:
+  action
+  safety_ok
+  blocked_reasons[]
+  projected_temp_error_f
+  projected_vpd_error_kpa
+  resource_cost
+  relay_churn_cost
+  confidence
+```
+
+Selection rule:
+
+```text
+eligible = candidates where safety_ok
+sort eligible by:
+  projected_temp_error_f ascending
+  projected_vpd_error_kpa ascending
+  resource_cost ascending
+  relay_churn_cost ascending
+  prior_action_hold_preference descending
+choose first
+```
+
+Projection does not need to be a complex ML model on day one. The first version
+can use calibrated slopes and conservative defaults:
+
+- Vent cooling rate by outdoor temp, wind, solar, and current vent/fan state.
+- Mister VPD response by zone, dew margin, current RH, and recent pulse history.
+- Fog VPD/temp response and overshoot risk.
+- Heat recovery rate by stage and outdoor temp.
+- Dehum/vent effect by outdoor dewpoint advantage.
+
+Historical context should continuously refine these estimates offline and feed
+back into bounded intent values. Firmware must still operate safely if the
+historical model is missing or stale.
+
+## ClimateIntent Surface
+
+The AI tuning surface should be compact and semantic. It should tune
+forecast-aware intent and tradeoff thresholds, not relay mechanics.
+
+Proposed Tier 1 intent fields:
+
+| Field | Meaning | First range |
+|---|---|---|
+| `temp_target_f` | Center of desired temperature band | crop-bounded |
+| `temp_band_f` | Width of desired temperature band | `3-12F` |
+| `vpd_target_kpa` | Center of desired VPD band | crop-bounded |
+| `vpd_band_kpa` | Width of desired VPD band | `0.35-1.2` |
+| `forecast_temp_bias_f` | Anticipatory temp offset from forecast pressure | `-4..4F` |
+| `forecast_vpd_bias_kpa` | Anticipatory VPD offset from forecast pressure | `-0.4..0.4` |
+| `solar_precool_gain_f` | Cooling lead under strong solar ramp | `0..4F` |
+| `thermal_lead_time_min` | How early preconditioning may begin | `0..90` |
+| `economizer_temp_advantage_f` | Outdoor temp advantage needed for vent cooling | `1..15F` |
+| `economizer_dewpoint_advantage_f` | Outdoor dewpoint advantage for dry-air decisions | `1..15F` |
+| `moisture_engage_vpd_excess_kpa` | VPD excess before mister assist | `0..0.5` |
+| `mist_duty_limit_pct` | Max mister duty during the period | `0..100` |
+| `fog_escalate_vpd_excess_kpa` | VPD excess before fog candidate is eligible | `0.1..0.8` |
+| `dew_margin_floor_f` | Minimum air temp minus dewpoint for wet actions | `3..15F` |
+| `wet_cutoff_hour` | Latest local hour for climate wetting | `17..24` |
+| `daily_mist_budget_gal` | Daily climate-water budget | site-bounded |
+| `resource_sensitivity` | Preference for conserving water/electricity | `0..1` |
+| `relay_churn_penalty` | Preference for holding stable action | `0..1` |
+
+This replaces the planner needing to reason about dozens of low-level fields
+such as individual fog windows, mister pulse gaps, stage delays, and scattered
+direct-wet bypasses. Those can exist internally or as operator/reserved fields,
+but they should not be the AI's primary control surface.
+
+## Context Inputs For AI
+
+Live context:
+
+- Current temp/VPD/dew margin by zone.
+- Current band, intent, and selected action.
+- Relay truth and pulse/gap timers.
+- Water and electricity used today.
+- Open alerts and sensor health.
+- Occupancy, leak, irrigation, and fertigation locks.
+
+Forecast context:
+
+- Solar ramp and cloud cover.
+- Outdoor temp/RH/dewpoint.
+- Wind and gusts.
+- Precipitation risk.
+- Evening humidity rebound and overnight low.
+
+Historical context:
+
+- Vent cooling slope under similar solar/wind/outdoor conditions.
+- Mister response per zone and per dew margin.
+- Fog response, overshoot, and recovery time.
+- Resource cost per compliance-hour gained.
+- Common failure modes: stuck dry zone, stale sensor, command churn, humidity
+  rebound, and over-wetting.
+
+Greenhouse context:
+
+- Relay inventory: `heat1`, `heat2`, `vent`, `fan1`, `fan2`, `fog`,
+  `mister_south`, `mister_west`, `mister_center`, DLI lights.
+- Excluded relays: drip/fert relays and fert master valve.
+- Zone layout and wettable zones.
+- Crop bands and crop-local priorities.
+- Water budget and known feedback sensor gaps.
+
+## Preconditioning Strategy
+
+AI should use forecast and historical response to set intent before stress
+arrives.
+
+Examples:
+
+- If strong solar and dry outdoor air are forecast, lower the effective cooling
+  target before the temp high edge is crossed and permit low-duty mister assist
+  earlier.
+- If outdoor air is cooler and drier by enough margin, favor `VENT_COOL` early.
+- If outdoor air is hot and dry, avoid excessive venting unless temperature
+  priority requires it; use bounded moisture assist when VPD pressure persists.
+- If evening VPD remains high and dew margin is safe, extend wet eligibility
+  within `wet_cutoff_hour` rather than hard-closing all moisture paths.
+- If recent fog/mist caused VPD overshoot, increase resource sensitivity and
+  fog escalation excess until the scorecard stabilizes.
+
+The planner should emit intent for forecast segments, not one giant daily
+posture. A useful cadence is sunrise, solar ramp, peak stress, decline, sunset,
+and forecast-deviation triggers.
+
+## Firmware Invariants
+
+Required invariants:
+
+- No non-safety heat while vent/fan air exchange is active.
+- Heat2 cannot run without heat1.
+- No fog/mister during occupancy inhibit.
+- No wet action below dew-margin floor.
+- No climate logic drives fert/drip relays.
+- No relay runs without plausible sensors except hardwired safety fallback.
+- Relay min-on/min-off and dwell guards are respected.
+- Vent/fan sequencing prevents fan-with-closed-vent except explicit circulation
+  or safety heat.
+- Water budget is enforced unless a named safety/emergency policy allows a
+  bounded exception.
+- A stale forecast or stale historical model degrades to deterministic defaults,
+  not unsafe behavior.
+
+## Observability Contract
+
+The current system is too hard to reason about from the outside. The new
+controller must publish:
+
+- `climate_action`: selected candidate action.
+- `priority_axis`: `safety`, `temp`, `vpd`, or `resource`.
+- `temp_error_f` and `vpd_error_kpa`.
+- `candidate_summary`: compact top candidate and first rejected reason.
+- `moisture_assist_state`: `inactive`, `engage_delay`, `pulse_on`,
+  `pulse_gap`, `blocked`, or `served`.
+- `moisture_zone`: active zone or `none`.
+- `next_mist_eligible_s`.
+- `fog_margin_kpa`: VPD margin to fog threshold.
+- `fog_block_reason`: `none`, `below_threshold`, `time_window`,
+  `dew_margin`, `rh_ceiling`, `temp_low`, `occupancy`, `relay_min_off`,
+  or `resource_budget`.
+- `resource_cost_estimate`: water and electric cost estimate for selected
+  action.
+- Actual relay truth for each climate relay.
+
+This would have made the 2026-05-24 case obvious:
+
+```text
+climate_action=VENT_COOL_MIST_ASSIST
+priority_axis=temp
+moisture_assist_state=pulse_gap
+next_mist_eligible_s=...
+fog_block_reason=below_threshold,time_window
+```
+
+## Rollout Plan
+
+1. Design and registry planning.
+   - Land this doc and backlog entry.
+   - Draft `ClimateIntent` schema and ownership map.
+   - Decide which current tunables become internal/operator-only.
+
+2. Firmware production-path implementation.
+   - Implement the single controller path that owns relay decisions.
+   - Add strict-priority tests for safety, temperature compliance, VPD
+     compliance, and resource minimization.
+   - Add diagnostic fields for chosen action, priority axis, block reasons,
+     timers, target error, and band error.
+
+3. Cross-agent contract handoff.
+   - Coordinator owns schema changes.
+   - Genai/planner owns `ClimateIntent` emission and forecast/historical
+     context use.
+   - Ingestor owns dispatcher routing, confirmation, and state logging.
+   - Firmware owns action selection and relay application.
+
+4. Behavior-changing release.
+   - Firmware PR must include replay diff, invariant output, unit-test delta,
+     coordinator reproduction, planner concurrence, rollback plan, and service
+     restart documentation.
+   - Operator approval is required for freeze-rule overrides and OTA timing.
+   - Post-OTA health validation must confirm sensor registry, dispatcher,
+     planner, database, site/API, and greenhouse relay state agree.
+
+## Acceptance Gates
+
+The implementation is not complete until all of these are true:
+
+- A final `ClimateIntent` schema exists with bounded fields and ownership.
+- Firmware candidate action selection is the single production path.
+- Replay coverage includes at least the hot/dry May 2026 windows and the
+  current replay corpus.
+- Observability exposes action, priority axis, block reasons, and timers.
+- Tests prove candidate selection follows the strict priority order.
+- Tests prove climate logic cannot drive fert/drip relays.
+- `make test-firmware`, `make firmware-invariants`, and firmware replay pass.
+- No critical/high alerts block rollout.
+- A behavior-changing OTA is separately approved under freeze rules.
+
+## Near-Term Backlog Breakdown
+
+Recommended implementation tasks:
+
+1. `F-CI-1`: Finalize the single production controller path and action model.
+2. `F-CI-2`: Define `ClimateIntent` schema and registry ownership.
+3. `F-CI-3`: Add firmware candidate action projection structs and strict-priority tests.
+4. `F-CI-4`: Add observability fields for selected action, priority axis, block reasons, target error, and band error.
+5. `F-CI-5`: Wire planner/dispatcher to emit bounded intent.
+6. `F-CI-6`: Run replay, invariant, compile, service-health, and post-OTA audit gates.
+7. `F-CI-7`: Deploy only with explicit operator approval and rollback path.

--- a/firmware/greenhouse/controls.yaml
+++ b/firmware/greenhouse/controls.yaml
@@ -101,6 +101,14 @@ interval:
 
           auto set_relay = [&](RelayMeta &r,bool want,bool force_on,bool force_off=false){
             update_runtime(r);
+            if(force_off){
+              if(r.sw->state){
+                r.sw->turn_off();
+                r.last_off_ms = now_ms;
+                update_runtime(r);
+              }
+              return;
+            }
             if(want){
               if(!r.sw->state && (force_on || can_on(r))){
                 r.sw->turn_on();
@@ -387,7 +395,7 @@ interval:
 
           SensorInputs sensor_in = {
               .temp_f = Tin, .vpd_kpa = VPD, .rh_pct = RHin,
-              .dew_point_f = isnan(id(dewpoint_avg).state) ? Tin - 10.0f : id(dewpoint_avg).state,
+              .dew_point_f = id(dewpoint_avg).state,
               .outdoor_rh_pct = isnan(id(ha_outdoor_rh).state) ? 30.0f : id(ha_outdoor_rh).state,
               .enthalpy_delta = isnan(dH) ? -5.0f : dH,
               .solar_w_m2 = isnan(id(tempest_solar_w_m2)) ? 0.0f : id(tempest_solar_w_m2),
@@ -457,24 +465,82 @@ interval:
 
           validate_setpoints(setpts);
           setpts.sw_fsm_controller_enabled = true;
+          setpts.sw_dwell_gate_enabled = true;
           if (!id(sw_fsm_controller_enabled)) {
               id(sw_fsm_controller_enabled) = true;
               id(sw_fsm_controller_enabled_switch).publish_state(true);
           }
+          if (!id(sw_dwell_gate_enabled)) {
+              id(sw_dwell_gate_enabled) = true;
+              id(sw_dwell_gate_enabled_switch).publish_state(true);
+          }
           Mode mode = determine_mode(sensor_in, setpts, ctl_state, dt_ms);
           RelayOutputs relay_out = resolve_equipment(mode, sensor_in, setpts, ctl_state, leadIs1);
+          const bool wet_dew_margin_ok = wet_dew_margin_safe(sensor_in);
+          const float fog_vpd_width = std::max(0.2f, setpts.vpd_high - setpts.vpd_low);
+          const float fog_vpd_high_eff = setpts.vpd_high - fog_vpd_width * 0.25f;
+          const bool fog_vpd_pressure = VPD > (fog_vpd_high_eff + setpts.fog_escalation_kpa);
+          const bool fog_dew_margin_block =
+              !wet_dew_margin_ok
+              && (id(manual_fog_active)
+                  || ((mode == SAFETY_COOL || mode == VENTILATE) && fog_vpd_pressure)
+                  || (mode == SEALED_MIST && ctl_state.mist_stage >= MIST_S2 && fog_vpd_pressure));
 
           bool willHeat1 = relay_out.heat1, willHeat2 = relay_out.heat2;
           bool willFan1 = relay_out.fan1, willFan2 = relay_out.fan2;
           bool willFog = relay_out.fog, willVent = relay_out.vent;
 
-          // Manual overrides (ESP32-only, not in header)
-          if(id(manual_fan_active)){ willFan1 = true; willFan2 = true; willVent = true; }
-          if(id(manual_fog_active)){ willFog = true; }
-          if(id(vent_lock_active) && !id(manual_fan_active) && mode != SAFETY_COOL){
+          // Manual overrides are operator intent, not safety bypasses. Keep
+          // them below the hard rails and below temp-low recovery priority.
+          const bool manual_fan_requested = id(manual_fan_active);
+          const bool manual_fan_effective =
+              manual_fan_requested && manual_fan_override_allowed(mode, sensor_in, setpts);
+          static bool manual_fan_suppressed_prev = false;
+          const bool manual_fan_suppressed = manual_fan_requested && !manual_fan_effective;
+          if(manual_fan_suppressed != manual_fan_suppressed_prev) {
+            ESP_LOGW(
+              "interlock",
+              manual_fan_suppressed
+                ? "Manual fan override suppressed by safety/temp rail"
+                : "Manual fan override suppression cleared");
+            manual_fan_suppressed_prev = manual_fan_suppressed;
+          }
+          if(manual_fan_effective){ willFan1 = true; willFan2 = true; willVent = true; }
+          const bool manual_fog_requested = id(manual_fog_active);
+          const bool manual_fog_effective =
+              manual_fog_requested && manual_fog_override_allowed(mode, sensor_in, setpts);
+          static bool manual_fog_suppressed_prev = false;
+          const bool manual_fog_suppressed = manual_fog_requested && !manual_fog_effective;
+          if(manual_fog_suppressed != manual_fog_suppressed_prev) {
+            ESP_LOGW(
+              "interlock",
+              manual_fog_suppressed
+                ? "Manual fog override suppressed by safety/fog rail"
+                : "Manual fog override suppression cleared");
+            manual_fog_suppressed_prev = manual_fog_suppressed;
+          }
+          if(manual_fog_effective){ willFog = true; }
+          if(id(vent_lock_active) && !manual_fan_effective && vent_lock_suppresses_air_exchange(mode)){
             willFan1 = false;
             willFan2 = false;
             willVent = false;
+          }
+          const bool heat_priority_air_release =
+              heat_priority_releases_air_exchange(
+                  mode, sensor_in, setpts, relay_out, manual_fan_effective);
+          static bool heat_priority_air_release_prev = false;
+          if (heat_priority_air_release) {
+              willFan1 = false;
+              willFan2 = false;
+              willVent = false;
+          }
+          if (heat_priority_air_release != heat_priority_air_release_prev) {
+              if (heat_priority_air_release) {
+                  ESP_LOGI("interlock","Temp-low heat priority: forcing fan/vent off before heat");
+              } else {
+                  ESP_LOGI("interlock","Temp-low heat priority: fan/vent release cleared");
+              }
+              heat_priority_air_release_prev = heat_priority_air_release;
           }
 
           /**************** 11a — FAN/VENT + VENT-CLOSE INTERLOCKS ***************/
@@ -486,7 +552,11 @@ interval:
           // it runs the lead fan with vent closed to keep heat in.
           const bool fan_physically_on = id(fan1_rly)->state || id(fan2_rly)->state;
           const bool fan_wanted = willFan1 || willFan2;
-          const bool fan_requires_vent = mode != SAFETY_HEAT && (fan_physically_on || fan_wanted);
+          const bool fan_requires_vent =
+              !heat_priority_air_release
+              && mode != SAFETY_HEAT
+              && mode != SENSOR_FAULT
+              && (fan_physically_on || fan_wanted);
           const bool fan_vent_interlock_active = fan_requires_vent && !willVent;
           static bool fan_vent_interlock_prev = false;
           if (fan_requires_vent) {
@@ -567,29 +637,49 @@ interval:
           if (id(fog_closes_vent) && vent_is_open && !open_vent_fog_assist) {
               willFog = false;
           }
-
-          /**************** 10 — CYCLE COUNTERS ***********************************/
-          if(willHeat1 && !id(heat1_rly)->state) id(cnt_heat1_today) += 1;
-          if(willHeat2 && !id(heat2_rly)->state) id(cnt_heat2_today) += 1;
-          if(willFog && !id(fog_rly)->state)     id(cnt_fog_today) += 1;
-          if(willFan1 && !id(fan1_rly)->state)   id(cnt_fan1_today) += 1;
-          if(willFan2 && !id(fan2_rly)->state)   id(cnt_fan2_today) += 1;
-          if(willVent && !id(vent_rly)->state)    id(cnt_vent_today) += 1;
+          if (!wet_dew_margin_ok) {
+              willFog = false;
+          }
 
           /**************** 11 — APPLY RELAY OUTPUTS ******************************/
-          const bool force_heat_off = heat_air_exchange_interlock_active;
+          const bool force_all_climate_relays_off = mode == SENSOR_FAULT;
+          const bool force_heat_off = force_all_climate_relays_off || heat_air_exchange_interlock_active;
+          const bool force_vent_off =
+              force_all_climate_relays_off || mode == SAFETY_HEAT || heat_priority_air_release;
+          const bool force_fan1_off =
+              force_all_climate_relays_off || heat_priority_air_release || (mode == SAFETY_HEAT && !willFan1);
+          const bool force_fan2_off =
+              force_all_climate_relays_off || heat_priority_air_release || (mode == SAFETY_HEAT && !willFan2);
+          const bool force_fog_relay_off_now =
+              force_fog_relay_off(mode, sensor_in, heat_priority_air_release);
           const bool heat1_will_be_on_after_apply =
               (willHeat1 && (id(heat1_rly)->state || can_on(R[0])))
               || (id(heat1_rly)->state && !force_heat_off && !can_off(R[0]));
           const bool force_heat2_off =
               force_heat_off
               || (id(heat2_rly)->state && !willHeat2 && !heat1_will_be_on_after_apply);
+          const bool heat1_was_on = id(heat1_rly)->state;
+          const bool heat2_was_on = id(heat2_rly)->state;
+          const bool vent_was_on = id(vent_rly)->state;
+          const bool fan1_was_on = id(fan1_rly)->state;
+          const bool fan2_was_on = id(fan2_rly)->state;
+          const bool fog_was_on = id(fog_rly)->state;
           set_relay(R[0], willHeat1, false, force_heat_off);
           set_relay(R[1], willHeat2, false, force_heat2_off);
-          set_relay(R[5], willVent, fan_requires_vent);
-          set_relay(R[2], willFan1, false);
-          set_relay(R[3], willFan2, false);
-          set_relay(R[4], willFog, false);
+          set_relay(R[5], willVent, fan_requires_vent, force_vent_off);
+          set_relay(R[2], willFan1, false, force_fan1_off);
+          set_relay(R[3], willFan2, false, force_fan2_off);
+          set_relay(R[4], willFog, false, force_fog_relay_off_now);
+
+          /**************** 11b — CYCLE COUNTERS **********************************/
+          // Count physical relay rising edges after set_relay() applies
+          // force-off, force-on, and min-dwell gates.
+          if(!heat1_was_on && id(heat1_rly)->state) id(cnt_heat1_today) += 1;
+          if(!heat2_was_on && id(heat2_rly)->state) id(cnt_heat2_today) += 1;
+          if(!fog_was_on && id(fog_rly)->state)     id(cnt_fog_today) += 1;
+          if(!fan1_was_on && id(fan1_rly)->state)   id(cnt_fan1_today) += 1;
+          if(!fan2_was_on && id(fan2_rly)->state)   id(cnt_fan2_today) += 1;
+          if(!vent_was_on && id(vent_rly)->state)   id(cnt_vent_today) += 1;
 
           /**************** 12 — MISTER STATE MACHINE *****************************/
           // Runs only for SEALED_MIST or explicit VENTILATE assist. Zone stress
@@ -600,6 +690,8 @@ interval:
           {
             const uint32_t MISTER_ENGAGE_DELAY_MS = uint32_t(id(mister_engage_delay_s)) * 1000UL;
             const uint32_t MISTER_ALL_DELAY_MS    = uint32_t(id(mister_all_delay_s))    * 1000UL;
+            const bool force_mister_relay_off_now =
+                force_mister_relays_off(mode, sensor_in, heat_priority_air_release);
 
             float south_vpd = id(vpd_south).state;
             float west_vpd  = id(vpd_west).state;
@@ -734,6 +826,38 @@ interval:
               }
             };
             direct_wet_relay_watchdog();
+            static bool force_mister_relay_off_prev = false;
+            if(force_mister_relay_off_now) {
+              id(south_wall_mister).turn_off();
+              id(south_wall_mister_fertilized).turn_off();
+              id(west_wall_mister).turn_off();
+              id(west_wall_mister_fertilized).turn_off();
+              id(center_mister).turn_off();
+              if(!id(south_wall_mister_fertilized).state &&
+                 !id(west_wall_mister_fertilized).state &&
+                 !id(wall_drips_fertilized).state &&
+                 !id(center_drips_fertilized).state) {
+                id(fertilizer_master_valve).turn_off();
+              }
+              if(id(mister_pulse_zone) > 0) {
+                id(mister_pulse_zone) = 0;
+                id(mister_pulse_timer_ms) = 0;
+              }
+              if(id(mister_state) > 0) {
+                id(mister_state) = 0;
+                id(mister_selected_zone) = 0;
+                id(mister_duty_phase) = 0;
+                id(mister_duty_timer_ms) = 0;
+              }
+            }
+            if(force_mister_relay_off_now != force_mister_relay_off_prev) {
+              ESP_LOGI(
+                "interlock",
+                force_mister_relay_off_now
+                  ? "Mister relays forced off by safety/dew-margin/heat-priority rail"
+                  : "Mister relay force-off rail cleared");
+              force_mister_relay_off_prev = force_mister_relay_off_now;
+            }
             auto first_allowed_mister_zone = [&]() -> int {
               if(south_wet_allowed) return 1;
               if(west_wet_allowed) return 2;
@@ -788,10 +912,22 @@ interval:
                   budget_block
                   || !zone_mister_demand
                   || !any_mister_wet_allowed
+                  || force_mister_relay_off_now
+                  || !wet_dew_margin_ok
                   || irrigation_block
                   || occupancy_blocks;
               if(mister_blocked) {
-                if(budget_block) {
+                if(force_mister_relay_off_now) {
+                  if(heat_priority_air_release) {
+                    snprintf(moisture_block_reason, sizeof(moisture_block_reason), "heat_priority");
+                  } else if(mode == SAFETY_HEAT) {
+                    snprintf(moisture_block_reason, sizeof(moisture_block_reason), "safety_heat");
+                  } else if(mode == SENSOR_FAULT) {
+                    snprintf(moisture_block_reason, sizeof(moisture_block_reason), "sensor_fault");
+                  } else {
+                    snprintf(moisture_block_reason, sizeof(moisture_block_reason), "dew_margin");
+                  }
+                } else if(budget_block) {
                   snprintf(moisture_block_reason, sizeof(moisture_block_reason), "water_budget");
                 } else if(!zone_mister_demand) {
                   snprintf(
@@ -1204,6 +1340,16 @@ interval:
             char fog_block_reason[64];
             if(id(fog_rly)->state) {
               snprintf(fog_block_reason, sizeof(fog_block_reason), "served");
+            } else if(force_fog_relay_off_now && (id(manual_fog_active) || relay_out.fog || willFog)) {
+              if(heat_priority_air_release) {
+                snprintf(fog_block_reason, sizeof(fog_block_reason), "heat_priority");
+              } else if(mode == SAFETY_HEAT) {
+                snprintf(fog_block_reason, sizeof(fog_block_reason), "safety_heat");
+              } else if(mode == SENSOR_FAULT) {
+                snprintf(fog_block_reason, sizeof(fog_block_reason), "sensor_fault");
+              } else {
+                snprintf(fog_block_reason, sizeof(fog_block_reason), "dew_margin");
+              }
             } else if(of.fog_gate_window) {
               if(id(fog_stress_window_extend_enabled)
                  && fog_stress_extension_hour
@@ -1217,6 +1363,8 @@ interval:
               snprintf(fog_block_reason, sizeof(fog_block_reason), "rh_ceiling");
             } else if(of.fog_gate_temp) {
               snprintf(fog_block_reason, sizeof(fog_block_reason), "temp_low");
+            } else if(fog_dew_margin_block) {
+              snprintf(fog_block_reason, sizeof(fog_block_reason), "dew_margin");
             } else if(relay_out.fog && id(fog_closes_vent) && vent_is_open && !open_vent_fog_assist) {
               snprintf(fog_block_reason, sizeof(fog_block_reason), "vent_interlock");
             } else if(willFog && !id(fog_rly)->state) {
@@ -1552,9 +1700,6 @@ interval:
           uint32_t irrig_dt = (irrig_now < irrig_last_ms) ? 0 : (irrig_now - irrig_last_ms);
           irrig_last_ms = irrig_now;
 
-          // Track which job entered flush (persists across ticks)
-          static int flush_origin = 0;
-
           // ── VPD stress accumulator ──
           float cur_vpd = id(average_vpd_kpa).state;
           float vpd_hi = id(target_vpd_high_kpa);
@@ -1654,6 +1799,28 @@ interval:
             auto irrig_direct_wet_allowed = [&](bool is_wall) -> bool {
               return irrig_direct_wet_allowed_zone(is_wall ? 4 : 3);
             };
+            const float irrig_temp_f = id(average_temperature).state;
+            const float irrig_case_temp_f = id(case_temperature).state;
+            float irrig_control_temp_f = irrig_temp_f;
+            if(isnan(irrig_control_temp_f) && !isnan(irrig_case_temp_f)) {
+              irrig_control_temp_f = irrig_case_temp_f;
+            }
+            const bool irrig_sensor_fault =
+              isnan(irrig_control_temp_f) ||
+              irrig_control_temp_f < -20.0f ||
+              irrig_control_temp_f > 140.0f;
+            const bool irrig_safety_heat =
+              !irrig_sensor_fault && irrig_control_temp_f <= id(safety_min_f);
+            const Mode irrig_wet_mode =
+              irrig_sensor_fault ? SENSOR_FAULT : (irrig_safety_heat ? SAFETY_HEAT : IDLE);
+            SensorInputs irrig_wet_inputs{};
+            irrig_wet_inputs.temp_f = irrig_control_temp_f;
+            irrig_wet_inputs.dew_point_f = id(dewpoint_avg).state;
+            const bool irrig_mister_safety_off = force_mister_relays_off(irrig_wet_mode, irrig_wet_inputs, false);
+            const bool irrig_mister_occupancy_block =
+              id(occupancy_inhibit_enabled) && id(greenhouse_occupied);
+            const bool irrig_mister_block =
+              irrig_mister_safety_off || irrig_mister_occupancy_block;
             auto turn_off_all_irrigation = [&]() {
               id(wall_drips).turn_off();
               id(wall_drips_fertilized).turn_off();
@@ -1661,10 +1828,34 @@ interval:
               id(south_wall_mister_fertilized).turn_off();
               id(west_wall_mister).turn_off();
               id(west_wall_mister_fertilized).turn_off();
+              id(center_mister).turn_off();
               id(center_drips).turn_off();
               id(center_drips_fertilized).turn_off();
               id(fertilizer_master_valve).turn_off();
             };
+            const bool irrigation_physically_on =
+              id(wall_drips).state ||
+              id(wall_drips_fertilized).state ||
+              id(south_wall_mister).state ||
+              id(south_wall_mister_fertilized).state ||
+              id(west_wall_mister).state ||
+              id(west_wall_mister_fertilized).state ||
+              id(center_mister).state ||
+              id(center_drips).state ||
+              id(center_drips_fertilized).state ||
+              id(fertilizer_master_valve).state;
+            if(irrig_sensor_fault) {
+              const bool had_irrigation_work =
+                id(irrig_state) > 0 || id(irrig_queue) != 0 || irrigation_physically_on;
+              turn_off_all_irrigation();
+              id(irrig_state) = 0;
+              id(irrig_queue) = 0;
+              id(irrig_timer_ms) = 0;
+              if(had_irrigation_work) {
+                ESP_LOGW("irrig","STOPPED all irrigation by sensor-fault rail");
+              }
+              return;
+            }
             if(id(direct_wet_gate_enabled) && id(irrig_state) > 0) {
               bool active_wall = id(irrig_state) == 1 || id(irrig_state) == 2 || id(irrig_state) == 5;
               bool active_south = id(irrig_state) == 7 || id(irrig_state) == 9;
@@ -1680,10 +1871,45 @@ interval:
                 ESP_LOGW("irrig","STOPPED by direct-wet gate");
               }
             }
-            sync_fert_master("watchdog");
+            if(irrig_mister_block && id(irrig_state) > 0) {
+              bool active_south_mister = id(irrig_state) == 7 || id(irrig_state) == 9;
+              bool active_west_mister = id(irrig_state) == 8 || id(irrig_state) == 10;
+              if(active_south_mister || active_west_mister) {
+                id(south_wall_mister).turn_off();
+                id(south_wall_mister_fertilized).turn_off();
+                id(west_wall_mister).turn_off();
+                id(west_wall_mister_fertilized).turn_off();
+                if(!id(wall_drips_fertilized).state && !id(center_drips_fertilized).state) {
+                  id(fertilizer_master_valve).turn_off();
+                }
+                id(irrig_state) = 0;
+                id(irrig_timer_ms) = 0;
+                ESP_LOGW(
+                  "irrig",
+                  irrig_mister_occupancy_block
+                    ? "STOPPED mister job by occupancy rail"
+                    : "STOPPED mister job by safety/dew-margin rail");
+              }
+            }
 
-            // ── Skip if globally disabled ──
-            if(!id(irrig_enabled)) return;
+            // ── Global disable is an immediate executor stop, not just a
+            // scheduling gate. Otherwise an in-flight job can leave a valve on
+            // forever because the countdown/cleanup block below is skipped.
+            // Keep this before fertilizer-master sync so a disabled controller
+            // cannot briefly re-open the master through the watchdog interlock.
+            if(!id(irrig_enabled)) {
+              const bool had_irrigation_work =
+                id(irrig_state) > 0 || id(irrig_queue) != 0 || irrigation_physically_on;
+              turn_off_all_irrigation();
+              id(irrig_state) = 0;
+              id(irrig_queue) = 0;
+              id(irrig_timer_ms) = 0;
+              if(had_irrigation_work) {
+                ESP_LOGW("irrig","STOPPED all irrigation because irrigation is disabled");
+              }
+              return;
+            }
+            sync_fert_master("watchdog");
 
           // ── Schedule check (only when idle, no queue pending) ──
           if(id(irrig_state) == 0 && id(irrig_queue) == 0 &&
@@ -1774,17 +2000,30 @@ interval:
                 const char* drop_zone = (job_zone == 1) ? "SOUTH" : (job_zone == 2) ? "WEST" : (job_zone == 3) ? "CENTER" : "WALL";
                 ESP_LOGW("irrig","DROP QUEUED %s job (direct-wet gate)", drop_zone);
                 job = 0;
+              } else if((job_zone == 1 || job_zone == 2) && irrig_mister_block) {
+                const char* drop_zone = (job_zone == 1) ? "SOUTH" : "WEST";
+                ESP_LOGW(
+                  "irrig",
+                  irrig_mister_occupancy_block
+                    ? "DROP QUEUED %s mister job (occupancy rail)"
+                    : "DROP QUEUED %s mister job (safety/dew-margin rail)",
+                  drop_zone);
+                job = 0;
               }
             }
 
             if(job > 0){
-              id(irrig_state) = job;
-
               bool is_wall = (job == 1 || job == 2);
               bool is_center = (job == 3 || job == 4);
               bool is_south_mister = (job == 7);
               bool is_west_mister = (job == 8);
               bool is_fert = (job == 2 || job == 4 || is_south_mister || is_west_mister);
+              const char* job_name = (job == 1) ? "WALL_CLEAN" :
+                (job == 2) ? "WALL_FERT" :
+                (job == 3) ? "CENTER_CLEAN" :
+                (job == 4) ? "CENTER_FERT" :
+                (job == 7) ? "SOUTH_MISTER_FERT" :
+                (job == 8) ? "WEST_MISTER_FERT" : "UNKNOWN";
               int base_min = is_fert
                 ? (is_center ? id(irrig_center_fert_duration_min) : id(irrig_wall_fert_duration_min))
                 : (is_center ? id(irrig_center_duration_min) : id(irrig_wall_duration_min));
@@ -1798,42 +2037,43 @@ interval:
                          stress_hrs, id(irrig_vpd_boost_threshold_hrs), base_min);
               }
 
-              id(irrig_timer_ms) = uint32_t(base_min) * 60000UL;
+              if(base_min <= 0){
+                id(irrig_timer_ms) = 0;
+                ESP_LOGW("irrig","DROP QUEUED %s job (zero duration)", job_name);
+                job = 0;
+              } else {
+                id(irrig_state) = job;
+                id(irrig_timer_ms) = uint32_t(base_min) * 60000UL;
 
-              id(wall_drips).turn_off();
-              id(wall_drips_fertilized).turn_off();
-              id(south_wall_mister).turn_off();
-              id(south_wall_mister_fertilized).turn_off();
-              id(west_wall_mister).turn_off();
-              id(west_wall_mister_fertilized).turn_off();
-              id(center_drips).turn_off();
-              id(center_drips_fertilized).turn_off();
-              id(center_mister).turn_off();
+                id(wall_drips).turn_off();
+                id(wall_drips_fertilized).turn_off();
+                id(south_wall_mister).turn_off();
+                id(south_wall_mister_fertilized).turn_off();
+                id(west_wall_mister).turn_off();
+                id(west_wall_mister_fertilized).turn_off();
+                id(center_drips).turn_off();
+                id(center_drips_fertilized).turn_off();
+                id(center_mister).turn_off();
 
-              // Open the fert master before any fertilized drip/mister relay.
-              if(is_fert && !id(fertilizer_master_valve).state) id(fertilizer_master_valve).turn_on();
+                // Open the fert master before any fertilized drip/mister relay.
+                if(is_fert && !id(fertilizer_master_valve).state) id(fertilizer_master_valve).turn_on();
 
-              // Turn on drip line. sprint-7: count one cycle per dispatch —
-              // matches equipment_state's rising-edge count for the
-              // underlying relay. Fert/clean increment the same zone
-              // counter (audit granularity is per-zone).
-              switch(job){
-                case 1: id(wall_drips).turn_on();              id(cnt_drip_wall_today)   += 1; break;
-                case 2: id(wall_drips_fertilized).turn_on();   id(cnt_drip_wall_today)   += 1; break;
-                case 3: id(center_drips).turn_on();            id(cnt_drip_center_today) += 1; break;
-                case 4: id(center_drips_fertilized).turn_on(); id(cnt_drip_center_today) += 1; break;
-                case 7: id(south_wall_mister_fertilized).turn_on(); id(cnt_mister_south_today) += 1; break;
-                case 8: id(west_wall_mister_fertilized).turn_on();  id(cnt_mister_west_today)  += 1; break;
+                // Turn on drip line. sprint-7: count one cycle per dispatch —
+                // matches equipment_state's rising-edge count for the
+                // underlying relay. Fert/clean increment the same zone
+                // counter (audit granularity is per-zone).
+                switch(job){
+                  case 1: id(wall_drips).turn_on();              id(cnt_drip_wall_today)   += 1; break;
+                  case 2: id(wall_drips_fertilized).turn_on();   id(cnt_drip_wall_today)   += 1; break;
+                  case 3: id(center_drips).turn_on();            id(cnt_drip_center_today) += 1; break;
+                  case 4: id(center_drips_fertilized).turn_on(); id(cnt_drip_center_today) += 1; break;
+                  case 7: id(south_wall_mister_fertilized).turn_on(); id(cnt_mister_south_today) += 1; break;
+                  case 8: id(west_wall_mister_fertilized).turn_on();  id(cnt_mister_west_today)  += 1; break;
+                }
+                sync_fert_master("job-start");
+
+                ESP_LOGI("irrig","START %s — %dmin%s", job_name, base_min, fert_queue_pending ? " (fert queue)" : "");
               }
-              sync_fert_master("job-start");
-
-              const char* job_name = (job == 1) ? "WALL_CLEAN" :
-                (job == 2) ? "WALL_FERT" :
-                (job == 3) ? "CENTER_CLEAN" :
-                (job == 4) ? "CENTER_FERT" :
-                (job == 7) ? "SOUTH_MISTER_FERT" :
-                (job == 8) ? "WEST_MISTER_FERT" : "UNKNOWN";
-              ESP_LOGI("irrig","START %s — %dmin%s", job_name, base_min, fert_queue_pending ? " (fert queue)" : "");
             }
           }
 
@@ -1863,8 +2103,11 @@ interval:
 
               // Fert → flush with clean water
               int flush_min = is_center ? id(irrig_center_flush_min) : id(irrig_wall_flush_min);
-              if(is_fert && flush_min > 0){
-                flush_origin = job;
+              int flush_zone = is_south_mister ? 1 : is_west_mister ? 2 : is_center ? 3 : 4;
+              const bool flush_direct_wet_allowed = irrig_direct_wet_allowed_zone(flush_zone);
+              const bool flush_mister_blocked =
+                (is_south_mister || is_west_mister) && irrig_mister_block;
+              if(is_fert && flush_min > 0 && flush_direct_wet_allowed && !flush_mister_blocked){
                 id(irrig_state) = is_center ? 6 : is_south_mister ? 9 : is_west_mister ? 10 : 5;
                 id(irrig_timer_ms) = uint32_t(flush_min) * 60000UL;
                 // Flush is a separate rising edge on the matching clean relay,
@@ -1876,6 +2119,15 @@ interval:
                 const char* flush_name = is_south_mister ? "SOUTH_MISTER" : is_west_mister ? "WEST_MISTER" : is_center ? "CENTER" : "WALL";
                 ESP_LOGI("irrig","FLUSH %s — %dmin", flush_name, flush_min);
               } else {
+                if(is_fert && flush_min > 0 && (!flush_direct_wet_allowed || flush_mister_blocked)) {
+                  const char* flush_name = is_south_mister ? "SOUTH_MISTER" : is_west_mister ? "WEST_MISTER" : is_center ? "CENTER" : "WALL";
+                  ESP_LOGW(
+                    "irrig",
+                    flush_mister_blocked
+                      ? "SKIP FLUSH %s by safety/dew-margin/occupancy rail"
+                      : "SKIP FLUSH %s by direct-wet gate",
+                    flush_name);
+                }
                 // Done — finalize
                 if(is_wall){
                   id(irrig_wall_cycle_count) += 1;

--- a/firmware/greenhouse/globals.yaml
+++ b/firmware/greenhouse/globals.yaml
@@ -1118,15 +1118,13 @@ globals:
     restore_value: no
     initial_value: '180'
 
-  # ─── Phase-2 dwell gate ───────────────────────────────────────────
-  # 5-min hold on non-safety mode transitions to kill whipsaw. Default
-  # OFF for shadow-mode bake; planner flips to ON after 14d replay +
-  # shadow validation. See plan Phase 2 in
-  # .claude-agents/iris-dev/plans/yo-iris-dev-you-help-humming-stonebraker.md
+  # ─── Production dwell gate ────────────────────────────────────────
+  # 5-min hold on non-safety mode transitions to kill whipsaw. Locked ON
+  # by the control loop so the ESP32 has one live enforcement path.
   - id: sw_dwell_gate_enabled
     type: bool
     restore_value: no
-    initial_value: 'false'
+    initial_value: 'true'
 
   - id: dwell_gate_ms
     type: int

--- a/firmware/greenhouse/sensors.yaml
+++ b/firmware/greenhouse/sensors.yaml
@@ -1079,6 +1079,78 @@ sensor:
       float vpd = es*(1.0f-RHin/100.0f);
       return vpd < 0.0f ? 0.0f : vpd;
 
+  - platform: template
+    id: ctl_temp_band_error_f
+    name: "Control Temp Band Error (°F)"
+    unit_of_measurement: "°F"
+    state_class: measurement
+    accuracy_decimals: 1
+    entity_category: diagnostic
+    update_interval: 10s
+    lambda: |-
+      if(isnan(id(control_tin).state)) return NAN;
+      Setpoints sp = default_setpoints();
+      sp.temp_low = id(target_temp_low_f);
+      sp.temp_high = id(target_temp_high_f);
+      validate_setpoints(sp);
+      SensorInputs in{};
+      in.temp_f = id(control_tin).state;
+      return temp_band_error_f(in, sp);
+
+  - platform: template
+    id: ctl_temp_target_error_f
+    name: "Control Temp Target Error (°F)"
+    unit_of_measurement: "°F"
+    state_class: measurement
+    accuracy_decimals: 1
+    entity_category: diagnostic
+    update_interval: 10s
+    lambda: |-
+      if(isnan(id(control_tin).state)) return NAN;
+      Setpoints sp = default_setpoints();
+      sp.temp_low = id(target_temp_low_f);
+      sp.temp_high = id(target_temp_high_f);
+      validate_setpoints(sp);
+      SensorInputs in{};
+      in.temp_f = id(control_tin).state;
+      return temp_target_error_f(in, sp);
+
+  - platform: template
+    id: ctl_vpd_band_error_kpa
+    name: "Control VPD Band Error (kPa)"
+    unit_of_measurement: "kPa"
+    state_class: measurement
+    accuracy_decimals: 2
+    entity_category: diagnostic
+    update_interval: 10s
+    lambda: |-
+      if(isnan(id(control_vpd_kpa).state)) return NAN;
+      Setpoints sp = default_setpoints();
+      sp.vpd_low = id(target_vpd_low_kpa);
+      sp.vpd_high = id(target_vpd_high_kpa);
+      validate_setpoints(sp);
+      SensorInputs in{};
+      in.vpd_kpa = id(control_vpd_kpa).state;
+      return vpd_band_error_kpa(in, sp);
+
+  - platform: template
+    id: ctl_vpd_target_error_kpa
+    name: "Control VPD Target Error (kPa)"
+    unit_of_measurement: "kPa"
+    state_class: measurement
+    accuracy_decimals: 2
+    entity_category: diagnostic
+    update_interval: 10s
+    lambda: |-
+      if(isnan(id(control_vpd_kpa).state)) return NAN;
+      Setpoints sp = default_setpoints();
+      sp.vpd_low = id(target_vpd_low_kpa);
+      sp.vpd_high = id(target_vpd_high_kpa);
+      validate_setpoints(sp);
+      SensorInputs in{};
+      in.vpd_kpa = id(control_vpd_kpa).state;
+      return vpd_target_error_kpa(in, sp);
+
 ################################################################################
 # 7. CONFIGURATION / SET‑POINT OUTPUTS  – entity_category fixed to “diagnostic”
 ################################################################################

--- a/firmware/greenhouse/tunables.yaml
+++ b/firmware/greenhouse/tunables.yaml
@@ -2041,14 +2041,13 @@ switch:
           id(sw_summer_vent_enabled) = false;
           id(sw_summer_vent_enabled_switch).publish_state(false);
 
-  # Phase-2 dwell gate master switch. Default OFF (shadow-mode bake).
-  # After 14d of replay + shadow validation per plan Phase 2 gate,
-  # planner flips this to ON to activate the 5-min mode-dwell hold.
+  # Production dwell gate master switch. Kept as a compatibility/readback
+  # surface, but the ESPHome control loop locks it ON.
   - platform: template
     id: sw_dwell_gate_enabled_switch
     name: "Dwell Gate Enabled"
     icon: "mdi:timer-lock"
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     lambda: 'return id(sw_dwell_gate_enabled);'
     turn_on_action:
       - lambda: |
@@ -2056,8 +2055,9 @@ switch:
           id(sw_dwell_gate_enabled_switch).publish_state(true);
     turn_off_action:
       - lambda: |
-          id(sw_dwell_gate_enabled) = false;
-          id(sw_dwell_gate_enabled_switch).publish_state(false);
+          id(sw_dwell_gate_enabled) = true;
+          id(sw_dwell_gate_enabled_switch).publish_state(true);
+          ESP_LOGW("tunables", "Dwell Gate Enabled is locked ON by the unified controller contract");
 
   - platform: template
     id: sw_fsm_controller_enabled_switch

--- a/firmware/lib/greenhouse_logic.h
+++ b/firmware/lib/greenhouse_logic.h
@@ -148,12 +148,120 @@ inline bool day_mask_allows(int day_mask, int day_of_week_zero_sunday) noexcept 
     return (day_mask & (1 << day_of_week_zero_sunday)) != 0;
 }
 
-// True iff all of RH, temp, and hour-of-day permit fogging. Occupancy is
-// NOT checked here — see moisture_blocked_by_occupancy().
+static constexpr float WET_DEW_MARGIN_FLOOR_F = 3.0f;
+
+inline bool wet_dew_margin_safe(const SensorInputs& in) noexcept {
+    return std::isfinite(in.temp_f)
+        && std::isfinite(in.dew_point_f)
+        && (in.temp_f - in.dew_point_f) >= WET_DEW_MARGIN_FLOOR_F;
+}
+
+// True iff all of RH, temp, dew-margin, and hour-of-day permit fogging.
+// Occupancy is NOT checked here — see moisture_blocked_by_occupancy().
 inline bool fog_permitted(const SensorInputs& in, const Setpoints& sp) noexcept {
     return (in.rh_pct  <= sp.fog_rh_ceiling)
         && (in.temp_f  >= sp.fog_min_temp)
+        && wet_dew_margin_safe(in)
         && fog_hour_permitted(in, sp);
+}
+
+// Caller-side relay interlock helper: when normal heat is the selected
+// equipment and the house is below the lower temp band, release air exchange
+// immediately. The caller still suppresses heat until the physical fan/vent
+// relays are confirmed off; this only prevents min-on dwell from prolonging
+// an already cold vent/fan state.
+inline bool heat_priority_releases_air_exchange(
+    Mode mode,
+    const SensorInputs& in,
+    const Setpoints& sp,
+    const RelayOutputs& out,
+    bool manual_fan_active
+) noexcept {
+    return !manual_fan_active
+        && mode != SAFETY_HEAT
+        && in.temp_f < sp.temp_low
+        && (out.heat1 || out.heat2);
+}
+
+inline bool manual_fan_override_allowed(
+    Mode mode,
+    const SensorInputs& in,
+    const Setpoints& sp
+) noexcept {
+    return mode != SENSOR_FAULT
+        && mode != SAFETY_HEAT
+        && std::isfinite(in.temp_f)
+        && in.temp_f >= sp.temp_low;
+}
+
+inline bool manual_fog_override_allowed(
+    Mode mode,
+    const SensorInputs& in,
+    const Setpoints& sp
+) noexcept {
+    return mode != SENSOR_FAULT
+        && mode != SAFETY_HEAT
+        && std::isfinite(in.temp_f)
+        && std::isfinite(in.rh_pct)
+        && in.temp_f >= sp.fog_min_temp
+        && in.rh_pct <= sp.fog_rh_ceiling
+        && wet_dew_margin_safe(in);
+}
+
+inline bool vent_lock_suppresses_air_exchange(Mode mode) noexcept {
+    return mode != SAFETY_COOL
+        && mode != SAFETY_HEAT
+        && mode != SENSOR_FAULT;
+}
+
+inline bool force_fog_relay_off(
+    Mode mode,
+    const SensorInputs& in,
+    bool heat_priority_air_release
+) noexcept {
+    return mode == SENSOR_FAULT
+        || mode == SAFETY_HEAT
+        || heat_priority_air_release
+        || !wet_dew_margin_safe(in);
+}
+
+inline bool force_mister_relays_off(
+    Mode mode,
+    const SensorInputs& in,
+    bool heat_priority_air_release
+) noexcept {
+    return mode == SENSOR_FAULT
+        || mode == SAFETY_HEAT
+        || heat_priority_air_release
+        || !wet_dew_margin_safe(in);
+}
+
+inline float signed_band_error(float actual, float low, float high) noexcept {
+    if (!std::isfinite(actual) || !std::isfinite(low) || !std::isfinite(high)) return NAN;
+    if (actual < low) return actual - low;
+    if (actual > high) return actual - high;
+    return 0.0f;
+}
+
+inline float signed_midpoint_error(float actual, float low, float high) noexcept {
+    if (!std::isfinite(actual) || !std::isfinite(low) || !std::isfinite(high)) return NAN;
+    return actual - ((low + high) * 0.5f);
+}
+
+inline float temp_band_error_f(const SensorInputs& in, const Setpoints& sp) noexcept {
+    return signed_band_error(in.temp_f, sp.temp_low, sp.temp_high);
+}
+
+inline float vpd_band_error_kpa(const SensorInputs& in, const Setpoints& sp) noexcept {
+    return signed_band_error(in.vpd_kpa, sp.vpd_low, sp.vpd_high);
+}
+
+inline float temp_target_error_f(const SensorInputs& in, const Setpoints& sp) noexcept {
+    return signed_midpoint_error(in.temp_f, sp.temp_low, sp.temp_high);
+}
+
+inline float vpd_target_error_kpa(const SensorInputs& in, const Setpoints& sp) noexcept {
+    return signed_midpoint_error(in.vpd_kpa, sp.vpd_low, sp.vpd_high);
 }
 
 // Unified band-first controller clamps VPD hysteresis against the actual band width. The
@@ -441,6 +549,7 @@ inline Mode determine_mode_band_first(
     const bool safety_heat = in.temp_f <= sp.safety_min;
     const bool was_cooling = (prev == VENTILATE) || (prev == THERMAL_RELIEF);
     const bool vpd_high = in.vpd_kpa > sp.vpd_high;
+    const bool vpd_extreme_dry = in.vpd_kpa > sp.vpd_max_safe;
     const bool vpd_high_resolved = in.vpd_kpa <= (sp.vpd_high - HV);
     const bool outdoor_cold_for_vent =
         std::isfinite(in.outdoor_temp_f) && in.outdoor_temp_f < (sp.temp_low - sp.cold_vent_guard_delta_f);
@@ -457,10 +566,19 @@ inline Mode determine_mode_band_first(
 
     const bool cold_dehum_allowed =
         !outdoor_cold_for_vent || in.temp_f > (sp.temp_low + std::max(2.0f, sp.temp_hysteresis));
-    const bool vpd_low_enter = in.vpd_kpa < (sp.vpd_low - HV) && !sp.econ_block && cold_dehum_allowed;
-    const bool vpd_dehum_exit = in.vpd_kpa >= sp.vpd_low || !cold_dehum_allowed;
+    const bool vpd_low_enter =
+        in.vpd_kpa < (sp.vpd_low - HV) && !sp.econ_block && !temp_below_band && cold_dehum_allowed;
+    const bool vpd_dehum_exit = in.vpd_kpa >= sp.vpd_low || temp_below_band || !cold_dehum_allowed;
     const bool was_dehum = prev == DEHUM_VENT;
     const bool moisture_blocked = moisture_blocked_by_occupancy(in, sp);
+    const bool wet_margin_ok = wet_dew_margin_safe(in);
+    const bool dry_override_can_humidify =
+        vpd_extreme_dry
+        && !moisture_blocked
+        && !temp_below_band
+        && !needs_cooling
+        && wet_margin_ok
+        && in.temp_f < (sp.safety_max - sp.safety_max_seal_margin_f);
 
     {
         if (temp_below_band) {
@@ -505,6 +623,7 @@ inline Mode determine_mode_band_first(
     }
 
     Mode mode = IDLE;
+    bool fresh_seal_entry = false;
     state.dry_override_active = false;
     state.last_mode_reason = "idle";
 
@@ -530,9 +649,11 @@ inline Mode determine_mode_band_first(
         state.vent_mist_assist_active = false;
     } else if (prev == SEALED_MIST) {
         state.sealed_timer_ms = sat_add(state.sealed_timer_ms, dt_ms);
-        if (vpd_high_resolved || moisture_blocked) {
+        if (vpd_high_resolved || moisture_blocked || !wet_margin_ok) {
             mode = needs_cooling ? VENTILATE : IDLE;
-            state.last_mode_reason = moisture_blocked ? "moisture_blocked" : "humidify_resolved";
+            state.last_mode_reason = !wet_margin_ok
+                ? "dew_margin"
+                : (moisture_blocked ? "moisture_blocked" : "humidify_resolved");
             state.sealed_timer_ms = 0;
             state.vpd_watch_timer_ms = 0;
             state.relief_cycle_count = 0;
@@ -566,6 +687,17 @@ inline Mode determine_mode_band_first(
         mode = VENTILATE;
         state.last_mode_reason = state.override_summer_vent ? "summer_vent" : "temp_high";
         state.sealed_timer_ms = 0;
+    } else if (dry_override_can_humidify) {
+        mode = SEALED_MIST;
+        state.last_mode_reason = "dry_override";
+        state.dry_override_active = true;
+        state.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+        state.sealed_timer_ms = dt_ms;
+        state.mist_stage = MIST_S1;
+        state.mist_stage_timer_ms = 0;
+        fresh_seal_entry = true;
+        state.vent_latch_timer_ms = 0;
+        state.mist_backoff_timer_ms = 0;
     } else if (vpd_low_enter) {
         mode = DEHUM_VENT;
         state.last_mode_reason = "vpd_low";
@@ -581,16 +713,20 @@ inline Mode determine_mode_band_first(
     } else if (humidify_ready
                && !moisture_blocked
                && !temp_below_band
+               && wet_margin_ok
                && in.temp_f < (sp.safety_max - sp.safety_max_seal_margin_f)) {
         mode = SEALED_MIST;
         state.last_mode_reason = "humidify_enter";
         state.sealed_timer_ms = dt_ms;
         state.mist_stage = MIST_S1;
         state.mist_stage_timer_ms = 0;
+        fresh_seal_entry = true;
         state.vent_latch_timer_ms = 0;
     } else {
         mode = IDLE;
-        if (needs_heating_s1) {
+        if (vpd_high && !wet_margin_ok) {
+            state.last_mode_reason = "dew_margin";
+        } else if (needs_heating_s1) {
             state.last_mode_reason = state.heat2_latched ? "heat_stage2" : "heat_stage1";
         } else {
             state.last_mode_reason = "idle";
@@ -600,13 +736,34 @@ inline Mode determine_mode_band_first(
 
     {
         const bool safety_preempts_dwell =
-            (mode == SAFETY_COOL) || (mode == SAFETY_HEAT) || (mode == SENSOR_FAULT);
+            (mode == SAFETY_COOL) || (mode == SAFETY_HEAT) || (mode == SENSOR_FAULT)
+            || state.dry_override_active;
+        // Mode dwell is a churn guard, not a license to remain outside the temp band.
+        const bool temp_priority_preempts_dwell =
+            ((mode == VENTILATE) && needs_cooling) || temp_below_band;
+        // The dwell gate reduces churn; it must not delay an already-mature
+        // wet-recovery decision when VPD is outside the band and the wet rails
+        // are safe, but it also must not flip directly from dehumidifying to
+        // humidifying inside the dwell window.
+        const bool humidify_enter_preempts_dwell =
+            (mode == SEALED_MIST)
+            && humidify_ready
+            && wet_margin_ok
+            && (state.mode_prev == IDLE || state.mode_prev == SEALED_MIST);
+        // Likewise, dwell must not keep the house sealed after the
+        // humidification demand has resolved or an occupancy/safety rail has
+        // asked moisture to stand down.
+        const bool humidify_exit_preempts_dwell =
+            (state.mode_prev == SEALED_MIST) && (mode != SEALED_MIST);
         const bool mode_would_change = mode != state.mode_prev;
         const bool in_dwell = state.last_transition_tick_ms < sp.dwell_gate_ms;
         if (sp.sw_dwell_gate_enabled
             && mode_would_change
             && in_dwell
-            && !safety_preempts_dwell) {
+            && !safety_preempts_dwell
+            && !temp_priority_preempts_dwell
+            && !humidify_enter_preempts_dwell
+            && !humidify_exit_preempts_dwell) {
             mode = state.mode_prev;
             state.last_mode_reason = "dwell_hold";
         }
@@ -618,51 +775,60 @@ inline Mode determine_mode_band_first(
     }
 
     if (mode == SEALED_MIST) {
-        state.mist_stage_timer_ms = sat_add(state.mist_stage_timer_ms, dt_ms);
-        switch (state.mist_stage) {
-            case MIST_WATCH:
-                state.mist_stage = MIST_S1;
-                state.mist_stage_timer_ms = 0;
-                break;
-            case MIST_S1:
-                if (state.mist_stage_timer_ms >= sp.mist_s2_delay_ms && in.vpd_kpa > sp.vpd_high) {
-                    state.mist_stage = MIST_S2;
-                    state.mist_stage_timer_ms = 0;
-                }
-                break;
-            case MIST_S2: {
-                const bool fog_gated = !fog_permitted(in, sp) || moisture_blocked;
-                if (in.vpd_kpa > sp.vpd_high + sp.fog_escalation_kpa && !fog_gated) {
-                    state.mist_stage = MIST_FOG;
-                    state.mist_stage_timer_ms = 0;
-                } else if (vpd_high_resolved) {
+        if (fresh_seal_entry) {
+            state.mist_stage = MIST_S1;
+            state.mist_stage_timer_ms = 0;
+        } else {
+            state.mist_stage_timer_ms = sat_add(state.mist_stage_timer_ms, dt_ms);
+            switch (state.mist_stage) {
+                case MIST_WATCH:
                     state.mist_stage = MIST_S1;
                     state.mist_stage_timer_ms = 0;
+                    break;
+                case MIST_S1:
+                    if (state.mist_stage_timer_ms >= sp.mist_s2_delay_ms && in.vpd_kpa > sp.vpd_high) {
+                        state.mist_stage = MIST_S2;
+                        state.mist_stage_timer_ms = 0;
+                    }
+                    break;
+                case MIST_S2: {
+                    const bool fog_gated = !fog_permitted(in, sp) || moisture_blocked;
+                    if (in.vpd_kpa > sp.vpd_high + sp.fog_escalation_kpa && !fog_gated) {
+                        state.mist_stage = MIST_FOG;
+                        state.mist_stage_timer_ms = 0;
+                    } else if (vpd_high_resolved) {
+                        state.mist_stage = MIST_S1;
+                        state.mist_stage_timer_ms = 0;
+                    }
+                    break;
                 }
-                break;
-            }
-            case MIST_FOG:
-                if (in.vpd_kpa <= sp.vpd_high + sp.fog_escalation_kpa) {
-                    state.mist_stage = MIST_S2;
+                case MIST_FOG:
+                    if (in.vpd_kpa <= sp.vpd_high + sp.fog_escalation_kpa) {
+                        state.mist_stage = MIST_S2;
+                        state.mist_stage_timer_ms = 0;
+                    }
+                    break;
+                default:
+                    state.mist_stage = MIST_WATCH;
                     state.mist_stage_timer_ms = 0;
-                }
-                break;
-            default:
-                state.mist_stage = MIST_WATCH;
-                state.mist_stage_timer_ms = 0;
-                break;
+                    break;
+            }
         }
     } else if (state.mist_stage != MIST_WATCH) {
         state.mist_stage = MIST_WATCH;
         state.mist_stage_timer_ms = 0;
     }
 
+    // Open-vent wet assist is not a seal request. If temp already requires
+    // VENTILATE and VPD is above band, bounded moisture helps both compliance
+    // objectives and should not wait behind the sealed-humidification dwell.
     state.vent_mist_assist_active =
         (mode == VENTILATE)
-        && humidify_ready
+        && vpd_high
         && !moisture_blocked
         && !safety_cool
         && !safety_heat
+        && wet_margin_ok
         && in.temp_f < (sp.safety_max - sp.safety_max_seal_margin_f);
 
     state.mode = mode;
@@ -1019,7 +1185,7 @@ inline Mode determine_mode(
         // documented in backlog (P3#15 still open).
     }
 
-    // ── Phase-2 dwell gate ────────────────────────────────────────────
+    // ── Dwell gate ────────────────────────────────────────────────────
     // Hold non-safety mode transitions for at least sp.dwell_gate_ms after
     // the most recent accepted transition. Closes the whipsaw pattern
     // observed 2026-04-17 (59 mode changes in 2h stable window) and
@@ -1029,11 +1195,6 @@ inline Mode determine_mode(
     // Preempts: safety rails (SAFETY_COOL/HEAT), FAULT_HOLD-equivalent
     // (SENSOR_FAULT), R2-3 dry override, vpd_min_safe rescue. Safety
     // must ALWAYS fire immediately — no dwell gate on life-safety paths.
-    //
-    // Shadow mode: default sp.sw_dwell_gate_enabled=false. Firmware
-    // logs what it WOULD decide (via last_mode_reason suffix) but still
-    // applies the transition. After 14d shadow-mode bake, flip to true.
-    // See plan Phase 2 gate criteria.
     //
     // Accounting: last_transition_tick_ms is a "ms since last accepted
     // transition" accumulator. Each cycle: += dt_ms if mode unchanged,
@@ -1068,8 +1229,8 @@ inline Mode determine_mode(
             mode = state.mode_prev;
             state.last_mode_reason = "dwell_hold";
         }
-        // Update accumulator regardless of flag state — shadow mode needs
-        // the counter so post-flip the first transition has correct dwell.
+        // Update accumulator regardless of flag state so explicit forensics
+        // that toggle the gate still keep correct transition age.
         if (mode != state.mode_prev) {
             state.last_transition_tick_ms = 0;
         } else {
@@ -1241,6 +1402,10 @@ inline RelayOutputs resolve_equipment(
     const ControlState& state,
     bool lead_is_fan1
 ) {
+    if (!sensors_plausible(in)) {
+        return {false, false, false, false, false, false};
+    }
+
     // Sprint-12 legacy: interior targets (25% inside band). band-first controller
     // uses the same lower-quartile heat target while cooling at the raw high
     // edge; heat2 still protects the lower edge.

--- a/firmware/lib/greenhouse_types.h
+++ b/firmware/lib/greenhouse_types.h
@@ -110,14 +110,13 @@ struct Setpoints {
     float    vent_prefer_dp_delta_f;       // outdoor DP must be ≥ this much lower (°F)
     uint32_t outdoor_staleness_max_s;      // gate disables when outdoor data older than this (s)
     uint32_t summer_vent_min_runtime_s;    // min VENTILATE dwell after gate fires (s; reserved)
-    // Phase-2 (firmware stabilization plan): mode-transition dwell gate.
-    // When sw_dwell_gate_enabled is true, non-safety mode transitions are
-    // held for at least dwell_gate_ms after the last accepted transition.
-    // Safety rails, R2-3 dry override, and vpd_min_safe rescue preempt the
-    // dwell. Projected 80% reduction in whipsaw events (Explore B: 59 mode
-    // changes in 2h on 2026-04-17 stress window). Default OFF for shadow-
-    // mode bake; operator / planner flips to ON after 14d of replay +
-    // shadow validation.
+    // Production mode-transition dwell gate. Non-safety transitions are held
+    // for at least dwell_gate_ms after the last accepted transition. Safety
+    // rails, temp-band enforcement, VPD wet recovery, R2-3 dry override, and
+    // vpd_min_safe rescue preempt the dwell. Projected 80% reduction in
+    // whipsaw events (Explore B: 59 mode changes in 2h on 2026-04-17 stress
+    // window). ESPHome locks this ON; the field remains for readback and
+    // explicit test/forensics control.
     bool     sw_dwell_gate_enabled;
     uint32_t dwell_gate_ms;                // default 300000 (5 min)
     // Unified band-first controller. Kept as a compatibility/readback field,
@@ -183,9 +182,9 @@ struct ControlState {
     // Phase-2: monotonic tick count (ms, saturating) at which the most
     // recent mode transition was accepted. Drives the dwell gate —
     // new mode proposals within dwell_gate_ms of this timestamp are
-    // held (unless safety preempts). Updated by determine_mode on each
-    // non-held transition. Initialized to 0 which means "already past
-    // dwell at boot" so the first real decision isn't gated.
+    // held (unless a compliance/safety path preempts). Updated by
+    // determine_mode on each non-held transition. Initialized past dwell so
+    // the first real decision after boot is not gated.
     uint32_t last_transition_tick_ms;
     // band-first controller: lockout after a sealed humidification attempt times out.
     // During this window the firmware suppresses new SEALED_MIST entries while
@@ -336,8 +335,9 @@ inline Setpoints default_setpoints() {
         // disabling the gate.
         .outdoor_staleness_max_s = 600u,
         .summer_vent_min_runtime_s = 180u,
-        // Phase-2 dwell gate. Default OFF (shadow-mode bake before flipping
-        // to active). 5-min dwell projected to reduce whipsaw 80%.
+        // Dwell gate. ESPHome production locks this ON, but the library
+        // default stays OFF so tests can exercise the rollback/fallback path
+        // explicitly.
         .sw_dwell_gate_enabled = false,
         .dwell_gate_ms = 300000u,
         // Library fallback remains legacy so old unit tests/replay rows can
@@ -482,7 +482,7 @@ inline ControlState initial_state() {
         .heat2_latched = false,
         .override_summer_vent = false,
         .last_mode_reason = "init",
-        .last_transition_tick_ms = 0,
+        .last_transition_tick_ms = UINT32_MAX,
         .mist_backoff_timer_ms = 0,
         .vent_mist_assist_active = false
     };

--- a/firmware/test/invariants.h
+++ b/firmware/test/invariants.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * invariants.h — 16 firmware behavioral invariants enforced against replay
+ * invariants.h — 20 firmware behavioral invariants enforced against replay
  * traces. Each invariant is a pure function over a stream of per-minute
  * TraceRow records. First breach fails the replay run.
  *
@@ -71,6 +71,7 @@ struct TraceRow {
     // State (observed from telemetry)
     std::string greenhouse_state;  // "SEALED_MIST_S1"/"VENTILATE"/...
     std::string mode_reason;       // sprint-15.1 diagnostic
+    bool dry_override_active;       // one-cycle VPD max-safe humidity rescue edge
     bool summer_vent_active;        // determine_mode() set override_summer_vent
     bool vent_mist_assist_active;   // band-first controller humidification assist while ventilating
 
@@ -224,6 +225,74 @@ inline bool check_16_heat2_requires_heat1(const TraceRow& r, ReportFn report = d
     return true;
 }
 
+// #17: wet actions and wet postures require a minimum air/dewpoint spread.
+// This is a condensation/leaf-wetness safety rail, not a planner resource
+// preference. SEALED_MIST and vent-mist assist are included even if relay
+// interlocks later keep the physical outputs off: the controller should not
+// claim a wet recovery mode when the wet rail is unsafe or unobservable.
+inline bool check_17_wet_actions_require_dew_margin(const TraceRow& r, ReportFn report = default_report) {
+    const bool any_wet = r.eq_fog || r.eq_mister_south || r.eq_mister_west || r.eq_mister_center;
+    const bool wet_posture = mode_is_sealed(r.greenhouse_state) || r.vent_mist_assist_active;
+    const bool dew_margin_ok =
+        std::isfinite(r.temp_f)
+        && std::isfinite(r.dew_point_f)
+        && (r.temp_f - r.dew_point_f) >= WET_DEW_MARGIN_FLOOR_F;
+    if ((any_wet || wet_posture) && !dew_margin_ok) {
+        report(17, "wet_action_dew_margin", r, "wet action/posture below dew-margin floor");
+        return false;
+    }
+    return true;
+}
+
+// #18: non-safety heat never overlaps active air exchange. SAFETY_HEAT may run
+// one circulation fan with the vent closed, but heat with vent, or heat with
+// fans outside SAFETY_HEAT, is contradictory relay truth.
+inline bool check_18_heat_air_exchange_exclusive(const TraceRow& r, ReportFn report = default_report) {
+    const bool any_heat = r.eq_heat1 || r.eq_heat2;
+    if (!any_heat) return true;
+
+    if (r.eq_vent) {
+        report(18, "heat_with_vent", r, "heat ON while vent ON");
+        return false;
+    }
+    if ((r.eq_fan1 || r.eq_fan2) && r.greenhouse_state != "SAFETY_HEAT") {
+        report(18, "non_safety_heat_with_fan", r, "non-safety heat ON while fan ON");
+        return false;
+    }
+    if (r.greenhouse_state == "SAFETY_HEAT" && r.eq_fan1 && r.eq_fan2) {
+        report(18, "safety_heat_two_fans", r, "SAFETY_HEAT with both fans ON");
+        return false;
+    }
+    return true;
+}
+
+// #19: SENSOR_FAULT is a hard fail-safe state. Firmware should not keep climate
+// relays energized when the controller no longer trusts its feedback sensors.
+inline bool check_19_sensor_fault_all_relays_off(const TraceRow& r, ReportFn report = default_report) {
+    if (r.greenhouse_state != "SENSOR_FAULT") return true;
+
+    const bool any_relay =
+        r.eq_fog || r.eq_vent || r.eq_fan1 || r.eq_fan2 || r.eq_heat1 || r.eq_heat2 ||
+        r.eq_mister_south || r.eq_mister_west || r.eq_mister_center;
+    if (any_relay) {
+        report(19, "sensor_fault_active_relay", r, "SENSOR_FAULT with climate relay ON");
+        return false;
+    }
+    return true;
+}
+
+// #20: SAFETY_HEAT is allowed to run heat plus one closed-vent circulation fan,
+// but it must never add fog or misters while trying to recover from cold.
+inline bool check_20_safety_heat_no_wet_actions(const TraceRow& r, ReportFn report = default_report) {
+    if (r.greenhouse_state != "SAFETY_HEAT") return true;
+
+    if (r.eq_fog || r.eq_mister_south || r.eq_mister_west || r.eq_mister_center) {
+        report(20, "safety_heat_wet_action", r, "SAFETY_HEAT with fog/mister ON");
+        return false;
+    }
+    return true;
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Windowed invariants — evaluated over rolling windows. Helpers maintain
 // per-check state via a small context struct. Caller iterates rows and
@@ -357,6 +426,7 @@ inline bool check_10_equipment_toggle_auditable(Ctx10& c, const TraceRow& r, Rep
         const bool mode_changed = r.greenhouse_state != c.prev_mode;
         const bool reason_changed = r.mode_reason != c.prev_reason;
         const bool reason_auditable = r.mode_reason == "dehum_continue"
+                                   || r.mode_reason == "dew_margin"
                                    || r.mode_reason == "dry_override"
                                    || r.mode_reason == "dwell_expired"
                                    || r.mode_reason == "dwell_hold"
@@ -454,14 +524,24 @@ inline bool check_14_vent_cold_day_cap(Ctx14& c, const TraceRow& r, ReportFn rep
     return true;
 }
 
-// #13 — dry_override_active must clear within vpd_dry_override_max_ms of setting.
-// Not currently observable from replay CSV (would need ControlState snapshot).
-// Deferred to replay_diff.cpp which has full ControlState; leave a stub here.
-struct Ctx13 { /* unused in CSV-only replay */ };
-inline bool check_13_dry_override_clear(Ctx13& /*c*/, const TraceRow& /*r*/) { return true; }
+// #13 — dry_override_active is an edge flag, not a sticky operating mode.
+// It may fire on the row where firmware preempts the normal humidify dwell for
+// VPD > vpd_max_safe, but it must clear on the next control row. Sustained dry
+// recovery is represented by SEALED_MIST/humidify_continue, not a stale
+// override flag that would pollute audit trails and dwell preemption.
+struct Ctx13 { bool previous_dry_override = false; };
+inline bool check_13_dry_override_clear(Ctx13& c, const TraceRow& r, ReportFn report = default_report) {
+    if (r.dry_override_active && c.previous_dry_override) {
+        report(13, "dry_override_sticky", r, "dry_override_active remained true across consecutive rows");
+        c.previous_dry_override = true;
+        return false;
+    }
+    c.previous_dry_override = r.dry_override_active;
+    return true;
+}
 
 // ─────────────────────────────────────────────────────────────────────────
-// Public entry point — iterate all 16 invariants over a trace.
+// Public entry point — iterate all 20 invariants over a trace.
 // Returns 0 on pass, non-zero = count of violated invariants.
 // ─────────────────────────────────────────────────────────────────────────
 struct Runner {
@@ -482,10 +562,14 @@ struct Runner {
         if (!check_10_equipment_toggle_auditable(c10, r, report))   { failures++; ok = false; }
         if (!check_11_fog_heat_exclusive(r, report))                { failures++; ok = false; }
         if (!check_12_mist_progression(c12, r, report))             { failures++; ok = false; }
-        check_13_dry_override_clear(c13, r);   // deferred
+        if (!check_13_dry_override_clear(c13, r, report))           { failures++; ok = false; }
         if (!check_14_vent_cold_day_cap(c14, r, report))            { failures++; ok = false; }
         if (!check_15_mode_equipment_consistent(r, report))         { failures++; ok = false; }
         if (!check_16_heat2_requires_heat1(r, report))              { failures++; ok = false; }
+        if (!check_17_wet_actions_require_dew_margin(r, report))    { failures++; ok = false; }
+        if (!check_18_heat_air_exchange_exclusive(r, report))       { failures++; ok = false; }
+        if (!check_19_sensor_fault_all_relays_off(r, report))       { failures++; ok = false; }
+        if (!check_20_safety_heat_no_wet_actions(r, report))        { failures++; ok = false; }
         return ok;
     }
 };

--- a/firmware/test/replay_emit.cpp
+++ b/firmware/test/replay_emit.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
         in.temp_f = parse_float(get("temp_avg"), 70.0f);
         in.rh_pct = parse_float(get("rh_avg"), 50.0f);
         in.vpd_kpa = parse_float(get("vpd_avg"), 0.8f);
-        in.dew_point_f = parse_float(get("indoor_dew_point"), in.temp_f - 10.0f);
+        in.dew_point_f = parse_float(get("indoor_dew_point"), NAN);
         in.enthalpy_delta = parse_float(get("enthalpy_delta"), -5.0f);
         in.solar_w_m2 = parse_float(get("solar_irradiance_w_m2"), 0.0f);
         // zone vpds unavailable in this CSV; use avg
@@ -168,17 +168,12 @@ int main(int argc, char** argv) {
         if (!force_fsm || !*force_fsm || *force_fsm != '0') {
             sp.sw_fsm_controller_enabled = true;
         }
-        // Phase-2 preview hook: DWELL_ENABLED=1 env var flips the dwell-gate
-        // master switch + bumps temp_hysteresis to 2.0°F (the two bundled
-        // Phase-2 knobs). Default off — run with flag on to see projected
-        // whipsaw reduction against the same corpus/same setpoints.
-        static const bool dwell_preview_on = []{
-            const char* e = std::getenv("DWELL_ENABLED");
-            return e && *e && *e != '0';
-        }();
-        if (dwell_preview_on) {
+        // Production ESPHome locks the dwell gate ON before every control
+        // tick. Keep replay aligned by default; set REPLAY_EMIT_FORCE_DWELL=0
+        // only for explicit historical forensics.
+        const char* force_dwell = std::getenv("REPLAY_EMIT_FORCE_DWELL");
+        if (!force_dwell || !*force_dwell || *force_dwell != '0') {
             sp.sw_dwell_gate_enabled = true;
-            sp.temp_hysteresis = 2.0f;
         }
         // validate_setpoints applies firmware clamps
         validate_setpoints(sp);

--- a/firmware/test/replay_invariants.cpp
+++ b/firmware/test/replay_invariants.cpp
@@ -1,6 +1,6 @@
 /*
  * replay_invariants.cpp — Phase-0 bulletproof-firmware harness.
- * Reads extended replay CSV and runs the 16 invariants from invariants.h.
+ * Reads extended replay CSV and runs the 20 invariants from invariants.h.
  *
  * Sibling to replay_overrides.cpp (which replays evaluate_overrides counts).
  * This file focuses on the invariant suite; the dual-ref old-vs-new mode
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
         r.temp_f  = parse_float(get("temp_avg"), 70.0f);
         r.rh_pct  = parse_float(get("rh_avg"), 50.0f);
         r.vpd_kpa = parse_float(get("vpd_avg"), 0.8f);
-        r.dew_point_f = parse_float(get("indoor_dew_point"), r.temp_f - 10.0f);
+        r.dew_point_f = parse_float(get("indoor_dew_point"), NAN);
 
         r.outdoor_temp_f     = parse_float(get("outdoor_temp_f"), NAN);
         r.outdoor_rh_pct     = parse_float(get("outdoor_rh_pct"), NAN);
@@ -217,6 +217,10 @@ int main(int argc, char** argv) {
         const char* force_fsm = std::getenv("REPLAY_INVARIANTS_FORCE_FSM");
         if (!force_fsm || *force_fsm != '0') {
             sp.sw_fsm_controller_enabled = true;
+        }
+        const char* force_dwell = std::getenv("REPLAY_INVARIANTS_FORCE_DWELL");
+        if (!force_dwell || *force_dwell != '0') {
+            sp.sw_dwell_gate_enabled = true;
         }
         validate_setpoints(sp);
 
@@ -278,6 +282,7 @@ int main(int argc, char** argv) {
             r.greenhouse_state = MODE_NAMES[(int)mode];
         }
         r.mode_reason = state.last_mode_reason ? state.last_mode_reason : "";
+        r.dry_override_active = state.dry_override_active;
         r.summer_vent_active = state.override_summer_vent;
         r.vent_mist_assist_active = state.vent_mist_assist_active;
 
@@ -287,10 +292,11 @@ int main(int argc, char** argv) {
         r.eq_fan2 = out.fan2 ? 1 : 0;
         r.eq_heat1 = out.heat1 ? 1 : 0;
         r.eq_heat2 = out.heat2 ? 1 : 0;
-        const bool any_mister = (mode == SEALED_MIST) || state.vent_mist_assist_active;
+        const bool any_mister = wet_dew_margin_safe(in)
+            && ((mode == SEALED_MIST) || state.vent_mist_assist_active);
         r.eq_mister_south = any_mister ? 1 : 0;
-        r.eq_mister_west = (mode == SEALED_MIST && state.mist_stage >= MIST_S2) ? 1 : 0;
-        r.eq_mister_center = (mode == SEALED_MIST && state.mist_stage >= MIST_S2) ? 1 : 0;
+        r.eq_mister_west = (any_mister && mode == SEALED_MIST && state.mist_stage >= MIST_S2) ? 1 : 0;
+        r.eq_mister_center = (any_mister && mode == SEALED_MIST && state.mist_stage >= MIST_S2) ? 1 : 0;
 
         runner.run(r, stats_report);
         rows++;
@@ -299,7 +305,7 @@ int main(int argc, char** argv) {
     // Summary
     std::printf("\n═══ Invariant summary — %ld rows ═══\n", rows);
     if (g_stats.counts_by_id.empty()) {
-        std::printf("  ✓ All 16 invariants passed.\n");
+        std::printf("  ✓ All 20 invariants passed.\n");
         return 0;
     }
     std::printf("  %d total violations across %zu distinct invariants.\n",

--- a/firmware/test/replay_overrides.cpp
+++ b/firmware/test/replay_overrides.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[]) {
         in.outdoor_rh_pct = parse_float(get("outdoor_rh_pct"), 30.0f);
         in.enthalpy_delta = parse_float(get("enthalpy_delta"), -5.0f);
         in.solar_w_m2 = parse_float(get("solar_irradiance_w_m2"), 0.0f);
-        in.dew_point_f = parse_float(get("indoor_dew_point"), in.temp_f - 10.0f);
+        in.dew_point_f = parse_float(get("indoor_dew_point"), NAN);
         in.vpd_south = in.vpd_kpa;
         in.vpd_west = in.vpd_kpa;
         in.vpd_east = in.vpd_kpa;
@@ -237,6 +237,10 @@ int main(int argc, char* argv[]) {
         const char* force_fsm = std::getenv("REPLAY_OVERRIDES_FORCE_FSM");
         if (!force_fsm || !*force_fsm || *force_fsm != '0') {
             sp.sw_fsm_controller_enabled = true;
+        }
+        const char* force_dwell = std::getenv("REPLAY_OVERRIDES_FORCE_DWELL");
+        if (!force_dwell || !*force_dwell || *force_dwell != '0') {
+            sp.sw_dwell_gate_enabled = true;
         }
         validate_setpoints(sp);
 

--- a/firmware/test/test_greenhouse_logic.cpp
+++ b/firmware/test/test_greenhouse_logic.cpp
@@ -6,12 +6,15 @@
  */
 
 #include "greenhouse_logic.h"
+#include "invariants.h"
 #include <cstdio>
 #include <cstring>
 #include <cassert>
 #include <vector>
 #include <cmath>
 #include <string>
+#include <fstream>
+#include <sstream>
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -30,6 +33,8 @@ static int tests_failed = 0;
 
 struct TestEntry { const char* name; void (*fn)(); };
 static std::vector<TestEntry> test_registry;
+
+static void ignore_invariant_report(int, const char*, const invariants::TraceRow&, const char*) {}
 
 static SensorInputs make_inputs(float temp, float vpd, float rh = 60.0f) {
     // Sprint-15: outdoor data defaults to STALE so the new summer-vent
@@ -406,6 +411,41 @@ TEST(fix8_sensor_fault_equipment) {
     ASSERT_FALSE(out.heat2);
     ASSERT_FALSE(out.vent);
     ASSERT_FALSE(out.fan1);
+    ASSERT_FALSE(out.fog);
+    PASS();
+}
+
+TEST(resolve_equipment_fails_closed_on_implausible_sensors) {
+    auto sp = band_setpoints();
+    auto s = initial_state();
+    s.heat2_latched = true;
+    s.mist_stage = MIST_FOG;
+
+    auto in = make_inputs(NAN, 1.8f);
+    auto out = resolve_equipment(SAFETY_HEAT, in, sp, s, true);
+    ASSERT_FALSE(out.heat1);
+    ASSERT_FALSE(out.heat2);
+    ASSERT_FALSE(out.vent);
+    ASSERT_FALSE(out.fan1);
+    ASSERT_FALSE(out.fan2);
+    ASSERT_FALSE(out.fog);
+
+    in = make_inputs(85.0f, NAN);
+    out = resolve_equipment(VENTILATE, in, sp, s, true);
+    ASSERT_FALSE(out.heat1);
+    ASSERT_FALSE(out.heat2);
+    ASSERT_FALSE(out.vent);
+    ASSERT_FALSE(out.fan1);
+    ASSERT_FALSE(out.fan2);
+    ASSERT_FALSE(out.fog);
+
+    in = make_inputs(72.0f, 1.8f, 150.0f);
+    out = resolve_equipment(SEALED_MIST, in, sp, s, true);
+    ASSERT_FALSE(out.heat1);
+    ASSERT_FALSE(out.heat2);
+    ASSERT_FALSE(out.vent);
+    ASSERT_FALSE(out.fan1);
+    ASSERT_FALSE(out.fan2);
     ASSERT_FALSE(out.fog);
     PASS();
 }
@@ -950,6 +990,36 @@ TEST(obs1e_vpd_dry_override_clears_on_next_cycle_when_conditions_pass) {
     PASS();
 }
 
+TEST(invariant_13_allows_single_dry_override_edge) {
+    invariants::Ctx13 ctx;
+    invariants::TraceRow r{};
+    r.ts_unix_s = 1;
+    r.greenhouse_state = "SEALED_MIST_S1";
+    r.mode_reason = "dry_override";
+    r.dry_override_active = true;
+    ASSERT_TRUE(invariants::check_13_dry_override_clear(ctx, r, ignore_invariant_report));
+
+    r.ts_unix_s = 61;
+    r.mode_reason = "humidify_continue";
+    r.dry_override_active = false;
+    ASSERT_TRUE(invariants::check_13_dry_override_clear(ctx, r, ignore_invariant_report));
+    PASS();
+}
+
+TEST(invariant_13_rejects_sticky_dry_override_edge) {
+    invariants::Ctx13 ctx;
+    invariants::TraceRow r{};
+    r.ts_unix_s = 1;
+    r.greenhouse_state = "SEALED_MIST_S1";
+    r.mode_reason = "dry_override";
+    r.dry_override_active = true;
+    ASSERT_TRUE(invariants::check_13_dry_override_clear(ctx, r, ignore_invariant_report));
+
+    r.ts_unix_s = 61;
+    ASSERT_FALSE(invariants::check_13_dry_override_clear(ctx, r, ignore_invariant_report));
+    PASS();
+}
+
 TEST(obs1e_all_quiet_on_idle_in_band) {
     auto sp = default_setpoints();
     auto s = initial_state();
@@ -1065,6 +1135,268 @@ TEST(s8_fog_window_wraps_midnight) {
     ASSERT_FALSE(fog_permitted(in, sp));
     in.local_hour = 6;
     ASSERT_FALSE(fog_permitted(in, sp));
+    PASS();
+}
+
+TEST(wet_dew_margin_floor_blocks_fog) {
+    auto sp = band_setpoints();
+    sp.fog_rh_ceiling = 95.0f;
+    sp.fog_min_temp = 55.0f;
+    sp.fog_window_start = 7;
+    sp.fog_window_end = 17;
+
+    auto in = make_inputs(80.0f, sp.vpd_high + sp.fog_escalation_kpa + 0.2f, 70.0f);
+    in.local_hour = 12;
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F - 0.2f);
+
+    ASSERT_FALSE(wet_dew_margin_safe(in));
+    ASSERT_FALSE(fog_permitted(in, sp));
+    in.dew_point_f = NAN;
+    ASSERT_FALSE(wet_dew_margin_safe(in));
+    ASSERT_FALSE(fog_permitted(in, sp));
+
+    auto s = initial_state();
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F - 0.2f);
+    auto out = resolve_equipment(VENTILATE, in, sp, s, true);
+    ASSERT_FALSE(out.fog);
+    PASS();
+}
+
+TEST(wet_relay_force_off_tracks_safety_dew_margin_and_heat_priority) {
+    auto in = make_inputs(80.0f, 1.8f, 70.0f);
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F + 1.0f);
+
+    ASSERT_FALSE(force_fog_relay_off(VENTILATE, in, false));
+    ASSERT_TRUE(force_fog_relay_off(VENTILATE, in, true));
+    ASSERT_FALSE(force_mister_relays_off(VENTILATE, in, false));
+    ASSERT_TRUE(force_mister_relays_off(VENTILATE, in, true));
+
+    ASSERT_TRUE(force_fog_relay_off(SAFETY_HEAT, in, false));
+    ASSERT_TRUE(force_mister_relays_off(SAFETY_HEAT, in, false));
+    ASSERT_TRUE(force_fog_relay_off(SENSOR_FAULT, in, false));
+    ASSERT_TRUE(force_mister_relays_off(SENSOR_FAULT, in, false));
+
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F - 0.1f);
+    ASSERT_TRUE(force_fog_relay_off(VENTILATE, in, false));
+    ASSERT_TRUE(force_mister_relays_off(VENTILATE, in, false));
+    PASS();
+}
+
+TEST(manual_fan_override_yields_to_safety_and_temp_recovery) {
+    auto sp = band_setpoints();
+    auto in = make_inputs(sp.temp_low + 0.5f, sp.vpd_high);
+
+    ASSERT_TRUE(manual_fan_override_allowed(VENTILATE, in, sp));
+
+    in.temp_f = sp.temp_low - 0.1f;
+    ASSERT_FALSE(manual_fan_override_allowed(IDLE, in, sp));
+
+    in.temp_f = sp.temp_low + 0.5f;
+    ASSERT_FALSE(manual_fan_override_allowed(SAFETY_HEAT, in, sp));
+    ASSERT_FALSE(manual_fan_override_allowed(SENSOR_FAULT, in, sp));
+
+    in.temp_f = NAN;
+    ASSERT_FALSE(manual_fan_override_allowed(VENTILATE, in, sp));
+    PASS();
+}
+
+TEST(manual_fog_override_yields_to_safety_and_fog_rails) {
+    auto sp = band_setpoints();
+    sp.fog_min_temp = 55.0f;
+    sp.fog_rh_ceiling = 90.0f;
+    auto in = make_inputs(70.0f, sp.vpd_high + 0.5f, 70.0f);
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F + 1.0f);
+
+    ASSERT_TRUE(manual_fog_override_allowed(VENTILATE, in, sp));
+
+    in.rh_pct = sp.fog_rh_ceiling + 0.1f;
+    ASSERT_FALSE(manual_fog_override_allowed(VENTILATE, in, sp));
+
+    in.rh_pct = 70.0f;
+    in.temp_f = sp.fog_min_temp - 0.1f;
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F + 1.0f);
+    ASSERT_FALSE(manual_fog_override_allowed(VENTILATE, in, sp));
+
+    in.temp_f = 70.0f;
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F - 0.1f);
+    ASSERT_FALSE(manual_fog_override_allowed(VENTILATE, in, sp));
+
+    in.dew_point_f = in.temp_f - (WET_DEW_MARGIN_FLOOR_F + 1.0f);
+    ASSERT_FALSE(manual_fog_override_allowed(SAFETY_HEAT, in, sp));
+    ASSERT_FALSE(manual_fog_override_allowed(SENSOR_FAULT, in, sp));
+    PASS();
+}
+
+TEST(vent_lock_yields_to_safety_modes) {
+    ASSERT_TRUE(vent_lock_suppresses_air_exchange(IDLE));
+    ASSERT_TRUE(vent_lock_suppresses_air_exchange(VENTILATE));
+    ASSERT_TRUE(vent_lock_suppresses_air_exchange(SEALED_MIST));
+    ASSERT_FALSE(vent_lock_suppresses_air_exchange(SAFETY_COOL));
+    ASSERT_FALSE(vent_lock_suppresses_air_exchange(SAFETY_HEAT));
+    ASSERT_FALSE(vent_lock_suppresses_air_exchange(SENSOR_FAULT));
+    PASS();
+}
+
+TEST(band_error_helpers_report_signed_pressure) {
+    auto sp = band_setpoints();
+    auto in = make_inputs(sp.temp_high + 1.5f, sp.vpd_high + 0.25f);
+
+    ASSERT_TRUE(std::fabs(temp_band_error_f(in, sp) - 1.5f) < 0.001f);
+    ASSERT_TRUE(std::fabs(vpd_band_error_kpa(in, sp) - 0.25f) < 0.001f);
+
+    in.temp_f = sp.temp_low - 2.0f;
+    in.vpd_kpa = sp.vpd_low - 0.10f;
+    ASSERT_TRUE(std::fabs(temp_band_error_f(in, sp) + 2.0f) < 0.001f);
+    ASSERT_TRUE(std::fabs(vpd_band_error_kpa(in, sp) + 0.10f) < 0.001f);
+
+    in.temp_f = (sp.temp_low + sp.temp_high) * 0.5f;
+    in.vpd_kpa = (sp.vpd_low + sp.vpd_high) * 0.5f;
+    ASSERT_TRUE(std::fabs(temp_band_error_f(in, sp)) < 0.001f);
+    ASSERT_TRUE(std::fabs(vpd_band_error_kpa(in, sp)) < 0.001f);
+    ASSERT_TRUE(std::fabs(temp_target_error_f(in, sp)) < 0.001f);
+    ASSERT_TRUE(std::fabs(vpd_target_error_kpa(in, sp)) < 0.001f);
+    PASS();
+}
+
+TEST(irrigation_sensor_fault_is_executor_stop) {
+    std::ifstream file("greenhouse/controls.yaml");
+    ASSERT_TRUE(file.good());
+
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    const std::string src = buf.str();
+
+    const std::string rail = "if(irrig_sensor_fault) {";
+    const size_t rail_pos = src.find(rail);
+    ASSERT_TRUE(rail_pos != std::string::npos);
+
+    const size_t next_gate_pos = src.find("if(id(direct_wet_gate_enabled)", rail_pos);
+    ASSERT_TRUE(next_gate_pos != std::string::npos);
+    ASSERT_TRUE(next_gate_pos > rail_pos);
+
+    const std::string block = src.substr(rail_pos, next_gate_pos - rail_pos);
+    ASSERT_TRUE(block.find("turn_off_all_irrigation();") != std::string::npos);
+    ASSERT_TRUE(block.find("id(irrig_state) = 0;") != std::string::npos);
+    ASSERT_TRUE(block.find("id(irrig_queue) = 0;") != std::string::npos);
+    ASSERT_TRUE(block.find("id(irrig_timer_ms) = 0;") != std::string::npos);
+    ASSERT_TRUE(block.find("return;") != std::string::npos);
+    ASSERT_TRUE(src.find("irrig_wet_inputs.temp_f = irrig_control_temp_f;") != std::string::npos);
+    ASSERT_TRUE(src.find("irrig_wet_inputs.temp_f = irrig_temp_f;") == std::string::npos);
+
+    const size_t disable_pos = src.find("if(!id(irrig_enabled))");
+    ASSERT_TRUE(disable_pos != std::string::npos);
+    const size_t sync_pos = src.find("sync_fert_master(\"watchdog\")");
+    ASSERT_TRUE(sync_pos != std::string::npos);
+    ASSERT_TRUE(disable_pos < sync_pos);
+    PASS();
+}
+
+TEST(irrigation_flush_rechecks_wet_rails_before_opening_relay) {
+    std::ifstream file("greenhouse/controls.yaml");
+    ASSERT_TRUE(file.good());
+
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    const std::string src = buf.str();
+
+    const size_t flush_pos = src.find("flush with clean water");
+    ASSERT_TRUE(flush_pos != std::string::npos);
+
+    const size_t flush_countdown_pos = src.find("Flush countdown", flush_pos);
+    ASSERT_TRUE(flush_countdown_pos != std::string::npos);
+    ASSERT_TRUE(flush_countdown_pos > flush_pos);
+
+    const std::string block = src.substr(flush_pos, flush_countdown_pos - flush_pos);
+    ASSERT_TRUE(block.find("const bool flush_direct_wet_allowed = irrig_direct_wet_allowed_zone(flush_zone);") != std::string::npos);
+    ASSERT_TRUE(block.find("const bool flush_mister_blocked") != std::string::npos);
+    ASSERT_TRUE(block.find("if(is_fert && flush_min > 0 && flush_direct_wet_allowed && !flush_mister_blocked)") != std::string::npos);
+    ASSERT_TRUE(block.find("SKIP FLUSH %s by direct-wet gate") != std::string::npos);
+    ASSERT_TRUE(block.find("SKIP FLUSH %s by safety/dew-margin/occupancy rail") != std::string::npos);
+    PASS();
+}
+
+TEST(irrigation_zero_duration_jobs_drop_before_relay_start) {
+    std::ifstream file("greenhouse/controls.yaml");
+    ASSERT_TRUE(file.good());
+
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    const std::string src = buf.str();
+
+    ASSERT_TRUE(src.find("flush_origin") == std::string::npos);
+
+    const size_t zero_pos = src.find("if(base_min <= 0)");
+    ASSERT_TRUE(zero_pos != std::string::npos);
+    const size_t state_pos = src.find("id(irrig_state) = job;", zero_pos);
+    const size_t timer_pos = src.find("id(irrig_timer_ms) = uint32_t(base_min) * 60000UL;", zero_pos);
+    const size_t relay_pos = src.find("id(fertilizer_master_valve).turn_on()", zero_pos);
+    ASSERT_TRUE(state_pos != std::string::npos);
+    ASSERT_TRUE(timer_pos != std::string::npos);
+    ASSERT_TRUE(relay_pos != std::string::npos);
+    ASSERT_TRUE(zero_pos < state_pos);
+    ASSERT_TRUE(zero_pos < timer_pos);
+    ASSERT_TRUE(zero_pos < relay_pos);
+
+    const std::string zero_block = src.substr(zero_pos, state_pos - zero_pos);
+    ASSERT_TRUE(zero_block.find("id(irrig_timer_ms) = 0;") != std::string::npos);
+    ASSERT_TRUE(zero_block.find("DROP QUEUED %s job (zero duration)") != std::string::npos);
+    ASSERT_TRUE(zero_block.find("turn_on()") == std::string::npos);
+    ASSERT_TRUE(zero_block.find("cnt_drip") == std::string::npos);
+    ASSERT_TRUE(zero_block.find("cnt_mister") == std::string::npos);
+    PASS();
+}
+
+TEST(climate_cycle_counters_track_post_apply_relay_edges) {
+    std::ifstream file("greenhouse/controls.yaml");
+    ASSERT_TRUE(file.good());
+
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    const std::string src = buf.str();
+
+    const size_t apply_pos = src.find("APPLY RELAY OUTPUTS");
+    const size_t counter_pos = src.find("11b");
+    ASSERT_TRUE(apply_pos != std::string::npos);
+    ASSERT_TRUE(counter_pos != std::string::npos);
+    ASSERT_TRUE(apply_pos < counter_pos);
+
+    const std::string apply_block = src.substr(apply_pos, counter_pos - apply_pos);
+    ASSERT_TRUE(apply_block.find("const bool heat1_was_on = id(heat1_rly)->state;") != std::string::npos);
+    ASSERT_TRUE(apply_block.find("set_relay(R[4], willFog, false, force_fog_relay_off_now);") != std::string::npos);
+
+    const size_t mister_pos = src.find("MISTER STATE MACHINE", counter_pos);
+    ASSERT_TRUE(mister_pos != std::string::npos);
+    const std::string counter_block = src.substr(counter_pos, mister_pos - counter_pos);
+    ASSERT_TRUE(counter_block.find("if(!heat1_was_on && id(heat1_rly)->state)") != std::string::npos);
+    ASSERT_TRUE(counter_block.find("if(!vent_was_on && id(vent_rly)->state)") != std::string::npos);
+    ASSERT_TRUE(src.find("if(willHeat1 && !id(heat1_rly)->state)") == std::string::npos);
+    ASSERT_TRUE(src.find("if(willVent && !id(vent_rly)->state)") == std::string::npos);
+    PASS();
+}
+
+TEST(production_control_loop_locks_dwell_gate_on) {
+    std::ifstream controls("greenhouse/controls.yaml");
+    ASSERT_TRUE(controls.good());
+    std::ostringstream control_buf;
+    control_buf << controls.rdbuf();
+    const std::string control_src = control_buf.str();
+
+    ASSERT_TRUE(control_src.find("setpts.sw_dwell_gate_enabled = true;") != std::string::npos);
+    ASSERT_TRUE(control_src.find("id(sw_dwell_gate_enabled) = true;") != std::string::npos);
+
+    std::ifstream tunables("greenhouse/tunables.yaml");
+    ASSERT_TRUE(tunables.good());
+    std::ostringstream tunable_buf;
+    tunable_buf << tunables.rdbuf();
+    const std::string tunable_src = tunable_buf.str();
+    const size_t switch_pos = tunable_src.find("id: sw_dwell_gate_enabled_switch");
+    ASSERT_TRUE(switch_pos != std::string::npos);
+    const size_t fsm_pos = tunable_src.find("id: sw_fsm_controller_enabled_switch", switch_pos);
+    ASSERT_TRUE(fsm_pos != std::string::npos);
+    const std::string dwell_switch = tunable_src.substr(switch_pos, fsm_pos - switch_pos);
+    ASSERT_TRUE(dwell_switch.find("restore_mode: RESTORE_DEFAULT_ON") != std::string::npos);
+    ASSERT_TRUE(dwell_switch.find("Dwell Gate Enabled is locked ON") != std::string::npos);
+    ASSERT_TRUE(dwell_switch.find("id(sw_dwell_gate_enabled) = false;") == std::string::npos);
     PASS();
 }
 
@@ -1791,11 +2123,26 @@ TEST(s15_1_mode_reason_idle_default) {
 // ═══════════════════════════════════════════════════════════════════
 
 TEST(phase2_dwell_gate_off_by_default) {
-    // Default: sw_dwell_gate_enabled=false → no hold, current behavior
-    // preserved. This test ensures the feature flag works — if the default
-    // flipped on, this test would catch it and force review.
+    // Library fallback default stays OFF so targeted tests and rollback
+    // forensics can still exercise the raw cascade. Production ESPHome locks
+    // this field ON before calling determine_mode().
     auto sp = band_setpoints();
     ASSERT_TRUE(!sp.sw_dwell_gate_enabled);
+    PASS();
+}
+
+TEST(phase2_dwell_gate_bootstrap_allows_first_transition) {
+    // Dwell enforcement starts after the first accepted transition. Boot
+    // should not strand the controller in IDLE for five minutes before its
+    // first non-safety correction.
+    auto sp = band_setpoints();
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+
+    auto s = initial_state();
+    Mode m = determine_mode(make_inputs(85.0f, 1.0f), sp, s, 5000);
+
+    ASSERT_EQ(m, VENTILATE);
     PASS();
 }
 
@@ -1916,9 +2263,8 @@ TEST(phase2_dwell_gate_thermal_relief_exit_preempts) {
 
 TEST(phase2_dwell_gate_tracks_ticks_when_off) {
     // Even with gate OFF, last_transition_tick_ms must still accumulate
-    // so that when the gate is flipped ON later (live operation), the
-    // first transition has correct dwell accounting. Shadow mode requires
-    // this so we don't mis-count when flipping on.
+    // so explicit forensics that flip the gate during replay do not
+    // mis-count transition age.
     auto sp = band_setpoints();
     sp.sw_dwell_gate_enabled = false;  // OFF
 
@@ -2230,6 +2576,51 @@ TEST(band_first_dehum_enters_below_vpd_low_hysteresis_and_exits_at_low_edge) {
     PASS();
 }
 
+TEST(band_first_temp_low_blocks_dehum_even_when_vpd_low) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    const float HV = band_vpd_hysteresis(sp);
+
+    Mode m = determine_mode(make_inputs(sp.temp_low - 0.2f, sp.vpd_low - HV - 0.01f), sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "heat_stage2");
+    PASS();
+}
+
+TEST(band_first_temp_low_heat_priority_releases_air_exchange) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    const float HV = band_vpd_hysteresis(sp);
+    auto in = make_inputs(sp.temp_low - 0.2f, sp.vpd_low - HV - 0.01f);
+
+    Mode m = determine_mode(in, sp, s, 5000);
+    auto out = resolve_equipment(m, in, sp, s, true);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(out.heat1);
+    ASSERT_TRUE(out.heat2);
+    ASSERT_TRUE(heat_priority_releases_air_exchange(m, in, sp, out, false));
+    ASSERT_FALSE(heat_priority_releases_air_exchange(m, in, sp, out, true));
+    PASS();
+}
+
+TEST(safety_heat_circulation_does_not_release_air_exchange_helper) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    auto in = make_inputs(sp.safety_min - 0.2f, sp.vpd_low);
+
+    Mode m = determine_mode(in, sp, s, 5000);
+    auto out = resolve_equipment(m, in, sp, s, true);
+
+    ASSERT_EQ(m, SAFETY_HEAT);
+    ASSERT_TRUE(out.heat1);
+    ASSERT_TRUE(out.heat2);
+    ASSERT_TRUE(out.fan1);
+    ASSERT_FALSE(heat_priority_releases_air_exchange(m, in, sp, out, false));
+    PASS();
+}
+
 TEST(band_first_dehum_overshoot_respects_existing_dwell_hold) {
     auto sp = band_first_setpoints();
     sp.sw_dwell_gate_enabled = true;
@@ -2247,7 +2638,7 @@ TEST(band_first_dehum_overshoot_respects_existing_dwell_hold) {
     PASS();
 }
 
-TEST(band_first_dehum_overshoot_cooling_respects_existing_dwell_hold) {
+TEST(band_first_temp_high_preempts_dehum_dwell_hold) {
     auto sp = band_first_setpoints();
     sp.sw_dwell_gate_enabled = true;
     sp.dwell_gate_ms = 300000;
@@ -2258,12 +2649,174 @@ TEST(band_first_dehum_overshoot_cooling_respects_existing_dwell_hold) {
 
     Mode m = determine_mode(make_inputs(sp.temp_high + 1.0f, sp.vpd_high + 0.2f), sp, s, 5000);
 
-    ASSERT_EQ(m, DEHUM_VENT);
+    ASSERT_EQ(m, VENTILATE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "temp_high");
+    ASSERT_TRUE(s.vent_mist_assist_active);
+    PASS();
+}
+
+TEST(band_first_hot_dry_vent_mist_assist_does_not_wait_for_seal_dwell) {
+    auto sp = band_first_setpoints();
+    sp.vpd_watch_dwell_ms = 120000;
+    auto s = initial_state();
+
+    Mode m = determine_mode(make_inputs(sp.temp_high + 1.0f, sp.vpd_high + 0.05f), sp, s, 5000);
+
+    ASSERT_EQ(m, VENTILATE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "temp_high");
+    ASSERT_TRUE(s.vpd_watch_timer_ms < sp.vpd_watch_dwell_ms);
+    ASSERT_TRUE(s.vent_mist_assist_active);
+    PASS();
+}
+
+TEST(band_first_hot_dry_vent_mist_assist_requires_wet_dew_margin) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    auto in = make_inputs(sp.temp_high + 1.0f, sp.vpd_high + 0.05f);
+    in.dew_point_f = NAN;
+
+    Mode m = determine_mode(in, sp, s, 5000);
+
+    ASSERT_EQ(m, VENTILATE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "temp_high");
+    ASSERT_FALSE(s.vent_mist_assist_active);
+    auto f = evaluate_overrides(in, sp, s, m);
+    ASSERT_FALSE(f.vent_mist_assist);
+    PASS();
+}
+
+TEST(band_first_humidify_ready_preempts_dwell_hold) {
+    auto sp = band_first_setpoints();
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+    auto s = initial_state();
+    s.mode = IDLE;
+    s.mode_prev = IDLE;
+    s.last_transition_tick_ms = 10000;
+    s.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+
+    Mode m = determine_mode(make_inputs(74.0f, sp.vpd_high + 0.2f), sp, s, 5000);
+
+    ASSERT_EQ(m, SEALED_MIST);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "humidify_enter");
+    PASS();
+}
+
+TEST(band_first_humidify_entry_requires_wet_dew_margin) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    s.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+    auto in = make_inputs(74.0f, sp.vpd_high + 0.2f);
+    in.dew_point_f = NAN;
+
+    Mode m = determine_mode(in, sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "dew_margin");
+    ASSERT_FALSE(s.dry_override_active);
     ASSERT_FALSE(s.vent_mist_assist_active);
     PASS();
 }
 
-TEST(band_first_sealed_temp_preempt_respects_existing_dwell_gate) {
+TEST(band_first_unsafe_dew_margin_exits_sealed_mist) {
+    auto sp = band_first_setpoints();
+    auto s = initial_state();
+    s.mode = SEALED_MIST;
+    s.mode_prev = SEALED_MIST;
+    s.sealed_timer_ms = 30000;
+    s.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+    s.mist_stage = MIST_S2;
+    auto in = make_inputs(74.0f, sp.vpd_high + 0.2f);
+    in.dew_point_f = NAN;
+
+    Mode m = determine_mode(in, sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "dew_margin");
+    ASSERT_EQ(s.mist_stage, MIST_WATCH);
+    ASSERT_EQ(s.vpd_watch_timer_ms, 0u);
+    PASS();
+}
+
+TEST(band_first_vpd_max_safe_dry_override_bypasses_humidify_dwell) {
+    auto sp = band_first_setpoints();
+    sp.vpd_watch_dwell_ms = 120000;
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+    auto s = initial_state();
+    s.mode = IDLE;
+    s.mode_prev = IDLE;
+    s.last_transition_tick_ms = 0;
+
+    Mode m = determine_mode(make_inputs(74.0f, sp.vpd_max_safe + 0.1f), sp, s, 5000);
+
+    ASSERT_EQ(m, SEALED_MIST);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "dry_override");
+    ASSERT_TRUE(s.dry_override_active);
+    ASSERT_EQ(s.vpd_watch_timer_ms, sp.vpd_watch_dwell_ms);
+    PASS();
+}
+
+TEST(band_first_vpd_max_safe_dry_override_yields_to_temp_priority) {
+    auto sp = band_first_setpoints();
+    sp.vpd_watch_dwell_ms = 120000;
+    auto s = initial_state();
+
+    Mode m = determine_mode(make_inputs(sp.temp_high + 1.0f, sp.vpd_max_safe + 0.1f), sp, s, 5000);
+
+    ASSERT_EQ(m, VENTILATE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "temp_high");
+    ASSERT_FALSE(s.dry_override_active);
+    ASSERT_TRUE(s.vent_mist_assist_active);
+    PASS();
+}
+
+TEST(band_first_vpd_max_safe_dry_override_requires_wet_dew_margin) {
+    auto sp = band_first_setpoints();
+    sp.vpd_watch_dwell_ms = 120000;
+    auto s = initial_state();
+    auto in = make_inputs(74.0f, sp.vpd_max_safe + 0.1f);
+    in.dew_point_f = NAN;
+
+    Mode m = determine_mode(in, sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_FALSE(s.dry_override_active);
+    PASS();
+}
+
+TEST(band_first_fresh_dry_override_does_not_skip_to_mist_s2) {
+    auto sp = band_first_setpoints();
+    sp.vpd_watch_dwell_ms = 120000;
+    sp.mist_s2_delay_ms = 5000;
+    auto s = initial_state();
+
+    Mode m = determine_mode(make_inputs(74.0f, sp.vpd_max_safe + 0.1f), sp, s, 5000);
+
+    ASSERT_EQ(m, SEALED_MIST);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "dry_override");
+    ASSERT_EQ(s.mist_stage, MIST_S1);
+    ASSERT_EQ(s.mist_stage_timer_ms, 0u);
+    PASS();
+}
+
+TEST(band_first_temp_low_preempts_dehum_dwell_hold) {
+    auto sp = band_first_setpoints();
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+    auto s = initial_state();
+    s.mode = DEHUM_VENT;
+    s.mode_prev = DEHUM_VENT;
+    s.last_transition_tick_ms = 10000;
+
+    Mode m = determine_mode(make_inputs(sp.temp_low - 0.2f, sp.vpd_low - 0.2f), sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "heat_stage2");
+    PASS();
+}
+
+TEST(band_first_temp_high_preempts_sealed_dwell_hold) {
     auto sp = band_first_setpoints();
     sp.sw_dwell_gate_enabled = true;
     sp.dwell_gate_ms = 300000;
@@ -2277,9 +2830,52 @@ TEST(band_first_sealed_temp_preempt_respects_existing_dwell_gate) {
 
     Mode m = determine_mode(make_inputs(sp.temp_high + 1.0f, sp.vpd_high + 0.2f), sp, s, 5000);
 
-    ASSERT_EQ(m, SEALED_MIST);
-    ASSERT_TRUE(std::string(s.last_mode_reason) == "dwell_hold");
-    ASSERT_FALSE(s.vent_mist_assist_active);
+    ASSERT_EQ(m, VENTILATE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "temp_preempts_humidify");
+    ASSERT_TRUE(s.vent_mist_assist_active);
+    PASS();
+}
+
+TEST(band_first_resolved_humidify_exit_preempts_dwell_hold) {
+    auto sp = band_first_setpoints();
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+    auto s = initial_state();
+    s.mode = SEALED_MIST;
+    s.mode_prev = SEALED_MIST;
+    s.last_transition_tick_ms = 10000;
+    s.sealed_timer_ms = 30000;
+    s.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+    s.mist_stage = MIST_S2;
+
+    Mode m = determine_mode(make_inputs(74.0f, sp.vpd_high - band_vpd_hysteresis(sp) - 0.01f), sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "humidify_resolved");
+    ASSERT_EQ(s.mist_stage, MIST_WATCH);
+    PASS();
+}
+
+TEST(band_first_occupancy_humidify_exit_preempts_dwell_hold) {
+    auto sp = band_first_setpoints();
+    sp.sw_dwell_gate_enabled = true;
+    sp.dwell_gate_ms = 300000;
+    sp.occupancy_inhibit = true;
+    auto s = initial_state();
+    s.mode = SEALED_MIST;
+    s.mode_prev = SEALED_MIST;
+    s.last_transition_tick_ms = 10000;
+    s.sealed_timer_ms = 30000;
+    s.vpd_watch_timer_ms = sp.vpd_watch_dwell_ms;
+    s.mist_stage = MIST_S2;
+
+    auto in = make_inputs(74.0f, sp.vpd_high + 0.2f);
+    in.occupied = true;
+    Mode m = determine_mode(in, sp, s, 5000);
+
+    ASSERT_EQ(m, IDLE);
+    ASSERT_TRUE(std::string(s.last_mode_reason) == "moisture_blocked");
+    ASSERT_EQ(s.mist_stage, MIST_WATCH);
     PASS();
 }
 


### PR DESCRIPTION
## Summary

Preserves the previously dirty firmware-agent worktree as a reviewable branch instead of leaving validated controller hardening and docs only on disk.

## Scope

- Adds the final climate-intent controller design note.
- Hardens firmware wet/fog/dew-margin, dwell, manual override, target-error, and replay/invariant logic.
- Extends ESPHome YAML, replay emitters, firmware tests, schema drift guards, and related docs.
- Updates firmware backlog notes so the no-shadow, one-controller-path decision is tracked in repo docs.

## Rebase status

Rebased onto current `origin/main` (`15ab9d2`) on 2026-05-25. GitHub now reports the draft PR as mergeable/clean.

## Validation

Run from `/mnt/iris/verdify-worktrees/firmware` after the rebase:

- `git diff --check` passed.
- `make lint` passed.
- `make test-firmware` passed: `192 passed, 0 failed` plus replay flag synthetic checks.
- `make firmware-invariants` passed: `193525` replay rows, all `20` invariants passed.
- `make firmware-check` passed: ESPHome compile success, config hash `0xae4f1659`, RAM 14.1%, flash 57.3%.

## Notes

This is a draft preservation PR. It should not be treated as merge-ready or as firmware OTA authorization by itself. The active production controller closeout remains tracked in #8, and any behavior-changing firmware merge/OTA still needs the normal replay, invariant, compile, coordinator review, and operator approval gates.
