### PR TITLE
lab.verdify.ai -> k3s: lab-site (Quartz) component + IngressRoutes (#124)

### DIFF
--- a/deploy/k8s/components/lab-site/kustomization.yaml
+++ b/deploy/k8s/components/lab-site/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Kustomize COMPONENT: the verdify-lab Quartz research-site workload (#124).
+# Referenced explicitly by overlays/dev + overlays/prod + overlays/staging via
+# `components:` — deliberately NOT a base resource so it never auto-renders into
+# every overlay. See lab-site.yaml header for the full rationale (build source =
+# the separate verdify-site repo Dockerfile.k3s; nginx static serve on :8080;
+# stateless, no device path). The image (ghcr.io/verdifyconsultancy/verdify-lab)
+# is pinned to a @sha256 digest by each consuming overlay's images: transformer
+# (a PLACEHOLDER all-zeros digest until verdify-site is CI-published).
+resources:
+  - lab-site.yaml

--- a/deploy/k8s/components/lab-site/lab-site.yaml
+++ b/deploy/k8s/components/lab-site/lab-site.yaml
@@ -1,0 +1,142 @@
+# Verdify lab/research site — lab.verdify.ai (#124, part of #88 / #111 / #15).
+#
+# WHAT: the public Quartz static research garden ("the lab"). The site source is
+# the Quartz tree in this monorepo's site/ (quartz.config.ts), but the runtime
+# IMAGE is built/published SEPARATELY from the verdify-site repo's Dockerfile.k3s
+# (Quartz `npx quartz build` -> static public/ -> nginx serves it). This monorepo
+# carries ONLY the immutable @sha256 image digest pin (each consuming overlay's
+# images: transformer) + these manifests — same containment posture as #116 www.
+#
+# IMAGE — MUST BE BUILT/PUBLISHED SEPARATELY (not done by these manifests):
+#   ghcr.io/verdifyconsultancy/verdify-lab
+# As of authoring the image is NOT published yet — the issue notes verdify-site is
+# an orphan (repo:None) so CI cannot publish it until a #99-class GHCR repo relink
+# (and the IRIS-011 host matrix). So every consuming overlay pins a PLACEHOLDER
+# all-zeros @sha256 digest (identical posture to verdify-planner). The digest
+# write-back flow (k8s-manifests.yml) advances it to the real GHCR digest once
+# container-publish for verdify-lab is green. Rebuild recipe (verdify-site repo):
+#   gh repo clone VerdifyConsultancy/verdify-site && cd verdify-site
+#   docker build -f Dockerfile.k3s \
+#     -t ghcr.io/verdifyconsultancy/verdify-lab:sha-$(git rev-parse --short HEAD) .
+#   docker push ghcr.io/verdifyconsultancy/verdify-lab:sha-<sha>   # -> @sha256 digest
+#
+# RUNTIME / PORT (load-bearing): the Quartz output is plain static HTML served by
+# nginx. To preserve the non-root posture used across the web tier (runAsNonRoot,
+# readOnlyRootFilesystem, drop ALL caps) the image MUST run nginx-unprivileged and
+# LISTEN ON 8080 — NOT the privileged :80 the in-repo site/nginx.conf currently
+# uses. The separate Dockerfile.k3s owns that nginx listen-port + the static-site
+# location/try_files rules (mirroring site/nginx.conf, adjusted to :8080). The
+# container :8080 + Service targetPort + probe all stay in lockstep on 8080, the
+# same contract Traefik's kubernetescrd provider resolves against (Service port).
+#
+# WHY A KUSTOMIZE COMPONENT (not a base resource): #5 hard rule — anything added
+# to deploy/k8s/base renders into overlays/staging, which the live
+# verdify-local-staging ArgoCD app syncs. A Component is referenced explicitly per
+# overlay, so merging to live/platform-main keeps the live staging app's rendered
+# shape under the author's control. lab-site is pure web tier, STATELESS (no PVC,
+# emptyDir scratch only), NO device path — it never touches the ESP32.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-lab
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: lab-site
+  strategy:
+    # Stateless static site — a rolling replace is safe (no single-writer/device
+    # constraint; the api/mcp/ingestor safety posture does not apply here).
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: lab-site
+    spec:
+      imagePullSecrets:
+        - name: ghcr-jvallery-readonly
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: lab-site
+          # Pinned to an immutable @sha256 digest by each consuming overlay's
+          # images: transformer (NEVER a mutable :latest/:sha tag). Image name
+          # only here. Built from the verdify-site repo Dockerfile.k3s (see header).
+          image: ghcr.io/verdifyconsultancy/verdify-lab
+          # No command override: the verdify-site Dockerfile.k3s CMD (nginx -g
+          # 'daemon off;') stays authoritative, so the build source owns the
+          # serve config (nginx-unprivileged listening on :8080 — see header).
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "32Mi"
+            limits:
+              memory: "128Mi"
+          # nginx-unprivileged needs writable scratch under a read-only root FS.
+          # All emptyDir (ephemeral) — the served content is baked into the image
+          # layer, so NO PVC and NO synology-iscsi-ssd dependency (stateless).
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+          # Static site served at "/"; use the homepage as the probe target (no
+          # dedicated /healthz in a Quartz static build).
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verdify-lab
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  # ClusterIP — the public front door is the shared apps Traefik via the per-env
+  # IngressRoute (dev: lab.k3s.verdify.ai; prod: lab.verdify.ai; staging:
+  # lab-staging.vallery.net). No per-app LoadBalancer (the ADR-15 anti-pattern);
+  # same as www/planner/mcp.
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: lab-site
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -34,13 +34,17 @@ resources:
   # EDGE/WAN: host-route the dev verdify-www on www.k3s.verdify.ai through the
   # same shared apps Traefik (#116). See www-ingressroute.yaml.
   - www-ingressroute.yaml
+  # EDGE/WAN: host-route the dev verdify-lab Quartz site on lab.k3s.verdify.ai
+  # through the same shared apps Traefik (#124). See lab-ingressroute.yaml.
+  - lab-ingressroute.yaml
 
-# verdify-planner (#117) + verdify-www (#116) — referenced as Components, NOT
-# added to base, so they never render into overlays/staging. Same pattern in
-# overlays/prod.
+# verdify-planner (#117) + verdify-www (#116) + verdify-lab (#124) — referenced as
+# Components, NOT added to base, so they never render into overlays/staging. Same
+# pattern in overlays/prod.
 components:
   - ../../components/planner
   - ../../components/www
+  - ../../components/lab-site
 
 patches:
   # APP_ENV=dev + VERDIFY_DEVICE_WRITE_ENABLED=0 (dev never writes the device).
@@ -76,3 +80,9 @@ images:
   # the upstream verdify-www repo at sha d3720dc (see components/www/www.yaml).
   - name: ghcr.io/verdifyconsultancy/verdify-www
     digest: sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+  # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
+  # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
+  # #99-class relink. The digest write-back flow pins the real GHCR digest once
+  # container-publish for verdify-lab is green. See components/lab-site/lab-site.yaml.
+  - name: ghcr.io/verdifyconsultancy/verdify-lab
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/deploy/k8s/overlays/dev/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/dev/lab-ingressroute.yaml
@@ -1,0 +1,39 @@
+# dev verdify-lab edge exposure on the *.k3s.verdify.ai dev/stage domain (#124).
+#
+# CONFIRMED ARCHITECTURE: dev/stage URLs live on *.k3s.verdify.ai; prod owns the
+# bare lab.verdify.ai host. This routes the dev verdify-lab THROUGH the shared
+# apps Traefik (traefik-apps on the .7.10 VIP) — the ONE conformant front door,
+# identical pattern to overlays/dev/www-ingressroute.yaml (www.k3s.verdify.ai).
+#
+# INERT-ON-MERGE: there is no verdify-dev ArgoCD Application CR yet (laptop-root
+# gate). The live verdify-local-staging app syncs ONLY overlays/staging, so this
+# IngressRoute is never reconciled by merging to live/platform-main. It is the
+# reviewable target shape. The lab.k3s.verdify.ai DNS, the traefik-apps host-route
+# acceptance, and a public *.k3s.verdify.ai wildcard Certificate (cert-manager
+# letsencrypt-dns01) are platform-layer prerequisites (needs:nexus — same gate as
+# the dev www route / the api route's residual TLS gap). HTTP routing is the shape.
+#
+# No strip-identity Middleware here: the research site is fully public and trusts
+# no forward-auth identity (unlike the api). tls: {} == Traefik default cert.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: verdify-lab
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  entryPoints:
+    - websecure
+    - web
+  routes:
+    # dev lab on the dev/stage domain. The component verdify-lab Service is
+    # ClusterIP :8080 (no LoadBalancer overlay in dev). Traefik's kubernetescrd
+    # provider resolves against the Service .spec.ports[].port, which is 8080.
+    - kind: Rule
+      match: Host(`lab.k3s.verdify.ai`)
+      services:
+        - name: verdify-lab
+          port: 8080
+  tls: {}

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -30,6 +30,9 @@ resources:
   # EDGE/WAN: host-route the prod verdify-www on www.verdify.ai + apex through the
   # shared apps Traefik (.7.10) (#116). See www-ingressroute.yaml.
   - www-ingressroute.yaml
+  # EDGE/WAN: host-route the prod verdify-lab Quartz site on lab.verdify.ai through
+  # the same shared apps Traefik (.7.10) (#124). See lab-ingressroute.yaml.
+  - lab-ingressroute.yaml
 
 # verdify-planner (#117) + verdify-mqtt fan-out broker (#113) — referenced as
 # Components, NOT added to base, so they never render into overlays/staging (the
@@ -50,6 +53,12 @@ components:
   # stateless, NO device path; referenced by dev + prod, never staging. Built
   # from the upstream verdify-www repo (see components/www/www.yaml).
   - ../../components/www
+  # #124 verdify-lab — the public Quartz research site (lab.verdify.ai). Pure web
+  # tier, stateless (no PVC), NO device path; referenced by dev + prod. NOT yet in
+  # staging because its image is unpublished (placeholder digest -> ImagePullBackOff
+  # would degrade the live staging app). Built from the verdify-site repo
+  # Dockerfile.k3s (see components/lab-site/lab-site.yaml).
+  - ../../components/lab-site
 
 patches:
   # DEVICE-WRITE INTERLOCK (#79): VERDIFY_DEVICE_WRITE_ENABLED=1 — prod only.
@@ -89,3 +98,9 @@ images:
   # same known-good digest; the promotion flow advances it on a content rebuild.
   - name: ghcr.io/verdifyconsultancy/verdify-www
     digest: sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+  # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
+  # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
+  # #99-class relink. The digest write-back flow pins the real GHCR digest once
+  # container-publish for verdify-lab is green. See components/lab-site/lab-site.yaml.
+  - name: ghcr.io/verdifyconsultancy/verdify-lab
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/deploy/k8s/overlays/prod/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/prod/lab-ingressroute.yaml
@@ -1,0 +1,42 @@
+# prod verdify-lab edge exposure on the production lab.verdify.ai host (#124).
+#
+# CONFIRMED ARCHITECTURE: prod owns the bare *.verdify.ai hosts
+# (www/lab/api/graphs.verdify.ai); dev/stage live on *.k3s.verdify.ai. This routes
+# the prod verdify-lab THROUGH the shared apps Traefik (traefik-apps on the .7.10
+# VIP) — the ONE conformant front door, the same one-pattern as the prod www route
+# (overlays/prod/www-ingressroute.yaml www.verdify.ai rule).
+#
+# INERT-ON-MERGE: there is no verdify-prod ArgoCD Application CR yet (laptop-root
+# gate). The live verdify-local-staging app syncs ONLY overlays/staging, so this
+# IngressRoute is never reconciled by merging to live/platform-main. It is the
+# reviewable target shape. The cloudflared vallery-edge tunnel forwarding
+# lab.verdify.ai -> .7.10, the *.verdify.ai split-horizon DNS, and a public
+# wildcard-verdify-ai Certificate (cert-manager letsencrypt-dns01; the same
+# residual gate documented for www.verdify.ai/api.verdify.ai) are platform-layer
+# prerequisites (needs:nexus). HTTP routing is the shape here.
+#
+# No strip-identity Middleware: the research site is fully public and trusts no
+# forward-auth identity (unlike the api). tls: {} == Traefik default cert until
+# the *.verdify.ai wildcard lands.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: verdify-lab
+  namespace: verdify-prod
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  entryPoints:
+    - websecure
+    - web
+  routes:
+    # prod lab on the product domain. The component verdify-lab Service is
+    # ClusterIP :8080 (no per-app LoadBalancer — the ADR-15 anti-pattern). Traefik
+    # resolves against the Service .spec.ports[].port (8080).
+    - kind: Rule
+      match: Host(`lab.verdify.ai`)
+      services:
+        - name: verdify-lab
+          port: 8080
+  tls: {}

--- a/deploy/k8s/overlays/staging/allow-lab-from-ingress.yaml
+++ b/deploy/k8s/overlays/staging/allow-lab-from-ingress.yaml
@@ -1,0 +1,39 @@
+# Allow the shared apps-ingress (traefik-apps) + the apps VLAN to reach
+# verdify-lab:8080 in staging. Mirrors allow-www-from-ingress.yaml. The base
+# default-deny-ingress (networkpolicy.yaml rule 1) otherwise drops all ingress to
+# the lab pod under a NetworkPolicy-enforcing CNI.
+#
+# NOT WIRED INTO overlays/staging/kustomization.yaml YET — paired with
+# lab-ingressroute.yaml, both are the reviewable target shape, added to staging in
+# the same PR that flips the placeholder verdify-lab digest to a real published
+# one (see lab-ingressroute.yaml header). flannel does NOT enforce NetworkPolicy
+# on the live cluster today (same note as base allow-api-from-ingress and the
+# staging allow-www-from-ingress), so this is a contract for the planned Cilium
+# re-CNI (ADR-17): it names BOTH the k3s built-in "traefik" namespace, the
+# "traefik-apps" shared-ingress namespace (the pod source for the .7.10 VIP), and
+# the apps VLAN ipBlock — the union the www allow uses already.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-lab-from-ingress
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: lab-site
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik-apps
+        - ipBlock:
+            cidr: 192.168.7.0/24
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/deploy/k8s/overlays/staging/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/staging/lab-ingressroute.yaml
@@ -1,0 +1,46 @@
+# staging verdify-lab edge exposure (#124) — the staging Quartz research site
+# routed THROUGH the shared apps Traefik (.7.10), same one-front-door pattern as
+# overlays/staging/www-ingressroute.yaml (www-staging.vallery.net).
+#
+# NOT WIRED INTO overlays/staging/kustomization.yaml YET (deliberate): unlike
+# verdify-www — whose image is REAL + published + pullable, so it is safe in the
+# live-synced staging overlay — the verdify-lab image is NOT published yet
+# (verdify-site is an orphan GHCR repo; the overlays pin an all-zeros PLACEHOLDER
+# digest). Referencing the lab Component in overlays/staging would render a pod
+# that ImagePullBackOffs and DEGRADE the live verdify-local-staging ArgoCD app —
+# the exact #5 containment rule that keeps the planner/mqtt/setpoint/hermes
+# Components out of staging. So this route + its NetworkPolicy (allow-lab-from-
+# ingress.yaml) are the REVIEWABLE TARGET SHAPE for staging; they are added to
+# overlays/staging/kustomization.yaml in the SAME PR that flips the placeholder
+# digest to the first real published verdify-lab @sha256 (i.e. after the #99-class
+# GHCR relink unblocks CI publish). Until then they live here unreferenced.
+#
+# HOST: staging owns *-staging on the vallery.net edge, same convention as the
+# www route (www-staging.vallery.net) and the api route (verdify-staging.vallery.net).
+# The cloudflared vallery-edge host-forward for lab-staging.vallery.net + the
+# matching DNS record are platform-layer (laptop-root) prerequisites (needs:nexus).
+#
+# No strip-identity Middleware: the research site is fully public. tls: {} ==
+# Traefik default cert.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: verdify-lab
+  namespace: verdify-staging
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  entryPoints:
+    - websecure
+    - web
+  routes:
+    # The component verdify-lab Service is ClusterIP :8080 (no LoadBalancer
+    # overlay). Traefik's kubernetescrd provider resolves against the Service
+    # .spec.ports[].port, which is 8080.
+    - kind: Rule
+      match: Host(`lab-staging.vallery.net`)
+      services:
+        - name: verdify-lab
+          port: 8080
+  tls: {}


### PR DESCRIPTION
Closes #124

Authors the **verdify-lab** Quartz research-site k8s component + per-overlay IngressRoutes, mirroring the #116 `www` pattern (the issue's "deployable like www" target). **Author-only: NOT deployed, do NOT merge until the GHCR image is published.**

## What lands
- `deploy/k8s/components/lab-site/lab-site.yaml` — Deployment + ClusterIP Service. Stateless: emptyDir scratch for nginx tmp/cache/run, **no PVC**, no synology-iscsi-ssd dependency. Pure web tier, **no device path**, never writes the ESP32. Non-root posture (`runAsNonRoot`, `readOnlyRootFilesystem`, drop ALL caps), `ghcr-jvallery-readonly` pull secret. Image name only (`ghcr.io/verdifyconsultancy/verdify-lab`), container/Service on `:8080`.
- `deploy/k8s/components/lab-site/kustomization.yaml` — Kustomize Component (NOT a base resource, so it never auto-renders into the live-synced `overlays/staging` — the #5 hard rule).
- `overlays/dev` + `overlays/prod` — wire the Component + a lab IngressRoute (`lab.k3s.verdify.ai` / `lab.verdify.ai`) + a **PLACEHOLDER all-zeros `@sha256` digest** pin (same posture as `verdify-planner`). dev/prod are INERT on merge (no ArgoCD App CR yet).
- `overlays/staging/lab-ingressroute.yaml` (`lab-staging.vallery.net`) + `overlays/staging/allow-lab-from-ingress.yaml` — authored as the reviewable **target shape** but **deliberately NOT wired** into staging's `kustomization.yaml`: the verdify-lab image is unpublished (verdify-site is an orphan GHCR repo), so a placeholder digest would ImagePullBackOff and degrade the live `verdify-local-staging` ArgoCD app. They get wired in the same PR that flips the placeholder to the first real published digest.

## Image — built/published SEPARATELY (not by these manifests)
The runtime image is built from the **verdify-site** repo `Dockerfile.k3s` (Quartz `npx quartz build` -> static `public/` -> nginx-unprivileged serving on `:8080`). **Blocked at the GHCR layer** until a #99-class repo relink unblocks CI publish (verdify-site is `repo:None`). The `Dockerfile.k3s` must configure nginx to listen on `:8080` (the in-repo `site/nginx.conf` listens on the privileged `:80`; the non-root posture needs `:8080`, matching the Service contract Traefik resolves against).

`needs:nexus` — lab.* DNS/cert (cloudflared host-forward + split-horizon DNS + cert-manager wildcard) is a platform-layer (laptop-root) prerequisite. **Not required for authoring.**

## Validation (UTC 2026-06-01 ~16:40)
- `kustomize build overlays/{dev,prod,staging}` — all green (26 / 35 / 23 docs).
- `kubeconform -strict -summary -ignore-missing-schemas` (the exact CI command) — **0 invalid, 0 errors** across all three overlays (CRD IngressRoutes + Secrets leniently skipped, as in CI).
- `make lint` — `All checks passed!`
- staging renders **zero** verdify-lab refs (live ArgoCD app shape untouched); dev/prod render the lab Deployment/Service/IngressRoute pinned to `verdify-lab@sha256:0000...`.

## Guardrails honored
No device path; never sets `DEVICE_WRITE=1` / allow-esp32-egress; no secret values (placeholder digests + secret references only); no new numbered `db/migrations`; not merged; not applied to any cluster.

Part of #88 / #111 / #15.

requested-by: iris (shared territory — `deploy/k8s/overlays/staging/**` is the live-synced overlay; staging files are authored unwired so the live app is byte-identical)