### PR TITLE
db(migrations): TWIN-6 twin_decisions + firmware_twin_divergence hypertables + twin_ro role (#33)

### DIFF
--- a/db/migrations/155-twin-observability-tables.sql
+++ b/db/migrations/155-twin-observability-tables.sql
@@ -1,0 +1,182 @@
+-- 155-twin-observability-tables.sql
+-- =============================================================================
+-- TWIN-6 (issue #33): firmware digital-twin observability schema.
+--
+-- Design: docs/design/firmware-digital-twin.md §5.2 (observability schema) and
+-- §5.3 (the read-only / no-actuation safety model, layer L2). The MVP and all
+-- comparison streams write to these two tables; nothing else in the repo owns
+-- them. Serialized shared-territory migration (db/migrations) — coordinator
+-- reviewed.
+--
+-- Adds:
+--   1. twin_decisions          — hypertable, 1:1 with replay_emit's TSV row
+--                                (+ climate_action via describe_effective_
+--                                climate_decision(), + twin_metadata jsonb).
+--   2. firmware_twin_divergence — windowed disagreement summary (counts/pcts,
+--                                per-relay breakdown, by_mode/by_daypart/
+--                                by_outdoor_band jsonb conditioning, worst
+--                                examples).
+--   3. twin_ro                  — group role (NOLOGIN). SELECT on the telemetry
+--                                tables the twin reads; INSERT on ONLY the two
+--                                tables above; NO UPDATE/DELETE anywhere and NO
+--                                write on any control-plane table (L2 of the
+--                                four independent read-only guarantees).
+--
+-- ADDITIVE ONLY. Net-new tables + role; no DROP/ALTER of live data. On live,
+-- to_regclass('public.twin_decisions') and ('public.firmware_twin_divergence')
+-- are NULL, and twin_ro does not exist.
+--
+-- #23 rollback-replay safety: this migration is NON-self-transactional — it has
+-- NO top-level BEGIN;/COMMIT; and NO commit-forcing statement (no CREATE INDEX
+-- CONCURRENTLY; create_hypertable runs fine inside psql's implicit autocommit).
+-- It is therefore SAFE to wrap in an outer `BEGIN; ... ROLLBACK;` for
+-- rollback-validation: there is no inner COMMIT to defeat the rollback. Every
+-- statement is idempotent (IF NOT EXISTS / if_not_exists => TRUE / a
+-- role-exists shim / REVOKE-then-GRANT), so it is also safe to re-run.
+--
+-- ROLLBACK (documented; for the disposable rollback fixture, never live):
+--   REVOKE ALL ON public.twin_decisions, public.firmware_twin_divergence FROM twin_ro;
+--   REVOKE ALL ON public.climate, public.equipment_state, public.system_state,
+--          public.setpoint_snapshot, public.setpoint_changes,
+--          public.climate_action_log FROM twin_ro;
+--   DROP TABLE IF EXISTS public.firmware_twin_divergence;
+--   DROP TABLE IF EXISTS public.twin_decisions;
+--   DROP ROLE IF EXISTS twin_ro;
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 1. twin_decisions: per-tick twin FSM output (1:1 with replay_emit TSV)
+-- ─────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.twin_decisions (
+    ts             timestamptz NOT NULL,
+    twin_env       text NOT NULL,            -- 'dev' | 'stage' | 'prod'
+    twin_ref       text NOT NULL,            -- git sha / fw_version the image was pinned to
+    input_ts       timestamptz NOT NULL,     -- the climate row that drove this decision
+    mode           text NOT NULL,
+    climate_action text,                     -- via describe_effective_climate_decision (§2.4)
+    mist_stage     integer NOT NULL,
+    relay_fog      boolean NOT NULL,
+    relay_vent     boolean NOT NULL,
+    relay_fan1     boolean NOT NULL,
+    relay_fan2     boolean NOT NULL,
+    relay_heat1    boolean NOT NULL,
+    relay_heat2    boolean NOT NULL,
+    mode_reason    text,
+    override_bits  integer NOT NULL,
+    twin_metadata  jsonb,                     -- vpd_zone_inputs='homogenized', warmup flags, etc.
+    greenhouse_id  text DEFAULT 'vallery' REFERENCES public.greenhouses(id),
+    CONSTRAINT twin_decisions_env_chk CHECK (twin_env IN ('dev', 'stage', 'prod'))
+);
+
+SELECT create_hypertable('public.twin_decisions', 'ts', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_twin_decisions_env_ts
+    ON public.twin_decisions (twin_env, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_twin_decisions_input_ts
+    ON public.twin_decisions (twin_env, input_ts DESC);
+
+COMMENT ON TABLE public.twin_decisions IS
+    'Firmware digital-twin per-tick FSM output (TWIN-6). 1:1 map of replay_emit''s TSV row plus climate_action and twin_metadata, so the live driver does no semantic translation. One row per twin (dev/stage/prod) per settled input tick. Written by the twin via the read-only twin_ro role (INSERT-only). Design: firmware-digital-twin.md §5.2.';
+COMMENT ON COLUMN public.twin_decisions.twin_env IS
+    'Which twin produced the row: dev (CI candidate), stage (bake candidate), prod (last-good shadow).';
+COMMENT ON COLUMN public.twin_decisions.twin_ref IS
+    'git sha / fw_version the twin image was pinned to; lets the bake/agreement gates confirm the twin ran the intended SHA.';
+COMMENT ON COLUMN public.twin_decisions.input_ts IS
+    'The climate telemetry row timestamp that drove this decision (the twin lags live by the settling window).';
+COMMENT ON COLUMN public.twin_decisions.climate_action IS
+    'Effective climate action via describe_effective_climate_decision() (greenhouse_logic.h); not a separate translation table.';
+COMMENT ON COLUMN public.twin_decisions.twin_metadata IS
+    'Free-form per-row context: vpd_zone_inputs, warm-up flags, econ_block reconstruction notes, etc.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 2. firmware_twin_divergence: windowed disagreement summary
+-- ─────────────────────────────────────────────────────────────────────
+-- One row per (comparison, window). comparison is e.g. 'stage_vs_prod' (bake
+-- agreement gate) or 'prod_vs_reality' (deployed-firmware drift). Holds the
+-- rolling relay-disagreement counts/pcts, the per-relay breakdown, the
+-- by_mode/by_daypart/by_outdoor_band jsonb conditioning, and worst_examples.
+CREATE TABLE IF NOT EXISTS public.firmware_twin_divergence (
+    ts                timestamptz NOT NULL,        -- when the summary was computed
+    comparison        text NOT NULL,               -- 'stage_vs_prod' | 'prod_vs_reality' | 'dev_vs_corpus' ...
+    window_start      timestamptz NOT NULL,
+    window_end        timestamptz NOT NULL,
+    ref_twin_ref      text,                         -- the reference side SHA (e.g. prod last-good)
+    cmp_twin_ref      text,                         -- the candidate side SHA (e.g. stage candidate)
+    samples           integer NOT NULL,
+    disagree_count    integer NOT NULL,
+    relay_disagree_pct double precision NOT NULL,
+    mode_disagree_pct  double precision,
+    per_relay         jsonb DEFAULT '{}'::jsonb NOT NULL,  -- {"fog": 0.0, "vent": 1.2, "fan1": 0.0, ...}
+    by_mode           jsonb DEFAULT '{}'::jsonb NOT NULL,
+    by_daypart        jsonb DEFAULT '{}'::jsonb NOT NULL,
+    by_outdoor_band   jsonb DEFAULT '{}'::jsonb NOT NULL,
+    worst_examples    jsonb DEFAULT '[]'::jsonb NOT NULL,
+    greenhouse_id     text DEFAULT 'vallery' REFERENCES public.greenhouses(id),
+    CONSTRAINT firmware_twin_divergence_window_chk CHECK (window_end >= window_start),
+    CONSTRAINT firmware_twin_divergence_pct_chk CHECK (
+        relay_disagree_pct >= 0 AND relay_disagree_pct <= 100
+    )
+);
+
+SELECT create_hypertable('public.firmware_twin_divergence', 'ts', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_firmware_twin_divergence_cmp_ts
+    ON public.firmware_twin_divergence (comparison, ts DESC);
+
+COMMENT ON TABLE public.firmware_twin_divergence IS
+    'Windowed firmware-twin disagreement summary (TWIN-6). One row per (comparison, window): rolling relay-disagreement counts/pcts, per-relay breakdown, by_mode/by_daypart/by_outdoor_band jsonb conditioning, and worst_examples. Feeds the live agreement gate (rule 8), the 48h bake clock (rule 3), and the alert_monitor rows that plug into firmware-deploy-preflight (rule 1). Design: firmware-digital-twin.md §5.2/§5.3. Written by twin_ro (INSERT-only).';
+COMMENT ON COLUMN public.firmware_twin_divergence.comparison IS
+    'stage_vs_prod (bake agreement) | prod_vs_reality (deployed drift) | dev_vs_corpus etc.';
+COMMENT ON COLUMN public.firmware_twin_divergence.relay_disagree_pct IS
+    'Percent of samples in the window where any relay output differed between the two sides (0..100); the gated quantity for THRESHOLD_PCT.';
+COMMENT ON COLUMN public.firmware_twin_divergence.per_relay IS
+    'Per-relay disagreement pct: {"fog":0.0,"vent":1.2,"fan1":0.0,"fan2":0.0,"heat1":0.0,"heat2":0.0}.';
+COMMENT ON COLUMN public.firmware_twin_divergence.worst_examples IS
+    'Array of the highest-divergence input rows for triage: [{"input_ts":..., "ref":..., "cmp":..., "relays":...}].';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 3. twin_ro: read-only twin role (safety layer L2)
+-- ─────────────────────────────────────────────────────────────────────
+-- Design §5.3 L2: the twin holds a DB role that can ONLY read the telemetry it
+-- needs and INSERT into the two observability tables above. NO UPDATE, NO
+-- DELETE, and NO write on any control-plane table. The twin container's
+-- entrypoint additionally asserts at startup that this role cannot write a
+-- control table. PostgreSQL has no `CREATE ROLE IF NOT EXISTS`, so use the
+-- standard idempotent DO-block shim. NOLOGIN group role: the per-twin login
+-- user (created out-of-band with a secret password) is GRANTed this role; we
+-- never put a credential in a migration.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'twin_ro') THEN
+        CREATE ROLE twin_ro NOLOGIN;
+    END IF;
+END
+$$;
+
+-- Idempotent reset: revoke everything we manage, then re-grant the exact narrow
+-- set. REVOKE-then-GRANT makes re-applying the migration converge to the same
+-- privilege set even if a prior run or manual change drifted it.
+REVOKE ALL ON public.twin_decisions FROM twin_ro;
+REVOKE ALL ON public.firmware_twin_divergence FROM twin_ro;
+REVOKE ALL ON public.climate FROM twin_ro;
+REVOKE ALL ON public.equipment_state FROM twin_ro;
+REVOKE ALL ON public.system_state FROM twin_ro;
+REVOKE ALL ON public.setpoint_snapshot FROM twin_ro;
+REVOKE ALL ON public.setpoint_changes FROM twin_ro;
+REVOKE ALL ON public.climate_action_log FROM twin_ro;
+
+-- READ: the telemetry the twin feeds on (design §5.3 L2 explicit list).
+GRANT SELECT ON public.climate            TO twin_ro;
+GRANT SELECT ON public.equipment_state    TO twin_ro;
+GRANT SELECT ON public.system_state       TO twin_ro;
+GRANT SELECT ON public.setpoint_snapshot  TO twin_ro;
+GRANT SELECT ON public.setpoint_changes   TO twin_ro;
+GRANT SELECT ON public.climate_action_log TO twin_ro;
+
+-- WRITE: INSERT ONLY, and ONLY on the two observability tables. No UPDATE,
+-- no DELETE, no TRUNCATE — append-only by privilege.
+GRANT INSERT ON public.twin_decisions           TO twin_ro;
+GRANT INSERT ON public.firmware_twin_divergence  TO twin_ro;
+
+COMMENT ON ROLE twin_ro IS
+    'Firmware digital-twin read-only role (TWIN-6, safety layer L2). SELECT on climate/equipment_state/system_state/setpoint_snapshot/setpoint_changes/climate_action_log; INSERT ONLY on twin_decisions/firmware_twin_divergence; NO UPDATE/DELETE and NO write on any control-plane table. NOLOGIN group role; per-twin login users are GRANTed this role. Design: firmware-digital-twin.md §5.3.';

--- a/db/migrations/tests/test-155-twin-observability-tables.sql
+++ b/db/migrations/tests/test-155-twin-observability-tables.sql
@@ -1,0 +1,388 @@
+-- Fixture test for migration 155 (issue #33, TWIN-6).
+--
+-- Self-contained, self-asserting SQL fixture for a DISPOSABLE throwaway DB only.
+-- REQUIRES TimescaleDB: migration 155 calls create_hypertable() on both new
+-- tables, so this fixture MUST run on a timescale/timescaledb-ha (or equivalent)
+-- image, NOT vanilla postgres. It:
+--   1. stands up the minimal dependency schema the migration references
+--      (greenhouses + the six telemetry tables; the three live-hypertable ones
+--      are made hypertables here too so privileges/shape match prod),
+--   2. APPLIES migration 155,
+--   3. asserts BOTH new tables exist AND are real hypertables (to_regclass +
+--      timescaledb_information.hypertables + a chunk is created on insert),
+--   4. asserts twin_ro has EXACTLY: SELECT on the six telemetry tables, INSERT
+--      on the two observability tables, and NOTHING ELSE — no UPDATE, no DELETE
+--      anywhere, no control-plane write — including a LIVE attempt (as twin_ro)
+--      to INSERT into equipment_state that MUST raise insufficient_privilege,
+--   5. proves IDEMPOTENCY (re-applies the migration body inline = no error, same
+--      privilege set, no duplicate hypertable),
+--   6. runs the documented ROLLBACK and asserts a clean teardown (both tables
+--      and the role gone).
+--
+-- Every check RAISEs EXCEPTION on failure, so a clean run ending in the final
+-- NOTICE means apply + idempotency + rollback all pass.
+--
+-- Run against a DISPOSABLE TimescaleDB throwaway DB, e.g.:
+--   psql -v ON_ERROR_STOP=1 -f db/migrations/tests/test-155-twin-observability-tables.sql
+-- NEVER run this against the live DB — it creates/drops schema objects and a role.
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- 0. Preconditions: TimescaleDB present; prod owner role exists.
+-- ---------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        RAISE EXCEPTION 'PRECONDITION FAIL: timescaledb extension required for migration 155 fixture';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'verdify') THEN
+        CREATE ROLE verdify;
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Minimal dependency schema (clean slate, in dependency order).
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS public.firmware_twin_divergence CASCADE;
+DROP TABLE IF EXISTS public.twin_decisions CASCADE;
+DROP TABLE IF EXISTS public.climate_action_log CASCADE;
+DROP TABLE IF EXISTS public.setpoint_changes CASCADE;
+DROP TABLE IF EXISTS public.setpoint_snapshot CASCADE;
+DROP TABLE IF EXISTS public.system_state CASCADE;
+DROP TABLE IF EXISTS public.equipment_state CASCADE;
+DROP TABLE IF EXISTS public.climate CASCADE;
+DROP TABLE IF EXISTS public.greenhouses CASCADE;
+DROP ROLE IF EXISTS twin_ro;
+
+CREATE TABLE public.greenhouses (
+    id   text NOT NULL PRIMARY KEY,
+    name text NOT NULL
+);
+INSERT INTO public.greenhouses (id, name) VALUES ('vallery', 'Vallery');
+
+-- Telemetry tables the twin reads. The three that are hypertables in prod
+-- (climate, equipment_state, system_state) are made hypertables here too.
+CREATE TABLE public.climate (
+    ts            timestamptz NOT NULL,
+    temp_f        double precision,
+    greenhouse_id text DEFAULT 'vallery'
+);
+SELECT create_hypertable('public.climate', 'ts');
+
+CREATE TABLE public.equipment_state (
+    ts            timestamptz NOT NULL,
+    equipment     text NOT NULL,
+    state         boolean NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+SELECT create_hypertable('public.equipment_state', 'ts');
+
+CREATE TABLE public.system_state (
+    ts            timestamptz NOT NULL,
+    entity        text NOT NULL,
+    value         text NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+SELECT create_hypertable('public.system_state', 'ts');
+
+-- setpoint_snapshot / setpoint_changes / climate_action_log are plain tables
+-- here; only SELECT is granted on them so shape detail is irrelevant.
+CREATE TABLE public.setpoint_snapshot (
+    ts            timestamptz NOT NULL,
+    parameter     text NOT NULL,
+    value         double precision NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+CREATE TABLE public.setpoint_changes (
+    ts            timestamptz NOT NULL,
+    parameter     text NOT NULL,
+    value         double precision NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+CREATE TABLE public.climate_action_log (
+    ts             timestamptz NOT NULL,
+    climate_action text NOT NULL,
+    greenhouse_id  text DEFAULT 'vallery'
+);
+
+ALTER TABLE public.greenhouses        OWNER TO verdify;
+ALTER TABLE public.climate            OWNER TO verdify;
+ALTER TABLE public.equipment_state    OWNER TO verdify;
+ALTER TABLE public.system_state       OWNER TO verdify;
+ALTER TABLE public.setpoint_snapshot  OWNER TO verdify;
+ALTER TABLE public.setpoint_changes   OWNER TO verdify;
+ALTER TABLE public.climate_action_log OWNER TO verdify;
+
+-- ===========================================================================
+-- 2. APPLY migration 155.
+-- ===========================================================================
+\echo '--- applying migration 155 ---'
+\i :migration
+
+-- ---------------------------------------------------------------------------
+-- 3. Assert both new tables exist AND are hypertables.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE n int;
+BEGIN
+    IF to_regclass('public.twin_decisions') IS NULL THEN
+        RAISE EXCEPTION 'APPLY FAIL: twin_decisions not created';
+    END IF;
+    IF to_regclass('public.firmware_twin_divergence') IS NULL THEN
+        RAISE EXCEPTION 'APPLY FAIL: firmware_twin_divergence not created';
+    END IF;
+
+    -- TimescaleDB hypertable catalog (timescaledb_information.hypertables).
+    SELECT count(*) INTO n
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public'
+       AND hypertable_name IN ('twin_decisions', 'firmware_twin_divergence');
+    IF n <> 2 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected 2 new hypertables in catalog, got %', n;
+    END IF;
+
+    RAISE NOTICE 'APPLY OK: both tables exist and are registered hypertables.';
+END
+$$;
+
+-- Insert a row into each and confirm a chunk materializes (hypertable proof).
+INSERT INTO public.twin_decisions
+    (ts, twin_env, twin_ref, input_ts, mode, climate_action, mist_stage,
+     relay_fog, relay_vent, relay_fan1, relay_fan2, relay_heat1, relay_heat2,
+     mode_reason, override_bits, twin_metadata)
+VALUES
+    (now(), 'prod', 'deadbeef', now(), 'IDLE', 'IDLE', 0,
+     false, false, false, false, false, false,
+     'band_ok', 0, '{"vpd_zone_inputs":"homogenized"}'::jsonb);
+
+INSERT INTO public.firmware_twin_divergence
+    (ts, comparison, window_start, window_end, ref_twin_ref, cmp_twin_ref,
+     samples, disagree_count, relay_disagree_pct, mode_disagree_pct)
+VALUES
+    (now(), 'stage_vs_prod', now() - interval '48 hours', now(), 'prodsha', 'stagesha',
+     17280, 0, 0.0, 0.0);
+
+DO $$
+DECLARE c int;
+BEGIN
+    SELECT count(*) INTO c FROM timescaledb_information.chunks
+     WHERE hypertable_name IN ('twin_decisions', 'firmware_twin_divergence');
+    IF c < 2 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected >=2 chunks after insert (one per hypertable), got %', c;
+    END IF;
+    -- env CHECK constraint must reject a bogus env.
+    BEGIN
+        INSERT INTO public.twin_decisions
+            (ts, twin_env, twin_ref, input_ts, mode, mist_stage,
+             relay_fog, relay_vent, relay_fan1, relay_fan2, relay_heat1, relay_heat2,
+             override_bits)
+        VALUES (now(), 'bogus', 'x', now(), 'IDLE', 0,
+                false, false, false, false, false, false, 0);
+        RAISE EXCEPTION 'APPLY FAIL: twin_env CHECK did not reject bogus env';
+    EXCEPTION WHEN check_violation THEN
+        NULL; -- expected
+    END;
+    RAISE NOTICE 'APPLY OK: chunks materialized; twin_env CHECK enforced.';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Assert twin_ro privilege set is EXACTLY the intended narrow set.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    rec record;
+    n_select int;
+    n_insert int;
+    n_bad    int;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'twin_ro') THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro role not created';
+    END IF;
+
+    -- All table privileges held by twin_ro in public, via the live grant catalog.
+    -- Expect: SELECT on the six telemetry tables; INSERT on the two obs tables.
+    SELECT count(*) INTO n_select
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public'
+       AND privilege_type = 'SELECT'
+       AND table_name IN ('climate','equipment_state','system_state',
+                          'setpoint_snapshot','setpoint_changes','climate_action_log');
+    IF n_select <> 6 THEN
+        RAISE EXCEPTION 'PRIV FAIL: expected 6 SELECT grants, got %', n_select;
+    END IF;
+
+    SELECT count(*) INTO n_insert
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public'
+       AND privilege_type = 'INSERT'
+       AND table_name IN ('twin_decisions','firmware_twin_divergence');
+    IF n_insert <> 2 THEN
+        RAISE EXCEPTION 'PRIV FAIL: expected 2 INSERT grants, got %', n_insert;
+    END IF;
+
+    -- ANY UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER granted to twin_ro = fail.
+    SELECT count(*) INTO n_bad
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public'
+       AND privilege_type IN ('UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER');
+    IF n_bad <> 0 THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro holds % UPDATE/DELETE-class grant(s) (must be 0)', n_bad;
+    END IF;
+
+    -- SELECT must NOT be granted on the observability tables (INSERT-only there)
+    -- and INSERT must NOT be granted on any telemetry table.
+    SELECT count(*) INTO n_bad
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public'
+       AND privilege_type = 'INSERT'
+       AND table_name IN ('climate','equipment_state','system_state',
+                          'setpoint_snapshot','setpoint_changes','climate_action_log');
+    IF n_bad <> 0 THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro has INSERT on % control/telemetry table(s) (must be 0)', n_bad;
+    END IF;
+
+    -- Total grant rows must be exactly 8 (6 SELECT + 2 INSERT) — nothing extra.
+    SELECT count(*) INTO n_bad
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public';
+    IF n_bad <> 8 THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro has % total grants, expected exactly 8', n_bad;
+    END IF;
+
+    -- Role must be NOLOGIN (group role; no credential lives in a migration).
+    SELECT count(*) INTO n_bad FROM pg_roles WHERE rolname = 'twin_ro' AND rolcanlogin;
+    IF n_bad <> 0 THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro must be NOLOGIN';
+    END IF;
+
+    RAISE NOTICE 'PRIV OK: twin_ro = exactly 6 SELECT + 2 INSERT, no UPDATE/DELETE, NOLOGIN.';
+END
+$$;
+
+-- LIVE denial proof: as twin_ro, a control-plane write MUST raise
+-- insufficient_privilege (this is the L2 entrypoint assertion the design
+-- requires). SET ROLE drops to twin_ro; the INSERT must fail; RESET ROLE
+-- restores. We wrap in a savepoint so the failed write doesn't poison the
+-- session.
+DO $$
+DECLARE got_denied boolean := false;
+BEGIN
+    SET LOCAL ROLE twin_ro;
+    BEGIN
+        INSERT INTO public.equipment_state (ts, equipment, state)
+        VALUES (now(), 'fan1', true);
+    EXCEPTION WHEN insufficient_privilege THEN
+        got_denied := true;
+    END;
+    RESET ROLE;
+    IF NOT got_denied THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro was ALLOWED to INSERT into control table equipment_state';
+    END IF;
+    RAISE NOTICE 'PRIV OK: twin_ro INSERT into equipment_state denied (insufficient_privilege).';
+END
+$$;
+
+-- LIVE allow proof: as twin_ro, INSERT into twin_decisions MUST succeed,
+-- but UPDATE/DELETE on it MUST be denied (append-only).
+DO $$
+DECLARE denied_update boolean := false; denied_delete boolean := false;
+BEGIN
+    SET LOCAL ROLE twin_ro;
+    INSERT INTO public.twin_decisions
+        (ts, twin_env, twin_ref, input_ts, mode, mist_stage,
+         relay_fog, relay_vent, relay_fan1, relay_fan2, relay_heat1, relay_heat2,
+         override_bits)
+    VALUES (now(), 'stage', 'roprobe', now(), 'IDLE', 0,
+            false, false, false, false, false, false, 0);
+    BEGIN
+        UPDATE public.twin_decisions SET mode = 'HEAT' WHERE twin_ref = 'roprobe';
+    EXCEPTION WHEN insufficient_privilege THEN
+        denied_update := true;
+    END;
+    BEGIN
+        DELETE FROM public.twin_decisions WHERE twin_ref = 'roprobe';
+    EXCEPTION WHEN insufficient_privilege THEN
+        denied_delete := true;
+    END;
+    RESET ROLE;
+    IF NOT denied_update THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro was ALLOWED to UPDATE twin_decisions (must be INSERT-only)';
+    END IF;
+    IF NOT denied_delete THEN
+        RAISE EXCEPTION 'PRIV FAIL: twin_ro was ALLOWED to DELETE twin_decisions (must be INSERT-only)';
+    END IF;
+    RAISE NOTICE 'PRIV OK: twin_ro can INSERT twin_decisions but UPDATE/DELETE denied.';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. IDEMPOTENCY: re-apply the migration body; must not error and must not
+--    change the privilege set or duplicate the hypertables.
+-- ---------------------------------------------------------------------------
+\echo '--- re-applying migration 155 (idempotency) ---'
+\i :migration
+
+DO $$
+DECLARE n_grants int; n_hyper int;
+BEGIN
+    SELECT count(*) INTO n_grants
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'twin_ro' AND table_schema = 'public';
+    IF n_grants <> 8 THEN
+        RAISE EXCEPTION 'IDEMPOTENCY FAIL: re-apply changed grant count to % (expected 8)', n_grants;
+    END IF;
+    SELECT count(*) INTO n_hyper
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public'
+       AND hypertable_name IN ('twin_decisions','firmware_twin_divergence');
+    IF n_hyper <> 2 THEN
+        RAISE EXCEPTION 'IDEMPOTENCY FAIL: hypertable count is % (expected 2)', n_hyper;
+    END IF;
+    RAISE NOTICE 'IDEMPOTENCY OK: re-apply is a no-op (8 grants, 2 hypertables, no error).';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. ROLLBACK (the documented rollback from the migration header / PR body).
+-- ---------------------------------------------------------------------------
+\echo '--- applying documented rollback ---'
+REVOKE ALL ON public.twin_decisions, public.firmware_twin_divergence FROM twin_ro;
+REVOKE ALL ON public.climate, public.equipment_state, public.system_state,
+       public.setpoint_snapshot, public.setpoint_changes,
+       public.climate_action_log FROM twin_ro;
+DROP TABLE IF EXISTS public.firmware_twin_divergence;
+DROP TABLE IF EXISTS public.twin_decisions;
+DROP ROLE IF EXISTS twin_ro;
+
+DO $$
+DECLARE n int;
+BEGIN
+    IF to_regclass('public.twin_decisions') IS NOT NULL THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: twin_decisions still present';
+    END IF;
+    IF to_regclass('public.firmware_twin_divergence') IS NOT NULL THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: firmware_twin_divergence still present';
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'twin_ro') THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: twin_ro role still present';
+    END IF;
+    SELECT count(*) INTO n FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public'
+       AND hypertable_name IN ('twin_decisions','firmware_twin_divergence');
+    IF n <> 0 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: % twin hypertable(s) still in catalog', n;
+    END IF;
+    -- Dependency tables the twin only read must be untouched by the rollback.
+    IF to_regclass('public.climate') IS NULL OR to_regclass('public.equipment_state') IS NULL THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: rollback should not drop telemetry tables';
+    END IF;
+    RAISE NOTICE 'ROLLBACK OK: both tables + twin_ro gone; telemetry tables intact.';
+END
+$$;
+
+DO $$ BEGIN RAISE NOTICE 'ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).'; END $$;


### PR DESCRIPTION
Closes #33

TWIN-6 (firmware-digital-twin.md §5.2/§5.3): the firmware digital-twin observability schema. Serialized shared-territory migration (`db/migrations/`).

**requested-by: iris (shared territory — db/migrations, serialized)**

## What this adds (additive only)
`db/migrations/155-twin-observability-tables.sql`:
1. **`twin_decisions`** — TimescaleDB hypertable, 1:1 with `replay_emit`'s TSV row (+ `climate_action` via `describe_effective_climate_decision()`, + `twin_metadata` jsonb). Indexes `(twin_env, ts DESC)` and `(twin_env, input_ts DESC)`; `twin_env` CHECK in ('dev','stage','prod').
2. **`firmware_twin_divergence`** — TimescaleDB hypertable summarizing windowed disagreement (counts/pcts, per-relay breakdown, `by_mode`/`by_daypart`/`by_outdoor_band` jsonb conditioning, `worst_examples`); index `(comparison, ts DESC)`.
3. **`twin_ro`** — NOLOGIN group role = safety layer **L2**: SELECT on `climate, equipment_state, system_state, setpoint_snapshot, setpoint_changes, climate_action_log`; INSERT **only** on the two observability tables; **no** UPDATE/DELETE anywhere; **no** control-plane write.

Live evidence (issue): `to_regclass('public.twin_decisions')` and `('public.firmware_twin_divergence')` are NULL; `twin_ro` does not exist. Net-new.

## Migration-safety (issue #23)
**NON-self-transactional**: NO top-level `BEGIN;`/`COMMIT;`, NO `CREATE INDEX CONCURRENTLY` (none needed — `create_hypertable` runs fine in psql's implicit autocommit). So there is no inner COMMIT to defeat an outer rollback-replay. Verified by wrapping the migration in `BEGIN; … ROLLBACK;` on the throwaway DB → all twin objects absent afterward (rollback effective). Idempotent throughout: `IF NOT EXISTS`, `create_hypertable(..., if_not_exists => TRUE)`, role-exists `DO` shim, REVOKE-then-GRANT.

No secret/credential in the migration: `twin_ro` is NOLOGIN; per-twin login users are GRANTed the role out-of-band.

## Fixture test evidence (REQUIRES TimescaleDB)
`db/migrations/tests/test-155-twin-observability-tables.sql` — self-asserting; RAISEs EXCEPTION on any failure. Run on a **disposable** `timescale/timescaledb:latest-pg16` (TimescaleDB 2.25.2) container, then destroyed.

UTC: 2026-06-01T21:03:16Z

```
APPLY OK: both tables exist and are registered hypertables.
APPLY OK: chunks materialized; twin_env CHECK enforced.
PRIV OK: twin_ro = exactly 6 SELECT + 2 INSERT, no UPDATE/DELETE, NOLOGIN.
PRIV OK: twin_ro INSERT into equipment_state denied (insufficient_privilege).
PRIV OK: twin_ro can INSERT twin_decisions but UPDATE/DELETE denied.
IDEMPOTENCY OK: re-apply is a no-op (8 grants, 2 hypertables, no error).
ROLLBACK OK: both tables + twin_ro gone; telemetry tables intact.
ALL FIXTURE ASSERTIONS PASSED (apply + idempotency + rollback).
```
- **apply**: both `twin_decisions` + `firmware_twin_divergence` present (`to_regclass` + `timescaledb_information.hypertables` = 2), chunks materialize on insert.
- **role**: exactly 6 SELECT + 2 INSERT grants, zero UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER, no SELECT on obs tables, no INSERT on telemetry, NOLOGIN; **live** `SET ROLE twin_ro` → INSERT into `equipment_state` raises `insufficient_privilege` (the L2 entrypoint assertion); UPDATE/DELETE on `twin_decisions` denied (append-only).
- **idempotency**: re-applying the migration body is a clean no-op (8 grants, 2 hypertables, no error).
- **rollback**: the documented rollback below drops both tables + role; telemetry tables untouched.

`make lint` (ruff): **All checks passed** (no Python changed; SQL-only PR).

## Documented ROLLBACK
```sql
REVOKE ALL ON public.twin_decisions, public.firmware_twin_divergence FROM twin_ro;
REVOKE ALL ON public.climate, public.equipment_state, public.system_state,
       public.setpoint_snapshot, public.setpoint_changes,
       public.climate_action_log FROM twin_ro;
DROP TABLE IF EXISTS public.firmware_twin_divergence;
DROP TABLE IF EXISTS public.twin_decisions;
DROP ROLE IF EXISTS twin_ro;
```

## State
**state:MERGED** — merged to the repo here. The schema is **applied later by the migrate Job at k3s/cutover** (state:DEPLOYED then), NOT now. This PR does not touch the live VM DB or the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)