### PR TITLE
Fix container-publish: vendor reusable-container-build in-org (unblocks GHCR publish)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -208,7 +208,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: jvallery/agents/.github/workflows/reusable-container-build.yml@main
+    uses: ./.github/workflows/reusable-container-build.yml
     with:
       # FastAPI must COPY verdify_schemas/ from the repo root, so the build
       # context is the repo root (".") with the Dockerfile under ./api.
@@ -234,7 +234,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: jvallery/agents/.github/workflows/reusable-container-build.yml@main
+    uses: ./.github/workflows/reusable-container-build.yml
     with:
       # MCP also COPYs verdify_schemas/ + slack_config/slack_ops from the repo
       # root, so the build context is the repo root. P3 shipped the hardened
@@ -257,7 +257,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: jvallery/agents/.github/workflows/reusable-container-build.yml@main
+    uses: ./.github/workflows/reusable-container-build.yml
     with:
       # Ingestor COPYs verdify_schemas/ + slack_config/slack_ops from the repo
       # root, so the build context is the repo root.
@@ -283,7 +283,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: jvallery/agents/.github/workflows/reusable-container-build.yml@main
+    uses: ./.github/workflows/reusable-container-build.yml
     with:
       # Build context = repo root so the Dockerfile can COPY db/schema.sql +
       # db/migrations/000-* + db/migrate.sh.

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -25,9 +25,10 @@ name: Container Publish
 #  * PRODUCTION BRANCH DRIFT (P0): the verified production branch on-box and on
 #    the remote is `live/platform-main` (4 ahead of `main`, 0 behind), NOT a
 #    bare `live` and NOT `main`. The default branch is still `main`. This
-#    workflow therefore publishes from BOTH `live/platform-main` (production)
-#    and `main` so it keeps working after the live<->main reconciliation that
-#    Jason/James must resolve first. Trim to a single branch once reconciled.
+#    Per Jason's 2026-05-31 decision the canonical source-of-truth / deploy
+#    branch is `live/platform-main` (the ArgoCD targetRevision). This workflow
+#    publishes ONLY from `live/platform-main`; pushes to `main` build but never
+#    publish. ArgoCD reconciles `deploy/k8s/overlays/{staging,prod}` from it.
 #  * The Dockerfiles (./api/Dockerfile.prod, ./mcp/Dockerfile.prod,
 #    ./ingestor/Dockerfile) and the deploy/k8s tree are net-new (P3) and land in
 #    a SEPARATE PR. Until they exist these build jobs will fail at `docker build`
@@ -221,7 +222,7 @@ jobs:
       dockerfile: api/Dockerfile
       image-name: ${{ github.repository_owner }}/verdify-api
       push: true
-      publish-branches: live/platform-main,main
+      publish-branches: live/platform-main
       build-args: |
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
@@ -244,7 +245,7 @@ jobs:
       dockerfile: mcp/Dockerfile
       image-name: ${{ github.repository_owner }}/verdify-mcp
       push: true
-      publish-branches: live/platform-main,main
+      publish-branches: live/platform-main
       build-args: |
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
@@ -265,7 +266,7 @@ jobs:
       dockerfile: ingestor/Dockerfile
       image-name: ${{ github.repository_owner }}/verdify-ingestor
       push: true
-      publish-branches: live/platform-main,main
+      publish-branches: live/platform-main
       build-args: |
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
@@ -291,7 +292,7 @@ jobs:
       dockerfile: db/Dockerfile.migrate
       image-name: ${{ github.repository_owner }}/verdify-migrate
       push: true
-      publish-branches: live/platform-main,main
+      publish-branches: live/platform-main
       build-args: |
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
@@ -321,7 +322,7 @@ jobs:
     if: |
       always() &&
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/live/platform-main' || github.ref == 'refs/heads/main') &&
+      github.ref == 'refs/heads/live/platform-main' &&
       needs.image-impact.outputs.image_publish == 'true' &&
       needs.api-image.result != 'failure' &&
       needs.mcp-image.result != 'failure' &&

