### PR TITLE
feat(staging): migrate verdify-db PVC local-path -> synology-iscsi-ssd (worker, frees node1)

### DIFF
--- a/deploy/k8s/overlays/staging/db-storageclass-iscsi.yaml
+++ b/deploy/k8s/overlays/staging/db-storageclass-iscsi.yaml
@@ -1,0 +1,36 @@
+# STAGING-ONLY storage migration: move verdify-db off the node-pinned local-path
+# PVC onto the proven synology-iscsi-ssd StorageClass (csi.san.synology.com,
+# /volume1 SSD, reclaim=Retain, WaitForFirstConsumer, expandable).
+#
+# WHY a staging-overlay patch and NOT a base edit: the base
+# db-statefulset.yaml volumeClaimTemplate (storageClassName: local-path) is
+# shared by BOTH overlays/staging AND overlays/prod. Editing the base would
+# silently retarget prod's DB storage too. Prod is OUT OF SCOPE for this
+# migration and MUST stay on its base local-path until its own gated cutover, so
+# the SC override lives here, in the staging overlay, only.
+#
+# volumeClaimTemplate.spec.storageClassName is IMMUTABLE on a live StatefulSet:
+# applying this patch is necessarily paired with a delete+recreate of the STS
+# (and its old PVC + released PV) so ArgoCD recreates verdify-db-0 with a fresh
+# synology-iscsi-ssd PVC that binds when the pod schedules onto a WORKER (node1
+# is cordoned to return it to etcd-only isolation). Data is preserved via the
+# verified preflight pg_dump on NAS-backed /mnt/jason and restored post-recreate
+# (timescaledb_pre/post_restore), NOT carried on the volume.
+#
+# The whole volumeClaimTemplate list element is restated (kustomize strategic
+# merge keys volumeClaimTemplates by metadata.name and replaces the matched
+# element) so accessModes + storage size are preserved alongside the new SC.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: verdify-db
+spec:
+  volumeClaimTemplates:
+    - metadata:
+        name: db-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: synology-iscsi-ssd
+        resources:
+          requests:
+            storage: 50Gi

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -57,6 +57,13 @@ patches:
   # DEVICE-WRITE INTERLOCK (#79): explicit VERDIFY_DEVICE_WRITE_ENABLED=0 in
   # staging (the only place it is NOT 1). See device-write-configmap.yaml.
   - path: device-write-configmap.yaml
+  # STORAGE MIGRATION (staging-only): move verdify-db off node-pinned local-path
+  # onto synology-iscsi-ssd so the DB lands on a WORKER and frees node1 to
+  # etcd-only isolation. STS volumeClaimTemplate.storageClassName is immutable,
+  # so committing this is paired with a STS+PVC+PV delete/recreate; data is
+  # preserved via the verified preflight pg_dump, not the volume. Prod stays on
+  # base local-path. See db-storageclass-iscsi.yaml.
+  - path: db-storageclass-iscsi.yaml
 
 # Image digest pins. Canonical namespace is
 # ghcr.io/verdifyconsultancy/verdify-{api,mcp,ingestor,migrate}, immutable @sha256


### PR DESCRIPTION
## What

Migrate the **staging** TimescaleDB (`verdify-db` StatefulSet, ns `verdify-staging`) off the node1-pinned `local-path` PVC onto the proven **`synology-iscsi-ssd`** StorageClass (`csi.san.synology.com`, `/volume1` SSD, reclaim=Retain, WaitForFirstConsumer, expandable) so `verdify-db-0` schedules onto a **worker** (node4/5) and `vm-k3s-node1` can be cordoned back to **etcd-only isolation**.

## Why a staging-overlay patch (NOT a base edit)

`deploy/k8s/base/db-statefulset.yaml` (`storageClassName: local-path`) is shared by **both** `overlays/staging` and `overlays/prod`. Editing the base would silently retarget **prod**'s DB storage. Prod is out of scope and must stay on `local-path` until its own gated cutover, so the SC override lives only in the staging overlay (`db-storageclass-iscsi.yaml`).

Verified by local `kustomize build`:
- staging STS -> `storageClassName: synology-iscsi-ssd`
- prod STS    -> `storageClassName: local-path` (unchanged)

## Immutability + data safety

`volumeClaimTemplate.spec.storageClassName` is immutable on a live STS, so applying this is paired with a `STS + old PVC + released local-path PV` delete/recreate (ArgoCD `verdify-local-staging`, selfHeal=true, recreates with the new template). Data is **NOT** carried on the volume — it is preserved via a verified preflight `pg_dump -Fc` on NAS-backed `/mnt/jason` and restored post-recreate using `timescaledb_pre_restore()/post_restore()`. Brief staging DB downtime during recreate is expected and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)