### PR TITLE
fix(staging): verdify-api LB externalTrafficPolicy Local -> Cluster (durable .7.21 off-cluster fix)

### DIFF
--- a/deploy/k8s/overlays/staging/api-loadbalancer.yaml
+++ b/deploy/k8s/overlays/staging/api-loadbalancer.yaml
@@ -36,7 +36,18 @@ metadata:
     metallb.universe.tf/loadBalancerIPs: 192.168.7.21   # PLACEHOLDER — reserve via registry, confirm with Jason
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
+  # externalTrafficPolicy: Cluster — DURABLE off-cluster reachability fix (laptop-root,
+  # 2026-05-31, jvallery/agents#361). apps-pool is advertised to the UDM via MetalLB
+  # BGP (bgpadvertisement/apps-pool, peer "udm"). Under ETP=Local only the single node
+  # hosting the api pod advertises .7.21, so a resize-driven pod reschedule + a BGP/FIB
+  # re-advertise gap silently blackholes the VIP off-cluster (.7.21 -> 000). The two
+  # PROVEN-WORKING apps-pool VIPs behind the same BGP advertisement — traefik-apps
+  # (.7.10) and gravity-ui (.7.22) — both use ETP=Cluster, so every speaker advertises
+  # the VIP and kube-proxy hairpins to the pod regardless of which node it lands on.
+  # Match that pattern. (We lose client source-IP, acceptable: this is a staging api
+  # behind the edge; the ADR-15 convergence to a host-routed IngressRoute behind the
+  # shared .7.10 apps-ingress remains the end-state and supersedes this whole LB.)
+  externalTrafficPolicy: Cluster
   selector:
     app.kubernetes.io/component: api
   # $patch: replace — the base verdify-api Service already exposes a port named


### PR DESCRIPTION
## What

Change `verdify-api` LoadBalancer (overlay `deploy/k8s/overlays/staging/api-loadbalancer.yaml`) from `externalTrafficPolicy: Local` to `Cluster`.

## Why (durable fix for jvallery/agents#361)

`apps-pool` (192.168.7.10-.250) is advertised to the UDM via MetalLB **BGP** (`bgpadvertisement/apps-pool`, peer `udm`). Under **ETP=Local** only the single node currently hosting the api pod advertises `192.168.7.21`. A resize-driven pod reschedule (pod moved to vm-k3s-node4) plus the known BGP/FIB re-advertise gap silently blackholed the VIP off-cluster: `.7.21 -> 000` from orbit and the Mac.

The two **proven-working** apps-pool VIPs behind the *same* BGP advertisement both use **ETP=Cluster**:
- `traefik-apps` .7.10 (the shared apps-ingress)
- `gravity-ui` .7.22

ETP=Cluster makes every speaker advertise the VIP and lets kube-proxy hairpin to the pod regardless of which node it lands on — resilient to reschedules. Trade-off: client source-IP is no longer preserved, acceptable for a staging API behind the edge.

ArgoCD `selfHeal` reverts live `kubectl patch`, so this must land in the manifest the `verdify-local-staging` app syncs (`live/platform-main`, path `deploy/k8s/overlays/staging`).

## Verification
- `kustomize build deploy/k8s/overlays/staging` renders cleanly with `externalTrafficPolicy: Cluster`, `type: LoadBalancer`, port `80 -> http`, address-pool annotation intact.
- Post-merge: ArgoCD syncs, then re-probe `.7.21` off-cluster, durability-gated >=10 min.

## Note
This LB remains the documented ADR-15 interim anti-pattern; the end-state is a host-routed IngressRoute behind the shared `.7.10` apps-ingress (add-then-drop), which supersedes this entire Service.

Refs jvallery/agents#361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)