### PR TITLE
migration 153: extend v_data_pipeline_health to weather_station + annotate intentionally-dark sources (#42)

### DIFF
--- a/db/migrations/153-pipeline-health-weather-station-dark-sources.sql
+++ b/db/migrations/153-pipeline-health-weather-station-dark-sources.sql
@@ -1,0 +1,212 @@
+-- Migration 153: Extend v_data_pipeline_health to cover weather_station and to
+--                explicitly annotate intentionally-dark sources (issue #42,
+--                audit §7-#8 / P1).
+--
+-- CONTEXT
+-- `SELECT DISTINCT source FROM v_data_pipeline_health` returns only 8 sources
+-- (climate, hydro, equipment, diagnostics, energy, setpoints, forecast,
+-- daily_summary). weather_station -- the raw Tempest/Panorama feed, live but
+-- intermittent -- is the genuine gap: a fully dead weather_station pipeline is
+-- currently invisible to the freshness view. Separately, two tables look "stale"
+-- forever by design and must not be mistaken for broken pipelines:
+--   * esp32_logs       -- intentionally dark (firmware log ingestion off; 90bc358)
+--   * irrigation_log   -- intentionally retired (migration 134; canonical
+--                         irrigation/fertigation is reconstructed from
+--                         equipment_state in v_irrigation_fertigation_runs).
+-- The view should monitor weather_station like the other live sources AND carry
+-- an explicit annotation on the two intentional ones, so a dead live pipeline
+-- can never silently slip in disguised as an "expected-dark" source.
+--
+-- FIX
+-- CREATE OR REPLACE the view. Every existing source row (climate, hydro,
+-- equipment, diagnostics, energy, setpoints, forecast, daily_summary) is
+-- reproduced VERBATIM from the production definition (db/schema.sql), including
+-- the existing five output columns in the same order and names:
+--     source, rows_1h, rows_24h, age_s, null_pct_1h
+-- so every existing consumer (api/main.py /api/v1/public/data-health and the
+-- forecast freshness lookup; v_data_trust_ledger) sees an unchanged shape. Two
+-- columns are APPENDED (additive — appended last, never reorders existing ones):
+--     cadence_threshold_s int   -- per-source freshness threshold in seconds
+--                                  (NULL for sources that already had bespoke
+--                                  thresholds wired in v_data_trust_ledger, i.e.
+--                                  the legacy 8; the view stays the source of
+--                                  truth for the NEW rows only).
+--     health text               -- 'ok' | 'stale' | 'intentional_dark'
+-- and three rows are ADDED:
+--   * weather_station -- age_s from max(ts); threshold 86400s (24h). The Tempest
+--     feed is intermittent (the issue notes ~7d intermittency at the extreme),
+--     but a 24h ceiling still catches a fully-dead pipeline while tolerating the
+--     normal intermittency. health = 'stale' once age_s exceeds the threshold,
+--     else 'ok'. An empty table (no rows ever) reports age_s = NULL and
+--     health = 'stale' (cannot prove freshness).
+--   * esp32_logs      -- health = 'intentional_dark', age_s informational
+--     (max(ts) if any rows, else NULL), cadence_threshold_s = NULL. NOT flagged.
+--   * irrigation_log  -- health = 'intentional_dark', same treatment.
+-- The eight legacy rows get health = 'ok' (their freshness is already gated by
+-- the bespoke checks in v_data_trust_ledger / alert_monitor; this migration does
+-- not change their semantics, only labels them so the new `health` column is
+-- non-NULL across the board).
+--
+-- SCOPE NOTE
+-- The issue's `alert_monitor raises on weather_station staleness` acceptance
+-- criterion is ingestor-owned Python (ingestor/tasks.py::alert_monitor) and ships
+-- as a separate follow-on PR into ingestor scope. This migration is the
+-- shared-territory DB-view layer only (the issue's explicit `Depends on`).
+--
+-- IDEMPOTENCY
+-- CREATE OR REPLACE VIEW is inherently idempotent: re-applying replaces the view
+-- with the identical definition (no-op, no error). Additive / non-destructive:
+-- no DROP, no table or row touched, no live data removed. Pure read-side change.
+-- NB: CREATE OR REPLACE VIEW only permits ADDING columns at the end (which this
+-- does); it never reorders or drops existing columns, so the replace is accepted
+-- against the live view in place.
+--
+-- ROLLBACK (documented; see PR body) -- restore the prior view definition
+-- verbatim (8 sources, the original 5 columns, no health/cadence_threshold_s).
+-- IMPORTANT: CREATE OR REPLACE VIEW can only APPEND columns; it CANNOT drop them
+-- (Postgres errors "cannot drop columns from view"). So the rollback to the
+-- narrower prior view must DROP first. v_data_trust_ledger depends on this view
+-- (referencing only source + age_s -- both survive in the forward migration, so
+-- the forward CREATE OR REPLACE is accepted in place), therefore the rollback
+-- must DROP ... CASCADE and recreate the dependent too:
+--   DROP VIEW public.v_data_pipeline_health CASCADE;   -- also drops v_data_trust_ledger
+--   CREATE VIEW public.v_data_pipeline_health AS
+--    SELECT 'climate'::text AS source, ... (8 UNION ALL branches, 5 columns) ...
+--   FROM public.daily_summary;
+--   ALTER VIEW public.v_data_pipeline_health OWNER TO verdify;
+--   -- then recreate v_data_trust_ledger from db/schema.sql verbatim.
+-- The full prior text of BOTH views is in db/schema.sql (v_data_pipeline_health
+-- lines 23764-23821; v_data_trust_ledger from line 24610) and reproduced in the
+-- PR body. The fixture test applies the v_data_pipeline_health rollback verbatim
+-- (no dependent present in the throwaway DB, so a plain DROP VIEW) and asserts
+-- the view returns to 8 rows / 5 columns with no health/cadence_threshold_s.
+--
+-- ROLLBACK-REPLAY SAFETY (issue #23)
+-- This migration contains NO top-level COMMIT and no commit-forcing statement
+-- (e.g. CREATE INDEX CONCURRENTLY). It is a single CREATE OR REPLACE VIEW (plus
+-- one ALTER VIEW ... OWNER and a COMMENT), so the rollback-validation harness can
+-- wrap it in an outer BEGIN..ROLLBACK without the migration self-committing and
+-- defeating the dry-run.
+--
+-- RESTARTS (CLAUDE.md rule 7): this migration does NOT touch verdify_schemas/**,
+-- ingestor/entity_map.py, or mcp/server.py, so no service-restart obligation is
+-- triggered. Read-side view change. No device contact.
+
+CREATE OR REPLACE VIEW public.v_data_pipeline_health AS
+ SELECT 'climate'::text AS source,
+    count(*) FILTER (WHERE (climate.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (climate.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(climate.ts))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.temp_avg IS NULL) OR (climate.rh_avg IS NULL) OR (climate.vpd_avg IS NULL) OR (climate.dew_point IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (climate.ts > (now() - '01:00:00'::interval))), 0))::double precision)) AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.climate
+UNION ALL
+ SELECT 'hydro'::text AS source,
+    count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))) AS rows_1h,
+    count(*) FILTER (WHERE ((climate.ts > (now() - '24:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(climate.ts) FILTER (WHERE ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL))))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NULL) OR (climate.hydro_ec_us_cm IS NULL)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))), 0))::double precision)) AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.climate
+UNION ALL
+ SELECT 'equipment'::text AS source,
+    count(*) FILTER (WHERE (equipment_state.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (equipment_state.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(equipment_state.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.equipment_state
+UNION ALL
+ SELECT 'diagnostics'::text AS source,
+    count(*) FILTER (WHERE (diagnostics.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (diagnostics.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(diagnostics.ts))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((diagnostics.ts > (now() - '01:00:00'::interval)) AND ((diagnostics.wifi_rssi IS NULL) OR (diagnostics.heap_bytes IS NULL) OR (diagnostics.uptime_s IS NULL) OR (diagnostics.active_probe_count IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (diagnostics.ts > (now() - '01:00:00'::interval))), 0))::double precision)) AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.diagnostics
+UNION ALL
+ SELECT 'energy'::text AS source,
+    count(*) FILTER (WHERE (energy.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (energy.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(energy.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.energy
+UNION ALL
+ SELECT 'setpoints'::text AS source,
+    count(*) FILTER (WHERE (setpoint_changes.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (setpoint_changes.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(setpoint_changes.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.setpoint_changes
+UNION ALL
+ SELECT 'forecast'::text AS source,
+    count(*) FILTER (WHERE (weather_forecast.fetched_at > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (weather_forecast.fetched_at > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(weather_forecast.fetched_at))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((weather_forecast.fetched_at = ( SELECT max(weather_forecast_1.fetched_at) AS max
+           FROM public.weather_forecast weather_forecast_1)) AND ((weather_forecast.temp_f IS NULL) OR (weather_forecast.rh_pct IS NULL) OR (weather_forecast.solar_w_m2 IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (weather_forecast.fetched_at = ( SELECT max(weather_forecast_1.fetched_at) AS max
+           FROM public.weather_forecast weather_forecast_1))), 0))::double precision)) AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.weather_forecast
+UNION ALL
+ SELECT 'daily_summary'::text AS source,
+    count(*) FILTER (WHERE (daily_summary.captured_at > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (daily_summary.captured_at > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(daily_summary.captured_at))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((daily_summary.date >= (((now() AT TIME ZONE 'America/Denver'::text))::date - 1)) AND ((daily_summary.temp_avg IS NULL) OR (daily_summary.rh_avg IS NULL) OR (daily_summary.vpd_avg IS NULL) OR (daily_summary.compliance_pct IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (daily_summary.date >= (((now() AT TIME ZONE 'America/Denver'::text))::date - 1))), 0))::double precision)) AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'ok'::text AS health
+   FROM public.daily_summary
+UNION ALL
+-- weather_station: live but intermittent raw Tempest/Panorama feed. Monitored
+-- with a 24h ceiling (86400s) -- generous for the normal intermittency, but a
+-- fully dead pipeline is caught. No rows at all => age_s NULL, health 'stale'.
+ SELECT 'weather_station'::text AS source,
+    count(*) FILTER (WHERE (weather_station.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (weather_station.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    (EXTRACT(epoch FROM (now() - max(weather_station.ts))))::integer AS age_s,
+    NULL::double precision AS null_pct_1h,
+    86400 AS cadence_threshold_s,
+        CASE
+            WHEN (max(weather_station.ts) IS NULL) THEN 'stale'::text
+            WHEN ((EXTRACT(epoch FROM (now() - max(weather_station.ts))))::integer > 86400) THEN 'stale'::text
+            ELSE 'ok'::text
+        END AS health
+   FROM public.weather_station
+UNION ALL
+-- esp32_logs: intentionally dark (firmware log ingestion off; commit 90bc358).
+-- Annotated so a dead live pipeline can't masquerade as this expected-dark one.
+ SELECT 'esp32_logs'::text AS source,
+    count(*) FILTER (WHERE (esp32_logs.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (esp32_logs.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    (EXTRACT(epoch FROM (now() - max(esp32_logs.ts))))::integer AS age_s,
+    NULL::double precision AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'intentional_dark'::text AS health
+   FROM public.esp32_logs
+UNION ALL
+-- irrigation_log: intentionally retired (migration 134; canonical events come
+-- from equipment_state via v_irrigation_fertigation_runs). Annotated, not flagged.
+ SELECT 'irrigation_log'::text AS source,
+    count(*) FILTER (WHERE (irrigation_log.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (irrigation_log.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    (EXTRACT(epoch FROM (now() - max(irrigation_log.ts))))::integer AS age_s,
+    NULL::double precision AS null_pct_1h,
+    NULL::integer AS cadence_threshold_s,
+    'intentional_dark'::text AS health
+   FROM public.irrigation_log;
+
+
+ALTER VIEW public.v_data_pipeline_health OWNER TO verdify;
+
+COMMENT ON VIEW public.v_data_pipeline_health IS
+'Per-source freshness/quality. Eight live sources plus weather_station (24h cadence_threshold_s; health ok/stale). esp32_logs and irrigation_log are annotated health=''intentional_dark'' (esp32_logs ingestion off per 90bc358; irrigation_log retired per migration 134) so a dead live pipeline cannot masquerade as an expected-dark source. Columns rows_1h/rows_24h/age_s/null_pct_1h preserved verbatim for existing consumers; cadence_threshold_s/health appended.';

--- a/db/migrations/tests/test-153-pipeline-health-weather-station-dark-sources.sql
+++ b/db/migrations/tests/test-153-pipeline-health-weather-station-dark-sources.sql
@@ -1,0 +1,312 @@
+-- Fixture test for migration 153 (issue #42).
+--
+-- Self-contained, self-asserting SQL fixture for a DISPOSABLE throwaway DB only.
+-- Stands up the minimal base tables v_data_pipeline_health reads (only the
+-- columns the view references; all plain tables -- no hypertable / TimescaleDB
+-- needed), seeds rows so each NEW source row exercises a distinct branch, applies
+-- the migration (CREATE OR REPLACE VIEW), asserts:
+--   * weather_station appears with an age_s + health column + cadence_threshold_s,
+--     fresh -> 'ok', past-threshold -> 'stale', empty -> 'stale' (age_s NULL),
+--   * esp32_logs and irrigation_log carry health = 'intentional_dark',
+--   * the eight legacy sources are still present with health = 'ok',
+--   * the legacy five columns (rows_1h, rows_24h, age_s, null_pct_1h) survive,
+-- then proves idempotency (re-apply CREATE OR REPLACE = no-op/no error, identical
+-- results), then proves the documented rollback restores the PRIOR definition
+-- (8 sources, no health / cadence_threshold_s columns). Every assertion RAISEs
+-- EXCEPTION on failure, so a clean run that prints the final NOTICE means apply +
+-- idempotency + rollback all pass.
+--
+-- Run against a throwaway DB, e.g.:
+--   psql -v ON_ERROR_STOP=1 -f db/migrations/tests/test-153-pipeline-health-weather-station-dark-sources.sql
+-- NEVER run this against the live DB -- it DROPs and recreates the base tables.
+
+\set ON_ERROR_STOP on
+
+-- The migration's ALTER VIEW ... OWNER TO verdify requires the verdify role.
+-- In production schema.sql already created it; on a bare throwaway DB we create
+-- it here so the migration body applies verbatim.
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='verdify') THEN
+        CREATE ROLE verdify;
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Minimal schema v_data_pipeline_health depends on (only the columns the view
+-- reads). All plain tables; no hypertable / TimescaleDB needed here.
+-- ---------------------------------------------------------------------------
+DROP VIEW IF EXISTS public.v_data_pipeline_health;
+DROP TABLE IF EXISTS public.climate;
+DROP TABLE IF EXISTS public.equipment_state;
+DROP TABLE IF EXISTS public.diagnostics;
+DROP TABLE IF EXISTS public.energy;
+DROP TABLE IF EXISTS public.setpoint_changes;
+DROP TABLE IF EXISTS public.weather_forecast;
+DROP TABLE IF EXISTS public.daily_summary;
+DROP TABLE IF EXISTS public.weather_station;
+DROP TABLE IF EXISTS public.esp32_logs;
+DROP TABLE IF EXISTS public.irrigation_log;
+
+CREATE TABLE public.climate (
+    ts             timestamptz NOT NULL,
+    temp_avg       double precision,
+    rh_avg         double precision,
+    vpd_avg        double precision,
+    dew_point      double precision,
+    hydro_ph       double precision,
+    hydro_ec_us_cm double precision
+);
+CREATE TABLE public.equipment_state  (ts timestamptz NOT NULL);
+CREATE TABLE public.diagnostics (
+    ts                 timestamptz NOT NULL,
+    wifi_rssi          double precision,
+    heap_bytes         bigint,
+    uptime_s           bigint,
+    active_probe_count integer
+);
+CREATE TABLE public.energy           (ts timestamptz NOT NULL);
+CREATE TABLE public.setpoint_changes (ts timestamptz NOT NULL);
+CREATE TABLE public.weather_forecast (
+    fetched_at  timestamptz NOT NULL,
+    temp_f      double precision,
+    rh_pct      double precision,
+    solar_w_m2  double precision
+);
+CREATE TABLE public.daily_summary (
+    date           date NOT NULL,
+    captured_at    timestamptz,
+    temp_avg       double precision,
+    rh_avg         double precision,
+    vpd_avg        double precision,
+    compliance_pct double precision
+);
+CREATE TABLE public.weather_station  (ts timestamptz NOT NULL);
+CREATE TABLE public.esp32_logs       (ts timestamptz NOT NULL);
+CREATE TABLE public.irrigation_log   (ts timestamptz NOT NULL);
+
+-- Mirror production: base tables are OWNER TO verdify, and the migration's
+-- ALTER VIEW ... OWNER TO verdify makes the view owner verdify -- align ownership
+-- so the view owner can read its base tables.
+ALTER TABLE public.climate          OWNER TO verdify;
+ALTER TABLE public.equipment_state  OWNER TO verdify;
+ALTER TABLE public.diagnostics      OWNER TO verdify;
+ALTER TABLE public.energy           OWNER TO verdify;
+ALTER TABLE public.setpoint_changes OWNER TO verdify;
+ALTER TABLE public.weather_forecast OWNER TO verdify;
+ALTER TABLE public.daily_summary    OWNER TO verdify;
+ALTER TABLE public.weather_station  OWNER TO verdify;
+ALTER TABLE public.esp32_logs       OWNER TO verdify;
+ALTER TABLE public.irrigation_log   OWNER TO verdify;
+
+-- ---------------------------------------------------------------------------
+-- Seed: keep the eight legacy sources present (one fresh row each) and exercise
+-- the weather_station fresh branch. The weather_station stale / empty branches
+-- are re-tested below by re-seeding, because the view aggregates max(ts).
+-- ---------------------------------------------------------------------------
+INSERT INTO public.climate (ts, temp_avg, rh_avg, vpd_avg, dew_point, hydro_ph, hydro_ec_us_cm)
+    VALUES (now(), 75, 60, 1.0, 50, 6.0, 1800);
+INSERT INTO public.equipment_state  (ts) VALUES (now());
+INSERT INTO public.diagnostics (ts, wifi_rssi, heap_bytes, uptime_s, active_probe_count)
+    VALUES (now(), -60, 100000, 3600, 4);
+INSERT INTO public.energy           (ts) VALUES (now());
+INSERT INTO public.setpoint_changes (ts) VALUES (now());
+INSERT INTO public.weather_forecast (fetched_at, temp_f, rh_pct, solar_w_m2)
+    VALUES (now(), 70, 55, 600);
+INSERT INTO public.daily_summary (date, captured_at, temp_avg, rh_avg, vpd_avg, compliance_pct)
+    VALUES (current_date, now(), 74, 58, 0.9, 92);
+-- weather_station fresh: 1h old -> well under the 24h threshold -> 'ok'.
+INSERT INTO public.weather_station (ts) VALUES (now() - interval '1 hour');
+-- esp32_logs / irrigation_log: seed an OLD row -- they must be 'intentional_dark'
+-- regardless of age (proving age never flags them as broken).
+INSERT INTO public.esp32_logs     (ts) VALUES (now() - interval '30 days');
+INSERT INTO public.irrigation_log (ts) VALUES (now() - interval '60 days');
+
+-- ===========================================================================
+-- APPLY (migration 153 body)
+-- ===========================================================================
+\i db/migrations/153-pipeline-health-weather-station-dark-sources.sql
+
+-- ---------------------------------------------------------------------------
+-- ASSERT apply.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    n        int;
+    h        text;
+    a        int;
+    thr      int;
+BEGIN
+    -- All 8 legacy sources still present, all health = 'ok'.
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health
+     WHERE source IN ('climate','hydro','equipment','diagnostics','energy','setpoints','forecast','daily_summary');
+    IF n <> 8 THEN RAISE EXCEPTION 'APPLY FAIL: expected 8 legacy sources, got %', n; END IF;
+
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health
+     WHERE source IN ('climate','hydro','equipment','diagnostics','energy','setpoints','forecast','daily_summary')
+       AND health = 'ok';
+    IF n <> 8 THEN RAISE EXCEPTION 'APPLY FAIL: expected 8 legacy sources health=ok, got %', n; END IF;
+
+    -- Total 11 source rows (8 legacy + weather_station + esp32_logs + irrigation_log).
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health;
+    IF n <> 11 THEN RAISE EXCEPTION 'APPLY FAIL: expected 11 total source rows, got %', n; END IF;
+
+    -- weather_station present with age_s, health, cadence_threshold_s.
+    SELECT health, age_s, cadence_threshold_s INTO h, a, thr
+      FROM public.v_data_pipeline_health WHERE source = 'weather_station';
+    IF h IS NULL THEN RAISE EXCEPTION 'APPLY FAIL: weather_station missing from view'; END IF;
+    IF thr <> 86400 THEN RAISE EXCEPTION 'APPLY FAIL: weather_station cadence_threshold_s should be 86400, got %', thr; END IF;
+    IF a IS NULL OR a < 3000 OR a > 4200 THEN
+        RAISE EXCEPTION 'APPLY FAIL: weather_station age_s should be ~3600 (1h old), got %', a;
+    END IF;
+    IF h <> 'ok' THEN RAISE EXCEPTION 'APPLY FAIL: fresh weather_station (1h) should be health=ok, got %', h; END IF;
+
+    -- esp32_logs / irrigation_log annotated intentional_dark (NOT flagged broken
+    -- despite being weeks old).
+    SELECT health INTO h FROM public.v_data_pipeline_health WHERE source = 'esp32_logs';
+    IF h <> 'intentional_dark' THEN RAISE EXCEPTION 'APPLY FAIL: esp32_logs should be intentional_dark, got %', h; END IF;
+    SELECT health INTO h FROM public.v_data_pipeline_health WHERE source = 'irrigation_log';
+    IF h <> 'intentional_dark' THEN RAISE EXCEPTION 'APPLY FAIL: irrigation_log should be intentional_dark, got %', h; END IF;
+
+    -- Legacy 5 columns survive (selecting them must not error; climate row exists).
+    SELECT rows_1h INTO n FROM public.v_data_pipeline_health WHERE source = 'climate';
+    IF n < 1 THEN RAISE EXCEPTION 'APPLY FAIL: climate rows_1h should be >= 1, got %', n; END IF;
+
+    RAISE NOTICE 'APPLY OK: 11 sources; weather_station fresh=ok w/ age_s+threshold; esp32_logs & irrigation_log intentional_dark; legacy 8 ok + 5 columns intact.';
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- weather_station STALE branch: push the only row past the 24h threshold.
+-- ---------------------------------------------------------------------------
+UPDATE public.weather_station SET ts = now() - interval '36 hours';
+DO $$
+DECLARE h text;
+BEGIN
+    SELECT health INTO h FROM public.v_data_pipeline_health WHERE source = 'weather_station';
+    IF h <> 'stale' THEN RAISE EXCEPTION 'APPLY FAIL: weather_station 36h old should be health=stale, got %', h; END IF;
+    RAISE NOTICE 'APPLY OK: weather_station past 24h threshold -> stale.';
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- weather_station EMPTY branch: no rows -> age_s NULL, health stale.
+-- ---------------------------------------------------------------------------
+DELETE FROM public.weather_station;
+DO $$
+DECLARE h text; a int;
+BEGIN
+    SELECT health, age_s INTO h, a FROM public.v_data_pipeline_health WHERE source = 'weather_station';
+    IF a IS NOT NULL THEN RAISE EXCEPTION 'APPLY FAIL: empty weather_station age_s should be NULL, got %', a; END IF;
+    IF h <> 'stale' THEN RAISE EXCEPTION 'APPLY FAIL: empty weather_station should be health=stale, got %', h; END IF;
+    RAISE NOTICE 'APPLY OK: empty weather_station -> age_s NULL, health stale.';
+END $$;
+-- Restore a fresh weather_station row for the idempotency re-check.
+INSERT INTO public.weather_station (ts) VALUES (now() - interval '1 hour');
+
+-- ===========================================================================
+-- RE-APPLY (idempotency): CREATE OR REPLACE must succeed and yield same shape.
+-- ===========================================================================
+\i db/migrations/153-pipeline-health-weather-station-dark-sources.sql
+
+DO $$
+DECLARE n int; h text;
+BEGIN
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health;
+    IF n <> 11 THEN RAISE EXCEPTION 'IDEMPOTENCY FAIL: re-apply changed source count, got %', n; END IF;
+    SELECT health INTO h FROM public.v_data_pipeline_health WHERE source = 'esp32_logs';
+    IF h <> 'intentional_dark' THEN RAISE EXCEPTION 'IDEMPOTENCY FAIL: esp32_logs annotation lost on re-apply, got %', h; END IF;
+    SELECT health INTO h FROM public.v_data_pipeline_health WHERE source = 'weather_station';
+    IF h <> 'ok' THEN RAISE EXCEPTION 'IDEMPOTENCY FAIL: fresh weather_station should be ok on re-apply, got %', h; END IF;
+    RAISE NOTICE 'IDEMPOTENCY OK: re-apply (CREATE OR REPLACE) succeeded, shape + annotations unchanged.';
+END $$;
+
+-- ===========================================================================
+-- ROLLBACK (documented rollback, verbatim prior definition) + assert prior shape.
+-- ---------------------------------------------------------------------------
+-- NOTE: CREATE OR REPLACE VIEW cannot DROP columns (Postgres: "cannot drop
+-- columns from view"), so the rollback to the narrower 5-column prior view must
+-- DROP the view first. In PRODUCTION v_data_trust_ledger depends on this view
+-- (referencing only source + age_s, both surviving), so the production rollback
+-- is `DROP VIEW public.v_data_pipeline_health CASCADE` followed by recreating
+-- BOTH the prior v_data_pipeline_health AND v_data_trust_ledger (see PR body).
+-- This throwaway DB has no dependent view, so a plain DROP VIEW suffices here.
+-- ===========================================================================
+DROP VIEW public.v_data_pipeline_health;
+CREATE OR REPLACE VIEW public.v_data_pipeline_health AS
+ SELECT 'climate'::text AS source,
+    count(*) FILTER (WHERE (climate.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (climate.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(climate.ts))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.temp_avg IS NULL) OR (climate.rh_avg IS NULL) OR (climate.vpd_avg IS NULL) OR (climate.dew_point IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (climate.ts > (now() - '01:00:00'::interval))), 0))::double precision)) AS null_pct_1h
+   FROM public.climate
+UNION ALL
+ SELECT 'hydro'::text AS source,
+    count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))) AS rows_1h,
+    count(*) FILTER (WHERE ((climate.ts > (now() - '24:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(climate.ts) FILTER (WHERE ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL))))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NULL) OR (climate.hydro_ec_us_cm IS NULL)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE ((climate.ts > (now() - '01:00:00'::interval)) AND ((climate.hydro_ph IS NOT NULL) OR (climate.hydro_ec_us_cm IS NOT NULL)))), 0))::double precision)) AS null_pct_1h
+   FROM public.climate
+UNION ALL
+ SELECT 'equipment'::text AS source,
+    count(*) FILTER (WHERE (equipment_state.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (equipment_state.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(equipment_state.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h
+   FROM public.equipment_state
+UNION ALL
+ SELECT 'diagnostics'::text AS source,
+    count(*) FILTER (WHERE (diagnostics.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (diagnostics.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(diagnostics.ts))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((diagnostics.ts > (now() - '01:00:00'::interval)) AND ((diagnostics.wifi_rssi IS NULL) OR (diagnostics.heap_bytes IS NULL) OR (diagnostics.uptime_s IS NULL) OR (diagnostics.active_probe_count IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (diagnostics.ts > (now() - '01:00:00'::interval))), 0))::double precision)) AS null_pct_1h
+   FROM public.diagnostics
+UNION ALL
+ SELECT 'energy'::text AS source,
+    count(*) FILTER (WHERE (energy.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (energy.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(energy.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h
+   FROM public.energy
+UNION ALL
+ SELECT 'setpoints'::text AS source,
+    count(*) FILTER (WHERE (setpoint_changes.ts > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (setpoint_changes.ts > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(setpoint_changes.ts))))::integer, 0) AS age_s,
+    NULL::double precision AS null_pct_1h
+   FROM public.setpoint_changes
+UNION ALL
+ SELECT 'forecast'::text AS source,
+    count(*) FILTER (WHERE (weather_forecast.fetched_at > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (weather_forecast.fetched_at > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(weather_forecast.fetched_at))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((weather_forecast.fetched_at = ( SELECT max(weather_forecast_1.fetched_at) AS max
+           FROM public.weather_forecast weather_forecast_1)) AND ((weather_forecast.temp_f IS NULL) OR (weather_forecast.rh_pct IS NULL) OR (weather_forecast.solar_w_m2 IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (weather_forecast.fetched_at = ( SELECT max(weather_forecast_1.fetched_at) AS max
+           FROM public.weather_forecast weather_forecast_1))), 0))::double precision)) AS null_pct_1h
+   FROM public.weather_forecast
+UNION ALL
+ SELECT 'daily_summary'::text AS source,
+    count(*) FILTER (WHERE (daily_summary.captured_at > (now() - '01:00:00'::interval))) AS rows_1h,
+    count(*) FILTER (WHERE (daily_summary.captured_at > (now() - '24:00:00'::interval))) AS rows_24h,
+    GREATEST((EXTRACT(epoch FROM (now() - max(daily_summary.captured_at))))::integer, 0) AS age_s,
+    ((100.0)::double precision * ((count(*) FILTER (WHERE ((daily_summary.date >= (((now() AT TIME ZONE 'America/Denver'::text))::date - 1)) AND ((daily_summary.temp_avg IS NULL) OR (daily_summary.rh_avg IS NULL) OR (daily_summary.vpd_avg IS NULL) OR (daily_summary.compliance_pct IS NULL)))))::double precision / (NULLIF(count(*) FILTER (WHERE (daily_summary.date >= (((now() AT TIME ZONE 'America/Denver'::text))::date - 1))), 0))::double precision)) AS null_pct_1h
+   FROM public.daily_summary;
+
+DO $$
+DECLARE n int; cols int;
+BEGIN
+    -- Prior view: exactly 8 sources, none of the new ones.
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health;
+    IF n <> 8 THEN RAISE EXCEPTION 'ROLLBACK FAIL: prior view should have 8 sources, got %', n; END IF;
+    SELECT count(*) INTO n FROM public.v_data_pipeline_health
+     WHERE source IN ('weather_station','esp32_logs','irrigation_log');
+    IF n <> 0 THEN RAISE EXCEPTION 'ROLLBACK FAIL: prior view should NOT contain the new sources, got %', n; END IF;
+    -- Prior view: exactly 5 columns (no health / cadence_threshold_s).
+    SELECT count(*) INTO cols FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'v_data_pipeline_health';
+    IF cols <> 5 THEN RAISE EXCEPTION 'ROLLBACK FAIL: prior view should have 5 columns, got %', cols; END IF;
+    SELECT count(*) INTO cols FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'v_data_pipeline_health'
+       AND column_name IN ('health','cadence_threshold_s');
+    IF cols <> 0 THEN RAISE EXCEPTION 'ROLLBACK FAIL: health/cadence_threshold_s columns should be gone, got %', cols; END IF;
+    RAISE NOTICE 'ROLLBACK OK: prior definition restored (8 sources, 5 columns, no health/cadence_threshold_s).';
+END $$;
+
+DO $$ BEGIN RAISE NOTICE 'ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).'; END $$;


### PR DESCRIPTION
Closes #42

## What
`CREATE OR REPLACE VIEW public.v_data_pipeline_health` (migration `153-pipeline-health-weather-station-dark-sources.sql`):

- **All 8 existing source rows preserved verbatim** (climate, hydro, equipment, diagnostics, energy, setpoints, forecast, daily_summary), and the existing 5 columns (`source, rows_1h, rows_24h, age_s, null_pct_1h`) kept in the same order/names. Non-breaking: `api/main.py` (`/api/v1/public/data-health` + the forecast freshness lookup) and `v_data_trust_ledger` select **named** columns, and `v_data_trust_ledger` references only `source` + `age_s` (both surviving).
- **Two columns appended:** `cadence_threshold_s int`, `health text` (`ok` | `stale` | `intentional_dark`).
- **weather_station** row added: `age_s` from `max(ts)`, `cadence_threshold_s = 86400` (24h — generous for the normal Tempest intermittency, still catches a fully dead pipeline). `health = 'stale'` once age exceeds the threshold or the table is empty (`age_s` NULL), else `'ok'`.
- **esp32_logs** and **irrigation_log** rows added with `health = 'intentional_dark'` (esp32_logs ingestion off per commit 90bc358; irrigation_log retired per migration 134) — explicitly NOT flagged broken regardless of age, so a dead live pipeline can't masquerade as an expected-dark source.

## Scope (no bundling)
This PR closes **only** the shared-territory DB-view layer — the issue's explicit `Depends on: Shared-territory DB view (coordinator-owned)`. The `alert_monitor raises on weather_station staleness` acceptance criterion is ingestor-owned Python (`ingestor/tasks.py::alert_monitor`) and ships as a separate follow-on PR into ingestor scope.

## Safety
- Additive / idempotent (`CREATE OR REPLACE VIEW`); no DROP, no table/row touched, no live data removed.
- **Rollback-replay-safe (issue #23):** no top-level `COMMIT`, no `CREATE INDEX CONCURRENTLY` or other commit-forcing statement — the harness can wrap it in an outer `BEGIN..ROLLBACK`.
- Does NOT touch `verdify_schemas/**`, `ingestor/entity_map.py`, or `mcp/server.py` ⇒ no service-restart obligation (CLAUDE.md rule 7). Read-side view change; no device contact.

## Fixture-test evidence (UTC 2026-06-01T20:43:54Z)
Ran on a **disposable** `postgres:16-alpine` container (`docker info` confirmed available), created and **destroyed** — never the live DB. `db/migrations/tests/test-153-pipeline-health-weather-station-dark-sources.sql`, `psql -v ON_ERROR_STOP=1`, exit 0:

```
NOTICE: APPLY OK: 11 sources; weather_station fresh=ok w/ age_s+threshold; esp32_logs & irrigation_log intentional_dark; legacy 8 ok + 5 columns intact.
NOTICE: APPLY OK: weather_station past 24h threshold -> stale.
NOTICE: APPLY OK: empty weather_station -> age_s NULL, health stale.
NOTICE: IDEMPOTENCY OK: re-apply (CREATE OR REPLACE) succeeded, shape + annotations unchanged.
NOTICE: ROLLBACK OK: prior definition restored (8 sources, 5 columns, no health/cadence_threshold_s).
NOTICE: ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).
PSQL_EXIT=0
```

Additionally validated the **production-realistic** paths with the `v_data_trust_ledger` dependent present:

```
NOTICE: FWD-WITH-DEPENDENT OK: applied in place (11 sources), v_data_trust_ledger intact.
NOTICE: ROLLBACK-CASCADE OK: DROP CASCADE removed both views.
EXIT=0
```

`make lint` → `All checks passed!`

## Rollback (documented)
**Important:** `CREATE OR REPLACE VIEW` can only APPEND columns, never drop them (Postgres: *"cannot drop columns from view"*). Reverting to the narrower 5-column prior view therefore requires a DROP. Because `v_data_trust_ledger` depends on this view, the production rollback is:

```sql
DROP VIEW public.v_data_pipeline_health CASCADE;   -- also drops v_data_trust_ledger
-- recreate the prior v_data_pipeline_health verbatim (8 UNION ALL branches,
-- original 5 columns: source, rows_1h, rows_24h, age_s, null_pct_1h) from
-- db/schema.sql lines 23764-23821:
CREATE VIEW public.v_data_pipeline_health AS
 SELECT 'climate'::text AS source, ... FROM public.climate
 UNION ALL ... (hydro, equipment, diagnostics, energy, setpoints, forecast)
 UNION ALL SELECT 'daily_summary'::text AS source, ... FROM public.daily_summary;
ALTER VIEW public.v_data_pipeline_health OWNER TO verdify;
-- then recreate v_data_trust_ledger verbatim from db/schema.sql (from line 24610).
```
The full prior text of both views is in `db/schema.sql`; the fixture applies the `v_data_pipeline_health` rollback verbatim (no dependent in the throwaway DB, so a plain `DROP VIEW`) and asserts the view returns to 8 rows / 5 columns.

requested-by: iris (shared territory — db/migrations, serialized)

---
**state:MERGED** — this migration is merged-to-repo here; it is **applied later by the migrate Job** at the k3s/cutover (state:DEPLOYED then), not by this PR. Migrate Job replays migrations against the in-cluster verdify-db StatefulSet only; it never touches the live VM DB or the device.