### PR TITLE
deploy(secrets): per-env secret contract + fix prod placeholder leak (#30)

### DIFF
--- a/deploy/k8s/SECRETS.md
+++ b/deploy/k8s/SECRETS.md
@@ -1,0 +1,131 @@
+# Verdify k3s secret contract (per-env)
+
+Owner: **Iris** (the CONTRACT — key names, per-env matrix, the two invariants, the
+sealed-artifact shape). Delivery MECHANISM is **Root** (`needs:root`): the SOPS+age
+sealing, the registry secret-meta, and the out-of-band apply step. Tracked under
+the secrets-out-of-.env umbrella **#30**; the concrete SOPS structure + staging
+seal + named prod inventory deliverable is **#66**.
+
+This file is the single source of truth for **which Secret carries which key in
+which env, and how the manifests reference it**. It contains **NO real secret
+material** — keys/refs only. The deploy manifests reference every Secret BY NAME;
+the real value arrives out-of-band from the fleet SOPS+age backend
+(`jvallery/agent-fleet-control`) BEFORE the ArgoCD app reconciles. `kustomize`
+cannot decrypt SOPS, so the in-repo `*.placeholder.yaml` files exist ONLY so
+`kustomize build` / `kubeconform` render a complete, lint-able manifest in CI.
+
+## Design basis
+
+k3s/ArgoCD migration design **§2.4** re-scopes secrets from GCP Secret Manager to
+**in-cluster secrets** (SOPS+age source-of-truth, a SOPS→reconciler / sealed-secrets
+controller in-cluster). Do NOT invent a second secrets system — reuse the fleet
+stack Root deploys for the other agents. Until that controller is confirmed live,
+the interim is a one-time out-of-band apply per the seal list; the GitOps
+secret-delivery step is the fast-follow.
+
+## The two invariants (CONTRACT, enforced by review + `kustomize build`)
+
+1. **LOCAL-CONFIG-IS-AN-ANNOTATION.** Every in-repo `*.placeholder.yaml` Secret MUST
+   carry `config.kubernetes.io/local-config: "true"` as an **annotation**, never a
+   label. `kustomize build` excludes objects with that **annotation** from its
+   output. As a **label** the object renders into the manifest, and an ArgoCD
+   Secret-blacklisted AppProject rejects the whole sync ("synchronization tasks are
+   not valid"). Verification: `kustomize build` of EVERY overlay must emit **zero**
+   `kind: Secret`. (This caught a real prod leak — see History.)
+
+2. **NAMESPACE-MATCH.** For each sealed Secret, the registry secret-meta
+   `target.namespace` MUST be byte-identical to:
+   - the overlay's `namespace:` directive,
+   - the overlay's `Namespace` object, and
+   - the ArgoCD `Application.spec.destination.namespace`.
+
+   A mismatch does NOT error — the sealed Secret silently never lands in the
+   workload's namespace and the pod starts without its credentials (or CrashLoops on
+   a missing key). The pinned namespaces are `verdify-dev`, `verdify-staging`,
+   `verdify-prod`.
+
+## Never
+
+- **Never** commit a real secret value, key, token, or password to this repo.
+- **Never** bake credentials into a container image (the manifests inject every
+  credential via `secretKeyRef` / `secretRef` / a mounted Secret volume at runtime).
+- **Never** set `DEVICE_WRITE=1` / an ESP32-egress allow in dev or staging — those
+  envs are device-dark. The device-write path + `ESP32_API_KEY` use live ONLY in
+  `verdify-prod`.
+- **Never** rotate/seal `ESP32_API_KEY` without explicit Jason confirmation of the
+  canonical value; it is the ESP32 Noise PSK and must never trigger a re-flash
+  (handoff §6). The live `.env` and the esphome `secrets.yaml` have DRIFTED (two
+  different shas); reconcile at source and seal from the canonical one.
+
+## Secret inventory (env-injected references — no values)
+
+Service → Secret → key wiring as authored in `deploy/k8s/{base,components}`:
+
+| Secret | Key | Consumed by (ref type) | dev | staging | prod |
+|---|---|---|---|---|---|
+| `verdify-app-secrets` | `POSTGRES_PASSWORD` | db / api / mcp / ingestor / migrate / planner / setpoint-server (`secretKeyRef`) | ✓ | ✓ | ✓ |
+| `verdify-app-secrets` | `VERDIFY_WRITE_API_KEY` | api (`secretKeyRef`; write guard `api/main.py`) | ✓ | ✓ | ✓ |
+| `verdify-app-secrets` | `MQTT_USER` | ingestor (`secretKeyRef`) | ✓ | ✓ | ✓ |
+| `verdify-app-secrets` | `MQTT_PASS` | ingestor (`secretKeyRef`) | ✓ | ✓ | ✓ |
+| `verdify-app-secrets` | `ESP32_API_KEY` | ingestor (`secretKeyRef`); **device-affecting** | ref-only¹ | ref-only¹ | ✓ |
+| `verdify-app-secrets` | `OPENAI_API_KEY` | planner (`secretKeyRef`, `optional: true`) | ✓ | — | ✓ |
+| `verdify-ha-token` | `ha_token.txt` | setpoint-server (volume mount); **device-affecting** | — | — | ✓ |
+| `verdify-hermes` | `OPENAI_API_KEY`, `HERMES_MCP_URL`² | hermes-iris (`envFrom.secretRef`) | — | — | ✓ |
+| `verdify-hermes-slack` | slack channel config | hermes-iris (optional volume mount; **non-secret** channel cfg) | — | — | opt |
+| `ghcr-jvallery-readonly` | `.dockerconfigjson` | all workloads (`imagePullSecrets`) | ✓ | ✓ | ✓ |
+
+¹ dev/staging are device-dark: the ingestor runs `replicas: 0` and egress to the
+device VLAN is denied. The key may be present in the sealed secret for shape parity
+but is never exercised — those envs never connect to the live ESP32.
+
+² `HERMES_MCP_URL` is the migration doc **R7** gate: it must point at
+`verdify-mcp.verdify-prod.svc:8000` and is repointed at SEAL time, never committed.
+
+`DB_PASS` / `DB_PASSWORD` / `DB_DSN` / `VERDIFY_DB_DSN` are derived in-manifest from
+`POSTGRES_PASSWORD` + the non-secret connection fields in the `verdify-config`
+ConfigMap (`$(VAR)` interpolation); they are NOT separate secret keys.
+
+## Sealed-artifact shape (Root delivers; Iris specifies)
+
+Each Secret above maps to a fleet sealed artifact:
+
+```
+agent-fleet-control/
+  registry/secrets/<id>.yaml            # meta: target.namespace + name + key list
+  secrets/encrypted/<id>.enc.yaml       # SOPS+age ciphertext (NEVER decrypted by kustomize)
+```
+
+The canonical sealed source for `verdify-app-secrets` is
+`agent-fleet-control/secrets/encrypted/verdify-app-secrets.enc.yaml`, sealed to the
+fleet age key and applied by the GitOps secret-delivery step BEFORE the app
+reconciles. As of 2026-05-31 it is ALREADY present in `verdify-staging` and decrypts
+byte-identical (`POSTGRES_PASSWORD`, `VERDIFY_WRITE_API_KEY`, `ESP32_API_KEY`,
+`MQTT_USER/PASS`) — re-applying is a no-op (avoid DB-auth drift). The dev + prod
+sealed artifacts land with their envs at **M3** (`needs:root`).
+
+For a REAL apply, drop the `- *.placeholder.yaml` lines from the overlay's
+`kustomization.yaml`; the sealed Secret is already in-cluster from the delivery step.
+
+## In-repo placeholder files (local build only)
+
+| File | Secret | Envs |
+|---|---|---|
+| `overlays/dev/secrets.placeholder.yaml` | `verdify-app-secrets` | dev |
+| `overlays/staging/secrets.placeholder.yaml` | `verdify-app-secrets` | staging |
+| `overlays/prod/secrets.placeholder.yaml` | `verdify-app-secrets` | prod |
+| `overlays/prod/ha-token.placeholder.yaml` | `verdify-ha-token` | prod |
+| `overlays/prod/hermes-secret.placeholder.yaml` | `verdify-hermes` | prod |
+
+`verdify-hermes-slack` (optional, non-secret channel config) and
+`ghcr-jvallery-readonly` (image-pull, delivered out-of-band by Root) have no
+placeholder — the workloads reference them as `optional` / `imagePullSecrets`, so
+`kustomize build` is complete without an in-repo stand-in.
+
+## History
+
+- 2026-06-01 (#30): `overlays/prod/secrets.placeholder.yaml` carried
+  `config.kubernetes.io/local-config` as a **label**, leaking the placeholder
+  `verdify-app-secrets` (5 fake keys) into `kustomize build overlays/prod` output —
+  in the device-write env. Fixed to an annotation; added the missing `verdify-hermes`
+  placeholder; codified the two invariants above. Every overlay now renders ZERO
+  `kind: Secret`.

--- a/deploy/k8s/overlays/prod/hermes-secret.placeholder.yaml
+++ b/deploy/k8s/overlays/prod/hermes-secret.placeholder.yaml
@@ -1,0 +1,42 @@
+# PLACEHOLDER hermes gateway Secret for LOCAL VALIDATION ONLY
+# (kustomize build / kubeconform). #119 hermes-iris, prod-only Component.
+#
+# THIS IS NOT A REAL CREDENTIAL and MUST NOT be applied to a real cluster. The
+# real verdify-hermes Secret is provided by the fleet SOPS+age secret backend and
+# applied OUT-OF-BAND by the GitOps secret-delivery step BEFORE this app
+# reconciles. It is the compose env_file /etc/verdify/hermes-iris.env ported to a
+# k8s Secret: the OpenAI key + any HERMES_* runtime env. hermes-iris reads it via
+# `envFrom.secretRef` (components/hermes-iris/hermes-iris.yaml), so the keys here
+# are env-var names, not file keys.
+#
+# MCP-URL GATE (migration doc R7): the MCP URL hermes calls lives INSIDE this
+# sealed env and MUST point at verdify-mcp.verdify-prod.svc:8000 BEFORE the
+# systemd MCP is stopped, or hermes fails at tool-call time. That is a gated
+# handoff edit at SEAL time (needs:root), never a value committed here.
+#
+# LOCAL-CONFIG INVARIANT (#30 contract): config.kubernetes.io/local-config is an
+# ANNOTATION (not a label) so `kustomize build` EXCLUDES this object from output —
+# no placeholder hermes/OpenAI material is ever emitted into a real-apply manifest.
+#
+# NAMESPACE-MATCH INVARIANT (#30 contract): the registry secret-meta
+# target.namespace MUST be byte-identical to this overlay's namespace
+# (verdify-prod) and the base Namespace object, or the sealed Secret silently
+# never mounts and hermes never starts.
+#
+# The placeholder key names mirror the contract surface ONLY; the values are fake.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verdify-hermes
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: hermes-iris
+  annotations:
+    # MUST be an ANNOTATION (not a label) — see LOCAL-CONFIG INVARIANT above.
+    config.kubernetes.io/local-config: "true"   # excluded from build output
+type: Opaque
+stringData:
+  OPENAI_API_KEY: "PLACEHOLDER_NOT_A_REAL_SECRET"
+  # HERMES_MCP_URL is the R7-gated MCP endpoint; the real value is repointed to
+  # verdify-mcp.verdify-prod.svc:8000 at seal time (needs:root), never here.
+  HERMES_MCP_URL: "PLACEHOLDER_NOT_A_REAL_SECRET"

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -24,6 +24,12 @@ resources:
   # the local-config ANNOTATION so it is EXCLUDED from build output (a
   # device-affecting HA token is never emitted). Real verdify-ha-token via SOPS.
   - ha-token.placeholder.yaml
+  # PLACEHOLDER hermes gateway Secret for local build ONLY (#119 hermes-iris).
+  # hermes-iris references verdify-hermes via envFrom.secretRef; this completes
+  # the #30 contract surface so the prod build is lint-able. local-config
+  # ANNOTATION -> EXCLUDED from build output (OpenAI key never emitted). Real
+  # verdify-hermes via SOPS out-of-band. See hermes-secret.placeholder.yaml.
+  - hermes-secret.placeholder.yaml
   # DEVICE WRITE PATH: the SINGLE egress allow letting the prod ingestor reach the
   # live device VLAN. See allow-ingestor-device-egress.yaml.
   - allow-ingestor-device-egress.yaml

--- a/deploy/k8s/overlays/prod/secrets.placeholder.yaml
+++ b/deploy/k8s/overlays/prod/secrets.placeholder.yaml
@@ -3,11 +3,24 @@
 # THIS IS NOT A REAL CREDENTIAL and MUST NOT be applied to a real cluster. In
 # production the verdify-app-secrets Secret is provided by the fleet SOPS+age
 # secret backend and applied by the GitOps secret-delivery step BEFORE this app
-# reconciles. The config.kubernetes.io/local-config label makes GitOps tooling
-# skip this object on real applies; for a real apply, drop the
-# `- secrets.placeholder.yaml` line from this overlay kustomization. It exists
-# ONLY so `kustomize build` yields a complete, lint-able manifest in CI without
-# reaching the secret backend.
+# reconciles. kustomize cannot decrypt SOPS, so this is NOT how the real secret
+# arrives — it exists ONLY so `kustomize build` / kubeconform yield a complete,
+# lint-able manifest in CI. For a real apply, drop the `- secrets.placeholder.yaml`
+# line from this overlay's kustomization.
+#
+# LOCAL-CONFIG INVARIANT (#30 contract): config.kubernetes.io/local-config MUST be
+# an ANNOTATION, not a label. `kustomize build` excludes objects carrying the
+# ANNOTATION from its output; as a LABEL it renders into the manifest and an
+# ArgoCD Secret-blacklisted AppProject rejects the whole sync ("synchronization
+# tasks are not valid"). This file previously carried it as a label, which leaked
+# the placeholder verdify-app-secrets (5 fake keys) into `kustomize build
+# overlays/prod` output — the most safety-critical env (device-write). Fixed to an
+# annotation so prod renders ZERO Secret objects, matching dev/staging/ha-token.
+#
+# NAMESPACE-MATCH INVARIANT (#30 contract): the registry secret-meta
+# target.namespace MUST be byte-identical to this overlay's namespace
+# (verdify-prod) and the base Namespace object, or the sealed Secret silently
+# never mounts (handoff §2.4).
 #
 # Canonical write-secret key is VERDIFY_WRITE_API_KEY (api/main.py write guard).
 # ESP32_API_KEY is device-affecting (Noise PSK) and sealed from the canonical
@@ -18,6 +31,8 @@ metadata:
   name: verdify-app-secrets
   labels:
     app.kubernetes.io/part-of: verdify
+  annotations:
+    # MUST be an ANNOTATION (not a label) — see LOCAL-CONFIG INVARIANT above.
     config.kubernetes.io/local-config: "true"   # never applied by GitOps
 type: Opaque
 stringData:


### PR DESCRIPTION
Closes #30

requested-by: iris (shared territory) — touches `deploy/k8s/**` (infra-adjacent).

## Scope (CONTRACT only — needs:root for delivery)

Per Jason's 2026-06-01 decision: **Iris owns the secret CONTRACT** (key names, the
per-env namespace-match invariant, the sealed-artifact shape, the
local-config-is-an-annotation invariant). **Root owns the SOPS/age delivery
MECHANISM** (`needs:root`, tracked in #66). This PR authors keys/refs ONLY — no
real secret values, no creds baked into images.

## What changed

1. **`deploy/k8s/SECRETS.md`** (new) — the single source of truth for the per-env
   secret contract:
   - Per-env secret matrix (which Secret carries which key in dev/staging/prod and
     which workload consumes it: `secretKeyRef` / `secretRef` / mounted volume).
   - Two enforced invariants:
     1. **LOCAL-CONFIG-IS-AN-ANNOTATION** — placeholder Secrets must carry
        `config.kubernetes.io/local-config` as an **annotation** (kustomize excludes
        it from build output). As a **label** it renders into the manifest and an
        ArgoCD Secret-blacklisted AppProject rejects the whole sync.
     2. **NAMESPACE-MATCH** — sealed-secret `target.namespace` must be byte-identical
        to the overlay namespace, the `Namespace` object, and the ArgoCD destination.
   - Sealed-artifact shape (`agent-fleet-control` registry meta + SOPS ciphertext),
     delivered out-of-band by Root before reconcile. `ESP32_API_KEY` device-safety
     guard (prod-only, no rotation without Jason's canonical-value confirmation).

2. **Fix: `overlays/prod/secrets.placeholder.yaml`** — it carried
   `config.kubernetes.io/local-config` as a **label**, so `kustomize build
   overlays/prod` **leaked the placeholder `verdify-app-secrets` (5 fake keys) into
   the rendered manifest** — in the device-write env, the worst case. Moved to an
   **annotation**. Prod now renders **zero** `kind: Secret`, matching dev/staging.

3. **`overlays/prod/hermes-secret.placeholder.yaml`** (new) — `verdify-hermes` is
   referenced by `components/hermes-iris` via `envFrom.secretRef` but had no in-tree
   placeholder. Added one (local-config annotation -> excluded from build output) so
   the contract surface is complete and lint-able.

## Validation (UTC 2026-06-01 ~16:40)

| Overlay | `kustomize build` | `kind: Secret` in output | kubeconform |
|---|---|---|---|
| base | OK | 0 | 14 valid / 0 invalid |
| dev | OK | 0 | 20 valid / 0 invalid (3 CRD skipped) |
| staging | OK | 0 | 20 valid / 0 invalid (3 CRD skipped) |
| prod | OK | **0 (was 1 — leak fixed)** | 30 valid / 0 invalid (1 CRD skipped) |

- **No real secret material** in any authored file — only `PLACEHOLDER_NOT_A_REAL_SECRET`.
  pre-commit `detect-private-key` passed.
- **Consumer refs intact** — prod build still references `verdify-app-secrets`,
  `verdify-hermes`, `verdify-ha-token`, `verdify-hermes-slack` by name (workloads
  inject creds at runtime; nothing baked into images).
- `make lint`: All checks passed (YAML/MD-only diff; no Python touched).

## Guardrails honored

- No device path: dev/staging stay device-dark; `ESP32_API_KEY` / device-write
  remain prod-only. No `DEVICE_WRITE=1` / esp32-egress authored for dev/stage.
- No real secret material; no secret values printed; placeholders only.
- No new numbered `db/migrations`.
- **Will NOT merge** — `needs:root` for the SOPS/age delivery mechanism (#66). This
  is the reviewable CONTRACT; real per-env sealed delivery lands with the envs at M3.