### PR TITLE
db(migration 152): gate v_daily_kpi.kwh behind a meter sanity check (#41)

### DIFF
--- a/db/migrations/152-kwh-coalesce-sanity-gate.sql
+++ b/db/migrations/152-kwh-coalesce-sanity-gate.sql
@@ -1,0 +1,130 @@
+-- Migration 152: Stop v_daily_kpi.kwh preferring the broken Shelly meter
+--                (issue #41, audit §7-#5 / P1).
+--
+-- CONTEXT
+-- v_daily_kpi.kwh historically computed:
+--     round((COALESCE(kwh_total, kwh_estimated, 0))::numeric, 2) AS kwh
+-- i.e. it blindly preferred the measured Shelly meter (daily_summary.kwh_total)
+-- and only fell through to the runtime-derived estimate (kwh_estimated) when the
+-- meter was NULL. The Shelly meter has been running 3-6x BELOW estimate
+-- (2026-05-30: meter 6.8 kWh vs estimate 41.0 kWh). A broken/zero/partial meter
+-- reading therefore FLOORS the KPI. The planner reads this view directly
+-- (gather-plan-context.sh surfaces it in the 7-day PLANNER SCORE TREND), and any
+-- dashboard consumer inherits the same broken floor. M3 only fixed the prose
+-- warning in iris_planner.py and the ingestor log line; the DB view feeding the
+-- planner trend was never corrected.
+--
+-- FIX
+-- CREATE OR REPLACE the view so kwh GATES the meter behind a sanity check:
+-- trust kwh_total ONLY when it is present, strictly positive, AND (there is no
+-- estimate to compare against, OR the meter is at least HALF the estimate). Any
+-- meter reading below ~half the estimate is rejected and the reliable estimate
+-- wins:
+--     CASE
+--       WHEN kwh_total IS NOT NULL
+--            AND kwh_total > 0
+--            AND (kwh_estimated IS NULL OR kwh_total >= 0.5 * kwh_estimated)
+--         THEN kwh_total
+--       ELSE COALESCE(kwh_estimated, kwh_total, 0)
+--     END
+-- A sane meter (>= half estimate) is still preferred — the estimate is the
+-- floor of last resort, never a silent override of a trustworthy meter. When
+-- the meter is NULL/zero/low and there is no estimate either, the final
+-- COALESCE keeps the legacy fallthrough (meter, then 0) so we never invent data.
+--
+-- Every OTHER output column of v_daily_kpi is reproduced VERBATIM from the
+-- production definition (db/schema.sql), including the planner_score formula —
+-- CREATE OR REPLACE preserves the full column set, order, and names, so the
+-- planner and dashboards see an unchanged shape with a corrected kwh only.
+--
+-- IDEMPOTENCY
+-- CREATE OR REPLACE VIEW is inherently idempotent: re-applying replaces the view
+-- with the identical definition (no-op, no error). Additive / non-destructive:
+-- no DROP, no table or row touched, no live data removed. Pure read-side change.
+--
+-- ROLLBACK (documented; see PR body) — restore the prior view definition:
+--   CREATE OR REPLACE VIEW public.v_daily_kpi AS
+--    SELECT date,
+--       round((COALESCE(compliance_pct, (0)::double precision))::numeric, 1) AS compliance_pct,
+--       round((COALESCE(temp_compliance_pct, (0)::double precision))::numeric, 1) AS temp_compliance_pct,
+--       round((COALESCE(vpd_compliance_pct, (0)::double precision))::numeric, 1) AS vpd_compliance_pct,
+--       round((COALESCE(stress_hours_heat, (0)::double precision))::numeric, 2) AS heat_stress_h,
+--       round((COALESCE(stress_hours_cold, (0)::double precision))::numeric, 2) AS cold_stress_h,
+--       round((COALESCE(stress_hours_vpd_high, (0)::double precision))::numeric, 2) AS vpd_high_stress_h,
+--       round((COALESCE(stress_hours_vpd_low, (0)::double precision))::numeric, 2) AS vpd_low_stress_h,
+--       round(((((COALESCE(stress_hours_heat, (0)::double precision) + COALESCE(stress_hours_cold, (0)::double precision)) + COALESCE(stress_hours_vpd_high, (0)::double precision)) + COALESCE(stress_hours_vpd_low, (0)::double precision)))::numeric, 2) AS total_stress_h,
+--       round((COALESCE(kwh_total, kwh_estimated, (0)::double precision))::numeric, 2) AS kwh,
+--       round((COALESCE(therms_estimated, gas_used_therms, (0)::double precision))::numeric, 3) AS therms,
+--       round((COALESCE(water_used_gal, (0)::double precision))::numeric, 0) AS water_gal,
+--       round((COALESCE(mister_water_gal, (0)::double precision))::numeric, 0) AS mister_water_gal,
+--       round((COALESCE(cost_electric, (0)::double precision))::numeric, 2) AS cost_electric,
+--       round((COALESCE(cost_gas, (0)::double precision))::numeric, 2) AS cost_gas,
+--       round((COALESCE(cost_water, (0)::double precision))::numeric, 2) AS cost_water,
+--       round((COALESCE(cost_total, (0)::double precision))::numeric, 2) AS cost_total,
+--       round((temp_min)::numeric, 1) AS temp_min,
+--       round((temp_max)::numeric, 1) AS temp_max,
+--       round((temp_avg)::numeric, 1) AS temp_avg,
+--       round((vpd_min)::numeric, 2) AS vpd_min,
+--       round((vpd_max)::numeric, 2) AS vpd_max,
+--       round((vpd_avg)::numeric, 2) AS vpd_avg,
+--       round((dli_final)::numeric, 1) AS dli,
+--       round((min_dp_margin_f)::numeric, 1) AS dp_margin_min_f,
+--       round((COALESCE(dp_risk_hours, (0)::double precision))::numeric, 1) AS dp_risk_hours,
+--       round(((((COALESCE(compliance_pct, (0)::double precision) / (100.0)::double precision) * (80)::double precision) + (GREATEST((0)::double precision, ((1.0)::double precision - LEAST((COALESCE(cost_total, (0)::double precision) / (15.0)::double precision), (1.0)::double precision))) * (20)::double precision)))::numeric, 1) AS planner_score
+--      FROM public.daily_summary
+--     WHERE (date IS NOT NULL)
+--     ORDER BY date;
+--
+-- ROLLBACK-REPLAY SAFETY (issue #23)
+-- This migration contains NO top-level COMMIT and no commit-forcing statement
+-- (e.g. CREATE INDEX CONCURRENTLY). It is a single CREATE OR REPLACE VIEW, so the
+-- rollback-validation harness can wrap it in an outer BEGIN..ROLLBACK without the
+-- migration self-committing and defeating the dry-run.
+--
+-- RESTARTS (CLAUDE.md rule 7): this migration does NOT touch verdify_schemas/**,
+-- ingestor/entity_map.py, or mcp/server.py, so no service-restart obligation is
+-- triggered. Read-side view change on a plain table (daily_summary). No device
+-- contact. The planner picks up the corrected kwh on its next read of the view.
+
+CREATE OR REPLACE VIEW public.v_daily_kpi AS
+ SELECT date,
+    round((COALESCE(compliance_pct, (0)::double precision))::numeric, 1) AS compliance_pct,
+    round((COALESCE(temp_compliance_pct, (0)::double precision))::numeric, 1) AS temp_compliance_pct,
+    round((COALESCE(vpd_compliance_pct, (0)::double precision))::numeric, 1) AS vpd_compliance_pct,
+    round((COALESCE(stress_hours_heat, (0)::double precision))::numeric, 2) AS heat_stress_h,
+    round((COALESCE(stress_hours_cold, (0)::double precision))::numeric, 2) AS cold_stress_h,
+    round((COALESCE(stress_hours_vpd_high, (0)::double precision))::numeric, 2) AS vpd_high_stress_h,
+    round((COALESCE(stress_hours_vpd_low, (0)::double precision))::numeric, 2) AS vpd_low_stress_h,
+    round(((((COALESCE(stress_hours_heat, (0)::double precision) + COALESCE(stress_hours_cold, (0)::double precision)) + COALESCE(stress_hours_vpd_high, (0)::double precision)) + COALESCE(stress_hours_vpd_low, (0)::double precision)))::numeric, 2) AS total_stress_h,
+    round((
+        CASE
+            WHEN kwh_total IS NOT NULL
+                 AND kwh_total > (0)::double precision
+                 AND (kwh_estimated IS NULL OR kwh_total >= ((0.5)::double precision * kwh_estimated))
+                THEN kwh_total
+            ELSE COALESCE(kwh_estimated, kwh_total, (0)::double precision)
+        END)::numeric, 2) AS kwh,
+    round((COALESCE(therms_estimated, gas_used_therms, (0)::double precision))::numeric, 3) AS therms,
+    round((COALESCE(water_used_gal, (0)::double precision))::numeric, 0) AS water_gal,
+    round((COALESCE(mister_water_gal, (0)::double precision))::numeric, 0) AS mister_water_gal,
+    round((COALESCE(cost_electric, (0)::double precision))::numeric, 2) AS cost_electric,
+    round((COALESCE(cost_gas, (0)::double precision))::numeric, 2) AS cost_gas,
+    round((COALESCE(cost_water, (0)::double precision))::numeric, 2) AS cost_water,
+    round((COALESCE(cost_total, (0)::double precision))::numeric, 2) AS cost_total,
+    round((temp_min)::numeric, 1) AS temp_min,
+    round((temp_max)::numeric, 1) AS temp_max,
+    round((temp_avg)::numeric, 1) AS temp_avg,
+    round((vpd_min)::numeric, 2) AS vpd_min,
+    round((vpd_max)::numeric, 2) AS vpd_max,
+    round((vpd_avg)::numeric, 2) AS vpd_avg,
+    round((dli_final)::numeric, 1) AS dli,
+    round((min_dp_margin_f)::numeric, 1) AS dp_margin_min_f,
+    round((COALESCE(dp_risk_hours, (0)::double precision))::numeric, 1) AS dp_risk_hours,
+    round(((((COALESCE(compliance_pct, (0)::double precision) / (100.0)::double precision) * (80)::double precision) + (GREATEST((0)::double precision, ((1.0)::double precision - LEAST((COALESCE(cost_total, (0)::double precision) / (15.0)::double precision), (1.0)::double precision))) * (20)::double precision)))::numeric, 1) AS planner_score
+   FROM public.daily_summary
+  WHERE (date IS NOT NULL)
+  ORDER BY date;
+
+ALTER VIEW public.v_daily_kpi OWNER TO verdify;
+
+COMMENT ON VIEW public.v_daily_kpi IS 'Daily KPI rollup over daily_summary. kwh GATES the measured Shelly meter (kwh_total) behind a sanity check (migration 152 / issue #41): the meter is trusted only when present, > 0, and >= half the runtime estimate (kwh_estimated); otherwise the estimate wins, so a broken/zero/low meter no longer floors the KPI the planner reads.';

--- a/db/migrations/tests/test-152-kwh-coalesce-sanity-gate.sql
+++ b/db/migrations/tests/test-152-kwh-coalesce-sanity-gate.sql
@@ -1,0 +1,188 @@
+-- Fixture test for migration 152 (issue #41).
+--
+-- Self-contained, self-asserting SQL fixture for a DISPOSABLE throwaway DB only.
+-- Stands up a minimal daily_summary (only the columns v_daily_kpi reads), seeds
+-- rows covering broken/low-meter, sane-meter, meter-only, and estimate-only
+-- cases, applies the migration (CREATE OR REPLACE VIEW), asserts kwh resolves to
+-- the reliable value, proves idempotency (re-apply CREATE OR REPLACE = no-op/no
+-- error and identical results), then proves the documented rollback restores the
+-- prior buggy behaviour (broken meter floors the KPI again). Every assertion
+-- RAISEs EXCEPTION on failure, so a clean run that prints the final NOTICE means
+-- apply + idempotency + rollback all pass.
+--
+-- Run against a throwaway DB, e.g.:
+--   psql -v ON_ERROR_STOP=1 -f db/migrations/tests/test-152-kwh-coalesce-sanity-gate.sql
+-- NEVER run this against the live DB — it DROPs and recreates daily_summary.
+
+\set ON_ERROR_STOP on
+
+-- The migration's ALTER VIEW ... OWNER TO verdify requires the verdify role.
+-- In production schema.sql already created it; on a bare throwaway DB we create
+-- it here so the migration body applies verbatim.
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='verdify') THEN
+        CREATE ROLE verdify;
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Minimal schema v_daily_kpi depends on (only the columns the view reads).
+-- daily_summary is a plain table; no hypertable / TimescaleDB needed here.
+-- ---------------------------------------------------------------------------
+DROP VIEW IF EXISTS public.v_daily_kpi;
+DROP TABLE IF EXISTS public.daily_summary;
+CREATE TABLE public.daily_summary (
+    date                  date NOT NULL,
+    compliance_pct        double precision,
+    temp_compliance_pct   double precision,
+    vpd_compliance_pct    double precision,
+    stress_hours_heat     double precision,
+    stress_hours_cold     double precision,
+    stress_hours_vpd_high double precision,
+    stress_hours_vpd_low  double precision,
+    kwh_total             double precision,
+    kwh_estimated         double precision,
+    therms_estimated      double precision,
+    gas_used_therms       double precision,
+    water_used_gal        double precision,
+    mister_water_gal      double precision,
+    cost_electric         double precision,
+    cost_gas              double precision,
+    cost_water            double precision,
+    cost_total            double precision,
+    temp_min              double precision,
+    temp_max              double precision,
+    temp_avg              double precision,
+    vpd_min               double precision,
+    vpd_max               double precision,
+    vpd_avg               double precision,
+    dli_final             double precision,
+    min_dp_margin_f       double precision,
+    dp_risk_hours         double precision
+);
+-- Mirror production: in schema.sql daily_summary is OWNER TO verdify, and the
+-- migration's ALTER VIEW ... OWNER TO verdify makes the view owner match. Align
+-- the throwaway table owner so the view's owner can read its base table.
+ALTER TABLE public.daily_summary OWNER TO verdify;
+
+-- ---------------------------------------------------------------------------
+-- Seed: every kwh decision branch.
+-- ---------------------------------------------------------------------------
+INSERT INTO public.daily_summary (date, kwh_total, kwh_estimated) VALUES
+    ('2026-05-30', 6.8,  41.0),   -- A: BROKEN/LOW meter (6.8 << half of 41=20.5) -> estimate must win (41.0)
+    ('2026-05-29', 0,    38.0),   -- B: ZERO meter -> estimate must win (38.0)
+    ('2026-05-28', NULL, 35.0),   -- C: NULL meter -> estimate wins (35.0), same as legacy
+    ('2026-05-27', 40.0, 41.0),   -- D: SANE meter (40 >= 20.5) -> meter kept (40.0)
+    ('2026-05-26', 22.0, 40.0),   -- E: meter exactly above half (22 >= 20.0) -> meter kept (22.0)
+    ('2026-05-25', 33.0, NULL),   -- F: meter present, NO estimate -> meter kept (33.0)
+    ('2026-05-24', NULL, NULL);   -- G: nothing -> 0.0 (never invent data)
+
+-- ===========================================================================
+-- APPLY (migration 152 body)
+-- ===========================================================================
+\i db/migrations/152-kwh-coalesce-sanity-gate.sql
+
+-- ---------------------------------------------------------------------------
+-- ASSERT apply: kwh resolves to the reliable value per branch.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE v numeric;
+BEGIN
+    -- A: broken/low meter rejected -> estimate.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-30';
+    IF v <> 41.00 THEN RAISE EXCEPTION 'APPLY FAIL A: broken meter 6.8 should yield estimate 41.00, got %', v; END IF;
+
+    -- B: zero meter rejected -> estimate.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-29';
+    IF v <> 38.00 THEN RAISE EXCEPTION 'APPLY FAIL B: zero meter should yield estimate 38.00, got %', v; END IF;
+
+    -- C: NULL meter -> estimate (unchanged from legacy).
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-28';
+    IF v <> 35.00 THEN RAISE EXCEPTION 'APPLY FAIL C: NULL meter should yield estimate 35.00, got %', v; END IF;
+
+    -- D: sane meter (>= half estimate) kept.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-27';
+    IF v <> 40.00 THEN RAISE EXCEPTION 'APPLY FAIL D: sane meter 40.0 should be kept, got %', v; END IF;
+
+    -- E: meter exactly above half estimate kept.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-26';
+    IF v <> 22.00 THEN RAISE EXCEPTION 'APPLY FAIL E: meter 22.0 (>= half 40) should be kept, got %', v; END IF;
+
+    -- F: meter present, no estimate -> meter kept.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-25';
+    IF v <> 33.00 THEN RAISE EXCEPTION 'APPLY FAIL F: meter 33.0 with no estimate should be kept, got %', v; END IF;
+
+    -- G: nothing -> 0.
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-24';
+    IF v <> 0.00 THEN RAISE EXCEPTION 'APPLY FAIL G: no meter/estimate should yield 0.00, got %', v; END IF;
+
+    RAISE NOTICE 'APPLY OK: broken/zero/low meter rejected -> estimate wins; sane meter kept; no-data -> 0.';
+END $$;
+
+-- ===========================================================================
+-- RE-APPLY (idempotency): CREATE OR REPLACE must succeed and yield identical kwh.
+-- ===========================================================================
+\i db/migrations/152-kwh-coalesce-sanity-gate.sql
+
+DO $$
+DECLARE v numeric;
+BEGIN
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-30';
+    IF v <> 41.00 THEN RAISE EXCEPTION 'IDEMPOTENCY FAIL: re-apply changed kwh for broken-meter row, got %', v; END IF;
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-27';
+    IF v <> 40.00 THEN RAISE EXCEPTION 'IDEMPOTENCY FAIL: re-apply changed kwh for sane-meter row, got %', v; END IF;
+    RAISE NOTICE 'IDEMPOTENCY OK: re-apply (CREATE OR REPLACE) succeeded, kwh unchanged.';
+END $$;
+
+-- ===========================================================================
+-- ROLLBACK (documented rollback, verbatim) + assert prior buggy behaviour back.
+-- ===========================================================================
+CREATE OR REPLACE VIEW public.v_daily_kpi AS
+ SELECT date,
+    round((COALESCE(compliance_pct, (0)::double precision))::numeric, 1) AS compliance_pct,
+    round((COALESCE(temp_compliance_pct, (0)::double precision))::numeric, 1) AS temp_compliance_pct,
+    round((COALESCE(vpd_compliance_pct, (0)::double precision))::numeric, 1) AS vpd_compliance_pct,
+    round((COALESCE(stress_hours_heat, (0)::double precision))::numeric, 2) AS heat_stress_h,
+    round((COALESCE(stress_hours_cold, (0)::double precision))::numeric, 2) AS cold_stress_h,
+    round((COALESCE(stress_hours_vpd_high, (0)::double precision))::numeric, 2) AS vpd_high_stress_h,
+    round((COALESCE(stress_hours_vpd_low, (0)::double precision))::numeric, 2) AS vpd_low_stress_h,
+    round(((((COALESCE(stress_hours_heat, (0)::double precision) + COALESCE(stress_hours_cold, (0)::double precision)) + COALESCE(stress_hours_vpd_high, (0)::double precision)) + COALESCE(stress_hours_vpd_low, (0)::double precision)))::numeric, 2) AS total_stress_h,
+    round((COALESCE(kwh_total, kwh_estimated, (0)::double precision))::numeric, 2) AS kwh,
+    round((COALESCE(therms_estimated, gas_used_therms, (0)::double precision))::numeric, 3) AS therms,
+    round((COALESCE(water_used_gal, (0)::double precision))::numeric, 0) AS water_gal,
+    round((COALESCE(mister_water_gal, (0)::double precision))::numeric, 0) AS mister_water_gal,
+    round((COALESCE(cost_electric, (0)::double precision))::numeric, 2) AS cost_electric,
+    round((COALESCE(cost_gas, (0)::double precision))::numeric, 2) AS cost_gas,
+    round((COALESCE(cost_water, (0)::double precision))::numeric, 2) AS cost_water,
+    round((COALESCE(cost_total, (0)::double precision))::numeric, 2) AS cost_total,
+    round((temp_min)::numeric, 1) AS temp_min,
+    round((temp_max)::numeric, 1) AS temp_max,
+    round((temp_avg)::numeric, 1) AS temp_avg,
+    round((vpd_min)::numeric, 2) AS vpd_min,
+    round((vpd_max)::numeric, 2) AS vpd_max,
+    round((vpd_avg)::numeric, 2) AS vpd_avg,
+    round((dli_final)::numeric, 1) AS dli,
+    round((min_dp_margin_f)::numeric, 1) AS dp_margin_min_f,
+    round((COALESCE(dp_risk_hours, (0)::double precision))::numeric, 1) AS dp_risk_hours,
+    round(((((COALESCE(compliance_pct, (0)::double precision) / (100.0)::double precision) * (80)::double precision) + (GREATEST((0)::double precision, ((1.0)::double precision - LEAST((COALESCE(cost_total, (0)::double precision) / (15.0)::double precision), (1.0)::double precision))) * (20)::double precision)))::numeric, 1) AS planner_score
+   FROM public.daily_summary
+  WHERE (date IS NOT NULL)
+  ORDER BY date;
+
+DO $$
+DECLARE v numeric;
+BEGIN
+    -- After rollback the broken meter floors the KPI again (legacy bug back).
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-30';
+    IF v <> 6.80 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: prior view should re-floor broken meter to 6.80, got %', v;
+    END IF;
+    -- Sane-meter row is identical under both definitions (sanity check).
+    SELECT kwh INTO v FROM public.v_daily_kpi WHERE date='2026-05-27';
+    IF v <> 40.00 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: sane-meter row should still be 40.00, got %', v;
+    END IF;
+    RAISE NOTICE 'ROLLBACK OK: prior definition restored (broken meter floors KPI again).';
+END $$;
+
+DO $$ BEGIN RAISE NOTICE 'ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).'; END $$;


### PR DESCRIPTION
Closes #41

## What
`CREATE OR REPLACE VIEW public.v_daily_kpi` (migration `152-kwh-coalesce-sanity-gate.sql`) to stop the broken Shelly meter flooring the kwh KPI.

Before (schema.sql:23624):
```sql
round((COALESCE(kwh_total, kwh_estimated, 0))::numeric, 2) AS kwh,
```
This blindly preferred the measured meter (`daily_summary.kwh_total`), only falling through to the runtime estimate (`kwh_estimated`) when the meter was NULL. The Shelly meter runs 3-6x below estimate (2026-05-30: meter 6.8 kWh vs estimate 41.0 kWh), so a broken/zero/partial reading **floors** the KPI the planner reads directly (gather-plan-context.sh -> 7-day PLANNER SCORE TREND) and any dashboard consumer.

After:
```sql
round((
    CASE
        WHEN kwh_total IS NOT NULL
             AND kwh_total > 0
             AND (kwh_estimated IS NULL OR kwh_total >= 0.5 * kwh_estimated)
            THEN kwh_total
        ELSE COALESCE(kwh_estimated, kwh_total, 0)
    END)::numeric, 2) AS kwh,
```
The meter is trusted **only** when present, > 0, and >= half the estimate; otherwise the reliable estimate wins. A sane meter (>= half estimate) is still preferred — the estimate is the floor of last resort, never a silent override of a trustworthy meter. Every other output column (including `planner_score`) is reproduced verbatim, so the view shape the planner/dashboards see is unchanged except for a corrected `kwh`.

## Fixture test evidence (applied on a disposable DB)
Ran `db/migrations/tests/test-152-kwh-coalesce-sanity-gate.sql` against a throwaway `postgres:16-alpine` container (created + destroyed; **never** the live DB). Minimal `daily_summary` seeded with every branch: broken/low meter (6.8 vs est 41.0), zero meter, NULL meter, sane meter, meter==half-estimate boundary, meter-only (no estimate), and no-data.

```
=== RUN FIXTURE ===
NOTICE:  APPLY OK: broken/zero/low meter rejected -> estimate wins; sane meter kept; no-data -> 0.
NOTICE:  IDEMPOTENCY OK: re-apply (CREATE OR REPLACE) succeeded, kwh unchanged.
NOTICE:  ROLLBACK OK: prior definition restored (broken meter floors KPI again).
NOTICE:  ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).
=== FIXTURE EXIT CODE: 0 ===
UTC timestamp: 2026-06-01T20:32:45Z
```
Key assertion: the broken meter row (kwh_total=6.8, kwh_estimated=41.0) resolves to **41.00** (estimate), not the broken 6.8 floor. `make lint` (ruff): All checks passed.

- Apply: green (kwh resolves to reliable value per branch)
- Idempotency: green (CREATE OR REPLACE re-apply = no-op, identical results)
- Rollback: green (prior definition restored; broken meter re-floors to 6.80, confirming the rollback target)

## Rollback
`CREATE OR REPLACE VIEW` back to the prior definition (captured verbatim from `db/schema.sql:23614-23644`). Full statement is in the migration header and re-run verbatim in the fixture's rollback section. The kwh column reverts to:
```sql
round((COALESCE(kwh_total, kwh_estimated, (0)::double precision))::numeric, 2) AS kwh,
```
with all other columns unchanged, plus `ALTER VIEW public.v_daily_kpi OWNER TO verdify;`.

## Safety
- **Rollback-replay-safe (issue #23):** single `CREATE OR REPLACE VIEW` + `ALTER VIEW OWNER` + `COMMENT` — no top-level COMMIT, no `CREATE INDEX CONCURRENTLY`. Wraps cleanly in an outer `BEGIN..ROLLBACK`.
- **Additive / non-destructive:** read-side view only; no DROP, no table/row touched, no live data removed. No device contact.
- **Restarts (CLAUDE.md rule 7):** does NOT touch `verdify_schemas/**`, `ingestor/entity_map.py`, or `mcp/server.py` -> no service-restart obligation. The planner picks up the corrected kwh on its next read.
- Matches existing numbering (next after 151) + style (header convention + verbatim view body) exactly.

requested-by: iris (shared territory — db/migrations, serialized)

**state: MERGED** on merge — the migration is merged to the repo here; it is **applied later by the migrate Job at the k3s/cutover** (state:DEPLOYED then), NOT now. Issue stays OPEN per the four-state lifecycle.