### PR TITLE
refactor(ingestor): retire _parse_float; route through HAEntityState.as_float() (#48)

### DIFF
--- a/ingestor/ingestor.py
+++ b/ingestor/ingestor.py
@@ -89,6 +89,7 @@ from verdify_schemas import (
     Diagnostics,
     EquipmentStateEvent,
     ESP32LogRow,
+    HAEntityState,
     OverrideEvent,
     SetpointChange,
     SetpointSnapshot,
@@ -422,14 +423,19 @@ async def write_state_transitions(pool: asyncpg.Pool, ts: datetime) -> set[str]:
     return {entity for _, entity, _ in validated}
 
 
-def _parse_float_state(value: str | None) -> float | None:
-    if value is None or value == "" or value == "none":
+def _finite_state_float(value: str | None) -> float | None:
+    """Parse a system_state string to a finite float, or None.
+
+    Routes the parse through the shared ``HAEntityState.as_float()`` contract
+    (handles unavailable / non-numeric values) and additionally rejects
+    non-finite results (inf/nan), which must never reach DB float columns.
+    """
+    if value is None:
         return None
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
+    parsed = HAEntityState(entity_id="system_state", state=value).as_float()
+    if parsed is None or not math.isfinite(parsed):
         return None
-    return parsed if math.isfinite(parsed) else None
+    return parsed
 
 
 def _parse_json_object(value: str | None) -> dict[str, Any]:
@@ -516,8 +522,8 @@ async def write_climate_action_log(pool: asyncpg.Pool, ts: datetime) -> bool:
             greenhouse_id=GREENHOUSE_ID,
             climate_action=action,
             priority_axis=priority_axis,
-            temp_band_error_f=_parse_float_state(state.system.get("climate_temp_error_f")),
-            vpd_band_error_kpa=_parse_float_state(state.system.get("climate_vpd_error_kpa")),
+            temp_band_error_f=_finite_state_float(state.system.get("climate_temp_error_f")),
+            vpd_band_error_kpa=_finite_state_float(state.system.get("climate_vpd_error_kpa")),
             moisture_assist_state=moisture_state,
             moisture_zone=moisture_zone,
             wet_assist_allowed=wet_assist_allowed,
@@ -662,8 +668,8 @@ async def write_climate_action_log(pool: asyncpg.Pool, ts: datetime) -> bool:
             ts,
             action,
             priority_axis,
-            _parse_float_state(state.system.get("climate_temp_error_f")),
-            _parse_float_state(state.system.get("climate_vpd_error_kpa")),
+            _finite_state_float(state.system.get("climate_temp_error_f")),
+            _finite_state_float(state.system.get("climate_vpd_error_kpa")),
             moisture_state,
             moisture_zone,
             wet_assist_allowed,

--- a/ingestor/tasks.py
+++ b/ingestor/tasks.py
@@ -813,15 +813,6 @@ def _ha_state(states: dict[str, dict], eid: str) -> HAEntityState | None:
         return None
 
 
-def _parse_float(s) -> float | None:
-    if s in ("unavailable", "unknown", "None", "", None):
-        return None
-    try:
-        return float(s)
-    except (ValueError, TypeError):
-        return None
-
-
 def _fetch_ha_entity(token: str, entity_id: str) -> dict | None:
     """Fetch a single HA entity state (blocking — run in executor for batch)."""
     url = f"{HA_URL}/api/states/{entity_id}"


### PR DESCRIPTION
Closes #48

## What
Pure code-health, behavior-preserving refactor (no device path). Retires the two `_parse_float*` helpers in the ingestor and routes float parsing through the shared `HAEntityState.as_float()` contract.

- `ingestor/tasks.py`: delete dead `_parse_float()` — it had **zero callers** and its body was byte-for-byte equivalent to `HAEntityState.as_float()`.
- `ingestor/ingestor.py`: rename `_parse_float_state` -> `_finite_state_float` and route its core parse through `HAEntityState.as_float()`, preserving the existing finite-value (`inf`/`nan`) guard required for the `temp_band_error_f` / `vpd_band_error_kpa` DB float columns. The 4 call sites in `write_climate_action_log` are updated in place.

After this change `grep -rn _parse_float ingestor/` is empty (the issue's success criterion).

## Behavioral equivalence
Verified old vs new for: `None`, `''`, `'none'`, `'None'`, `'unavailable'`, `'unknown'`, `'1.5'`, `'-3.0'`, `'0'`, `'inf'`, `'-inf'`, `'nan'`, `'abc'`, `'  2.5 '` — all inputs map to identical outputs. (The lowercase-`'none'` and capital-`'None'` and inf/nan edge cases are all preserved.)

## Validation (UTC)
- **Before-probe** `2026-06-01 15:56:03Z`: `grep -rn _parse_float ingestor/` returned 6 hits (ingestor.py: def + 4 callers = 5; tasks.py: 1 dead def).
- **After-probe** `2026-06-01 15:56:35Z`: `grep -rn _parse_float ingestor/` empty (exit 1). **Re-probe** post-commit confirmed empty.
- `make lint` `15:56:38Z`: **All checks passed!**
- Targeted tests `15:56:42Z`: `pytest -k "float or ingest or climate_action or as_float or external"` -> **57 passed**.
- Module tests `15:56:56Z`: `tests/test_05_ingestor.py` + `verdify_schemas/tests/test_external.py` -> **21 passed**.
- Climate-action-log contract tests `15:57:04Z`: `pytest test_12_fidelity.py -k "climate_action or climate_authority or band"` -> **16 passed**.
- Full `make test` `15:57:24Z`: **570 passed, 2 skipped, 1 failed**. The single failure is `test_planner_lessons_not_excessive` (61 active `planner_lessons` rows > 50 cleanup threshold) — a pre-existing, unrelated DB-data-state assertion in the planner/genai domain. **Confirmed it fails identically on `live/platform-main` with this change stashed** (`16:00:33Z`); it does not reference `_parse_float`, float parsing, or any file in this diff.

## Device safety
No device path. No live ingestor/setpoint/mcp run against the device. Single-writer interlock untouched.

## Scope / restart
Iris-owned ingestor scope only (`ingestor/ingestor.py`, `ingestor/tasks.py`). Did **not** touch `mcp/server.py`, `verdify_schemas/**`, or `ingestor/entity_map.py`, so rule-7 schema-restart doc is not triggered. Standard ingestor service bounce (`verdify-ingestor`) applies on deploy as for any ingestor source change.
