### PR TITLE
staging+prod: repin api/mcp/ingestor to app-code build sha-881d4d8 (image==source)

### DIFF
--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -58,10 +58,10 @@ patches:
 # (k8s-manifests.yml, no cross-repo PR / no ArgoCD Image Updater) will own these.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:4ace345dbff4e0ba749c2b4faf8aa3c1e1ca991939448b9382aeae7a4292f9f2
+    digest: sha256:ce4ca79f9e6442c39558cbe02b1665c3cddc3e269c1867997d4f292f3a5ce8ff
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
-    digest: sha256:7e880caf736802391bc6a5b3fd72abd3ca814cc3ee6dc58797c67be9e9cfff18
+    digest: sha256:9824020a0d2fe77191b2c01ca2634c3bcec6031b79d2fef1c3334b2d5665768d
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
-    digest: sha256:5be4321f5221b2670efa12798f2a524d3f4472254cbbe0519e355272213bc8a5
+    digest: sha256:4f141a5901f802e52b37b15a6a92b8d0bc906f3d854066e3ddd52911aa457d0d
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
     digest: sha256:7a39c3deb6df2182c7480cdd653bffa6575570bbfd262bf7c9694abcc58badf5


### PR DESCRIPTION
#92 smoke caught it: deployed images were sha-352f299e (pre-PR#94), so /health/detailed 404'd and the ingestor image lacked the device-write code gate. Repin api/mcp/ingestor to sha-881d4d859ff8 (the app-code build, verified pullable). Restores DoD#1 image==source. ArgoCD selfHeal will roll. Part of #15.