### PR TITLE
G8 lessons state machine: LessonState literal + lessons_manage transition guards (closes #44)

### DIFF
--- a/ingestor/iris_planner.py
+++ b/ingestor/iris_planner.py
@@ -707,6 +707,8 @@ and set the overnight posture.
 2. **Check lessons** — call `lessons`. Did today validate or invalidate any?
    - If a lesson was validated: `lessons_manage(action="validate", lesson_id=ID)`
    - If something new was learned: `lessons_manage(action="create", data=...)`
+   - If a newer lesson replaces an older one: `lessons_manage(action="supersede", lesson_id=OLD, data={"new_id": NEW})`
+     (lessons move proposed→validated→superseded/retired; superseding/retiring is terminal)
 3. **Check current conditions** — call `climate` for dew point margin and outdoor forecast.
 4. **Review overnight forecast** — call `forecast` for the next 12 hours.
 5. **Check alerts** — call `alerts`. Resolve any from today.

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -39,6 +39,7 @@ from verdify_schemas import (  # noqa: E402
     HarvestCreate,
     LessonCreate,
     LessonSummary,
+    LessonSupersede,
     LessonUpdate,
     LessonValidate,
     ObservationCreate,
@@ -54,6 +55,8 @@ from verdify_schemas import (  # noqa: E402
     SetpointSummary,
     SlackCommandRequest,
     TreatmentCreate,
+    derive_lesson_state,
+    is_legal_lesson_transition,
 )
 from verdify_schemas.climate_intent import (  # noqa: E402
     CLIMATE_INTENT_CONTRACT_VERSION,
@@ -2057,14 +2060,39 @@ async def alerts(action: str = "list", alert_id: int = 0, data: str = "") -> str
 # ═══════════════════════════════════════════════════════════════
 
 
+async def _lesson_state_row(conn, lesson_id: int) -> dict | None:
+    """Fetch the columns needed to derive a lesson's lifecycle state.
+
+    `last_validated > created_at` is the authoritative "validated beyond
+    creation" signal; `times_validated` is the fallback the derive helper uses
+    when that flag is unavailable. Returns None if the lesson doesn't exist.
+    """
+    return await conn.fetchrow(
+        """
+        SELECT id, is_active, superseded_by, times_validated,
+               (last_validated IS NOT NULL AND created_at IS NOT NULL
+                AND last_validated > created_at) AS has_independent_validation
+          FROM planner_lessons WHERE id = $1
+        """,
+        lesson_id,
+    )
+
+
 @mcp.tool()
 async def lessons_manage(action: str, lesson_id: int = 0, data: str = "") -> str:
     """Manage planner lessons (accumulated operational knowledge).
-    Actions: create, update, deactivate, validate.
+
+    Actions: create, update, deactivate, validate, supersede.
+    Lifecycle state machine (G8): proposed -> validated -> superseded/retired.
+    State is derived from is_active/superseded_by/validation history; illegal
+    transitions (e.g. validating a superseded or retired lesson) are rejected.
+
     create: data = {"category", "condition", "lesson", "confidence": "low|medium|high"}
     update: data = {"lesson"?, "condition"?, "confidence"?}
-    deactivate: mark lesson as inactive
-    validate: increment times_validated, optionally upgrade confidence"""
+    validate: proposed/validated -> validated; increment times_validated, optionally upgrade confidence
+    deactivate: proposed/validated -> retired (terminal)
+    supersede: proposed/validated -> superseded by a newer lesson;
+        data = {"new_id": <existing lesson id>} (terminal)"""
     d = json.loads(data) if data else {}
     conn = await _db()
     try:
@@ -2098,14 +2126,42 @@ async def lessons_manage(action: str, lesson_id: int = 0, data: str = "") -> str
             return _json(dict(row)) if row else json.dumps({"error": "Lesson not found"})
 
         elif action == "deactivate" and lesson_id:
+            cur = await _lesson_state_row(conn, lesson_id)
+            if cur is None:
+                return json.dumps({"error": "Lesson not found"})
+            state = derive_lesson_state(
+                is_active=cur["is_active"],
+                superseded_by=cur["superseded_by"],
+                times_validated=cur["times_validated"] or 1,
+                has_independent_validation=bool(cur["has_independent_validation"]),
+            )
+            if not is_legal_lesson_transition(state, "retired"):
+                return json.dumps(
+                    {"error": f"Illegal transition {state} -> retired", "lesson_id": lesson_id, "state": state}
+                )
+            if state == "retired":  # idempotent
+                return json.dumps({"ok": True, "lesson_id": lesson_id, "action": "deactivated", "state": "retired"})
             await conn.execute("UPDATE planner_lessons SET is_active = false WHERE id = $1", lesson_id)
-            return json.dumps({"ok": True, "lesson_id": lesson_id, "action": "deactivated"})
+            return json.dumps({"ok": True, "lesson_id": lesson_id, "action": "deactivated", "state": "retired"})
 
         elif action == "validate" and lesson_id:
             try:
                 val = LessonValidate.model_validate(d) if d else LessonValidate()
             except ValidationError as e:
                 return json.dumps({"error": "LessonValidate validation failed", "details": json.loads(e.json())})
+            cur = await _lesson_state_row(conn, lesson_id)
+            if cur is None:
+                return json.dumps({"error": "Lesson not found"})
+            state = derive_lesson_state(
+                is_active=cur["is_active"],
+                superseded_by=cur["superseded_by"],
+                times_validated=cur["times_validated"] or 1,
+                has_independent_validation=bool(cur["has_independent_validation"]),
+            )
+            if not is_legal_lesson_transition(state, "validated"):
+                return json.dumps(
+                    {"error": f"Illegal transition {state} -> validated", "lesson_id": lesson_id, "state": state}
+                )
             if val.confidence:
                 await conn.execute(
                     "UPDATE planner_lessons SET times_validated = times_validated + 1, "
@@ -2118,9 +2174,49 @@ async def lessons_manage(action: str, lesson_id: int = 0, data: str = "") -> str
                     "UPDATE planner_lessons SET times_validated = times_validated + 1, last_validated = now() WHERE id = $1",
                     lesson_id,
                 )
-            return json.dumps({"ok": True, "lesson_id": lesson_id, "action": "validated"})
+            return json.dumps({"ok": True, "lesson_id": lesson_id, "action": "validated", "state": "validated"})
 
-        return json.dumps({"error": f"Unknown action '{action}'. Use: create, update, deactivate, validate"})
+        elif action == "supersede" and lesson_id:
+            try:
+                sup = LessonSupersede.model_validate(d)
+            except ValidationError as e:
+                return json.dumps({"error": "LessonSupersede validation failed", "details": json.loads(e.json())})
+            if sup.new_id == lesson_id:
+                return json.dumps({"error": "A lesson cannot supersede itself", "lesson_id": lesson_id})
+            cur = await _lesson_state_row(conn, lesson_id)
+            if cur is None:
+                return json.dumps({"error": "Lesson not found", "lesson_id": lesson_id})
+            new_exists = await conn.fetchval("SELECT 1 FROM planner_lessons WHERE id = $1", sup.new_id)
+            if new_exists is None:
+                return json.dumps({"error": f"Superseding lesson {sup.new_id} not found", "new_id": sup.new_id})
+            state = derive_lesson_state(
+                is_active=cur["is_active"],
+                superseded_by=cur["superseded_by"],
+                times_validated=cur["times_validated"] or 1,
+                has_independent_validation=bool(cur["has_independent_validation"]),
+            )
+            if not is_legal_lesson_transition(state, "superseded"):
+                return json.dumps(
+                    {"error": f"Illegal transition {state} -> superseded", "lesson_id": lesson_id, "state": state}
+                )
+            # superseded lessons drop out of the live set (is_active=true AND
+            # superseded_by IS NULL); also flip is_active=false for clarity.
+            await conn.execute(
+                "UPDATE planner_lessons SET superseded_by = $2, is_active = false WHERE id = $1",
+                lesson_id,
+                sup.new_id,
+            )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "lesson_id": lesson_id,
+                    "action": "superseded",
+                    "superseded_by": sup.new_id,
+                    "state": "superseded",
+                }
+            )
+
+        return json.dumps({"error": f"Unknown action '{action}'. Use: create, update, deactivate, validate, supersede"})
     finally:
         await conn.close()
 

--- a/tests/test_lessons_state_machine.py
+++ b/tests/test_lessons_state_machine.py
@@ -1,0 +1,175 @@
+"""MCP `lessons_manage` state-machine boundary tests (G8, issue #44).
+
+Exercises the transition guards in mcp.server.lessons_manage with a stubbed
+asyncpg connection — no live DB required. Verifies that legal transitions
+mutate the table and illegal transitions (validating/superseding a terminal
+lesson) are rejected before any write.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# mcp/server.py runs as a top-level script (systemd: `python mcp/server.py`),
+# and `import mcp.server` resolves to the installed MCP SDK, not the repo file.
+# Load the repo module directly from its path under a unique name, mirroring how
+# tests/test_12_fidelity.py loads iris_planner/ingestor. DSN env default keeps
+# the import side-effect-free with no live DB.
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "mcp" / "server.py"
+_spec = importlib.util.spec_from_file_location("verdify_mcp_server", _SERVER_PATH)
+server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(server)
+
+
+def _fake_conn(state_row: dict | None, new_exists: int | None = 1) -> AsyncMock:
+    """An AsyncMock asyncpg connection.
+
+    `_lesson_state_row` issues the multi-column SELECT (returns `state_row`);
+    the supersede path also issues a `SELECT 1 ... WHERE id = new_id`
+    (`fetchval` returns `new_exists`). `execute` is a no-op spy.
+    """
+    conn = AsyncMock()
+    conn.fetchrow.return_value = state_row
+    conn.fetchval.return_value = new_exists
+    conn.execute.return_value = "UPDATE 1"
+    conn.close.return_value = None
+    return conn
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+PROPOSED = {
+    "id": 7,
+    "is_active": True,
+    "superseded_by": None,
+    "times_validated": 1,
+    "has_independent_validation": False,
+}
+VALIDATED = {**PROPOSED, "times_validated": 4, "has_independent_validation": True}
+SUPERSEDED = {**PROPOSED, "is_active": False, "superseded_by": 9}
+RETIRED = {**PROPOSED, "is_active": False, "superseded_by": None}
+
+
+class TestValidateGuard:
+    def test_validate_proposed_legal(self):
+        conn = _fake_conn(PROPOSED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("validate", lesson_id=7)))
+        assert out["ok"] is True
+        assert out["state"] == "validated"
+        conn.execute.assert_awaited()  # the increment ran
+
+    def test_validate_validated_legal_idempotent(self):
+        conn = _fake_conn(VALIDATED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("validate", lesson_id=7)))
+        assert out["ok"] is True
+
+    def test_validate_superseded_rejected(self):
+        conn = _fake_conn(SUPERSEDED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("validate", lesson_id=7)))
+        assert "Illegal transition" in out["error"]
+        assert out["state"] == "superseded"
+        conn.execute.assert_not_awaited()  # rejected before any write
+
+    def test_validate_retired_rejected(self):
+        conn = _fake_conn(RETIRED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("validate", lesson_id=7)))
+        assert "Illegal transition" in out["error"]
+        assert out["state"] == "retired"
+        conn.execute.assert_not_awaited()
+
+    def test_validate_missing_lesson(self):
+        conn = _fake_conn(None)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("validate", lesson_id=7)))
+        assert out["error"] == "Lesson not found"
+
+
+class TestDeactivateGuard:
+    def test_deactivate_proposed_legal(self):
+        conn = _fake_conn(PROPOSED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("deactivate", lesson_id=7)))
+        assert out["state"] == "retired"
+        conn.execute.assert_awaited()
+
+    def test_deactivate_superseded_rejected(self):
+        conn = _fake_conn(SUPERSEDED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("deactivate", lesson_id=7)))
+        assert "Illegal transition" in out["error"]
+        conn.execute.assert_not_awaited()
+
+    def test_deactivate_already_retired_idempotent(self):
+        conn = _fake_conn(RETIRED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("deactivate", lesson_id=7)))
+        assert out["state"] == "retired"
+        # idempotent: no write needed
+        conn.execute.assert_not_awaited()
+
+
+class TestSupersedeAction:
+    def test_supersede_proposed_legal(self):
+        conn = _fake_conn(PROPOSED, new_exists=1)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("supersede", lesson_id=7, data=json.dumps({"new_id": 9}))))
+        assert out["ok"] is True
+        assert out["state"] == "superseded"
+        assert out["superseded_by"] == 9
+        conn.execute.assert_awaited()
+
+    def test_supersede_self_rejected(self):
+        conn = _fake_conn(PROPOSED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("supersede", lesson_id=7, data=json.dumps({"new_id": 7}))))
+        assert "cannot supersede itself" in out["error"]
+        conn.execute.assert_not_awaited()
+
+    def test_supersede_missing_new_lesson_rejected(self):
+        conn = _fake_conn(PROPOSED, new_exists=None)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("supersede", lesson_id=7, data=json.dumps({"new_id": 9}))))
+        assert "not found" in out["error"]
+        conn.execute.assert_not_awaited()
+
+    def test_supersede_already_superseded_rejected(self):
+        conn = _fake_conn(SUPERSEDED, new_exists=1)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("supersede", lesson_id=7, data=json.dumps({"new_id": 9}))))
+        assert "Illegal transition" in out["error"]
+        assert out["state"] == "superseded"
+        conn.execute.assert_not_awaited()
+
+    def test_supersede_bad_payload_rejected(self):
+        conn = _fake_conn(PROPOSED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("supersede", lesson_id=7, data=json.dumps({"new_id": 0}))))
+        assert "LessonSupersede validation failed" in out["error"]
+
+
+class TestUnknownAction:
+    def test_unknown_action_lists_supersede(self):
+        conn = _fake_conn(PROPOSED)
+        with patch.object(server, "_db", AsyncMock(return_value=conn)):
+            out = json.loads(_run(server.lessons_manage("archive", lesson_id=7)))
+        assert "supersede" in out["error"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/verdify_schemas/__init__.py
+++ b/verdify_schemas/__init__.py
@@ -100,12 +100,17 @@ from .external import (
 from .forecast import ForecastHour
 from .forecast_ops import ForecastActionLog, ForecastActionRule, ForecastActionType
 from .lessons import (
+    LESSON_TRANSITIONS,
     LessonAction,
     LessonConfidence,
     LessonCreate,
+    LessonState,
+    LessonSupersede,
     LessonUpdate,
     LessonValidate,
     PlannerLesson,
+    derive_lesson_state,
+    is_legal_lesson_transition,
 )
 from .mcp_responses import (
     ClimateSnapshot,
@@ -354,10 +359,13 @@ __all__ = [
     "IrrigationLog",
     "IrrigationSchedule",
     "LabResult",
+    "LESSON_TRANSITIONS",
     "LessonAction",
     "LessonConfidence",
     "LessonCreate",
+    "LessonState",
     "LessonSummary",
+    "LessonSupersede",
     "LessonUpdate",
     "LessonValidate",
     "LessonsVaultFrontmatter",
@@ -477,4 +485,6 @@ __all__ = [
     "ZoneUpdate",
     "choose_climate_candidate",
     "climate_candidate_sort_key",
+    "derive_lesson_state",
+    "is_legal_lesson_transition",
 ]

--- a/verdify_schemas/lessons.py
+++ b/verdify_schemas/lessons.py
@@ -3,6 +3,11 @@
 - PlannerLesson: full row shape (planner_lessons table).
 - LessonAction: MCP `lessons_manage` tool input envelope (replaces free-form
   `action: str, data: str` pair).
+- LessonState: the typed lifecycle a lesson moves through, plus the legal
+  transition map and a guard. The state is *derived* from the existing
+  `planner_lessons` columns (`is_active`, `superseded_by`, validation history)
+  so the state machine needs no DB migration — the four states are a typed view
+  over data the table already carries.
 """
 
 from __future__ import annotations
@@ -12,6 +17,74 @@ from typing import Literal
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 LessonConfidence = Literal["low", "medium", "high"]
+
+# ── Lesson lifecycle state machine (G8) ──────────────────────────────────────
+#
+# A lesson starts `proposed` when Iris first records it, becomes `validated`
+# once it accrues an independent validation, can be `superseded` by a newer
+# lesson, or `retired` (deactivated) when it no longer applies. The state is
+# derived from existing columns rather than stored, so no migration is needed:
+#
+#   superseded  ← superseded_by IS NOT NULL  (highest precedence; terminal)
+#   retired     ← is_active = false          (terminal)
+#   validated   ← active and validated at least once beyond creation
+#   proposed    ← active, freshly created, not yet independently validated
+LessonState = Literal["proposed", "validated", "superseded", "retired"]
+
+# Legal forward transitions. A lesson may always idempotently "transition" to
+# its own state (e.g. re-validating a validated lesson). Terminal states
+# (superseded, retired) accept no onward transitions.
+LESSON_TRANSITIONS: dict[LessonState, frozenset[LessonState]] = {
+    "proposed": frozenset({"validated", "superseded", "retired"}),
+    "validated": frozenset({"superseded", "retired"}),
+    "superseded": frozenset(),
+    "retired": frozenset(),
+}
+
+
+def derive_lesson_state(
+    *,
+    is_active: bool,
+    superseded_by: int | None,
+    times_validated: int = 1,
+    has_independent_validation: bool = False,
+) -> LessonState:
+    """Compute a lesson's lifecycle state from its persisted columns.
+
+    Precedence matches the SQL the MCP read paths already use
+    (`is_active = true AND superseded_by IS NULL` selects the *live* set):
+
+    - `superseded_by` set ⇒ `superseded` (terminal), regardless of `is_active`.
+    - else not active ⇒ `retired` (terminal).
+    - else active and validated beyond creation ⇒ `validated`.
+    - else active and fresh ⇒ `proposed`.
+
+    `has_independent_validation` (e.g. `last_validated > created_at`) takes
+    precedence over the `times_validated` heuristic when the caller can supply
+    it; otherwise `times_validated > 1` flags a post-creation validation.
+    """
+    if superseded_by is not None:
+        return "superseded"
+    if not is_active:
+        return "retired"
+    if has_independent_validation or times_validated > 1:
+        return "validated"
+    return "proposed"
+
+
+def is_legal_lesson_transition(current: LessonState, target: LessonState) -> bool:
+    """True if `current → target` is allowed.
+
+    Idempotent self-transitions are legal only for *non-terminal* states (e.g.
+    re-validating a `validated` lesson). Terminal states (`superseded`,
+    `retired`) are absorbing: you cannot re-supersede or re-retire them, so a
+    self-transition into a terminal state is illegal.
+    """
+    if current == target:
+        # legal only if `current` still has at least one forward transition
+        # (i.e. it is non-terminal)
+        return bool(LESSON_TRANSITIONS.get(current, frozenset()))
+    return target in LESSON_TRANSITIONS.get(current, frozenset())
 
 
 class LessonCreate(BaseModel):
@@ -44,7 +117,20 @@ class LessonValidate(BaseModel):
     confidence: LessonConfidence | None = None
 
 
-LessonActionKind = Literal["list", "create", "update", "deactivate", "validate"]
+class LessonSupersede(BaseModel):
+    """MCP lessons_manage.supersede data payload.
+
+    Marks an existing lesson (`lesson_id`) as superseded *by* `new_id`. The new
+    lesson must already exist. Mirrors the `planner_lessons.superseded_by`
+    self-reference. The old lesson moves proposed/validated → superseded.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    new_id: int = Field(..., gt=0)
+
+
+LessonActionKind = Literal["list", "create", "update", "deactivate", "validate", "supersede"]
 
 
 class LessonAction(BaseModel):
@@ -54,7 +140,7 @@ class LessonAction(BaseModel):
 
     action: LessonActionKind
     lesson_id: int | None = None
-    data: LessonCreate | LessonUpdate | LessonValidate | None = None
+    data: LessonCreate | LessonUpdate | LessonValidate | LessonSupersede | None = None
 
 
 class PlannerLesson(BaseModel):

--- a/verdify_schemas/tests/test_alerts_crops_lessons.py
+++ b/verdify_schemas/tests/test_alerts_crops_lessons.py
@@ -26,11 +26,16 @@ from verdify_schemas.crops import (
     ObservationCreate,
 )
 from verdify_schemas.lessons import (
+    LESSON_TRANSITIONS,
     LessonAction,
     LessonCreate,
+    LessonState,
+    LessonSupersede,
     LessonUpdate,
     LessonValidate,
     PlannerLesson,
+    derive_lesson_state,
+    is_legal_lesson_transition,
 )
 from verdify_schemas.operations import HarvestCreate, TreatmentCreate
 
@@ -279,9 +284,98 @@ class TestLessonAction:
         a = LessonAction(action="deactivate", lesson_id=12)
         assert a.data is None
 
+    def test_supersede(self):
+        a = LessonAction(action="supersede", lesson_id=12, data=LessonSupersede(new_id=15))
+        assert a.action == "supersede"
+        assert isinstance(a.data, LessonSupersede)
+        assert a.data.new_id == 15
+
+    def test_supersede_rejects_nonpositive_new_id(self):
+        with pytest.raises(ValidationError):
+            LessonSupersede(new_id=0)
+
+    def test_rejects_unknown_action(self):
+        with pytest.raises(ValidationError):
+            LessonAction(action="archive")
+
     def test_rejects_bad_confidence(self):
         with pytest.raises(ValidationError):
             LessonCreate(category="x", condition="x", lesson="x", confidence="maybe")
+
+
+class TestLessonStateMachine:
+    """G8 lessons state machine: derive_lesson_state + transition guards."""
+
+    def test_derive_proposed_fresh(self):
+        # active, never superseded, single validation count, no independent validation
+        assert derive_lesson_state(is_active=True, superseded_by=None, times_validated=1) == "proposed"
+
+    def test_derive_validated_by_count(self):
+        assert derive_lesson_state(is_active=True, superseded_by=None, times_validated=3) == "validated"
+
+    def test_derive_validated_by_independent_flag(self):
+        # times_validated still 1, but last_validated > created_at observed
+        assert (
+            derive_lesson_state(is_active=True, superseded_by=None, times_validated=1, has_independent_validation=True)
+            == "validated"
+        )
+
+    def test_derive_retired(self):
+        assert derive_lesson_state(is_active=False, superseded_by=None, times_validated=2) == "retired"
+
+    def test_derive_superseded_takes_precedence(self):
+        # superseded_by set wins even if is_active somehow still true
+        assert derive_lesson_state(is_active=True, superseded_by=99, times_validated=5) == "superseded"
+        assert derive_lesson_state(is_active=False, superseded_by=99, times_validated=5) == "superseded"
+
+    # ── legal transitions ───────────────────────────────────────────────
+    @pytest.mark.parametrize(
+        "current,target",
+        [
+            ("proposed", "validated"),
+            ("proposed", "superseded"),
+            ("proposed", "retired"),
+            ("validated", "superseded"),
+            ("validated", "retired"),
+            # idempotent self-transitions are legal only for non-terminal states
+            ("proposed", "proposed"),
+            ("validated", "validated"),
+        ],
+    )
+    def test_legal_transitions(self, current, target):
+        assert is_legal_lesson_transition(current, target) is True
+
+    # ── illegal transitions ─────────────────────────────────────────────
+    @pytest.mark.parametrize(
+        "current,target",
+        [
+            # cannot go backwards
+            ("validated", "proposed"),
+            # terminal states accept no onward transitions
+            ("superseded", "validated"),
+            ("superseded", "retired"),
+            ("superseded", "proposed"),
+            ("retired", "validated"),
+            ("retired", "superseded"),
+            ("retired", "proposed"),
+            # terminal states are absorbing: no idempotent self-transition
+            ("superseded", "superseded"),
+            ("retired", "retired"),
+        ],
+    )
+    def test_illegal_transitions_rejected(self, current, target):
+        assert is_legal_lesson_transition(current, target) is False
+
+    def test_transition_map_covers_all_states(self):
+        states = set(LessonState.__args__)
+        assert set(LESSON_TRANSITIONS.keys()) == states
+        # every declared target is itself a valid state
+        for targets in LESSON_TRANSITIONS.values():
+            assert targets <= states
+
+    def test_terminal_states_have_no_forward_transitions(self):
+        assert LESSON_TRANSITIONS["superseded"] == frozenset()
+        assert LESSON_TRANSITIONS["retired"] == frozenset()
 
 
 class TestPlannerLesson:


### PR DESCRIPTION
Closes #44

## G8 lessons state machine

Adds a typed `LessonState` lifecycle and enforces its transitions at the MCP `lessons_manage` boundary, rejecting illegal transitions.

### Design decision: derived state, no DB migration
The four states are a **typed view over columns `planner_lessons` already carries** (`is_active`, `superseded_by`, validation history), matching the precedence the existing MCP read paths already use (`is_active = true AND superseded_by IS NULL` selects the live set). So this lands as **self-contained code with no `status` column / migration** — the issue's "Coordinator migration if a status column is needed" is *not* needed. A future `status` column can be layered on later if explicit storage is ever wanted; it is intentionally deferred to keep this PR in-lane and mergeable on its own.

```
superseded  ← superseded_by IS NOT NULL   (terminal, highest precedence)
retired     ← is_active = false           (terminal)
validated   ← active + validated beyond creation
proposed    ← active + fresh
```

### Changes
- `verdify_schemas/lessons.py`: `LessonState` literal, `LESSON_TRANSITIONS` map, `derive_lesson_state()`, `is_legal_lesson_transition()` (idempotent self-transition legal only for non-terminal states), `LessonSupersede` payload, `"supersede"` added to `LessonActionKind`.
- `mcp/server.py` `lessons_manage`: `validate`/`deactivate` derive current state and reject illegal transitions before any write; new `supersede` action (proposed/validated → superseded by an existing newer lesson); rejects self-supersede, missing new lesson, and terminal-state sources. Responses gain an additive `state` field; existing response shapes unchanged.
- `ingestor/iris_planner.py`: documents `supersede` + lifecycle in the SUNSET lesson-review step.

### Validation (UTC 2026-06-01T21:41Z)
- `make lint` — PASS (ruff check + pre-commit ruff format clean).
- `verdify_schemas/tests/test_alerts_crops_lessons.py::TestLessonStateMachine` — derive + legal/illegal transition guards + map invariants + supersede envelope. PASS.
- `tests/test_lessons_state_machine.py` — MCP-boundary guard tests with a stubbed asyncpg connection (no live DB): legal transitions write, illegal ones rejected before any `execute()`. PASS.
- Drift guards (`verdify_schemas/tests/test_drift_guards.py`) — PASS. No new DB-backed schema field, so subset/tenancy guards unaffected (`PENDING_MIGRATION_COLUMNS` untouched).
- 209 tests pass overall in the lessons/schema/drift scope.

### Rule 7 — services to bounce post-merge
Touches `verdify_schemas/**` and `mcp/server.py`: **restart `verdify-mcp`** after merge. No `ingestor/entity_map.py` change, so `verdify-ingestor` does not need a bounce for this PR.

### Scope / safety
No device path, no live writer, no DNS/firewall/host changes. Repo-only code + tests. Merge == MERGED, not deployed; the MCP restart is the host-gated residual.

requested-by: iris (shared territory: verdify_schemas/**, mcp/server.py)
