### PR TITLE
feat(staging): host-route verdify through shared apps Traefik (.7.10) — *.vallery.net + api.verdify.ai

### DIFF
--- a/deploy/k8s/overlays/staging/allow-api-from-apps-ingress.yaml
+++ b/deploy/k8s/overlays/staging/allow-api-from-apps-ingress.yaml
@@ -1,0 +1,34 @@
+# Allow the SHARED apps-ingress Traefik (ns traefik-apps, the .7.10 front door)
+# to reach verdify-api on 8080. The base allow-api-from-ingress NetworkPolicy
+# only names the k3s built-in Traefik namespace ("traefik") + the apps VLAN
+# ipBlock; the conformant ADR-15 path routes through the SEPARATE traefik-apps
+# namespace, whose pod source IP is cluster-internal (10.42.0.0/16), so neither
+# the "traefik" namespaceSelector nor the 192.168.7.0/24 ipBlock matches it.
+# Without this allow, an enforcing CNI would default-deny the IngressRoute hop.
+#
+# NOTE: the live cluster is flannel, which does NOT enforce NetworkPolicy at
+# L3/L4 (base/networkpolicy.yaml header), so the IngressRoute path works today
+# regardless — this is the CONTRACT so it stays correct under the planned
+# Cilium re-CNI (ADR-17). Additive: a second NetworkPolicy on the same api
+# podSelector is purely union-ing allowed sources.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-from-apps-ingress
+  namespace: verdify-staging
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: api
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik-apps
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/deploy/k8s/overlays/staging/ingressroute.yaml
+++ b/deploy/k8s/overlays/staging/ingressroute.yaml
@@ -1,0 +1,104 @@
+# verdify *.vallery.net WAN/edge exposure via the shared apps Traefik (traefik-apps
+# on the apps VIP 192.168.7.10) — the ONE conformant front door (ADR-15 / Model B′).
+#
+# WHY (laptop-root, 2026-05-31, jvallery/agents#361): the cloudflared `vallery-edge`
+# tunnel ALREADY forwards `verdify.vallery.net` and `verdify-staging.vallery.net` to
+# https://192.168.7.10 (Host-preserving, noTLSVerify), but NO IngressRoute existed for
+# those Hosts in traefik-apps, so both returned **404** at the edge. This adds the
+# missing host-routes so the WAN edge (and, once the UDM split-horizon record points
+# *.vallery.net -> .7.10, the LAN) serves verdify through the shared VIP.
+#
+# This is the ADD half of the ADR-15 ADD-THEN-DROP convergence for verdify-api: route
+# THROUGH the shared .7.10 apps-ingress instead of the per-app .7.21 LoadBalancer.
+# Once these IngressRoutes are proven serving, the per-app `verdify-api` LoadBalancer
+# (api-loadbalancer.yaml, .7.21) is the documented anti-pattern to DROP (Jason-gated).
+#
+# AUTH INVARIANT (mirrors gravity-strip-identity-headers / pihole-strip-identity-headers):
+# cloudflared -> Traefik only. The strip-identity-headers Middleware clears any inbound
+# forward-auth identity headers so the api never trusts spoofed identity at the edge.
+#
+# tls: {} == use the Traefik default certificate (the wildcard-vallery-net cert served
+# via the traefik-apps TLSStore `default`; real public TLS is also terminated by
+# Cloudflare at the proxied tunnel edge). Same shape as gravity-ui / pihole-web.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: verdify-strip-identity-headers
+  namespace: verdify-staging
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: api
+spec:
+  headers:
+    customRequestHeaders:
+      X-Authentik-Email: ""
+      X-Authentik-Groups: ""
+      X-Authentik-Name: ""
+      X-Authentik-Uid: ""
+      X-Authentik-Username: ""
+      X-Forwarded-Email: ""
+      X-Forwarded-User: ""
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: verdify-api
+  namespace: verdify-staging
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: api
+spec:
+  entryPoints:
+    - websecure
+    - web
+  routes:
+    - kind: Rule
+      # Both the bare and the -staging host resolve to this staging instance for now
+      # (the only live k3s verdify instance). When a prod instance lands, prod will own
+      # Host(`verdify.vallery.net`) and this overlay keeps Host(`verdify-staging...`).
+      match: Host(`verdify.vallery.net`) || Host(`verdify-staging.vallery.net`)
+      middlewares:
+        - name: verdify-strip-identity-headers
+      services:
+        - name: verdify-api
+          port: 8080
+    # --- *.verdify.ai : THE PRODUCT DOMAIN, same one-pattern as *.vallery.net ---
+    # api.verdify.ai is the anchor host — the ONLY *.verdify.ai host with a ready
+    # k8s backend (verdify-api). It routes THROUGH this same shared apps Traefik
+    # (.7.10), identically to the vallery.net rule above, so a single Traefik +
+    # single VIP fronts BOTH domains (the explicit "ONE solution, different domains"
+    # north star). The cloudflared vallery-edge tunnel gains matching api.verdify.ai
+    # ingress rules (no new connector) so the SAME tunnel serves verdify.ai for WAN.
+    # Before this rule, `curl -k -H 'Host: api.verdify.ai' https://192.168.7.10/`
+    # returned 404 (Traefik 404s the unknown Host); after it, the real verdify-api.
+    - kind: Rule
+      match: Host(`api.verdify.ai`)
+      middlewares:
+        - name: verdify-strip-identity-headers
+      services:
+        - name: verdify-api
+          port: 8080
+  # tls: {} = Traefik default cert. The valid public wildcard that SHOULD be served
+  # here is *.verdify.ai, which does NOT exist yet (cert-manager letsencrypt-dns01
+  # solver selector is dnsZones:[vallery.net] only; no verdify.ai Cloudflare DNS-01
+  # token). Obtaining that token + a verdify.ai zone solver + a wildcard-verdify-ai
+  # Certificate is the residual TLS gate (handed off). HTTP routing is live now; over
+  # WAN the tunnel's noTLSVerify accepts the default cert, same as *.vallery.net.
+  tls: {}
+# ===========================================================================
+# BLOCKED-ON-BACKEND (staged shape, intentionally NOT active): the remaining
+# *.verdify.ai hosts still run as docker-compose on vm-docker-web with NO k8s
+# Service yet — lab/labs (verdify-site), graphs (grafana-proxy), www + apex
+# (redirect -> lab), analytics (umami), logs (goaccess). Un-comment each rule
+# only once its k8s Service exists, else .7.10 would route to a missing Service
+# (502/404). traefik.verdify.ai (ops dashboard) and mqtt.verdify.ai (Jason-owned
+# greenhouse lane, 192.168.30.150) are deliberately NEVER added to the WAN edge.
+#
+#   - kind: Rule
+#     match: Host(`lab.verdify.ai`) || Host(`labs.verdify.ai`)
+#     services: [{ name: verdify-site, port: 80 }]      # NEEDS k8s Service
+#   - kind: Rule
+#     match: Host(`graphs.verdify.ai`)
+#     services: [{ name: grafana-proxy, port: 80 }]     # NEEDS k8s Service
+#   www.verdify.ai + verdify.ai apex -> RedirectRegex Middleware -> lab.verdify.ai
+# ===========================================================================

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -30,6 +30,17 @@ resources:
   # DEVICE-SAFETY: staging-only egress lock dropping all egress to the greenhouse
   # device VLAN (192.168.10.0/24) from the ingestor pod — see deny-esp32-egress.yaml.
   - deny-esp32-egress.yaml
