### PR TITLE
firmware(replay harness): gated --stream + climate_action column (TWIN-1/TWIN-2, #32)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ REPLAY_CORPUS_TMP ?= /tmp/verdify-replay-overrides.csv
 HERMES_IRIS_RUNTIME_DIR ?= /var/lib/verdify/hermes/iris
 HERMES_IRIS_ENV_FILE ?= /etc/verdify/hermes-iris.env
 
-.PHONY: help test lint format check lighting-audit-static lighting-audit-current lighting-audit-live lighting-audit-complete climate-intent-replay-report climate-authority-post-deploy-proof-plan climate-authority-post-deploy-proof firmware-check firmware-check-worktree firmware-check-all firmware-invariants firmware-replay firmware-replay-worktree firmware-audit-traceability-proof firmware-audit-worktree-proof firmware-dwell-preview firmware-deploy firmware-archive-artifacts firmware-promote-last-good smoke hermes-deploy-config hermes-restart hermes-smoke clean irrigation-migration-check irrigation-migration-proof irrigation-field-diagnostics irrigation-field-sensor-health-proof irrigation-stack-software-check irrigation-stack-check irrigation-feedback-check irrigation-feedback-discover irrigation-feedback-discovery-proof irrigation-feedback-work-order irrigation-feedback-work-order-proof irrigation-feedback-clear-stale-retained irrigation-feedback-clear-stale-near-misses irrigation-feedback-watch irrigation-feedback-watch-field irrigation-feedback-watch-field-proof irrigation-feedback-finalize-dry-run irrigation-feedback-finalize-dry-run-proof irrigation-feedback-finalize irrigation-feedback-finalize-proof irrigation-feedback-proof-json irrigation-sensor-health-proof irrigation-stack-proof irrigation-completion-audit irrigation-completion-audit-proof irrigation-acceptance irrigation-full-acceptance irrigation-post-deploy-acceptance-plan irrigation-post-deploy-acceptance
+.PHONY: help test lint format check lighting-audit-static lighting-audit-current lighting-audit-live lighting-audit-complete climate-intent-replay-report climate-authority-post-deploy-proof-plan climate-authority-post-deploy-proof firmware-check firmware-check-worktree firmware-check-all firmware-invariants firmware-replay firmware-replay-worktree firmware-replay-stream-check firmware-audit-traceability-proof firmware-audit-worktree-proof firmware-dwell-preview firmware-deploy firmware-archive-artifacts firmware-promote-last-good smoke hermes-deploy-config hermes-restart hermes-smoke clean irrigation-migration-check irrigation-migration-proof irrigation-field-diagnostics irrigation-field-sensor-health-proof irrigation-stack-software-check irrigation-stack-check irrigation-feedback-check irrigation-feedback-discover irrigation-feedback-discovery-proof irrigation-feedback-work-order irrigation-feedback-work-order-proof irrigation-feedback-clear-stale-retained irrigation-feedback-clear-stale-near-misses irrigation-feedback-watch irrigation-feedback-watch-field irrigation-feedback-watch-field-proof irrigation-feedback-finalize-dry-run irrigation-feedback-finalize-dry-run-proof irrigation-feedback-finalize irrigation-feedback-finalize-proof irrigation-feedback-proof-json irrigation-sensor-health-proof irrigation-stack-proof irrigation-completion-audit irrigation-completion-audit-proof irrigation-acceptance irrigation-full-acceptance irrigation-post-deploy-acceptance-plan irrigation-post-deploy-acceptance
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -100,6 +100,21 @@ test-firmware: ## Run native C++ logic tests + replay against golden CSV (same c
 test-replay-overrides: ## Validate evaluate_overrides() against full history + synthetic self-test (OBS-1e)
 	bash scripts/export-replay-overrides.sh
 	cd firmware && g++ -std=c++17 -O2 -I lib -o test/replay_overrides test/replay_overrides.cpp && ./test/replay_overrides test/data/replay_overrides.csv
+
+firmware-replay-stream-check: ## TWIN-1/2: build the gated replay_emit_follow (--stream + climate_action) and smoke it; prove stock batch output byte-identical
+	gzip -cd $(REPLAY_CORPUS_GZ) > $(REPLAY_CORPUS_TMP)
+	cd firmware && g++ -std=c++17 -O2 -I lib -o test/replay_emit test/replay_emit.cpp
+	cd firmware && g++ -std=c++17 -O2 -DREPLAY_EMIT_STREAM -I lib -o test/replay_emit_follow test/replay_emit.cpp
+	# stock batch header is the unchanged 11-column schema (rule-8 gate intact)
+	REPLAY_EMIT_FORCE_FSM=1 ./firmware/test/replay_emit $(REPLAY_CORPUS_TMP) 2>/dev/null | head -1 \
+	    | grep -qx 'ts	mode	relay_fog	relay_vent	relay_fan1	relay_fan2	relay_heat1	relay_heat2	mist_stage	reason	override_bits' \
+	    && echo "batch header byte-identical (11 cols) ✓"
+	# stream build emits the additive climate_action column via describe_effective_climate_decision()
+	REPLAY_EMIT_FORCE_FSM=1 sh -c 'tail -n +2 $(REPLAY_CORPUS_TMP) | head -50 | ./firmware/test/replay_emit_follow --stream --header-from $(REPLAY_CORPUS_TMP)' \
+	    | head -1 | grep -q 'climate_action' \
+	    && echo "stream header carries climate_action column ✓"
+	REPLAY_EMIT_FORCE_FSM=1 sh -c 'tail -n +2 $(REPLAY_CORPUS_TMP) | head -50 | ./firmware/test/replay_emit_follow --stream --header-from $(REPLAY_CORPUS_TMP)' \
+	    | tail -n +2 | awk -F"\t" 'NF==12{ok++} END{ if(ok>0){print "stream emitted "ok" decision rows w/ 12 cols ✓"} else {print "FAIL: no stream rows"; exit 1} }'
 
 firmware-invariants: ## Phase-0: run 16 invariants from invariants.h against the replay corpus (pass = bulletproof gate green)
 	gzip -cd $(REPLAY_CORPUS_GZ) > $(REPLAY_CORPUS_TMP)

--- a/firmware/test/.gitignore
+++ b/firmware/test/.gitignore
@@ -8,4 +8,5 @@ data/replay_overrides.prev.csv.gz
 # Golden fixtures (tracked) — see Makefile test-firmware target
 !data/replay_overrides.csv.gz
 replay_emit
+replay_emit_follow
 replay_invariants

--- a/firmware/test/replay_emit.cpp
+++ b/firmware/test/replay_emit.cpp
@@ -18,6 +18,31 @@
  * Output TSV columns:
  *   ts, mode, relay_bitmask, mist_stage, last_mode_reason,
  *   override_flags_bitmask
+ *
+ * --stream / follow build (digital-twin Phase 0, TWIN-1/TWIN-2):
+ *   When compiled with -DREPLAY_EMIT_STREAM the binary (built as
+ *   `replay_emit_follow`) keeps one resident ControlState and blocks on stdin
+ *   instead of exiting at EOF, so a long-running twin driver can feed one
+ *   telemetry line per tick and read back one decision row. The stream build
+ *   also appends a `climate_action` column derived from the existing
+ *   describe_effective_climate_decision() (greenhouse_logic.h) — no
+ *   translation table.
+ *
+ *   This is gated entirely behind the build flag: the stock `replay_emit`
+ *   binary (no -DREPLAY_EMIT_STREAM) is byte-for-byte unchanged — same 11
+ *   columns, same code path — so the rule-8 firmware-replay-diff CI gate,
+ *   firmware-invariants, and test-firmware are unaffected.
+ *
+ *   Compile: g++ -std=c++17 -DREPLAY_EMIT_STREAM -I../lib \
+ *                -o replay_emit_follow replay_emit.cpp
+ *   Run:     ./replay_emit_follow --stream --header-from data/replay_overrides.csv
+ *            (then write one TSV data line per tick on stdin; one decision row
+ *             is flushed per line. A header CSV path may also be passed
+ *             positionally, in which case its data rows prime the resident
+ *             state before stdin follow begins.)
+ *
+ *   This file is the OFFLINE replay harness only — it never touches the ESP32
+ *   firmware path and is not part of any OTA artifact.
  */
 
 #include "greenhouse_logic.h"
@@ -26,6 +51,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -73,37 +99,30 @@ static uint64_t parse_ts_unix(const std::string& s) {
 
 // MODE_NAMES is already defined in greenhouse_types.h (included via greenhouse_logic.h)
 
-int main(int argc, char** argv) {
-    if (argc < 2) { std::fprintf(stderr, "Usage: %s <replay.csv>\n", argv[0]); return 2; }
-    std::ifstream f(argv[1]);
-    if (!f) { std::fprintf(stderr, "Cannot open %s\n", argv[1]); return 2; }
+// process_row advances the resident ControlState by exactly one telemetry row
+// and prints one TSV decision line. The logic is identical for the batch path
+// and the stream/follow path — only the call site differs (a file loop vs a
+// stdin loop). `emit_climate_action` appends the additive climate_action
+// column derived from describe_effective_climate_decision(); it is only set on
+// the -DREPLAY_EMIT_STREAM build so the stock batch output stays byte-for-byte
+// identical and the rule-8 firmware-replay-diff gate is unaffected.
+static void process_row(const Header& h,
+                        const std::string& line,
+                        ControlState& state,
+                        uint64_t& last_ts_unix,
+                        bool emit_climate_action) {
+    std::vector<std::string> cols;
+    {
+        std::istringstream ss(line);
+        std::string tok;
+        while (std::getline(ss, tok, '\t')) cols.push_back(std::move(tok));
+    }
+    auto get = [&](const std::string& name, const std::string& def = "") -> std::string {
+        size_t i = h.of(name);
+        return (i == SIZE_MAX || i >= cols.size()) ? def : cols[i];
+    };
 
-    std::string line;
-    if (!std::getline(f, line)) { std::fprintf(stderr, "Empty\n"); return 2; }
-    Header h;
-    h.parse(line);
-
-    // Initialize controller state.
-    ControlState state = initial_state();
-    uint64_t last_ts_unix = 0;
-
-    // Emit header
-    std::printf("ts\tmode\trelay_fog\trelay_vent\trelay_fan1\trelay_fan2\trelay_heat1\trelay_heat2\tmist_stage\treason\toverride_bits\n");
-
-    long rows = 0;
-    while (std::getline(f, line)) {
-        std::vector<std::string> cols;
-        {
-            std::istringstream ss(line);
-            std::string tok;
-            while (std::getline(ss, tok, '\t')) cols.push_back(std::move(tok));
-        }
-        auto get = [&](const std::string& name, const std::string& def = "") -> std::string {
-            size_t i = h.of(name);
-            return (i == SIZE_MAX || i >= cols.size()) ? def : cols[i];
-        };
-
-        SensorInputs in{};
+    SensorInputs in{};
         in.temp_f = parse_float(get("temp_avg"), 70.0f);
         in.rh_pct = parse_float(get("rh_avg"), 50.0f);
         in.vpd_kpa = parse_float(get("vpd_avg"), 0.8f);
@@ -207,16 +226,155 @@ int main(int argc, char** argv) {
                           | (of.vpd_dry_override << 6) | (of.summer_vent_active << 7)
                           | (of.fog_heat_assist << 8) | (of.vent_mist_assist << 9);
 
-        std::printf("%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\n",
-                    ts.c_str(),
-                    MODE_NAMES[(int)mode],
-                    r.fog, r.vent, r.fan1, r.fan2, r.heat1, r.heat2,
-                    (int)state.mist_stage,
-                    reason,
-                    override_bits);
+        if (emit_climate_action) {
+            // Additive twin column (TWIN-2). Reuse the firmware's own mapping —
+            // describe_effective_climate_decision() in greenhouse_logic.h — so the
+            // twin's climate_action joins 1:1 against climate_action_log with no
+            // translation table.
+            const ClimateActionDecision decision =
+                describe_effective_climate_decision(mode, in, sp, state, r);
+            std::printf("%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%s\n",
+                        ts.c_str(),
+                        MODE_NAMES[(int)mode],
+                        r.fog, r.vent, r.fan1, r.fan2, r.heat1, r.heat2,
+                        (int)state.mist_stage,
+                        reason,
+                        override_bits,
+                        CLIMATE_ACTION_NAMES[(int)decision.climate_action]);
+        } else {
+            std::printf("%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\n",
+                        ts.c_str(),
+                        MODE_NAMES[(int)mode],
+                        r.fog, r.vent, r.fan1, r.fan2, r.heat1, r.heat2,
+                        (int)state.mist_stage,
+                        reason,
+                        override_bits);
+        }
+}
+
+#ifdef REPLAY_EMIT_STREAM
+// ── Stream / follow build (TWIN-1) ───────────────────────────────────────────
+// Gated entirely behind -DREPLAY_EMIT_STREAM (built as `replay_emit_follow`).
+// Keeps one resident ControlState and blocks on stdin instead of exiting at
+// EOF, so a long-running twin driver can feed one telemetry line per tick and
+// read back one decision row. Emits the additive climate_action column.
+//
+// Header source: from the positional CSV argument's first line, or from
+// `--header-from <csv>`. If a positional CSV is given, its DATA rows are
+// replayed first to prime the resident ControlState before stdin follow
+// begins (so a driver can hand the harness a warm-up window then stream).
+
+static int usage_stream(const char* argv0) {
+    std::fprintf(stderr,
+        "Usage: %s [--stream] [--header-from <csv> | <csv>]\n"
+        "  --stream            follow stdin (default in this build)\n"
+        "  --header-from <csv> read the TSV header from <csv>, do not replay its rows\n"
+        "  <csv>               read header from <csv> AND replay its data rows to\n"
+        "                      prime ControlState, then follow stdin\n"
+        "Reads one TSV telemetry line per stdin line; flushes one decision row\n"
+        "(with the climate_action column) per line. Resident ControlState.\n",
+        argv0);
+    return 2;
+}
+
+int main(int argc, char** argv) {
+    std::string header_csv;     // CSV used only for its header line
+    std::string prime_csv;      // CSV whose data rows prime ControlState
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--stream" || arg == "--follow") {
+            continue;  // follow is the only mode this build offers
+        } else if (arg == "--header-from") {
+            if (i + 1 >= argc) return usage_stream(argv[0]);
+            header_csv = argv[++i];
+        } else if (arg == "-h" || arg == "--help") {
+            return usage_stream(argv[0]);
+        } else if (arg[0] == '-') {
+            std::fprintf(stderr, "Unknown flag: %s\n", arg.c_str());
+            return usage_stream(argv[0]);
+        } else {
+            prime_csv = arg;          // positional CSV: header + prime rows
+            if (header_csv.empty()) header_csv = arg;
+        }
+    }
+    if (header_csv.empty()) {
+        std::fprintf(stderr, "Stream build needs a header: pass <csv> or --header-from <csv>.\n");
+        return usage_stream(argv[0]);
+    }
+
+    Header h;
+    {
+        std::ifstream hf(header_csv);
+        if (!hf) { std::fprintf(stderr, "Cannot open %s\n", header_csv.c_str()); return 2; }
+        std::string header_line;
+        if (!std::getline(hf, header_line)) { std::fprintf(stderr, "Empty header CSV\n"); return 2; }
+        h.parse(header_line);
+    }
+
+    ControlState state = initial_state();
+    uint64_t last_ts_unix = 0;
+
+    // Header includes the additive climate_action column.
+    std::printf("ts\tmode\trelay_fog\trelay_vent\trelay_fan1\trelay_fan2\trelay_heat1\trelay_heat2\tmist_stage\treason\toverride_bits\tclimate_action\n");
+    std::fflush(stdout);
+
+    // Prime: replay the data rows of the positional CSV (if any) to warm up
+    // ControlState before following stdin.
+    long primed = 0;
+    if (!prime_csv.empty()) {
+        std::ifstream pf(prime_csv);
+        if (!pf) { std::fprintf(stderr, "Cannot open %s\n", prime_csv.c_str()); return 2; }
+        std::string line;
+        std::getline(pf, line);  // discard header
+        while (std::getline(pf, line)) {
+            process_row(h, line, state, last_ts_unix, /*emit_climate_action=*/true);
+            primed++;
+        }
+        std::fflush(stdout);
+    }
+
+    // Follow: block on stdin, one decision row per input line, flush each tick
+    // so a driver reading the pipe sees the result immediately.
+    std::string line;
+    long ticks = 0;
+    while (std::getline(std::cin, line)) {
+        if (line.empty()) continue;
+        process_row(h, line, state, last_ts_unix, /*emit_climate_action=*/true);
+        std::fflush(stdout);
+        ticks++;
+    }
+
+    std::fprintf(stderr, "replay_emit_follow: primed %ld, streamed %ld rows\n", primed, ticks);
+    return 0;
+}
+
+#else  // batch build (stock replay_emit — unchanged behavior)
+
+int main(int argc, char** argv) {
+    if (argc < 2) { std::fprintf(stderr, "Usage: %s <replay.csv>\n", argv[0]); return 2; }
+    std::ifstream f(argv[1]);
+    if (!f) { std::fprintf(stderr, "Cannot open %s\n", argv[1]); return 2; }
+
+    std::string line;
+    if (!std::getline(f, line)) { std::fprintf(stderr, "Empty\n"); return 2; }
+    Header h;
+    h.parse(line);
+
+    // Initialize controller state.
+    ControlState state = initial_state();
+    uint64_t last_ts_unix = 0;
+
+    // Emit header
+    std::printf("ts\tmode\trelay_fog\trelay_vent\trelay_fan1\trelay_fan2\trelay_heat1\trelay_heat2\tmist_stage\treason\toverride_bits\n");
+
+    long rows = 0;
+    while (std::getline(f, line)) {
+        process_row(h, line, state, last_ts_unix, /*emit_climate_action=*/false);
         rows++;
     }
 
     std::fprintf(stderr, "replay_emit: %ld rows emitted\n", rows);
     return 0;
 }
+
+#endif  // REPLAY_EMIT_STREAM


### PR DESCRIPTION
Closes #32

## What & why
Phase 0 of the firmware digital-twin design (`docs/design/firmware-digital-twin.md` §6, TWIN-1/TWIN-2). Two additive extensions to the **OFFLINE replay harness** `firmware/test/replay_emit.cpp`. **No ESP32 path, no OTA, no on-device behavior change** — this is the native `g++` replay binary only.

**TWIN-1 — gated `--stream` / follow mode.** The per-row decision logic is factored into a shared `process_row()` helper. A new `main()` gated behind `-DREPLAY_EMIT_STREAM` (built as `replay_emit_follow`) keeps one **resident `ControlState`** and blocks on stdin instead of exiting at EOF, flushing one decision row per tick. Supports `--header-from <csv>` (header only) and a positional `<csv>` whose data rows prime `ControlState` before stdin follow begins. The stock `replay_emit` binary (compiled with no define) is **byte-for-byte unchanged** — same 11-column TSV, same code path — so the rule-8 `firmware-replay-diff` gate, `firmware-invariants`, and `test-firmware` are unaffected.

**TWIN-2 — `climate_action` column.** The stream build appends a `climate_action` column derived from the existing `describe_effective_climate_decision()` (`greenhouse_logic.h`), reusing the firmware's own `Mode`→`ClimateAction` mapping — **no translation table** (design §2.4 / line 89). The twin's `climate_action` then joins 1:1 against `climate_action_log.climate_action`.

Also: additive `make firmware-replay-stream-check` target (stock targets untouched); `firmware/test/.gitignore` ignores the `replay_emit_follow` artifact.

## Validation (rule 8 + rule 9 artifacts; all UTC, 2026-06-01)

**`make firmware-replay OLD=origin/live/platform-main NEW=HEAD`** — THRESHOLD_PCT=0:
```
═══ Replay diff summary ═══
  CSV:     .../replay_overrides.csv (193525 rows)
  Divergent rows: 0
  Diagnostic-only rows: 0 (ignored: mode/relay/mist unchanged)
  ✓ No divergence. Behavior preserved.
```

**`make firmware-invariants`**:
```
═══ Invariant summary — 193525 rows ═══
  ✓ All invariants passed.
```

**`make test-firmware`** — native logic tests + 8-month replay; all override flags + synthetic self-test pass (`occupancy_blocks_equipment … fog_heat_assist ✓`). Batch trace md5 **byte-identical** to the pre-change baseline: `efcaa124d1cb286daa7fc3c4927e36be`.

**`make lint`**: `All checks passed!`

**Stream-path proof** (`make firmware-replay-stream-check` + manual):
- `batch header byte-identical (11 cols) ✓`
- `stream header carries climate_action column ✓`
- `stream emitted 50 decision rows w/ 12 cols ✓`
- Resident-state continuity: priming the first 1000 rows via positional CSV then streaming the rest produces output **identical** to streaming all rows (193525 rows match) — proves `ControlState` is resident across the prime/stdin boundary.
- `climate_action` exercised over the full corpus: `VENTILATE`→`VENT_COOL`/`VENT_COOL_{MIST,FOG}_ASSIST`, `SEALED_MIST`→`SEALED_{HUMIDIFY,FOG}`, `IDLE`+heat→`HEAT` (55056 rows), `SAFETY_COOL`→`SAFETY_COOL`.

## Restart note
None. No `verdify_schemas/**`, `mcp/server.py`, or `ingestor/entity_map.py` touched (rule 7 n/a). No service bounce required — this is the offline replay harness + a Makefile target. No OTA (repo-only, rule-8 replay-diff = 0).

## Scope
`firmware/test/replay_emit.cpp` is the firmware agent's territory; the `Makefile` change is additive and self-contained.
requested-by: iris (shared territory: Makefile)
