### PR TITLE
ci: wire device-write safety gate test into CI (make #71 interlock PR-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,26 @@ jobs:
       - name: Database smoke tests (against CI Postgres)
         run: VERDIFY_DB_QUERY_MODE=direct pytest tests/test_02_database.py::TestSchemaIntegrity -q
 
+  device-write-gate:
+    name: Device-Write Safety Gate (single-writer interlock)
+    runs-on: ubuntu-latest
+    # Layer-3 of the #71 single-writer interlock. The ingestor must NEVER drive
+    # the physical ESP32 unless VERDIFY_DEVICE_WRITE_ENABLED == '1' (default-deny);
+    # this lets a k3s STAGING ingestor exist with zero risk to the live greenhouse.
+    # tests/test_device_write_gate.py mocks the aioesphomeapi client and asserts
+    # ZERO device writes when the gate is off. PR-blocking: a regression that
+    # re-opens push_to_esp32 / push_occupancy_to_esp32 with the gate off fails
+    # here. No Postgres / no device contact — every write path is mocked.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Python deps
+        run: pip install "pydantic>=2.8" pytest pyyaml
+      - name: Device-write gate tests (mocked client, default-deny)
+        run: pytest tests/test_device_write_gate.py -v
+
   firmware:
     name: Firmware Compile Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #131. Part of #71 (epic:device-safety). Handle: IRIS-W011b.

## What & why
Layer-3 of the #71 single-writer interlock shipped with #79 (`tests/test_device_write_gate.py`, 8 tests: gate off -> zero device calls; gate on -> pass-through), but **no workflow referenced it**. `ci.yml` ran only `verdify_schemas/tests/` + `tests/test_02_database.py::TestSchemaIntegrity`, so a regression re-opening `push_to_esp32` / `push_occupancy_to_esp32` with `VERDIFY_DEVICE_WRITE_ENABLED` off would **not** have failed CI.

## Change (purely additive, test-only, no device contact)
New dedicated PR-blocking CI job `device-write-gate` in `.github/workflows/ci.yml`:
```yaml
device-write-gate:
  name: Device-Write Safety Gate (single-writer interlock)
  ...
  - name: Device-write gate tests (mocked client, default-deny)
    run: pytest tests/test_device_write_gate.py -v
```
Standalone job (no Postgres, no device) — the test mocks the `aioesphomeapi` client via `MagicMock`, so there is zero device contact and the device-safety enforcement is explicit in the checks UI. +20 lines, single file.

## Validation (UTC)
- **Before** (2026-06-01 15:55:33Z): `grep -rn test_device_write .github/` -> NO hit (unenforced, as reported).
- **Clean-tree green** (15:55:50Z): `pytest tests/test_device_write_gate.py -v` -> `8 passed in 4.78s`.
- **Regression proof** (15:56:06Z): forced the gate open locally (`_device_writes_enabled` -> `return True`) and re-ran -> `5 failed, 3 passed` (the off-path no-op assertions fail when a device write path is re-opened). Restored the file; tree clean.
- **After** (15:57:02Z): `grep -rn test_device_write .github/` -> hit at `ci.yml:303` (`run: pytest tests/test_device_write_gate.py -v`). DoD met.
- **Re-probe** (15:57:19Z -> 15:57:24Z): exact CI command `pytest tests/test_device_write_gate.py -v` -> `8 passed`, exit 0.
- `make lint` (ruff) -> All checks passed (15:57:13Z).
- `make test` full suite (15:57:30Z -> 15:59:49Z): `587 passed, 2 skipped, 10 errors, 1 failed`. All failures are pre-existing environment issues unrelated to this change: 10 `test_04_planner.py::TestContextGathering` errors are "role 'test' does not exist" (no live DB in this worktree) and 1 `test_07_cron_replan.py` failure is a live-data assertion ("61 active lessons"). The device-write gate test passed within the run. This change is CI-YAML-only and cannot affect those tests.

`ci.yml` parses cleanly; jobs now include `device-write-gate` with all 4 steps.

## DoD check
- [x] A PR that removes/breaks the gate fails CI (proven: forced-open -> 5 failed).
- [x] A clean tree is green (8 passed).
- [x] `grep test_device_write .github/` returns a hit.

requested-by: iris (shared territory — coordinator review before merge)

Note on `needs:jason`: per the issue body this is `deps:none`, purely additive + test-gated coordinator-review of shared CI — NOT a device-execution hard-gate decision. No device path touched.

## Post-merge restart
None. No runtime/service code touched (`mcp/server.py`, `verdify_schemas/**`, `ingestor/entity_map.py` unchanged) — CI-config only, no service bounce required.
