### PR TITLE
fix(staging): placeholder secret local-config must be an annotation (unblocks ArgoCD cutover)

### DIFF
--- a/deploy/k8s/overlays/staging/secrets.placeholder.yaml
+++ b/deploy/k8s/overlays/staging/secrets.placeholder.yaml
@@ -31,6 +31,13 @@ metadata:
   name: verdify-app-secrets
   labels:
     app.kubernetes.io/part-of: verdify
+  annotations:
+    # MUST be an ANNOTATION (not a label): `kustomize build` excludes objects
+    # carrying the config.kubernetes.io/local-config ANNOTATION from its output.
+    # As a label it rendered into the manifest, and ArgoCD's Secret-blacklisted
+    # app-test project rejected the whole sync ("synchronization tasks are not
+    # valid"). The real verdify-app-secrets is delivered out-of-band (SOPS) and is
+    # already present in-cluster; this placeholder must never reach the cluster.
     config.kubernetes.io/local-config: "true"   # never applied by GitOps
 type: Opaque
 stringData:


### PR DESCRIPTION
The staging overlay placeholder verdify-app-secrets carried config.kubernetes.io/local-config as a **label**. kustomize only excludes local-config objects via the **annotation**, so the placeholder rendered into kustomize build output. ArgoCD's app-test project blacklists Secrets, so the rendered placeholder made the sync invalid ('synchronization tasks are not valid') and the staging cutover could not apply. This moves it to metadata.annotations so kustomize drops it; only the out-of-band SOPS secret (already in-cluster) is used.