### PR TITLE
docs: k3s migration roadmap + state-of-verdify report

### DIFF
--- a/docs/roadmap/k3s-migration-roadmap.md
+++ b/docs/roadmap/k3s-migration-roadmap.md
@@ -1,0 +1,117 @@
+# Verdify k3s Migration & CI/CD Roadmap (authoritative)
+
+_Owner: coordinator (verdify agent). Last replan: 2026-05-31. Supersedes scattered design/runbook notes for sequencing purposes; the master plan (`/mnt/agents/root/docs/verdify-k3s-migration-plan-2026-05-31.md`) remains the detailed technical reference._
+
+## 0. Goal (Jason, 2026-05-31)
+
+Be **GREEN in k3s** and have **reliable push-to-deploy CI/CD for BOTH staging and production**.
+
+## 1. Authoritative ground truth (do not contradict)
+
+- **Deploy branch / ArgoCD targetRevision = `live/platform-main`.** `main` is the GitHub default but NOT the deploy branch.
+- **Image namespace = `ghcr.io/verdifyconsultancy/verdify-{api,mcp,ingestor,migrate}`** (in-org). `jvallery/*` retiring.
+- **RACI:** the verdify agent OWNS building/bumping all containers, `deploy/k8s` manifests, CI, and migration execution. **laptop-root** owns the k3s substrate, ArgoCD Application CRs, SOPS keys, RBAC/kubeconfig. **James + Jason** own outward DNS/edge and irreversible deletes. git -> ArgoCD is the law of record.
+- **Cluster:** 5-node k3s v1.35.5. `verdify-staging` LIVE+Healthy (api 1/1, mcp 1/1, db STS 1/1, **ingestor 0/0** two-writer pin). `verdify-prod` empty scaffold. ArgoCD `verdify-local-staging` Synced/Suspended sourcing `jvallery/agent-fleet-control` rev main; repoint to `verdify-platform/deploy/k8s/overlays/staging` PARKED at PR jvallery/agents#274.
+- **Confirmed hazards:** TimescaleDB skew (cluster 2.17.2-pg16 vs live ~2.25.2 — downgrade hazard, #57); `VERDIFY_DEVICE_WRITE_ENABLED` reads back EMPTY; no `deny-esp32-egress`; all manifests still pin `jvallery/*`.
+
+## 2. Definition of GREEN
+
+**GREEN in k3s — STAGING:**
+1. ArgoCD `verdify-local-staging` **Synced + Healthy** sourcing `verdify-platform/deploy/k8s/overlays/staging` @ `live/platform-main`.
+2. api 1/1, mcp 1/1, verdify-db STS 1/1, **ingestor 0/0** (two-writer pin), all on `ghcr.io/verdifyconsultancy/verdify-*@sha256` digests (zero `jvallery/*`).
+3. A merge to `live/platform-main` builds in-org GHCR digests and **auto-bumps `overlays/staging` with no human action**; PRs build-without-publish.
+4. Secrets + 5 NetworkPolicies GitOps-managed via SOPS (`argocd-sops` CMP), no out-of-band drift.
+5. Device-safety interlock declared: staging pins `VERDIFY_DEVICE_WRITE_ENABLED=0` + ships `deny-esp32-egress`; device-write-gate CI test PR-blocking.
+
+**GREEN in k3s — PROD:**
+1. `verdify-prod` ArgoCD app(s) reconcile; non-ingestor workloads Healthy; control+data tiers **manual-sync** (no self-heal/auto-prune); ingestor stays 0 until G9.
+2. Prod is **never auto-rolled by a merge** — promotion is a deliberate `bump-prod` PR copying the SAME staging digests, CODEOWNERS(@jvallery)-gated, coordinator clicks Sync.
+3. After G9: exactly ONE ESP32 writer (k3s node IP), 2+ green cycles, G10 smoke green (image==source at `/health/detailed`).
+
+## 3. End-to-end CI/CD path
+
+```
+PR  ──ci.yml (G1 lint / G2 unit+schema+firmware / G3 strict-migration / G6 device-write-gate, all PR-blocking; PRs build-without-publish)
+  │
+merge to live/platform-main
+  │
+container-publish.yml ── builds + pushes ghcr.io/verdifyconsultancy/verdify-{api,mcp,ingestor,migrate}@sha256 (G4) + Trivy/SBOM (G5); #68 vendored the reusable wf in-org
+  │
+k8s-manifests.yml ── kustomize v5.4.3 + kubeconform -strict on deploy/k8s/** (renders Valid) AND digest-bump-back: kustomize edit set image into overlays/staging ONLY, commit with paths-ignore deploy/k8s/overlays/** (loop-broken). Never prod.
+  │
+ArgoCD verdify-local-staging ── auto-syncs staging to the new digest (G7)
+  │
+bump-prod PR (workflow_dispatch / make promote-prod SHA=<sha>) ── copies SAME staging digests into overlays/prod; promote-diff-guard + CODEOWNERS @jvallery (G8)
+  │
+coordinator clicks Sync on verdify-prod-control (manual) ── non-ingestor prod workloads roll
+  │
+G9 (Jason HARD STOP) ── atomic single-writer ESP32 handoff
+  │
+G10 ── post-deploy smoke + device-route ESTAB monitor (==1)
+```
+Rollback at any stage = `git revert` the bump commit -> OutOfSync -> Sync, or `kubectl rollout undo`.
+
+## 4. Phases -> Gates -> Sprints -> Epics -> Issues
+
+| Phase | Gates | Sprint | Sub-epic | Issues |
+|---|---|---|---|---|
+| **P0 Local plane** | 0a-0e | S3 (route prep can start earlier) | Prod cutover | NEW Phase-0 local plane |
+| **P1 Real runner + iSCSI DB + secrets + access** | G-DB-1/2, G11 | S1 (secrets/version) + S2 (runner/iSCSI) | Staging parity, DB migration | #57, #66, #30, #64(done); NEW migrate image, iSCSI STS |
+| **P2 DB migration** | G-DB-1..4, G3 | S2 | DB migration | #24, #28, #57; NEW DB load/validate runbook |
+| **P3 / G9 Atomic single-writer** | G9 (HARD) | S3 | Prod cutover, Device-safety | #25, #27, #67; NEW device-write-gate, deny-egress NetPol |
+| **P4 Web/content/obs local** | Gate 28 | S3 | Prod cutover, Observability | #58, #59, #60, #63; NEW web-tier into k3s |
+| **P5 WAN edge** | Gate 29/30 | S4 | Prod cutover | #67; NEW Cloudflare WAN view |
+| **P6 Decommission iris** | Gate 31 (HARD) | S4 | Decommission | #61, #62; NEW mask+decommission |
+| **CI/CD pipeline** | G1-G5, G10 | S1 (core), S2 (prod) | CI/CD pipeline green | #22, #23, #26, #56(done); NEW digest-bump-back, CODEOWNERS+promote-guard, docker-build, e2e smoke |
+
+## 5. Sprints (milestones)
+
+- **Sprint 1 — Sprint 2026-06-01 (existing #1, due 2026-06-14): GREEN IN K3S STAGING.** Day 1: #54 labels. Then #56 close (verify GHCR push) + image-namespace switch + overlays restructure + #57 version bump + device-safety interlock + #22 triggers + digest-bump-back + #66 secrets -> #65 ArgoCD repoint. Parallel Track-A P0s held here so they aren't crowded out: **#36 (June heat)**, **#39 (human plant verification)**.
+- **Sprint 2 — 2026-06-15..06-28: DB shell + load + prod overlay.** Real migrate image, iSCSI STS recreate, DB load/validate (G-DB-1..4), prod ArgoCD app, prod-promote mechanism + CODEOWNERS, #25 SHADOW_MODE, #58 /health/detailed.
+- **Sprint 3 — 2026-06-29..07-12: Atomic single-writer cutover + local edge.** Phase-0 local plane, G9 handoff (Jason), G10 smoke, Phase-4 web/content local, #27/#67 edge.
+- **Sprint 4 — 2026-07-13..07-26: WAN edge + iris decommission.** Phase-5 Cloudflare, Phase-6 mask+destroy (Gate 31), #61 host cleanup, #62 monorepo prune, #53 closed.
+
+## 6. DB migration & cutover sequence (copy-not-move)
+
+1. Bump TimescaleDB to >=2.25.2-pg16 in STS + both wait-for-db initContainers (#57) — **must precede any restore**.
+2. Recreate STS on synology-iscsi (Retain), prune=false (G-DB-2).
+3. Build real migrate image; prove idempotent on throwaway DB (G-DB-1).
+4. Dress-rehearsal dump->restore->validate (off the device-dark path).
+5. Open write-freeze window (Jason): `systemctl stop verdify-ingestor` on iris; confirm zero :6053 ESTAB.
+6. Final `pg_dump -Fc` -> `timescaledb_pre_restore()` -> `pg_restore --exit-on-error jobs=1` -> `timescaledb_post_restore()`; stream node->node (never land on iris).
+7. Re-assert 4 compression + 5 retention + 2 UDA jobs; `alembic stamp 0001_baseline`; flip migrate Job to PreSync (G-DB-3).
+8. Run 8 validation queries; counts match iris (G-DB-4, HARD precondition for G9).
+9. G9 atomic handoff: greenhouses repoint -> write gate ON + ingestor 0->1 on pinned node -> exactly one ESTAB -> setpoint-server up -> 2+ green cycles. Rollback: scale ->0, `systemctl start verdify-ingestor` on iris.
+
+## 7. The 5 absolute HARD STOPS
+
+G6 (staging can never write the device) · Gate 0b/Phase-1 firewall raw-socket proof (no ingestor connect) · G-DB-4 (no promotion vs unvalidated DB) · G9/Phase-3 (atomic single-writer handoff) · Gate 31/Phase-6 (irreversible repo/VM destroy).
+
+## 8. RACI summary
+
+| Area | R | A | C/I |
+|---|---|---|---|
+| Containers, deploy/k8s, CI, migration execution | verdify agent | verdify agent | laptop-root |
+| k3s substrate, ArgoCD CRs, SOPS keys, RBAC/kubeconfig, iSCSI SC | laptop-root | laptop-root | verdify agent |
+| Write-freeze window, G9 flip, irreversible destroy | Jason | Jason | verdify agent, laptop-root |
+| Outward DNS / Cloudflare edge / repo deletes | James + Jason | Jason | laptop-root |
+| nexus split-horizon DNS + cross-VLAN firewall | nexus + laptop-root | laptop-root | verdify agent |
+
+## 9. Track-A (greenhouse) — parallel, non-blocking
+
+Per CLAUDE.md "Track A outranks Track B": crop/firmware/planner work (#13/#14/#16 epics and their children, plus #36 heat, #39 human verification, #40/#41/#42 data-integrity, #43-52 hygiene) stays on its own track. **#36 and #39 are held P0 on Sprint 1** specifically so migration pressure does not deprioritize the 94-105F June-heat window and the top crop-safety gap. They run in parallel and do NOT block the migration critical path.
+
+
+---
+
+## Tracker index (executed 2026-05-31)
+
+**Top-level epic:** #15 (P0)
+
+**Sub-epics:** #69 CI/CD-green · #70 Staging-parity · #71 Device-safety · #72 DB-migration · #73 Prod-cutover · #74 Decommission · #75 Observability
+
+**Sprints (milestones):** #1 Sprint 2026-06-01 (staging-green) · #2 2026-06-15 (DB+prod-overlay) · #3 2026-06-29 (cutover+local-edge) · #4 2026-07-13 (WAN-edge+decommission)
+
+**Gap issues created:** #76 overlays-restructure · #77 image-namespace-switch · #78 digest-bump-back · #79 device-write-gate · #80 deny-esp32-egress NP · #81 first-real-docker-build · #82 CODEOWNERS+promote-guard · #83 migrate-image · #84 db-on-iscsi · #85 db-load+validate · #86 prod-ArgoCD-app · #87 local-plane DNS/TLS · #88 web-tier-into-k3s · #89 smoke+route-monitor · #90 WAN-edge · #91 decommission-VM · #92 e2e-green-smoke
+
+_Closed: #53 (GCP SaaS superseded), #64 (kubectl access done). Kept open: #56 (PR #68 fixed only the workflow-load half; images still need Dockerfiles to publish)._

--- a/docs/state-of-verdify-2026-05-31.md
+++ b/docs/state-of-verdify-2026-05-31.md
@@ -1,0 +1,142 @@
+# State of Verdify — Migration Report
+
+_Prepared for Jason · 2026-05-31 · synthesized from 7 independent tracer probes of host `vm-docker-iris`, branch `origin/firmware/cicd-golden-path` (PR #55), and the GitHub org._
+
+---
+
+## 1. Headline & overall status
+
+**The greenhouse is safe and the live control loop is healthy right now.** On `vm-docker-iris`, every Track-A component is fresh-to-the-second: `climate` and `climate_action_log` are 7s old, the ESP32 at `192.168.10.111:6053` is reachable, the planner delivered SUNRISE/SUNSET/MIDNIGHT/FORECAST_DEVIATION plans today, and there are **zero open critical/high alerts** (the firmware-deploy preflight block query returns 0).
+
+**The migration is on-track but earlier-stage than a green PR #55 suggests.** The k3s/ArgoCD target is fully designed, manifests are CI-validated, and a `verdify-staging` instance appears to have been stood up on root's cluster — but **no production cutover has begun, the build->publish->deploy pipeline has never run end-to-end (container-publish fails at workflow load), and the two P0 device-safety prerequisites are unimplemented.** The migration poses **no current threat** to the loop because nothing has been cut over; the risk is concentrated entirely in the future Stage 5/6 DB-and-ingestor handoff.
+
+**Overall: on-track-with-risks.** Track A is the strong story; Track B is well-architected scaffolding with several load-bearing gates still closed.
+
+---
+
+## 2. Deployment topology today — before / after
+
+### BEFORE (authoritative production — confirmed by probe)
+
+`vm-docker-iris` runs a **hybrid** stack. This is not a pure docker-compose world:
+
+- **Real-time control plane = HOST systemd units** on venv `/srv/greenhouse/.venv`: `verdify-ingestor` (PID 3658), `verdify-setpoint-server` (PID 3424, `0.0.0.0:8200`, the only thing touching the ESP32), `verdify-mcp` (PID 3421, `0.0.0.0:8000`). **These are the plants-alive services and they are NOT containers.**
+- **Stateful/edge = docker-compose** (~13–15 containers Up ~5h): `verdify-traefik` (TLS `:443`, Host()-routing), `verdify-timescaledb` (pg16, bound `127.0.0.1:5432`), `verdify-mqtt` (`:1883`), grafana(+proxy+renderer), `verdify-site` (Quartz/nginx), umami, goaccess, promtail, and the profile-gated `hermes-iris` planner gateway (`127.0.0.1:8642`).
+- **Scheduled work** split across systemd timers (forecast-page 30m, site-poll 10s, render-cache-warm) and `jason.crontab` (1AM pg_dump to `/mnt/iris/backups`, daily snapshots/vault writers, frigate, slack, metrics every 1m, daily-plan publish 3x/day).
+- **Deploy method:** manual `git merge` to `live/platform-main` + `systemctl restart` / `docker compose up` against the `/srv/verdify -> /mnt/iris/verdify` symlink. **No CD, no audit trail** — this is the documented root cause of the 2026-04-21 MCP staleness incident.
+
+### AFTER (target — `deploy/k8s/` on PR #55, design/validation only)
+
+A single Kustomize base deployed by **ArgoCD** into one pinned namespace **`verdify-staging`** (PodSecurity `restricted`): Deployments for api/mcp/ingestor, a StatefulSet for db, and a PreSync migration Job, fed by a non-secret ConfigMap + a SOPS/age-delivered Secret. Every pod hardened (non-root, dropped caps, read-only rootfs, seccomp). Device safety is fenced in git: **ingestor pinned `replicas:0`** in staging, and the device-VLAN egress NetworkPolicy is a **commented placeholder**.
+
+### Is there a live k3s cluster + ArgoCD?
+
+**Not on this host — confirmed.** `vm-docker-iris` has no `kubectl`/`k3s`/`helm`/`argocd` binary, no `k3s.service`, no kubeconfig, no `:6443` listener. The full compose+systemd stack is live.
+
+**Off-box, the picture is more advanced than the runbooks admit** (this is the central doc-vs-reality drift): the ArgoCD Application `verdify-local-staging` is **MERGED** (`jvallery/agents` PR #263, `selfHeal:true prune:false`, source = `jvallery/agent-fleet-control/manifests/verdify-staging`), the registry secret-meta PR #8 is **MERGED**, and the merged registry manifests' **header comments claim** the instance was "reconstructed from the live known-good verdify-staging cluster state," that the `.7.21` VIP "already serves 200 intra-cluster," and that the in-cluster DB "already carries the 208-table schema." **None of this is confirmable from `vm-docker-iris`** — the 5-node cluster is root's, reachable only from laptop-root. So: **staging is claimed-alive by merged artifacts and manifest comments; its current Synced/Healthy/pod state is unverified.** The two frozen runbooks (`@ f350bcd`) still say "nothing executed" and are a stale PREP snapshot.
+
+---
+
+## 3. What's working (confirmed-healthy)
+
+**Track A (greenhouse loop) — confirmed by probe:**
+- TimescaleDB healthy; `climate` (7s, 289,954 rows, 71.5°F/50% RH), `climate_action_log` (7s), `setpoint_changes` (~90s, 126,404), `equipment_state` (~2min), `setpoint_snapshot` (7s, 6.14M) all fresh.
+- ingestor / mcp / setpoint-server / hermes-iris all active ~5h; ESP32 TCP-reachable.
+- Planner firing normally (SUNRISE/SUNSET/MIDNIGHT/2× FORECAST_DEVIATION today, all delivered).
+- **Zero open critical/high alerts** → OTA deploy gate clear.
+- Public web tier serving live via local Traefik probes: `lab.verdify.ai` 200 (286 pages rebuilt 09:11 today), `api.verdify.ai` `/health` ok, `graphs.verdify.ai` 200. Today's plan and forecast pages are fresh.
+
+**Track B (migration) — confirmed:**
+- PR #55 is `MERGEABLE`/`CLEAN`; **all 8 `ci.yml` gate jobs + the `k8s-manifests` render/validate job pass** (kustomize v5.4.3 + kubeconform; 16/16 overlay, 15/15 base). **This refutes issue #22 for the branch** — CI does fire and pass on PR #55.
+- Manifests are coherent and safety-conscious: single pinned namespace, fail-closed api writes (omits `VERDIFY_ALLOW_UNAUTHENTICATED_WRITES`), correct probe choices (tcpSocket for FastMCP, not httpGet), ingestor `Recreate`/`replicas:0`, full NetworkPolicy set, ArgoCD PreSync migrate Job.
+- All build inputs exist on-branch (4 Dockerfiles, requirements, `catalog-info.yaml`); the `container-publish` / `k8s-manifests` workflows are fully authored and wired to the accessible reusable workflow.
+- Companion GitOps PRs **MERGED** (the runbook said "open"): `jvallery/agents#263`, `jvallery/agent-fleet-control#8`.
+
+---
+
+## 4. What's broken / blocking (ordered by severity)
+
+| # | Severity | Issue/PR | What | Evidence |
+|---|---|---|---|---|
+| 1 | **P0 HARD** | G1 (cutover-readiness) | **TimescaleDB version skew/downgrade**: live DB is `latest-pg16` (~2.25.2); k3s db-statefulset + migrate pin `2.17.2-pg16`. Unsupported downgrade — corrupts/refuses real restore. | manifest `db-statefulset.yaml`; live `timescale/timescaledb:latest-pg16` |
+| 2 | **P0** | #26 / PR #55 | **`container-publish.yml` fails at workflow load** — 0s, zero jobs, no check-run on every PR #55 run. **No image has ever been published to GHCR**; the whole deploy tail is unproven. | `gh run list` 5 runs all `failure`/0s; check-runs show only the 9 passing jobs, no publish check-run |
+| 3 | **P0** | #24, #25 | **Device-safety prereqs unimplemented on branch**: no ingestor `SHADOW_MODE`, no `ingestor-healthz.py`, no `scripts/lib/psql-verdify.sh`. Raw `docker exec ... psql` everywhere. | `git grep SHADOW_MODE` empty; both files "No such file or directory" |
+| 4 | **P0** | #22 | **Branch drift**: `live/platform-main` (aa6518c) is 4 ahead of `main` (fb17f43); prod-config CI only fires on `main`; PR #55/#12 based on `main`. PRs misreport coverage vs where code ships. | `rev-list 0 4`; `ci.yml` triggers |
+| 5 | P1 | DoD #1 | **No `/health/detailed` with baked `VERDIFY_GIT_SHA`** — image==source is not verifiable. | `api/main.py:911` has only `/health` |
+| 6 | P1 | #43 | **`site_content` RAG table 8 days stale** (max `updated_at` 2026-05-23, 165 rows); no scheduled refresh for `populate-site-content.py`. Degrades Iris retrieval silently (public HTML is fresh, so easy to miss). | DB query; grep finds no timer/cron/Makefile ref |
+| 7 | P1 | #42 | **weather_station (Tempest) ~8.7d stale**; **esp32_logs ~13.8d stale**. Tempest staleness risks pre-cool decisions before the Jun 4-9 heat cluster. Live climate/equipment telemetry unaffected. | `max(ts)` 2026-05-22 / 2026-05-17 |
+| 8 | P1 | — | **Two host units FAILED**: `verdify-forecast-page` + `verdify-plan-publish` (outbound HTTPS timeout in `publish-site-content.sh`). Today's content still published via the 09:11 rebuild, but path-triggered republish won't auto-fire until reset. | `systemctl status`; urllib URLError |
+| 9 | P2 | — | **Grafana render-cache-warm timer dead** since 2026-05-25 (HTTP 500s); iOS homepage panels may be cold. | journal 500s; timer disabled |
+| 10 | P2 | — | **Two `verdify-api` instances**: container `:8080` (public, Traefik-routed) + legacy host systemd `:8300` (unrouted, redundant attack surface). | `ss -tlnp`; docker labels |
+
+---
+
+## 5. In progress / staged-not-cut-over
+
+- **PR #55** (`firmware/cicd-golden-path` -> `main`, OPEN, CLEAN, 123 files, +41175/-733): the entire additive k3s package — `deploy/k8s/{base,overlays/local-staging,diagnostics}`, 4 Dockerfiles, `container-publish.yml`, `k8s-manifests.yml`. Explicitly **no cutover**, no firmware semantic edits. Carries a 2.54% intentional firmware replay-diff divergence (THRESHOLD_PCT override) needing coordinator + Iris concurrence.
+- **Image pins are placeholders** (`newTag: latest`); real immutable `ghcr.io/jvallery/verdify-<comp>:sha-<gitsha>` pins come from a cross-repo PR in `jvallery/agents` not yet wired.
+- **`request-gitops-promotion` is a deliberate safe no-op** — exits 0 when `AGENT_FLEET_PROJECT_TOKEN` is unset (it is). Even once publish is fixed, the cross-repo dispatch won't fire until the token lands.
+- **ArgoCD `targetRevision: main`** while production lives on `live/platform-main` — reconcile-before-reconciliation would deploy an older tree.
+- **migrate Job is a no-op** (`suspend:true` in the live-shape registry manifest; its image was a perpetual `ImagePullBackOff`); schema loaded out-of-band; real copy-not-move restore is a separate gated runbook.
+- **`verdify-www` (Astro) and `verdify-planner`** are split into their own repos with CI/deploy, but **the monorepo still carries the planner code and the full Quartz `site/` tree** — unpruned drift.
+- **No manifests for `verdify-site` / grafana / umami / goaccess** — the "move stateless services first" plan is undelivered for the web tier; api-only cutover would split the web stack across VM and k3s.
+
+---
+
+## 6. CI/CD & GitOps reality — intended path vs what executes
+
+**Intended:** push to a prod branch -> GitHub Actions builds+publishes per-service images to GHCR -> cross-repo dispatch asks `jvallery/agents` to open an image-pin GitOps PR -> ArgoCD (sole applier) reconciles pinned SHAs into `verdify-staging`. GitHub Actions never touches the cluster.
+
+**What executes today:**
+- ✅ **Build-validate half works**: `ci.yml` 8 gates + `k8s-manifests` render/validate run green on PR #55.
+- ❌ **Publish never succeeds**: `container-publish.yml` dies at workflow load (0 jobs). **No image artifact has ever been produced.**
+- ❌ **Promotion/reconcile tail never executed end-to-end**: blocked first by the publish failure, then by the unset `AGENT_FLEET_PROJECT_TOKEN` no-op, then by `targetRevision=main` ≠ production branch.
+- The Makefile has **no** k8s/container/argocd/deploy/publish targets — the only deploy target is `firmware-deploy` (OTA, heavily gated). Python-layer deploys remain **100% manual** (`git merge` + `systemctl restart`).
+
+**Net: the commit->pod path is wired on paper and validated for manifests, but the build->publish->deploy spine has zero successful end-to-end runs.** Believing "CD is wired" is the trap — three silent gates (publish load-failure, token no-op, branch mismatch) each independently prevent a deploy.
+
+---
+
+## 7. Risks to the live greenhouse from the migration (Track-A protection)
+
+1. **Two-writer ESP32 hazard (gravest).** Stage 5/6 (DB write-handoff + ingestor cutover) is the moment of max device risk. A momentary two-writer condition corrupts control. Today's only guard is the git-tracked `replicas:0` staging pin + `Recreate` + ArgoCD honoring it. **A manual scale to 1, or a stray RollingUpdate, would double-write.** Flipping to `replicas:1` is the single most dangerous action and is Jason-gated.
+2. **Safety nets not built (#24/#25).** SHADOW_MODE, healthz, and `psql-verdify.sh` don't exist. Without the psql abstraction, a DB move under cutover breaks firmware-deploy preflight, replay export, and the sensor-health sweep **simultaneously**.
+3. **TimescaleDB downgrade (G1).** Restoring the live DB onto a 2.17.2 statefulset would corrupt/refuse.
+4. **DB SPOF regression.** Base statefulset uses `storageClassName: local-path` for the live 2.3GB DB — the design doc itself says **do not** put the live DB on local-path (worse SPOF than the VM; no replication, pins to one node). Prefer Longhorn or ExternalName.
+5. **Device-VLAN reachability unproven at scale.** Host reaches ESP32 via UniFi inter-VLAN routing, not a local VLAN-10 NIC; the egress NetworkPolicy is commented-out and enabling it touches firewall posture (Jason-gated). A 2026-05-30 laptop-root spike hit the ESP32 at ~8ms, but whether that was from a real pod and whether the route is enabled is unconfirmed.
+6. **Dead replan cron fallback.** `jason.crontab` line 26 (5-min replan trigger) is empty; replan currently rides solely on the ingestor emitting FORECAST_DEVIATION. A naive cutover that stops the ingestor without restoring the cron path would **silently stop deviation-driven replanning** — dangerous with the Jun 4-9 heat cluster approaching while Tempest data is stale.
+7. **Stale rollback target.** `last-good` OTA is 2026-05-17 (#35 promotion to aa6518c pending bake, no archive artifact yet).
+
+**The migration's Track-A protections are sound by design** (copy-not-move, single-writer, ingestor-last, replicas:0). The exposure is that the **code enforcing them isn't built yet**, so cutover is further out than PR #55's green checks imply.
+
+---
+
+## 8. Repo / issue hygiene
+
+- **Org:** 8 repos under `VerdifyConsultancy`. `verdify-platform` (public monorepo) is source of truth. `verdify-planner` and `verdify-www` are real split-out repos — but the monorepo **still runs/contains** the planner code and Quartz tree (drift; same staleness class the migration exists to fix).
+- **Branch drift (load-bearing):** `live/platform-main` (aa6518c, prod) is **4 ahead of `main`** (fb17f43). PR #55 and PR #12 are based on `main`. **PR #12 is a trap** — its content already shipped to prod as aa6518c, it shows OPEN against `main` with zero CI, and merging it could re-introduce/conflict. **Close it.**
+- **Cross-org dependency:** the ArgoCD Application and image-promotion live in `jvallery/*` (laptop-root), outside the VerdifyConsultancy org and outside this repo's CI — the migration cannot complete without coordination across a boundary the in-org tracers can't see into. Source-of-truth for the deploy shape was deliberately **moved** to `jvallery/agent-fleet-control/manifests/verdify-staging` (to escape an ArgoCD ComparisonError), which means **merging PR #55 does NOT change what ArgoCD reconciles** — a subtle footgun.
+- **EPIC #15 (k3s/CICD):** sub-issues #22–#33. Open P0s include #22 (CI triggers), #24 (psql abstraction), #25 (SHADOW_MODE), plus #17/#20/#31. #27 (cluster ns + ESP32 reachability + storage), #30 (in-cluster secrets), #35 (OTA promote), #42/#43 (monitoring/RAG) all OPEN. K3S-0 hard gate (ArgoCD present? StorageClass? MetalLB CIDRs? GHCR PAT?) cannot be confirmed from `vm-docker-iris`.
+- Issue tracking itself is well-structured (42 open issues, P0–P3 + owner/epic/theme labels, 4 EPICs).
+
+---
+
+## 9. What to do next — cutover critical path
+
+### P0 blockers (must clear before any cutover)
+1. **Reconcile branch drift (#22).** Decide canonical branch, converge `main` ↔ `live/platform-main`, re-point PR #55 base and ArgoCD `targetRevision`, land the `ci.yml` trigger fix so production pushes are gated. **Close PR #12.**
+2. **Fix G1 DB version skew.** Bump db-statefulset + migrate image to `>=2.25.2-pg16` to match live before any Stage 0 restore. Revisit `local-path` for the live DB (Longhorn/ExternalName).
+3. **Make the pipeline actually publish.** Debug `container-publish.yml` load failure -> get one image into GHCR; configure `AGENT_FLEET_PROJECT_TOKEN`; add `/health/detailed` (baked `VERDIFY_GIT_SHA`) for DoD #1.
+4. **Build the device-safety nets (#24, #25):** `psql-verdify.sh` (and migrate all call sites), ingestor `SHADOW_MODE`/`DRY_RUN`, `ingestor-healthz.py`. No ingestor cutover without these.
+
+### P1 — establish ground truth & protect Track A
+5. **From laptop-root, get real cluster state**: `kubectl get applications -n argocd verdify-local-staging`, `argocd app get`, `kubectl get pods -n verdify-staging`. Confirm Synced/Healthy and pod reality; **update the frozen runbooks to match** (they understate how live staging is).
+6. **Track-A hygiene (independent of migration):** reset the failed forecast-page/plan-publish units; wire `populate-site-content.py` into a daily timer (#43); diagnose Tempest staleness (#42) **before Jun 4-9 heat (#36)**; restore the replan cron fallback or confirm the ingestor path is the intended sole trigger; promote/bake the aa6518c OTA (#35).
+7. **Resolve ESP32_API_KEY drift** with Jason confirming canonical value (must not trigger re-flash) — gates secret sealing (5/13 keys clean).
+
+### P2 — cleanup
+8. Decommission redundant host `verdify-api.service` (`:8300`) after confirming no consumers; prune planner + Quartz trees from the monorepo; re-enable or retire the grafana render-cache-warm timer; fix the no-op `After=verdify-timescaledb.service` ordering deps (DB is a container).
+
+---
+
+_Confidence notes: all "live-prod" Track-A facts and the absence of k3s on `vm-docker-iris` are **confirmed by direct probe**. The `verdify-staging` instance being alive on root's cluster is **claimed by merged GitOps artifacts + manifest header comments only** — its current Synced/Healthy/pod state is **unverified** (cluster unreachable from the probed host). The `container-publish.yml` root cause is **inferred, not extracted from a log** (the run emits no annotations)._


### PR DESCRIPTION
Authoritative migration roadmap + the 2026-05-31 state-of-verdify triage report.

The roadmap ties **phases → gates → 4 sprints → 8 epics → issues**, documents the end-to-end CI/CD path (commit on `live/platform-main` → `ghcr.io/verdifyconsultancy/*` digests → `k8s-manifests` digest-bump-back → ArgoCD), the DB migration + atomic single-writer cutover sequence, RACI, and a crisp **Definition of GREEN in k3s** for staging and prod.

Tracker was restructured to match this doc: top-level EPIC #15 + sub-epics #69–#75, sprints (milestones) #1–#4, and gap issues #76–#92. Closed #53 (GCP SaaS superseded) and #64 (kubectl access done).

Part of #15. requested-by: coordinator