### PR TITLE
K3S-2: ingestor SHADOW_MODE write-suppression + ingestor-healthz probe (#25)

### DIFF
--- a/ingestor/config.py
+++ b/ingestor/config.py
@@ -82,6 +82,15 @@ HERMES_URL = os.environ.get("HERMES_URL", "http://127.0.0.1:8642")
 HERMES_API_KEY = os.environ.get("HERMES_IRIS_API_KEY", "")
 HERMES_SESSION_PREFIX = os.environ.get("HERMES_SESSION_PREFIX", "hermes:iris:main")
 
+# ── Shadow mode (safe parallel-run guard) ─────────────────────────
+# When ON, the ingestor still consumes and parses all telemetry but suppresses
+# EVERY write: all DB INSERT/UPDATE/DELETE, all aioesphomeapi number/switch
+# device commands, and any state publish. Default OFF == zero behavior change
+# to the live single-writer. This is the hard pre-condition for running a
+# second (cluster) ingestor against the live DB/ESP32 without double-writing
+# telemetry or double-actuating the device. See K3S-2 / design §4.2.
+SHADOW_MODE = os.environ.get("VERDIFY_SHADOW_MODE", "").strip().lower() in {"1", "true", "yes", "on"}
+
 # ── Greenhouse ────────────────────────────────────────────────────
 GREENHOUSE_ID = os.environ.get("GREENHOUSE_ID", "vallery")
 LATITUDE = float(os.environ.get("LATITUDE", "40.1672"))

--- a/ingestor/esp32_push.py
+++ b/ingestor/esp32_push.py
@@ -72,6 +72,13 @@ async def push_to_esp32(changes: list[tuple[str, float, str]]) -> int:
     Returns:
         Count of successfully pushed changes. Returns 0 when disconnected.
     """
+    if shared.is_shadow_mode():
+        # SHADOW_MODE: never touch the device. This is the single chokepoint for
+        # all aioesphomeapi number_command/switch_command writes (RT setpoint
+        # listener, occupancy, dispatcher, reconnect reconcile all route here).
+        log.info("SHADOW_MODE: suppressed ESP32 push of %d change(s)", len(changes))
+        return 0
+
     # Device-write gate (#79): default-deny. No-op without a physical write when
     # VERDIFY_DEVICE_WRITE_ENABLED != '1'.
     if not _device_writes_enabled():

--- a/ingestor/ingestor-healthz.py
+++ b/ingestor/ingestor-healthz.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""ingestor-healthz.py — climate-freshness liveness/readiness probe.
+
+Checks how stale the most recent ``climate`` row is and exits non-zero when the
+ingestor has stopped persisting telemetry. Reuses the same freshness contract as
+the API ``/health`` endpoint (``SELECT extract(epoch FROM now() - max(ts)) FROM
+climate``; stale at > 300 s).
+
+Designed for a k3s liveness/readiness probe — exec form, no HTTP server needed:
+
+    livenessProbe:
+      exec:
+        command: ["python", "ingestor/ingestor-healthz.py"]
+      initialDelaySeconds: 60     # let a fresh ingestor connect + write one row
+      periodSeconds: 30
+      failureThreshold: 5         # ~150 s of staleness before restart
+      timeoutSeconds: 10
+
+Exit codes:
+    0  fresh   — max(ts) within the freshness window (or override)
+    1  stale   — no rows, or max(ts) older than the freshness window
+    2  error   — could not connect / query the database
+
+SHADOW_MODE note: this probe only READS (``max(ts)``); it never writes the DB or
+touches the device, so it is safe to run against the live DB from a shadow pod.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import asyncpg
+
+from config import DB_DSN
+
+# Same threshold the API /health endpoint uses to mark the ingestor "stale".
+DEFAULT_FRESHNESS_S = 300
+
+
+async def climate_age_seconds(dsn: str, timeout: float) -> float | None:
+    """Return seconds since the most recent climate row, or None if empty.
+
+    Reuses the API freshness query verbatim so the cluster probe and the API
+    health report agree on what "fresh" means.
+    """
+    conn = await asyncpg.connect(dsn, timeout=timeout)
+    try:
+        return await conn.fetchval("SELECT extract(epoch FROM now() - max(ts))::float FROM climate")
+    finally:
+        await conn.close()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ingestor climate-freshness probe")
+    parser.add_argument(
+        "--max-age",
+        type=float,
+        default=DEFAULT_FRESHNESS_S,
+        help=f"Stale threshold in seconds (default: {DEFAULT_FRESHNESS_S})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="DB connect/query timeout in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the human-readable status line (exit code only)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        age = asyncio.run(climate_age_seconds(DB_DSN, args.timeout))
+    except Exception as e:  # connection refused, auth, timeout, etc.
+        if not args.quiet:
+            print(f"ingestor-healthz: ERROR querying climate freshness: {e}", file=sys.stderr)
+        return 2
+
+    if age is None:
+        if not args.quiet:
+            print("ingestor-healthz: STALE — climate table is empty", file=sys.stderr)
+        return 1
+
+    if age > args.max_age:
+        if not args.quiet:
+            print(
+                f"ingestor-healthz: STALE — climate is {age:.0f}s old (> {args.max_age:.0f}s)",
+                file=sys.stderr,
+            )
+        return 1
+
+    if not args.quiet:
+        print(f"ingestor-healthz: OK — climate is {age:.0f}s old (<= {args.max_age:.0f}s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ingestor/ingestor.py
+++ b/ingestor/ingestor.py
@@ -2163,6 +2163,10 @@ async def main() -> None:
     assert_modes_consistent()
 
     pool = await asyncpg.create_pool(DB_DSN, min_size=2, max_size=10)
+    # SHADOW_MODE: wrap the pool so every acquired connection suppresses write
+    # SQL while still serving reads (freshness probe, config load). Default-off
+    # returns the pool unchanged — zero behavior change to the live writer.
+    pool = shared.wrap_pool_for_shadow(pool)
     log.info("DB connection pool ready")
 
     # ── #114: subscribe mode (dev/stage) — ingest FROM prod's fan-out bus ─────

--- a/ingestor/shared.py
+++ b/ingestor/shared.py
@@ -1,6 +1,138 @@
 """shared.py — Shared mutable state between ingestor and tasks."""
 
 import asyncio
+import logging
+
+log = logging.getLogger("shadow")
+
+
+def is_shadow_mode() -> bool:
+    """True when VERDIFY_SHADOW_MODE is set — suppress ALL writes.
+
+    Read through config so the flag has a single source of truth and tests can
+    monkeypatch config.SHADOW_MODE without re-importing this module.
+    """
+    try:
+        import config
+
+        return bool(config.SHADOW_MODE)
+    except Exception:
+        return False
+
+
+# SQL statements that mutate the DB. Shadow mode no-ops these while letting
+# reads (SELECT / WITH ... SELECT, fetch*) pass straight through, so freshness
+# probes and config loads still work during a parallel telemetry run.
+_WRITE_PREFIXES = (
+    "insert",
+    "update",
+    "delete",
+    "merge",
+    "copy",
+    "truncate",
+    "drop",
+    "alter",
+    "create",
+)
+
+
+def _is_write_sql(query: str) -> bool:
+    """Classify a SQL string as a mutating statement.
+
+    Skips leading whitespace and SQL line comments so that e.g. an indented
+    ``INSERT`` or a ``WITH x AS (...) INSERT`` is still recognized as a write.
+    """
+    if not isinstance(query, str):
+        return True  # be conservative: unknown shape -> treat as a write
+    stripped = query.lstrip()
+    while stripped.startswith("--"):
+        nl = stripped.find("\n")
+        if nl == -1:
+            return False
+        stripped = stripped[nl + 1 :].lstrip()
+    lowered = stripped.lower()
+    if lowered.startswith(_WRITE_PREFIXES):
+        return True
+    # CTEs may wrap a writing statement: WITH ... INSERT/UPDATE/DELETE ...
+    if lowered.startswith("with "):
+        return any(f" {kw} " in lowered or f"\n{kw} " in lowered for kw in ("insert", "update", "delete"))
+    return False
+
+
+class _ShadowConnection:
+    """Wraps an asyncpg connection so write statements become no-ops.
+
+    Reads (fetch/fetchval/fetchrow/cursor) and connection lifecycle delegate to
+    the real connection unchanged. Only execute/executemany/copy* are gated.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def execute(self, query, *args, **kwargs):
+        if _is_write_sql(query):
+            log.debug("SHADOW_MODE: suppressed execute: %.60s", query.lstrip() if isinstance(query, str) else query)
+            return "SHADOW"
+        return await self._conn.execute(query, *args, **kwargs)
+
+    async def executemany(self, query, args, **kwargs):
+        if _is_write_sql(query):
+            log.debug("SHADOW_MODE: suppressed executemany: %.60s", query.lstrip() if isinstance(query, str) else query)
+            return None
+        return await self._conn.executemany(query, args, **kwargs)
+
+    async def copy_records_to_table(self, *args, **kwargs):
+        log.debug("SHADOW_MODE: suppressed copy_records_to_table")
+        return "SHADOW"
+
+    async def copy_to_table(self, *args, **kwargs):
+        log.debug("SHADOW_MODE: suppressed copy_to_table")
+        return "SHADOW"
+
+    def __getattr__(self, name):
+        # Everything else (fetch, fetchval, fetchrow, cursor, transaction,
+        # add_listener, prepare, set_type_codec, ...) passes through.
+        return getattr(self._conn, name)
+
+
+class _ShadowAcquireContext:
+    """Async-context wrapper around pool.acquire() yielding a _ShadowConnection."""
+
+    def __init__(self, acquire_ctx):
+        self._ctx = acquire_ctx
+
+    async def __aenter__(self):
+        conn = await self._ctx.__aenter__()
+        return _ShadowConnection(conn)
+
+    async def __aexit__(self, *exc):
+        return await self._ctx.__aexit__(*exc)
+
+
+class _ShadowPool:
+    """Wraps an asyncpg pool so every acquired connection is write-suppressed.
+
+    Single DB chokepoint for SHADOW_MODE: all ingestor writes go through
+    ``async with pool.acquire() as conn: await conn.execute(...)``.
+    """
+
+    def __init__(self, pool):
+        self._pool = pool
+
+    def acquire(self, *args, **kwargs):
+        return _ShadowAcquireContext(self._pool.acquire(*args, **kwargs))
+
+    def __getattr__(self, name):
+        return getattr(self._pool, name)
+
+
+def wrap_pool_for_shadow(pool):
+    """Return a write-suppressing proxy when SHADOW_MODE is on, else the pool."""
+    if is_shadow_mode():
+        log.warning("SHADOW_MODE active: ALL ingestor DB writes are suppressed (telemetry consume/parse only)")
+        return _ShadowPool(pool)
+    return pool
+
 
 # ESP32 client reference, set by esp32_loop in ingestor.py
 # Used by dispatcher in tasks.py for direct setpoint push

--- a/tests/test_14_shadow_mode.py
+++ b/tests/test_14_shadow_mode.py
@@ -1,0 +1,261 @@
+"""Shadow-mode write-suppression regression tests (K3S-2 / issue #25).
+
+SHADOW_MODE (env VERDIFY_SHADOW_MODE) must suppress EVERY write — all DB
+INSERT/UPDATE/DELETE, all aioesphomeapi number/switch device commands — while
+still consuming/parsing telemetry. Default OFF must leave the live writer
+behavior unchanged. These tests mock the ESP32 client and the asyncpg
+connection so they run without a live device or DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INGESTOR_PATH = str(REPO_ROOT / "ingestor")
+if INGESTOR_PATH not in sys.path:
+    sys.path.insert(0, INGESTOR_PATH)
+
+
+class _RecordingClient:
+    """ESP32 client stub that records every command (and must NOT be called in shadow)."""
+
+    def __init__(self) -> None:
+        self.commands: list[tuple] = []
+
+    def number_command(self, key, val):
+        self.commands.append(("number", key, val))
+
+    def switch_command(self, key, state):
+        self.commands.append(("switch", key, state))
+
+
+class _RecordingConn:
+    """asyncpg connection stub recording which statements actually executed."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.executed_many: list[str] = []
+        self.fetchval_calls: list[str] = []
+
+    async def execute(self, query, *args, **kwargs):
+        self.executed.append(query)
+        return "INSERT 0 1"
+
+    async def executemany(self, query, args, **kwargs):
+        self.executed_many.append(query)
+        return None
+
+    async def fetchval(self, query, *args, **kwargs):
+        self.fetchval_calls.append(query)
+        return 42
+
+    async def fetch(self, query, *args, **kwargs):
+        self.fetchval_calls.append(query)
+        return []
+
+
+class _RecordingAcquire:
+    def __init__(self, conn: _RecordingConn) -> None:
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _RecordingPool:
+    def __init__(self, conn: _RecordingConn) -> None:
+        self.conn = conn
+
+    def acquire(self, *args, **kwargs):
+        return _RecordingAcquire(self.conn)
+
+
+# ── SQL classifier ────────────────────────────────────────────────
+
+
+def test_write_sql_classifier_flags_mutations_and_passes_reads():
+    import shared
+
+    assert shared._is_write_sql("INSERT INTO climate VALUES (1)")
+    assert shared._is_write_sql("  UPDATE setpoint_changes SET confirmed_at = now()")
+    assert shared._is_write_sql("DELETE FROM alert_log")
+    assert shared._is_write_sql("WITH y AS (SELECT 1) INSERT INTO x SELECT * FROM y")
+    assert shared._is_write_sql("COPY climate FROM STDIN")
+
+    assert not shared._is_write_sql("SELECT max(ts) FROM climate")
+    assert not shared._is_write_sql("  SELECT 1")
+    assert not shared._is_write_sql("WITH y AS (SELECT 1) SELECT * FROM y")
+    assert not shared._is_write_sql("-- comment\nSELECT 1")
+
+
+# ── DB suppression ────────────────────────────────────────────────
+
+
+def test_shadow_pool_suppresses_writes_but_allows_reads(monkeypatch):
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", True)
+
+    conn = _RecordingConn()
+    pool = shared.wrap_pool_for_shadow(_RecordingPool(conn))
+    assert isinstance(pool, shared._ShadowPool)
+
+    async def _run():
+        async with pool.acquire() as c:
+            await c.execute("INSERT INTO climate (ts) VALUES (now())")
+            await c.executemany("UPDATE setpoint_changes SET confirmed_at = now() WHERE parameter = $1", [("x",)])
+            age = await c.fetchval("SELECT extract(epoch FROM now() - max(ts))::int FROM climate")
+        return age
+
+    age = asyncio.run(_run())
+
+    # Writes never reached the real connection; the read passed straight through.
+    assert conn.executed == []
+    assert conn.executed_many == []
+    assert age == 42
+    assert conn.fetchval_calls == ["SELECT extract(epoch FROM now() - max(ts))::int FROM climate"]
+
+
+def test_shadow_pool_allows_reads_that_use_execute(monkeypatch):
+    """A non-mutating execute() (e.g. SET / SELECT) still reaches the DB."""
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", True)
+
+    conn = _RecordingConn()
+    pool = shared.wrap_pool_for_shadow(_RecordingPool(conn))
+
+    async def _run():
+        async with pool.acquire() as c:
+            await c.execute("SELECT 1")
+
+    asyncio.run(_run())
+    assert conn.executed == ["SELECT 1"]
+
+
+def test_default_off_pool_is_unwrapped_and_writes_pass_through(monkeypatch):
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", False)
+
+    conn = _RecordingConn()
+    raw_pool = _RecordingPool(conn)
+    pool = shared.wrap_pool_for_shadow(raw_pool)
+
+    # Default-off returns the exact same pool object — zero behavior change.
+    assert pool is raw_pool
+
+    async def _run():
+        async with pool.acquire() as c:
+            await c.execute("INSERT INTO climate (ts) VALUES (now())")
+            await c.executemany("UPDATE x SET a = $1", [(1,)])
+
+    asyncio.run(_run())
+    assert conn.executed == ["INSERT INTO climate (ts) VALUES (now())"]
+    assert conn.executed_many == ["UPDATE x SET a = $1"]
+
+
+# ── Device (ESP32) suppression ────────────────────────────────────
+
+
+def test_shadow_mode_suppresses_esp32_push(monkeypatch):
+    import esp32_push
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", True)
+
+    client = _RecordingClient()
+    shared.esp32["client"] = client
+    shared.esp32["keys"] = {"set_temp_low__f": 123, "greenhouse_occupied": 456}
+    shared.recently_pushed.clear()
+    shared.recently_pushed_values.clear()
+
+    pushed = asyncio.run(esp32_push.push_to_esp32([("set_temp_low__f", 64.0, "number")]))
+
+    # No device command issued, nothing marked as pushed.
+    assert pushed == 0
+    assert client.commands == []
+    assert shared.recently_pushed == {}
+    assert shared.recently_pushed_values == {}
+
+
+def test_shadow_mode_suppresses_occupancy_push(monkeypatch):
+    import esp32_push
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", True)
+
+    client = _RecordingClient()
+    shared.esp32["client"] = client
+    shared.esp32["keys"] = {"greenhouse_occupied": 456}
+    esp32_push._LAST_COMMAND_TS = 0.0
+
+    pushed = asyncio.run(esp32_push.push_occupancy_to_esp32(True, "test"))
+
+    assert pushed == 0
+    assert client.commands == []
+
+
+def test_default_off_esp32_push_still_actuates(monkeypatch):
+    import esp32_push
+    import shared
+
+    import config
+
+    monkeypatch.setattr(config, "SHADOW_MODE", False)
+    # The #79 device-write gate (default-deny) also guards this path; enable it so
+    # this test exercises the SHADOW_MODE-off actuation path, not the device gate.
+    monkeypatch.setenv("VERDIFY_DEVICE_WRITE_ENABLED", "1")
+
+    client = _RecordingClient()
+    shared.esp32["client"] = client
+    shared.esp32["keys"] = {"set_temp_low__f": 123}
+    shared.recently_pushed.clear()
+    shared.recently_pushed_values.clear()
+    esp32_push._LAST_COMMAND_TS = 0.0
+
+    pushed = asyncio.run(esp32_push.push_to_esp32([("set_temp_low__f", 64.0, "number")]))
+
+    assert pushed == 1
+    assert client.commands == [("number", 123, 64.0)]
+    assert "temp_low" in shared.recently_pushed
+
+
+# ── Static guards (no env needed) ─────────────────────────────────
+
+
+def test_shadow_mode_flag_is_default_off():
+    import config
+
+    # Default OFF: VERDIFY_SHADOW_MODE unset in the test env.
+    assert config.SHADOW_MODE is False
+
+
+def test_main_wraps_pool_for_shadow():
+    src = Path(INGESTOR_PATH, "ingestor.py").read_text()
+    assert "shared.wrap_pool_for_shadow(pool)" in src
+
+
+def test_healthz_probe_exists_and_reads_climate_freshness():
+    probe = Path(INGESTOR_PATH, "ingestor-healthz.py").read_text()
+    assert "max(ts)" in probe
+    assert "FROM climate" in probe
+    # k8s probe contract documented for the cluster ingestor.
+    assert "initialDelaySeconds: 60" in probe
+    assert "failureThreshold: 5" in probe


### PR DESCRIPTION
Closes #25

## What

Adds `VERDIFY_SHADOW_MODE` (default **OFF**) to the ingestor. When ON, the ingestor still consumes and parses all telemetry but suppresses **EVERY** write — all DB INSERT/UPDATE/DELETE, all aioesphomeapi number/switch device commands, and any state publish. This is the hard pre-condition (K3S-2 / design §4.2) for running a second (cluster) ingestor against the live DB/ESP32 without double-writing telemetry (which would corrupt the preflight `max(ts)` freshness check) or double-actuating the device.

Distinct from the shipped DEVICE_WRITE gate: that gate stops device writes only; SHADOW_MODE **also** suppresses DB + state writes.

## How (two centralized chokepoints, minimal diff)

- **DB writes** — `ingestor/shared.py` `wrap_pool_for_shadow(pool)` wraps the asyncpg pool so every acquired connection no-ops on mutating SQL (INSERT/UPDATE/DELETE/COPY/TRUNCATE/...) via `execute`/`executemany`/`copy_records_to_table`, while reads (`fetch*`, SELECT, `WITH ... SELECT`, comment-led SELECT) pass straight through. All 61 ingestor write call-sites route through `pool.acquire() -> conn.execute`, so one wrap covers them. Applied in `main()` right after `create_pool`. Default-off returns the pool object unchanged.
- **Device writes** — `ingestor/esp32_push.py` `push_to_esp32()` returns 0 in shadow mode before touching the client. Single path for all `number_command`/`switch_command` (RT setpoint listener, occupancy, dispatcher, reconnect reconcile).
- **Flag** — `ingestor/config.py` `SHADOW_MODE` from `VERDIFY_SHADOW_MODE` (accepts 1/true/yes/on).
- **`ingestor/ingestor-healthz.py`** — standalone climate-freshness probe reusing the api `/health` contract (`SELECT extract(epoch FROM now()-max(ts)) FROM climate`; stale > 300s). Read-only — safe to run from a shadow pod (never writes DB or device). Exit `0` fresh / `1` stale|empty / `2` db-error. Documented for k8s liveness `initialDelaySeconds: 60` / `failureThreshold: 5`.

Default-off == zero behavior change to the live single-writer. This change only **suppresses** the device + DB + state paths; it never writes them, keeping the single-writer interlock intact.

## Validation (UTC)

**Before** (base, 2026-06-01T16:05:59Z): `git show live/platform-main:ingestor/config.py | grep -c SHADOW_MODE` -> `0`; `ingestor-healthz.py` ABSENT at base.

**After** (2026-06-01T16:06:03Z): `grep -rc SHADOW_MODE ingestor/` -> hits in config.py(1), shared.py(10), esp32_push.py(2), ingestor-healthz.py(1), ingestor.py(1) — i.e. > 0.

- `make lint`: **All checks passed**
- `pytest tests/test_14_shadow_mode.py`: **10 passed** (SQL classifier; shadow pool suppresses writes but serves reads; default-off pool is the same object + writes pass through; shadow suppresses ESP32 setpoint + occupancy pushes with nothing marked recently_pushed; default-off still actuates; healthz contract present)
- `pytest tests/test_13_operational_recovery.py`: **12 passed** (default-off esp32_push behavior unchanged)
- healthz exit codes verified with a mocked asyncpg conn: fresh=0, stale=1, empty=1, db-error=2
- `make test`: **580 passed, 2 skipped, 1 failed**. The one failure is `tests/test_07_cron_replan.py::TestPlannerConfig::test_planner_lessons_not_excessive` (61 active planner lessons > 50) — a pre-existing live-DB **data** condition that reproduces identically on the base branch and is unrelated to this code change.

**Re-probe** (2026-06-01T16:10:38Z): `pytest tests/test_14_shadow_mode.py` -> 10 passed; grep still > 0.

## Rule 7 — service restart

Touches the ingestor write path -> **bounce `verdify-ingestor`** post-merge so the new pool-wrap / push gate take effect.

requested-by: iris (shared territory — touches the live ingestor write path; coordinator review before merge)