### PR TITLE
ci: repair k8s-manifests.yml ingestion failure (paths+paths-ignore on same event)

### DIFF
--- a/.github/workflows/k8s-manifests.yml
+++ b/.github/workflows/k8s-manifests.yml
@@ -23,17 +23,22 @@ on:
     branches:
       - live/platform-main
       - main
+    # INGESTION FIX (#126): GitHub rejects a workflow that puts BOTH `paths:` and
+    # `paths-ignore:` on the SAME event ("You cannot use both the paths and
+    # paths-ignore filters for the same event") — the rejection surfaces as a
+    # completed-FAILURE run with zero jobs ("This run likely failed because of a
+    # workflow file issue"), which is exactly how this gate was silently dead on
+    # every live/platform-main push. We express the #78 loop-break as a single
+    # `paths:` list with a trailing `!` negation instead. Per GitHub glob rules a
+    # later pattern overrides an earlier one, so a push whose diff is ENTIRELY
+    # under overlays/staging/** nets to "no match" (skipped, breaking the
+    # container-publish digest-bump rebuild loop), while a push that ALSO touches
+    # base/, overlays/prod/, argocd/, diagnostics/, or any non-staging path still
+    # matches and is validated. Same intent as the old paths-ignore, legal syntax.
     paths:
       - "deploy/k8s/**"
       - ".github/workflows/k8s-manifests.yml"
-    # LOOP-BREAK companion (#78): container-publish's bump-staging-digests job
-    # commits @sha256 digests back into overlays/staging/kustomization.yaml on
-    # every live/platform-main publish. That commit always kustomize-renders
-    # clean, so revalidating it here is pure noise. Ignore it. A push that ALSO
-    # touches base/, overlays/prod/, diagnostics/, or any non-staging-overlay
-    # path still matches `paths:` and is validated.
-    paths-ignore:
-      - "deploy/k8s/overlays/staging/**"
+      - "!deploy/k8s/overlays/staging/**"
   pull_request:
     branches:
       - live/platform-main


### PR DESCRIPTION
Closes #126

## Root cause (the zero-jobs ingestion failure)

`k8s-manifests.yml` completed-FAILURE with **zero jobs** on every push to `live/platform-main`. The YAML parses and the local kustomize/kubeconform render passes, so this was a GitHub workflow-file **ingestion rejection**, not a validation error.

The `push` trigger declared **both `paths:` and `paths-ignore:` on the same event**. GitHub documents this as illegal — "You cannot use both the `paths` and `paths-ignore` filters for the same event" — and rejects the workflow at ingestion, surfacing as exactly the zero-jobs / completed-failure / "This run likely failed because of a workflow file issue" signature.

`actionlint` v1.7.1 confirms the diagnosis on the **original** file and points at the fix:

```
35:5: both "paths" and "paths-ignore" filters cannot be used for the same event "push". note: use '!' to negate patterns [events]
```

Bisect of the `on:`/`jobs:` block clears the other two suspects:
- the bare `workflow_dispatch:` null entry is **not** the cause — `ci.yml` and `promote-diff-guard.yml` use the same bare null and run jobs fine;
- `container-publish.yml` uses `paths-ignore` **alone** on its push and runs fine.
The only workflow combining the two filters is the only one failing at ingestion.

## Fix

Collapse the push trigger to a single `paths:` list with a trailing `!` negation (the GitHub-idiomatic include+exclude on one event). Semantics are identical to the old `paths-ignore` (a later glob overrides an earlier one):
- a push whose diff is entirely under `overlays/staging/**` nets to no-match and is skipped — **the #78 container-publish digest-bump loop-break is preserved**;
- a push touching `base/`, `overlays/prod/`, `argocd/`, `diagnostics/`, or any other `deploy/k8s/**` path still matches and is validated.

The kustomize/kubeconform `validate` job is **untouched** — validation strength is preserved. Diff is one file, `on.push.paths` only.

## Evidence (no bare-green; UTC timestamps via `date -u`)

**BEFORE** (broken, re-probed 2026-06-01T15:54Z):
`gh run view 26754926502` (HEAD eecb05f, push 2026-06-01T12:29:07Z) -> `conclusion=failure, status=completed, jobs=[]` (zero jobs, ingestion rejection).
`actionlint /tmp/k8s-orig.yml` -> EXIT=1, flags line 35 `paths`+`paths-ignore` combo.

**AFTER** (fixed file, local):
- `actionlint` on committed `HEAD:.github/workflows/k8s-manifests.yml` -> EXIT=0.
- `python3 -c yaml.safe_load` -> parses; push trigger has `paths` only, no `paths-ignore`.
- kustomize v5.4.3 + kubeconform v0.6.7 mirror of the CI steps -> base (14 resources Valid), overlays dev (20 Valid/3 skipped), prod (31 Valid/1 skipped), staging (20 Valid/3 skipped). Validation intact.

**RE-PROBE (live run, the acceptance check — jobs>0 with a real validate result):**
- Triggered `workflow_dispatch` on `iris/126-repair-k8s-manifests-ingestion` at 2026-06-01T16:00:12Z -> **run 26766351406** (headSha 70ff6e1).
- Progression: `queued` -> `in_progress jobs=1` (16:00:32Z) -> **`completed jobs=1` conclusion=success** (16:00:45Z). No longer a zero-jobs ingestion failure.
- Job "Render and validate manifests" = success; every step ran for real: Install kustomize -> Install kubeconform -> Build and validate base -> Build and validate overlays, all success. This is a genuine validate result, not an ingestion bypass.

Note on the push-event leg of the DoD: the `push` trigger is intentionally scoped to branches `live/platform-main` and `main`, so it cannot fire on this feature branch (correct). The original failure occurred at *ingestion*, which precedes branch/event evaluation; fixing ingestion fixes all three triggers. The push trigger now carries the same legal `paths`-only shape as the already-working `pull_request` trigger and `container-publish.yml`. After merge to `live/platform-main`, the next push touching `deploy/k8s/**` outside `overlays/staging/**` (e.g. an `argocd/apps/**` change like eecb05f) will produce a real `jobs>0` run. A 24h settling re-probe should be captured post-merge.

## Local checks
- `make lint` -> All checks passed (no Python touched).
- `make test` -> 587 passed, 2 skipped; the only failures are environmental and unrelated to a YAML workflow change: 10 ERRORS in `test_04_planner.py::TestContextGathering` (no test DB: `role "test" does not exist`) and 1 FAILED `test_07_cron_replan.py::test_planner_lessons_not_excessive` (live-data assertion `61 active lessons <= 50`). None reference `.github/`.

## Coordination
requested-by: iris (shared territory — coordinator review before merge)
`.github/workflows/**` is shared infra per CLAUDE.md; landing as a PR for coordinator/James review, not an autonomous merge. No `mcp/server.py` / `verdify_schemas/**` / `ingestor/entity_map.py` touched -> no service bounce required (rule 7 n/a). No device contact.

Part of #69 (epic:cicd-green). Handle: IRIS-W001.
