### PR TITLE
Close planner_graph fold residual: ClimateIntent parity + planner image artifact + DDL serialization note (#102)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -7,10 +7,21 @@ name: Container Publish
 # (jvallery/agents) desired-state promotion workflow. The repo drives the
 # deployment: push -> build -> publish -> GitOps desired-state PR -> Argo CD.
 #
-# The Verdify application is composed of three image contexts (handoff §3):
+# The Verdify application is composed of these image contexts (handoff §3):
 #   - api       (FastAPI public crop catalog + setpoints)  ./api
 #   - mcp       (MCP transport server, Iris/Hermes tools)  ./mcp
 #   - ingestor  (telemetry + single-writer setpoint dispatcher, device loop) ./ingestor
+#   - planner   (standalone LangGraph planner, folded from verdify-planner #102) ./planner_graph
+#
+# ─── PLANNER IMAGE IS ARTIFACT-ONLY (#102) ───────────────────────────────────
+#  The planner-image job below builds + publishes ghcr.io/<owner>/verdify-planner
+#  so the folded planner_graph package stops being an un-built blob, but it is
+#  DELIBERATELY NOT wired into the deploy path. It is absent from both
+#  bump-staging-digests (the overlays/staging @sha256 write-back) and
+#  request-gitops-promotion (the Agent Fleet GitOps dispatch). The planner is not
+#  yet a deployed k3s workload — this image is a build artifact only. Wiring it
+#  into the deploy path is a separate, gated change once a planner Deployment +
+#  overlay exists. NEVER add `planner-image` to those two jobs in this PR's scope.
 #
 # Image publishing is gated by reusable-container-build.yml branch rules
 # (publish only from the production branch, never from a pull_request). Pull
@@ -80,6 +91,7 @@ jobs:
       api_impact: ${{ steps.impact.outputs.api_impact }}
       mcp_impact: ${{ steps.impact.outputs.mcp_impact }}
       ingestor_impact: ${{ steps.impact.outputs.ingestor_impact }}
+      planner_impact: ${{ steps.impact.outputs.planner_impact }}
       reason: ${{ steps.impact.outputs.reason }}
     steps:
       - name: Checkout
@@ -126,6 +138,7 @@ jobs:
           api_impact=false
           mcp_impact=false
           ingestor_impact=false
+          planner_impact=false
           doc_only=true
           any_changed=false
 
@@ -158,16 +171,25 @@ jobs:
             case "$f" in
               ingestor/*|slack_config.py|slack_ops/*|verdify_schemas/*|docker-compose.yml|pyproject.toml) ingestor_impact=true ;;
             esac
+            # planner image is built from the repo root with planner_graph/Dockerfile
+            # but COPYs ONLY planner_graph/** (its own pyproject.toml + uv.lock); it
+            # does NOT COPY the shared verdify_schemas/ — the planner carries its own
+            # copied contract mirror. So a verdify_schemas/ change does not impact the
+            # planner image, unlike the other three Python images.
+            case "$f" in
+              planner_graph/*) planner_impact=true ;;
+            esac
           done < "$changed_files"
 
           if [ "$manual" = "true" ]; then
             api_impact=true
             mcp_impact=true
             ingestor_impact=true
+            planner_impact=true
           fi
 
           any_image=false
-          { [ "$api_impact" = "true" ] || [ "$mcp_impact" = "true" ] || [ "$ingestor_impact" = "true" ]; } && any_image=true
+          { [ "$api_impact" = "true" ] || [ "$mcp_impact" = "true" ] || [ "$ingestor_impact" = "true" ] || [ "$planner_impact" = "true" ]; } && any_image=true
 
           image_publish=false
           if [ "$manual" = "true" ]; then
@@ -181,7 +203,7 @@ jobs:
             reason="no image-impacting files changed; skipping image publish"
           else
             image_publish=true
-            changed="api=$api_impact mcp=$mcp_impact ingestor=$ingestor_impact"
+            changed="api=$api_impact mcp=$mcp_impact ingestor=$ingestor_impact planner=$planner_impact"
             reason="image-impacting change ($changed)"
           fi
 
@@ -191,6 +213,7 @@ jobs:
             echo "api_impact=$api_impact"
             echo "mcp_impact=$mcp_impact"
             echo "ingestor_impact=$ingestor_impact"
+            echo "planner_impact=$planner_impact"
             echo "reason=$reason"
           } >> "$GITHUB_OUTPUT"
 
@@ -201,6 +224,7 @@ jobs:
             echo "- api_impact: \`$api_impact\`"
             echo "- mcp_impact: \`$mcp_impact\`"
             echo "- ingestor_impact: \`$ingestor_impact\`"
+            echo "- planner_impact: \`$planner_impact\` (artifact-only; not deployed)"
             echo "- reason: $reason"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -276,6 +300,34 @@ jobs:
       context: .
       dockerfile: ingestor/Dockerfile
       image-name: ${{ github.repository_owner }}/verdify-ingestor
+      push: true
+      publish-branches: live/platform-main
+      build-args: |
+        GIT_SHA=${{ github.sha }}
+        GIT_REF=${{ github.ref_name }}
+      extra-tags: local-dev
+
+  planner-image:
+    name: Build and publish planner image
+    needs: image-impact
+    # ARTIFACT-ONLY (#102): build + publish the folded standalone planner image so
+    # planner_graph/ stops being an unbuilt blob. This image is intentionally NOT
+    # consumed by bump-staging-digests or request-gitops-promotion below — the
+    # planner is not yet a deployed k3s workload. Publishing the artifact is not a
+    # deploy. The 4 deploy-path images stay api/mcp/ingestor/migrate.
+    if: needs.image-impact.outputs.image_publish == 'true' && (needs.image-impact.outputs.planner_impact == 'true' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-container-build.yml
+    with:
+      # Build context = repo root (matches api/mcp/ingestor convention); the
+      # Dockerfile lives at planner_graph/Dockerfile and COPYs only planner_graph/**
+      # (its own pyproject.toml + uv.lock with langgraph etc.), NOT the repo-root
+      # pyproject or the shared verdify_schemas (the planner carries its own mirror).
+      context: .
+      dockerfile: planner_graph/Dockerfile
+      image-name: ${{ github.repository_owner }}/verdify-planner
       push: true
       publish-branches: live/platform-main
       build-args: |

--- a/docs/backlog/cross-cutting.md
+++ b/docs/backlog/cross-cutting.md
@@ -243,6 +243,35 @@ Read-only multi-axis audit covered climate/weather, HVAC/control, water/soil/nut
 - [x] **Data trust ledger dashboard.** Added provisioned Grafana dashboard `greenhouse-data-trust-ledger` on `v_data_trust_ledger`, instrumentation readiness, and daily plan archive self-checks.
 - [x] **Daily plan archive self-check.** Added `daily_plan_archive_audit`, `v_daily_plan_archive_self_check`, and writer support in `scripts/generate-daily-plan.py`.
 
+## Planner DDL serialization (follow-up to #102)
+
+The standalone planner was folded into the monorepo as `planner_graph/` (issue
+#102, commit `1113a75`). One **residual remains for the coordinator** and is
+intentionally NOT authored in the #102 PR (db migrations are serialized — one
+migration PR at a time, coordinator-approved sequence):
+
+- [ ] **C-PLN1 Fold planner DDL into the serialized `db/migrations/` chain.**
+  The planner currently provisions its own Postgres tables OUTSIDE the canonical
+  numbered migration chain, which is a data-state divergence risk before the
+  management VM is decommissioned (#91):
+  - `planner_graph_runs` (+ `planner_graph_runs_status_idx`) — created at runtime
+    by `planner_graph/store.py` via `CREATE TABLE IF NOT EXISTS` on first run.
+  - `planner_memory_items`, `planner_memory_retrievals` (+ their indexes) —
+    created at runtime by `planner_graph/memory.py` and also captured in the
+    standalone `planner_graph/migrations/001_planner_memory.sql`.
+  - `planner_memory_embeddings` — documented in `planner_graph/docs/planner-memory.md`
+    (pgvector), provisioned alongside the memory backend.
+
+  Action for the coordinator (next migration slot, NOT in #102): port the DDL in
+  `planner_graph/migrations/001_planner_memory.sql` + the `store.py`
+  `planner_graph_runs` definition into the next numbered `db/migrations/NNN-*.sql`
+  (current head is `150-vanda-nutrient-recipe.sql`), add the tables to
+  `db/schema.sql`, and decide whether the runtime `CREATE TABLE IF NOT EXISTS`
+  guards in `store.py`/`memory.py` stay as defense-in-depth or are removed once
+  the migration is the single source of truth. These tables are currently NULL in
+  the live DB (planner memory backend not yet enabled in production), so this is a
+  pre-enable hardening step, not an in-flight-data migration.
+
 ## Open design questions (flagged earlier)
 
 1. Worktree migration path — rename `slot-*` to `worktrees/{agent}/` now vs. lazily per first sprint.

--- a/planner_graph/tests/test_verdify_contract.py
+++ b/planner_graph/tests/test_verdify_contract.py
@@ -84,6 +84,17 @@ def test_build_climate_intent_uses_bounded_single_path_surface() -> None:
         intent["moisture_engage_vpd_excess_kpa"]
         == TIER1_PLAN_DEFAULTS["direct_wet_stress_vpd_margin_kpa"]
     )
+    # all_zone_vpd_excess_kpa is the inverse of the canonical relation
+    # mister_all_kpa = vpd_high + all_zone_vpd_excess_kpa. vpd_high here is the
+    # top of the active band (vpd_target 1.0 + vpd_band 0.6 / 2 = 1.3), so the
+    # recovered excess is mister_all_kpa (1.9) - 1.3 = 0.6.
+    assert intent["all_zone_vpd_excess_kpa"] == pytest.approx(0.6)
+    # Moisture ladder invariant from verdify_schemas.climate_intent.ClimateIntent:
+    # all_zone_vpd_excess_kpa must never fall below moisture_engage_vpd_excess_kpa.
+    assert (
+        intent["all_zone_vpd_excess_kpa"]
+        >= intent["moisture_engage_vpd_excess_kpa"]
+    )
     assert (
         intent["fog_escalate_vpd_excess_kpa"]
         == TIER1_PLAN_DEFAULTS["fog_escalation_kpa"]

--- a/planner_graph/verdify_contract.py
+++ b/planner_graph/verdify_contract.py
@@ -75,6 +75,7 @@ CLIMATE_INTENT_DEFAULTS: dict[str, float] = {
     "economizer_temp_advantage_f": 5.0,
     "economizer_dewpoint_advantage_f": 5.0,
     "moisture_engage_vpd_excess_kpa": 0.05,
+    "all_zone_vpd_excess_kpa": 0.25,
     "mist_duty_limit_pct": 25.0,
     "fog_escalate_vpd_excess_kpa": 0.4,
     "dew_margin_floor_f": 10.0,
@@ -98,6 +99,7 @@ CLIMATE_INTENT_RANGES: dict[str, tuple[float, float]] = {
     "economizer_temp_advantage_f": (1.0, 15.0),
     "economizer_dewpoint_advantage_f": (1.0, 15.0),
     "moisture_engage_vpd_excess_kpa": (0.0, 0.5),
+    "all_zone_vpd_excess_kpa": (0.05, 0.8),
     "mist_duty_limit_pct": (0.0, 100.0),
     "fog_escalate_vpd_excess_kpa": (0.1, 0.8),
     "dew_margin_floor_f": (3.0, 15.0),
@@ -219,6 +221,18 @@ def build_climate_intent(active_plan_summary: object) -> dict[str, float]:
     )
     dwell = params["dwell_gate_ms"]
 
+    # all_zone_vpd_excess_kpa is the inverse of the canonical materializer
+    # relation `mister_all_kpa = vpd_high + all_zone_vpd_excess_kpa`
+    # (verdify_schemas.climate_intent.materialize_climate_intent_tier1). vpd_high
+    # is the top of the active VPD band (vpd_target + vpd_band/2). The canonical
+    # ClimateIntent enforces the moisture ladder all_zone >= moisture_engage, so
+    # we floor the recovered value at the engage excess before range-clamping.
+    moisture_engage_excess = params["direct_wet_stress_vpd_margin_kpa"]
+    vpd_high = vpd_target + (vpd_band / 2.0)
+    all_zone_vpd_excess_kpa = max(
+        params["mister_all_kpa"] - vpd_high, moisture_engage_excess
+    )
+
     intent = {
         **CLIMATE_INTENT_DEFAULTS,
         "temp_target_f": temp_target,
@@ -227,7 +241,8 @@ def build_climate_intent(active_plan_summary: object) -> dict[str, float]:
         "vpd_band_kpa": vpd_band,
         "economizer_temp_advantage_f": params["vent_prefer_temp_delta_f"],
         "economizer_dewpoint_advantage_f": params["vent_prefer_dp_delta_f"],
-        "moisture_engage_vpd_excess_kpa": params["direct_wet_stress_vpd_margin_kpa"],
+        "moisture_engage_vpd_excess_kpa": moisture_engage_excess,
+        "all_zone_vpd_excess_kpa": all_zone_vpd_excess_kpa,
         "mist_duty_limit_pct": duty_pct,
         "fog_escalate_vpd_excess_kpa": params["fog_escalation_kpa"],
         "dew_margin_floor_f": max(

--- a/verdify_schemas/tests/test_climate_intent.py
+++ b/verdify_schemas/tests/test_climate_intent.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import pathlib
 import re
 import subprocess
+import sys
 
 import pytest
 from pydantic import ValidationError
@@ -28,6 +30,27 @@ from verdify_schemas.tunable_registry import TIER1_REG, registry_value_error
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 DESIGN_DOC = REPO_ROOT / "docs" / "firmware-climate-intent-controller-final-design-2026-05-24.md"
+
+# Path to the folded standalone planner's local ClimateIntent mirror (#102).
+PLANNER_CONTRACT_PATH = REPO_ROOT / "planner_graph" / "verdify_contract.py"
+
+
+def _load_planner_contract():
+    """Load planner_graph/verdify_contract.py as a bare module.
+
+    The planner is a standalone service: importing the `planner_graph` package
+    triggers its runtime `__init__` (langgraph etc.), which is not a dependency
+    of verdify_schemas. The contract mirror itself is stdlib-only, so we load the
+    file directly to keep this drift guard runnable in the monorepo venv.
+    """
+
+    if not PLANNER_CONTRACT_PATH.exists():
+        pytest.skip("planner_graph/verdify_contract.py is not present")
+    spec = importlib.util.spec_from_file_location("planner_verdify_contract_mirror", PLANNER_CONTRACT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _section(text: str, start: str, end: str) -> str:
@@ -410,3 +433,54 @@ def test_fog_block_reasons_cover_stored_db_values() -> None:
             fog_block_reason=atom,
         )
         assert decision.fog_block_reason == atom
+
+
+def test_planner_mirror_emits_every_canonical_climate_intent_field() -> None:
+    """The folded standalone planner (#102) keeps a local ClimateIntent mirror in
+    planner_graph/verdify_contract.py. MCP's set_plan path requires every
+    canonical field, so build_climate_intent() must emit the full
+    CLIMATE_INTENT_FIELDS set. The residual drift was a missing
+    all_zone_vpd_excess_kpa; this guard fires if the mirror falls behind again."""
+    contract = _load_planner_contract()
+    intent = contract.build_climate_intent(
+        {
+            **contract.TIER1_PLAN_DEFAULTS,
+            "temp_low": 68.0,
+            "temp_high": 76.0,
+            "vpd_low": 0.7,
+            "vpd_high": 1.3,
+        }
+    )
+    emitted = set(intent)
+    missing = sorted(set(CLIMATE_INTENT_FIELDS) - emitted)
+    assert not missing, (
+        f"planner_graph.verdify_contract.build_climate_intent omits canonical "
+        f"ClimateIntent field(s): {missing}. The planner mirror has drifted from "
+        f"verdify_schemas.climate_intent.CLIMATE_INTENT_FIELDS; MCP set_plan would "
+        f"reject the payload with missing_fields."
+    )
+
+
+def test_planner_mirror_output_validates_against_canonical_climate_intent() -> None:
+    """The planner mirror carries extra band fields (temp/vpd target+band) that
+    MCP consumes separately; the canonical ClimateIntent surface is the
+    CLIMATE_INTENT_FIELDS subset. That subset must construct a valid
+    ClimateIntent, which also enforces the moisture ladder
+    all_zone_vpd_excess_kpa >= moisture_engage_vpd_excess_kpa."""
+    contract = _load_planner_contract()
+    intent = contract.build_climate_intent(
+        {
+            **contract.TIER1_PLAN_DEFAULTS,
+            "temp_low": 68.0,
+            "temp_high": 76.0,
+            "vpd_low": 0.7,
+            "vpd_high": 1.3,
+        }
+    )
+    canonical_payload = {k: intent[k] for k in CLIMATE_INTENT_FIELDS}
+    validated = ClimateIntent(**canonical_payload)
+    assert validated.all_zone_vpd_excess_kpa >= validated.moisture_engage_vpd_excess_kpa
+
+    # Defaults-only path (no Tier 1 context) must also stay valid.
+    default_intent = contract.build_climate_intent({"future_waypoints": 3})
+    ClimateIntent(**{k: default_intent[k] for k in CLIMATE_INTENT_FIELDS})


### PR DESCRIPTION
Closes #102

Closes the **residual** data-loss/divergence risk for the `planner_graph` fold. `planner_graph/` is already byte-identical in the monorepo (commit `1113a75`); this PR closes the three open residuals without authoring a new numbered migration.

## Only-in-split confirmation
Shallow-cloned `VerdifyConsultancy/verdify-planner` and did a per-file diff against the monorepo. The entire **application surface** is byte-identical:
- `planner_graph/**` package (incl. `migrations/001_planner_memory.sql`), `tests/`, `scripts/`, `docs/`, `fixtures/`, `pyproject.toml`, `uv.lock`, `project-assets.yml`, `README.md` — all identical.
- Only divergence: the `Dockerfile` (already correctly adapted in-monorepo for root build context + OCI labels — a deliberate, correct difference).
- Split-only files are repo scaffolding (`.agents/skills/**`, `AGENTS.md`, `skills-lock.json`, `.dockerignore`, the split's own `python-package-ci.yml`) — none are application code / data / evals.

**Conclusion: nothing application-level or data-bearing is only-in-split. No copy-in required.**

## (a) ClimateIntent contract drift — FIXED
The planner's local mirror `planner_graph/verdify_contract.py` omitted `all_zone_vpd_excess_kpa`, which canonical `verdify_schemas/climate_intent.py` lists in `CLIMATE_INTENT_FIELDS` (default 0.25, range 0.05–0.8, moisture-ladder invariant `all_zone >= moisture_engage`). MCP requires every field, so a planner `set_plan` would have failed `missing_fields`.

- Added the field to `CLIMATE_INTENT_DEFAULTS` / `CLIMATE_INTENT_RANGES`.
- `build_climate_intent()` now emits it as the inverse of the canonical materializer relation `mister_all_kpa = vpd_high + all_zone_vpd_excess_kpa`, floored at the engage excess so the ladder always holds.
- Extended the planner's `test_verdify_contract.py` and added **two cross-package parity guards** to `verdify_schemas/tests/test_climate_intent.py` (load the mirror directly — no langgraph dep) that fire if the mirror drifts again or stops validating against the canonical `ClimateIntent`.

### before / after / re-probe (UTC)
```
BEFORE 2026-06-01T16:05:03Z
  canonical CLIMATE_INTENT_FIELDS count: 15
  planner build_climate_intent emits count: 18
  MISSING from planner (canonical not emitted): ['all_zone_vpd_excess_kpa']
  all_zone_vpd_excess_kpa emitted?: False

AFTER  2026-06-01T16:08:36Z
  canonical count: 15 | planner emits: 19
  MISSING (canonical not emitted): []
  all_zone_vpd_excess_kpa emitted?: True value= 0.6  (= mister_all 1.9 - vpd_high 1.3)
  canonical ClimateIntent built OK; ladder all_zone>=engage: True
  defaults-only path validates OK; all_zone= 0.65

RE-PROBE 2026-06-01T16:13:14Z (post-commit)
  verdify_schemas/tests/test_climate_intent.py -k planner_mirror: 2 passed
```
(The 4 "extra" planner fields `temp_target_f/temp_band_f/vpd_target_kpa/vpd_band_kpa` carry band info MCP consumes separately and are out of scope — the canonical surface is the `CLIMATE_INTENT_FIELDS` subset, which now matches exactly.)

## (b) Image build job — ADDED (artifact only, NOT deployed)
Added a `planner-image` build/publish job to `.github/workflows/container-publish.yml` (`ghcr.io/<owner>/verdify-planner`, repo-root context + `planner_graph/Dockerfile`, plus `planner_impact` resolution on `planner_graph/**`).

**ARTIFACT ONLY:** `planner-image` is deliberately **absent** from both `bump-staging-digests` (the overlays/staging `@sha256` write-back) and `request-gitops-promotion` (the Agent Fleet GitOps dispatch). The planner is not yet a deployed k3s workload; publishing the artifact is not a deploy. Verified: `planner-image` does not appear in either deploy job's `needs:`.

Note: planner image build does NOT key on `verdify_schemas/**` (unlike api/mcp/ingestor) because the planner COPYs only `planner_graph/**` — it carries its own copied contract mirror.

## (c) Planner DDL serialization — FOLLOW-UP NOTE ONLY
Documented in `docs/backlog/cross-cutting.md` as **C-PLN1**: the planner-owned DDL (`planner_graph_runs` from `store.py`; `planner_memory_items` / `planner_memory_retrievals` from `migrations/001_planner_memory.sql` + `memory.py`; `planner_memory_embeddings`) bypasses the serialized `db/migrations/` chain and must be folded in by the coordinator in the next migration slot (head is `150-vanda-nutrient-recipe.sql`). **No numbered migration authored here** — migrations are serialized. These tables are NULL in the live DB (planner memory backend not yet enabled), so this is pre-enable hardening, not an in-flight-data migration.

## Validation
- `make lint` — **pass** (`All checks passed!`). Changed planner file lints clean under the planner's own ruff config; `planner_graph` is `extend-exclude`d from the repo ruleset (`pyproject.toml`), and the only repo-ruleset findings on `verdify_contract.py` (`I001`/`UP035`, lines 11-14) are pre-existing in base and untouched. New test files pass repo ruff + ruff-format (pre-commit hooks green).
- `make test` — **587 passed, 2 skipped, 1 failed, 10 errors** in this isolated worktree (no live DB/services). All 11 non-pass results are live-stack/DB conditions unrelated to this change: 10 errors in `test_04_planner.py` (`psql ... role "test" does not exist`) and 1 failure in `test_07_cron_replan.py::test_planner_lessons_not_excessive` (live DB has 61 active lessons). **Zero failures touch planner_graph / verdify_contract / climate_intent.**
- `verdify_schemas/tests/test_climate_intent.py` — **15/15 pass** including the 2 new parity guards and the existing materializer/ladder/drift guards.
- Planner `test_verdify_contract.py` assertions (incl. new `all_zone == 0.6` + ladder) verified by direct module load; the full planner suite needs its own langgraph venv and was not run here.

## Rule 7 / service restart
This PR does NOT touch `mcp/server.py`, `verdify_schemas/**` runtime models, or `ingestor/entity_map.py` (the `verdify_schemas` change is test-only). The contract mirror is the wire shape MCP validates, so the consuming service is **`verdify-mcp`** — restart it post-merge if MCP is updated to consume planner `set_plan` output; no restart is required by this PR alone.

requested-by: iris (shared territory — coordinator review before merge: `.github/workflows/container-publish.yml`, `verdify_schemas/tests/`, `docs/backlog/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