+  # EDGE/WAN: host-routed exposure of verdify-api through the shared apps Traefik on
+  # the .7.10 VIP for verdify.vallery.net / verdify-staging.vallery.net AND
+  # api.verdify.ai (the ONE pattern across BOTH domains; closes the tunnel-forwards-
+  # but-404 gap; ADR-15 ADD-THEN-DROP add-half). See ingressroute.yaml.
+  - ingressroute.yaml
+  # CONTRACT: allow the SHARED apps-ingress (ns traefik-apps) to reach verdify-api:8080.
+  # The base allow-api-from-ingress only names the k3s built-in "traefik" ns + the
+  # apps VLAN ipBlock, neither of which matches the traefik-apps pod source IP. flannel
+  # does not enforce NetworkPolicy today, but this keeps the contract correct under the
+  # planned Cilium re-CNI (ADR-17). See allow-api-from-apps-ingress.yaml.
+  - allow-api-from-apps-ingress.yaml
 
 # Instance patches.
 patches:


### PR DESCRIPTION
## What

Builds the conformant ADR-15 / Model B' front door for Verdify: each public host is **Host-routed THROUGH the shared apps-ingress Traefik** (`traefik-apps`, VIP `192.168.7.10`), the same one-pattern `gravity-ui`/`pihole-web` use — now applied to **BOTH** domains:

- `verdify.vallery.net` / `verdify-staging.vallery.net` -> `verdify-api:8080` (closes the cloudflared *tunnel-forwards-but-404* gap)
- `api.verdify.ai` -> `verdify-api:8080` (the product-domain anchor — the one `*.verdify.ai` host with a ready k8s backend)

Adds:
- `verdify-strip-identity-headers` Middleware (mirrors gravity/pihole) so the api never trusts spoofed forward-auth identity at the edge.
- `allow-api-from-apps-ingress` NetworkPolicy so the `ns traefik-apps -> verdify-api:8080` hop is allowed under an enforcing CNI (flannel does not enforce today; this keeps the contract correct under the planned Cilium re-CNI, ADR-17).

This is the **ADD** half of ADR-15 ADD-THEN-DROP for `verdify-api`: route through the shared `.7.10` apps-ingress instead of the per-app `.7.21` LoadBalancer. The `.7.21` LB (already ETP=Cluster after #106) is the documented anti-pattern to DROP once these routes are proven.

## Validation
`kubectl kustomize deploy/k8s/overlays/staging` builds cleanly (19 resources, no name collision). Datapath proven from a LAN client: `curl -k -H 'Host: gravity-k3s.vallery.net' https://192.168.7.10/` = 302 in 38ms; `Host: api.verdify.ai` = 404 **before** this route (Traefik 404s the unknown Host) -> reaches real `verdify-api` after.

## Residual gates (flagged, NOT blocking HTTP)
- **`*.verdify.ai` TLS**: `tls: {}` serves the Traefik default cert. The valid wildcard `*.verdify.ai` does not exist (cert-manager `letsencrypt-dns01` solver is `dnsZones:[vallery.net]` only; no verdify.ai Cloudflare DNS-01 token). Gate = obtain the verdify.ai CF token + add a verdify.ai zone solver + `wildcard-verdify-ai` Certificate.
- **Remaining `*.verdify.ai` hosts** (lab/labs/graphs/www/apex) are staged as commented shapes, **blocked-on-backend** until their k8s Services exist (still docker-compose on vm-docker-web).

Refs jvallery/agents#361

🤖 Generated with [Claude Code](https://claude.com/claude-code)