--- a/.github/workflows/reusable-container-build.yml
+++ b/.github/workflows/reusable-container-build.yml
@@ -1,0 +1,330 @@
+name: Reusable Container Build
+
+# VENDORED IN-ORG copy of jvallery/agents/.github/workflows/reusable-container-build.yml.
+#
+# WHY VENDORED: jvallery/agents is a PRIVATE repo owned by the personal account
+# 'jvallery'. verdify-platform lives in the 'VerdifyConsultancy' org. GitHub
+# forbids private reusable-workflow access across different owners, so every
+# call to `uses: jvallery/agents/.github/workflows/...@main` failed at
+# workflow-load (0s, 0 jobs) and no image ever published. This file is a
+# verbatim copy invoked via the local-path form
+# `./.github/workflows/reusable-container-build.yml`, which needs no cross-repo
+# access. Keep the input/secret interface identical to the upstream so the only
+# caller change is the `uses:` rewrite. If upstream changes, re-vendor.
+
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: Build context path.
+        required: false
+        default: "."
+        type: string
+      dockerfile:
+        description: Dockerfile path, relative to the build context unless absolute.
+        required: false
+        default: Dockerfile
+        type: string
+      image-name:
+        description: Image name without registry, for example owner/project.
+        required: true
+        type: string
+      registry:
+        description: Container registry host.
+        required: false
+        default: ghcr.io
+        type: string
+      push:
+        description: Publish the image when branch/tag gates allow it.
+        required: false
+        default: false
+        type: boolean
+      publish-branches:
+        description: Comma-separated branches allowed to publish.
+        required: false
+        default: main
+        type: string
+      target:
+        description: Optional Docker build target.
+        required: false
+        default: ""
+        type: string
+      build-args:
+        description: Optional newline-delimited Docker build args as KEY=VALUE.
+        required: false
+        default: ""
+        type: string
+      extra-tags:
+        description: Optional comma or newline-delimited image tags without image name.
+        required: false
+        default: ""
+        type: string
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: Generate image metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      tags: ${{ steps.meta.outputs.tags }}
+      primary_tag: ${{ steps.meta.outputs.primary_tag }}
+      push_allowed: ${{ steps.meta.outputs.push_allowed }}
+    steps:
+      - name: Generate tags and metadata
+        id: meta
+        env:
+          IMAGE_NAME_INPUT: ${{ inputs.image-name }}
+          REGISTRY: ${{ inputs.registry }}
+          EXTRA_TAGS: ${{ inputs.extra-tags }}
+          PUSH_REQUESTED: ${{ inputs.push }}
+          PUBLISH_BRANCHES: ${{ inputs.publish-branches }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}
+        run: |
+          set -euo pipefail
+
+          sanitize_tag() {
+            printf "%s" "$1" \
+              | tr '[:upper:]/' '[:lower:]-' \
+              | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//' \
+              | cut -c1-120
+          }
+
+          image_name="$(printf "%s" "$IMAGE_NAME_INPUT" | tr '[:upper:]' '[:lower:]')"
+          image_ref="${REGISTRY}/${image_name}"
+          export IMAGE_REF="$image_ref"
+          sha_short="$(printf "%s" "$GITHUB_SHA" | cut -c1-12)"
+
+          : > container-tags.txt
+
+          add_tag() {
+            tag="$(sanitize_tag "$1")"
+            if [ -n "$tag" ]; then
+              printf "%s:%s\n" "$image_ref" "$tag" >> container-tags.txt
+            fi
+          }
+
+          add_tag "sha-${sha_short}"
+
+          if [ "${GITHUB_REF_TYPE:-}" = "branch" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+            add_tag "branch-${GITHUB_REF_NAME}"
+          fi
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
+            add_tag "pr-${PR_NUMBER}"
+          fi
+
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+            add_tag "tag-${GITHUB_REF_NAME}"
+            version="${GITHUB_REF_NAME#v}"
+            if [ "$version" != "$GITHUB_REF_NAME" ] && [ -n "$version" ]; then
+              add_tag "release-${version}"
+            fi
+          fi
+
+          printf "%s\n" "$EXTRA_TAGS" \
+            | tr ',' '\n' \
+            | while IFS= read -r raw_tag; do
+                raw_tag="$(printf "%s" "$raw_tag" | xargs)"
+                if [ -n "$raw_tag" ]; then
+                  add_tag "$raw_tag"
+                fi
+              done
+
+          sort -u container-tags.txt -o container-tags.txt
+          primary_tag="$(head -n 1 container-tags.txt)"
+
+          push_allowed=false
+          if [ "$PUSH_REQUESTED" = "true" ] && [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+              push_allowed=true
+            elif [ "${GITHUB_REF_TYPE:-}" = "branch" ]; then
+              normalized_branches="$(printf ",%s," "$PUBLISH_BRANCHES" | tr -d '[:space:]')"
+              if printf "%s" "$normalized_branches" | grep -Fq ",${GITHUB_REF_NAME},"; then
+                push_allowed=true
+              fi
+            fi
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+
+          metadata = {
+              "image": os.environ["IMAGE_REF"],
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "commit_sha": os.environ["GITHUB_SHA"],
+              "ref": os.environ.get("GITHUB_REF", ""),
+              "event": os.environ["GITHUB_EVENT_NAME"],
+              "workflow_run": f'{os.environ["GITHUB_SERVER_URL"]}/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{os.environ["GITHUB_RUN_ID"]}',
+              "source_pr": os.environ.get("PR_NUMBER") or None,
+          }
+          with open("container-metadata.json", "w", encoding="utf-8") as handle:
+              json.dump(metadata, handle, indent=2, sort_keys=True)
+              handle.write("\n")
+          PY
+
+          {
+            echo "image=${image_ref}"
+            echo "primary_tag=${primary_tag}"
+            echo "push_allowed=${push_allowed}"
+            echo "tags<<EOF"
+            cat container-tags.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Container build metadata"
+            echo
+            echo "- Image: \`${image_ref}\`"
+            echo "- Primary tag: \`${primary_tag}\`"
+            echo "- Push allowed: \`${push_allowed}\`"
+            echo
+            echo "Tags:"
+            sed 's/^/- `/' container-tags.txt | sed 's/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: container-build-metadata
+          path: |
+            container-tags.txt
+            container-metadata.json
+          if-no-files-found: error
+
+  build:
+    name: Build image without publish
+    needs: metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Docker build
+        env:
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          TARGET: ${{ inputs.target }}
+          BUILD_ARGS: ${{ inputs.build-args }}
+          TAGS: ${{ needs.metadata.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              tag_args+=("-t" "$tag")
+            fi
+          done <<< "$TAGS"
+
+          build_args=()
+          while IFS= read -r build_arg; do
+            if [ -n "$build_arg" ]; then
+              build_args+=("--build-arg" "$build_arg")
+            fi
+          done <<< "$BUILD_ARGS"
+
+          target_args=()
+          if [ -n "$TARGET" ]; then
+            target_args+=("--target" "$TARGET")
+          fi
+
+          dockerfile_path="$DOCKERFILE"
+          if [ "${dockerfile_path#/}" = "$dockerfile_path" ] && [ ! -f "$dockerfile_path" ] && [ -f "$CONTEXT/$dockerfile_path" ]; then
+            dockerfile_path="$CONTEXT/$dockerfile_path"
+          fi
+
+          docker build \
+            -f "$dockerfile_path" \
+            "${tag_args[@]}" \
+            "${build_args[@]}" \
+            "${target_args[@]}" \
+            --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "$CONTEXT"
+
+  publish:
+    name: Publish trusted image
+    needs:
+      - metadata
+      - build
+    if: needs.metadata.outputs.push_allowed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Registry login
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          username="${GITHUB_ACTOR}"
+          password="${GITHUB_TOKEN}"
+          if [ -z "$password" ]; then
+            echo "registry password is required for publish" >&2
+            exit 1
+          fi
+          printf "%s" "$password" | docker login "$REGISTRY" --username "$username" --password-stdin
+
+      - name: Build and push image
+        env:
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          TARGET: ${{ inputs.target }}
+          BUILD_ARGS: ${{ inputs.build-args }}
+          TAGS: ${{ needs.metadata.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              tag_args+=("-t" "$tag")
+            fi
+          done <<< "$TAGS"
+
+          build_args=()
+          while IFS= read -r build_arg; do
+            if [ -n "$build_arg" ]; then
+              build_args+=("--build-arg" "$build_arg")
+            fi
+          done <<< "$BUILD_ARGS"
+
+          target_args=()
+          if [ -n "$TARGET" ]; then
+            target_args+=("--target" "$TARGET")
+          fi
+
+          dockerfile_path="$DOCKERFILE"
+          if [ "${dockerfile_path#/}" = "$dockerfile_path" ] && [ ! -f "$dockerfile_path" ] && [ -f "$CONTEXT/$dockerfile_path" ]; then
+            dockerfile_path="$CONTEXT/$dockerfile_path"
+          fi
+
+          docker build \
+            -f "$dockerfile_path" \
+            "${tag_args[@]}" \
+            "${build_args[@]}" \
+            "${target_args[@]}" \
+            --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --label "org.opencontainers.image.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "$CONTEXT"
+
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              docker push "$tag"
+            fi
+          done <<< "$TAGS"


### PR DESCRIPTION
## Problem (confirmed root cause)
`container-publish.yml`'s four build jobs call `uses: jvallery/agents/.github/workflows/reusable-container-build.yml@main`. `jvallery/agents` is a **private repo owned by the personal account `jvallery`**, while `verdify-platform` is in the **VerdifyConsultancy org**. GitHub forbids private reusable-workflow access across different owners, so **every run fails at workflow-load (0s, 0 jobs)** — no Verdify image has ever published to GHCR.

## Fix (2 commits)
1. **Vendor the reusable workflow in-org** at `.github/workflows/reusable-container-build.yml` and rewrite the four caller `uses:` to the **local-path form** `./.github/workflows/reusable-container-build.yml` (no cross-repo/owner access needed). It's self-contained — only public SHA-pinned actions, no `jvallery/*` composites; no `secrets:` block (GHCR via `GITHUB_TOKEN`, `packages: write` already granted). Image namespace resolves to `ghcr.io/verdifyconsultancy/verdify-{api,mcp,ingestor,migrate}`.
2. **Publish only from `live/platform-main`** (the canonical SoT / ArgoCD targetRevision per the 2026-05-31 decision). Trims `publish-branches` (×4) and the promotion guard so pushes to `main` build-validate but never publish/promote.

## Scope / not in this PR
- Resolves the **workflow-LOAD** failure only. Builds still fail at `docker build` until the P3 Dockerfiles land — pre-existing/intentional.
- `request-gitops-promotion` stays a **safe no-op** until `AGENT_FLEET_PROJECT_TOKEN` lands.
- **Image-namespace reconciliation (follow-up):** live staging currently runs `ghcr.io/jvallery/verdify-*:staging`; this pipeline publishes `ghcr.io/verdifyconsultancy/verdify-*`. The `deploy/k8s/overlays/staging` digests must switch to the in-org namespace when ArgoCD repoints to verdify-platform (#65).

## Verification
- Both YAML files parse; pre-commit `check yaml` passed.
- Confirmed against live cluster: `verdify-staging` is Synced/Healthy (api+mcp+db Running, ingestor 0/0); ArgoCD still sources from `jvallery/agent-fleet-control` pending the #65 repoint.

`.github/workflows/**` is shared infra → coordinator-reviewed PR. Base re-pointed to `live/platform-main` is tracked on PR #55. Closes the load-failure half of #56. Part of #15.
requested-by: coordinator