### PR TITLE
fix(k8s/dev): complete + verify verdify-dev overlay (device-dark SHADOW; correct App CR rationale)

### DIFF
--- a/deploy/k8s/argocd/apps/verdify-dev.yaml
+++ b/deploy/k8s/argocd/apps/verdify-dev.yaml
@@ -10,9 +10,13 @@
 # Shape mirrors the live verdify-local-staging Application (read from the cluster
 # 2026-05-31); only per-env fields + syncPolicy differ:
 #   - dev is an AUTOMATED env: automated{selfHeal:true, prune:true}. It is a
-#     read-only telemetry subscriber (VERDIFY_DEVICE_WRITE_ENABLED=0,
-#     ingestor replicas:0) and NEVER writes the ESP32, so auto-prune is safe —
-#     unlike prod, nothing here can touch the live device.
+#     read-only telemetry SUBSCRIBER (#114): VERDIFY_DEVICE_WRITE_ENABLED=0 +
+#     VERDIFY_INGEST_SOURCE=mqtt-subscribe, so the ingestor holds NO ESP32
+#     connection. It runs at replicas:1 (a subscriber is not a device writer;
+#     see overlays/dev/ingestor-replicas-zero.yaml), and the dev-only
+#     deny-esp32-egress NetworkPolicy drops all egress to the greenhouse VLAN
+#     as the belt-and-suspenders network half. NOTHING here can touch the live
+#     device, so auto-prune is safe — unlike prod.
 #
 # HARD PREREQUISITES before laptop-root applies (see
 # docs/runbooks/dev-prod-argocd-handover.md):


### PR DESCRIPTION
Closes #115.

`requested-by: iris (shared territory)` — touches `deploy/k8s/argocd/apps/` (ArgoCD App CRs are platform/shared infra; comment-only, no spec change).

## What this does
Completes + verifies `deploy/k8s/overlays/dev` against the issue DoD. The overlay was already substantially authored; the only manifest change here is a **documentation-accuracy fix** to the `verdify-dev` ArgoCD Application CR: its auto-prune-safety comment claimed `ingestor replicas:0`, contradicting the actual overlay which pins `replicas:1` in #114 subscribe (SHADOW) mode. A subscriber holds no ESP32 connection, so there is no single-writer concern — the comment now cites the real device-darkness interlocks (`device-write=0` + `mqtt-subscribe` + `deny-esp32-egress`) that make auto-prune safe in dev. No change to the rendered overlay.

## DoD verification (all present, device-dark)
| DoD item | Status | Evidence |
|---|---|---|
| verdify-dev owns its DB (seeded-copy StatefulSet, not prod DB) | ✅ | base `verdify-db` StatefulSet → `verdify-dev` ns; `db-storageclass.yaml` retargets PVC to `synology-iscsi-ssd`; schema via `verdify-migrate` PreSync hook |
| api/mcp present | ✅ | render from base (ClusterIP; mcp never LB) |
| planner/www present | ✅ | Components (never leak to staging) |
| ingestor SHADOW/subscribe, device-write=0 | ✅ | `VERDIFY_INGEST_SOURCE=mqtt-subscribe`, `VERDIFY_DEVICE_WRITE_ENABLED=0`, `replicas:1` subscriber, `Recreate` preserved |
| deny-esp32-egress NetworkPolicy present | ✅ | renders into dev; selects ingestor; drops 192.168.10.0/24 |
| NO device-write=1 / NO allow-egress in dev | ✅ | grep confirms none in dev tree |

## Validation (UTC)
- `2026-06-01T16:37:11Z` `kustomize build deploy/k8s/overlays/dev` → **exit 0** (987 lines)
- `2026-06-01T16:37:38Z` `… | kubeconform -strict -ignore-missing-schemas` → **20 valid / 0 invalid / 0 errors / 3 skipped** (Traefik CRDs)
- `2026-06-01T16:38:24Z` post-edit re-render → byte-identical to pre-edit (App CR change is outside the overlay); kubeconform unchanged
- `make lint` (ruff) → **all checks passed**
- Device-darkness grep: `VERDIFY_DEVICE_WRITE_ENABLED:"0"`, `mqtt-subscribe`, `deny-esp32-egress` present; no `allow-ingestor-device-egress`/`allow-esp32-egress`; all 22 namespaced objects pinned to `verdify-dev`.

## Out of scope / still blocked (needs:root + #117)
Not applied to any cluster (Root applies the App CR after images exist). Activation remains gated on: Root applying the verdify-dev App CR, provisioning `synology-iscsi-ssd`, delivering SOPS `verdify-app-secrets`; and replacing the planner placeholder digest `sha256:0000` (IRIS-PLANNER-DIGEST/#117) so selfHeal+prune stops ImagePullBackOff-ing the planner Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)