### PR TITLE
schema(views): per-zone grading view projections (ZoneBandRow + ZoneBandGradeRollup) — G8 schema-first

### DIFF
--- a/verdify_schemas/__init__.py
+++ b/verdify_schemas/__init__.py
@@ -249,6 +249,8 @@ from .views import (
     PlannerPerformance,
     PositionCurrentEntry,
     WaterBudgetRow,
+    ZoneBandGradeRollup,
+    ZoneBandRow,
 )
 
 __all__ = [
@@ -459,6 +461,8 @@ __all__ = [
     "UtilityCost",
     "VaultFrontmatter",
     "WaterBudgetRow",
+    "ZoneBandGradeRollup",
+    "ZoneBandRow",
     "ZoneDetail",
     "ZoneListItem",
     "ZoneObservation",

--- a/verdify_schemas/tests/test_views.py
+++ b/verdify_schemas/tests/test_views.py
@@ -18,6 +18,8 @@ from verdify_schemas.views import (
     PlanAccuracy,
     PlannerPerformance,
     WaterBudgetRow,
+    ZoneBandGradeRollup,
+    ZoneBandRow,
 )
 
 
@@ -131,6 +133,52 @@ class TestBandTraceBasic:
         assert row.greenhouse_id == "vallery"
 
 
+class TestZoneBandRowBasic:
+    def test_valid_minimal(self):
+        row = ZoneBandRow(
+            zone="center",
+            temp_low=70.0,
+            temp_high=88.0,
+            vpd_low=0.6,
+            vpd_high=1.2,
+            crop_basis="orchid",
+            is_proxy=True,
+        )
+        assert row.zone == "center"
+        assert row.is_proxy is True
+
+    def test_empty_zone_nullable_band(self):
+        # Empty zones (_default basis) may emit NULL band edges.
+        row = ZoneBandRow(zone="south", crop_basis="_default")
+        assert row.temp_low is None
+        assert row.crop_basis == "_default"
+
+    def test_tolerates_extra_columns(self):
+        # extra='ignore' so a future fn_zone_band column does not break readers.
+        row = ZoneBandRow.model_validate({"zone": "east", "temp_low": 65, "future_col": 1})
+        assert row.zone == "east"
+
+
+class TestZoneBandGradeRollupBasic:
+    def test_valid_minimal(self):
+        row = ZoneBandGradeRollup(
+            bucket="2026-05-28T13:00:00-06:00",
+            zone="center",
+            n=60,
+            sum_zone_score=42,
+            n_unachievable=44,
+            n_controller=10,
+            n_unknown=6,
+            proxy_center=True,
+        )
+        assert row.n == 60
+        assert row.zone == "center"
+
+    def test_rejects_negative_minute_count(self):
+        with pytest.raises(ValidationError):
+            ZoneBandGradeRollup(bucket="2026-05-28T13:00:00-06:00", zone="center", n=-1)
+
+
 # ── Live-DB drift guards (integration tests) ──
 # If the DB view drops / renames a column we depend on, these fail.
 
@@ -190,3 +238,20 @@ class TestLiveProjection:
         assert rows, "fn_band_trace returned no recent rows"
         for r in rows:
             BandTraceRow.model_validate(r)
+
+    def test_zone_band_live_rows(self):
+        # v_zone_band emits one row per zone (CROSS JOIN over 5 zones). If the
+        # view drops/renames a column ZoneBandRow depends on, model_validate
+        # fires here instead of producing None/KeyError in dashboards.
+        rows = _psql_json("SELECT * FROM v_zone_band ORDER BY zone")
+        assert rows, "v_zone_band returned no rows"
+        for r in rows:
+            ZoneBandRow.model_validate(r)
+
+    def test_zone_band_grade_rollup_live_rows(self):
+        # mv_zone_band_grade is a plain matview refreshed by verdify-ingestor;
+        # it may legitimately be empty (WITH NO DATA before first refresh), so
+        # only validate shape when rows are present.
+        rows = _psql_json("SELECT * FROM mv_zone_band_grade ORDER BY bucket DESC LIMIT 3")
+        for r in rows:
+            ZoneBandGradeRollup.model_validate(r)

--- a/verdify_schemas/views.py
+++ b/verdify_schemas/views.py
@@ -20,6 +20,8 @@ Views covered:
 - v_override_activity_24h     → OverrideActivity24h
 - v_clamp_activity_24h        → ClampActivity24h
 - v_band_trace_recent         → BandTraceRow
+- v_zone_band                 → ZoneBandRow          (per-zone live grading band)
+- mv_zone_band_grade          → ZoneBandGradeRollup  (hourly per-zone graded rollup)
 """
 
 from __future__ import annotations
@@ -219,6 +221,61 @@ class BandTraceRow(BaseModel):
     fw_minus_crop_vpd_low_kpa: float | None = None
     fw_minus_crop_vpd_high_kpa: float | None = None
     trace_quality_flag: str
+
+
+# ── Band-compliance rearchitecture: per-zone grading views (§6.8) ───────
+
+
+class ZoneBandRow(BaseModel):
+    """v_zone_band row — per-zone live grading band (ideal + stress) at now().
+
+    One row per zone (center, east, north, south, west). Projection of
+    `fn_zone_band(zone, now())` (migration 146.8). center→orchid; east→
+    intersection(ideal)/union(stress) of its crops; empty zones→`_default`.
+    Replaces `fn_target_band_smooth` as the dashboard band surface
+    (`v_target_curve` repointed here). `is_proxy` flags zones graded against
+    a proxy reading (center vpd_avg until the vpd_center probe lands, HW-1).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    zone: str
+    temp_low: float | None = None
+    temp_high: float | None = None
+    temp_stress_low: float | None = None
+    temp_stress_high: float | None = None
+    vpd_low: float | None = None
+    vpd_high: float | None = None
+    vpd_stress_low: float | None = None
+    vpd_stress_high: float | None = None
+    crop_basis: str | None = None
+    is_proxy: bool | None = None
+
+
+class ZoneBandGradeRollup(BaseModel):
+    """mv_zone_band_grade row — hourly per-zone graded-compliance rollup.
+
+    One row per (bucket, zone) over the trailing window. Sums of the
+    per-minute graded credit (`sum_g_temp` / `sum_g_vpd` / `sum_zone_score`)
+    plus the feasibility split (`n_unachievable` / `n_controller` / `n_unknown`
+    out of `n` total minutes). Refreshed by verdify-ingestor
+    (`REFRESH MATERIALIZED VIEW CONCURRENTLY mv_zone_band_grade`); replaces
+    `v_setpoint_compliance`. See band-compliance §6.4/§6.6.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    bucket: AwareDatetime
+    zone: str
+    n: int = Field(..., ge=0)
+    sum_g_temp: Decimal | None = None
+    sum_g_vpd: Decimal | None = None
+    sum_zone_score: Decimal | None = None
+    sum_score_unachievable: Decimal | None = None
+    n_unachievable: int | None = Field(default=None, ge=0)
+    n_controller: int | None = Field(default=None, ge=0)
+    n_unknown: int | None = Field(default=None, ge=0)
+    proxy_center: bool | None = None
 
 
 # ── Sprint 23: crop history views ──────────────────────────────────────


### PR DESCRIPTION
Closes #18

## What
G8 schema-first: completes the per-zone band-compliance schema surface (band-compliance §6.8/§8.3) one cycle AHEAD of the #19/#20 consumers.

Most of the v2 surface already landed (Vanda sprint-3 `aa6518c`): the `daily_summary.*_v2` columns + `DailyZoneComplianceRow` / `ComplianceZoneWeightRow` table models, the `ScorecardResponse` graded keys (`compliance_v2_*` / `graded_*`, so `extra='forbid'` no longer 500s the public `/api/v1/scorecard`), and the belt-and-suspenders try/except at `api/main.py` scorecard handler. The remaining acceptance gap was the per-zone **view** projection:

- `verdify_schemas/views.py`
  - `ZoneBandRow` — mirrors `v_zone_band` (per-zone live grading band: ideal + stress edges, `crop_basis`, `is_proxy`).
  - `ZoneBandGradeRollup` — mirrors `mv_zone_band_grade` (hourly per-zone graded rollup: `sum_g_temp/g_vpd/zone_score` + feasibility split `n_unachievable/n_controller/n_unknown`).
  - Both `extra='ignore'` so a future view column doesn't break dashboard readers.
- `verdify_schemas/__init__.py` — export both (import block + `__all__`).
- `verdify_schemas/tests/test_views.py` — unit tests (bounds + extra-column tolerance) + live-DB drift guards round-tripping real `v_zone_band` / `mv_zone_band_grade` rows.

## PENDING_MIGRATION_COLUMNS
Stays **empty**. Migration 146 is already in `db/schema.sql` — verified `daily_summary.*_v2`, `daily_zone_compliance`, `compliance_zone_weights`, `v_zone_band`, `mv_zone_band_grade` all present — so every `daily.py` table field is DB-backed and enforced by the drift guards. The two new models are view-projections (validated in `test_views.py`), not table drift guards.

## Validation (UTC 2026-06-01T21:12:52Z, read-only against live timescaledb)
- `make lint` (ruff: `ingestor/ api/ mcp/ scripts/*.py tests/ verdify_schemas/`) — **All checks passed!**
- `verdify_schemas/tests/test_drift_guards.py` — **136 passed** (live DB, read-only `information_schema` + LIMIT round-trips).
- `verdify_schemas/tests/` (full) — **587 passed, 2 skipped** (unrelated).
- New live guards: `test_zone_band_live_rows` + `test_zone_band_grade_rollup_live_rows` — **passed** against the real view/matview.

No device path, no writer, no SHADOW_MODE, no host mutation; DB access was read-only.

## Rule 7 — services to bounce post-merge
This PR touches `verdify_schemas/**`. Post-merge, bounce **verdify-mcp** (scorecard/context reads the graded rollups) and **verdify-ingestor** (writes the v2 columns / refreshes `mv_zone_band_grade`). Drift-guard + service-restart-drift-guard contracts satisfied.

## Firmware
Untouched — DB/schema-only, off the control path. No OTA, no replay impact.

## Status
Schema-first: keep #18 OPEN at `state:MERGED` after merge; consumers #19 (copy) / #20 (reward-swap apply) land later cycles.

requested-by: iris (shared territory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)