### PR TITLE
feat(ingestor): daily site_content RAG-refresh task (#43)

### DIFF
--- a/ingestor/ingestor.py
+++ b/ingestor/ingestor.py
@@ -84,6 +84,7 @@ from tasks import (
     setpoint_confirmation_monitor,
     setpoint_dispatcher,
     shelly_sync,
+    site_content_refresh,
     slack_operator_briefs,
     tempest_sync,
     water_flowing_sync,
@@ -1817,6 +1818,10 @@ async def task_loop(pool: asyncpg.Pool) -> None:
         ("ha_sensor_sync", 300, ha_sensor_sync),
         ("alert_monitor", 300, alert_monitor),
         ("planner_memory_ingest", 300, planner_memory_ingest_sync),
+        # Daily RAG-snapshot refresh: re-materialize the vault/docs corpus into
+        # site_content so Iris retrieval doesn't silently drift stale (#43).
+        # Read/embed side only — no device path. 86400s = daily cadence.
+        ("site_content_refresh", 86400, site_content_refresh),
         # reactive_planner removed in Sprint 5 P6 — replaced by forecast deviation monitor
         ("setpoint_dispatch", 300, setpoint_dispatcher),
         ("setpoint_confirmation", 300, setpoint_confirmation_monitor),

--- a/ingestor/tasks.py
+++ b/ingestor/tasks.py
@@ -1216,6 +1216,124 @@ async def matview_refresh(pool: asyncpg.Pool) -> None:
 
 
 # ═════════════════════════════════════════════════════════════════
+# 2b. SITE_CONTENT RAG REFRESH (daily, every 86400s)
+# ═════════════════════════════════════════════════════════════════
+# The site_content table is Iris's semantic-retrieval snapshot of the public
+# vault/docs corpus (chunked + embedded downstream by embed-corpora.py). Before
+# this task there was no scheduled refresh, so site_content silently drifted
+# stale (max(updated_at) lagged the vault by a week — issue #43). This task
+# re-materializes the corpus into site_content on a daily cadence using the same
+# walk helpers as scripts/populate-site-content.py (single source of truth for
+# what counts as a public RAG page), then asserts max(updated_at) lands back
+# inside the cadence freshness window. Read/embed side only — no device path.
+
+# Daily cadence; the freshness window allows one full cadence plus a grace
+# margin before the snapshot is considered stale. Kept as module constants so
+# the registration interval and the freshness assertion can't drift apart.
+SITE_CONTENT_REFRESH_INTERVAL_S = 86400  # 24h
+SITE_CONTENT_FRESHNESS_GRACE_S = 6 * 3600  # 6h slack for run jitter / long walks
+SITE_CONTENT_FRESHNESS_WINDOW_S = SITE_CONTENT_REFRESH_INTERVAL_S + SITE_CONTENT_FRESHNESS_GRACE_S
+
+_POPULATE_SITE_CONTENT_SCRIPT = REPO_ROOT / "scripts" / "populate-site-content.py"
+
+
+def _load_site_content_populator():
+    """Import scripts/populate-site-content.py as a module.
+
+    The filename uses hyphens, so it can't be imported with a plain `import`.
+    Loading it here keeps the corpus-walk logic (which roots count, which docs
+    are excluded, how page_path is derived, how a row is upserted) single-sourced
+    with the standalone populator instead of forking a second copy in tasks.py.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("populate_site_content", _POPULATE_SITE_CONTENT_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load populator from {_POPULATE_SITE_CONTENT_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _refresh_site_content_corpus(conn, populator) -> int:
+    """Upsert every in-scope corpus page into site_content; return rows touched.
+
+    Each upsert stamps updated_at = now() (see populator._upsert_site_doc), so a
+    successful pass advances the snapshot watermark. Missing roots (e.g. the
+    vault mount absent in an env) are skipped, mirroring the standalone script.
+    """
+    written = 0
+    for root, rel_root in populator.SITE_DOC_ROOTS:
+        if not root.is_dir():
+            continue
+        for md_path in sorted(root.rglob("*.md")):
+            if populator._is_excluded(md_path):
+                continue
+            # The repo playbook has its own table; don't mirror it into site_content.
+            if root == populator.REPO_ROOT / "docs" and md_path.parent.name == "planner":
+                continue
+            rel = populator._site_doc_relative_path(md_path, rel_root)
+            content = md_path.read_text(encoding="utf-8")
+            if not content.strip():
+                continue
+            await populator._upsert_site_doc(conn, rel, content)
+            written += 1
+    return written
+
+
+def site_content_is_fresh(max_updated_at: datetime | None, now: datetime | None = None) -> bool:
+    """True if site_content's newest row is inside the daily cadence window.
+
+    A None watermark (empty table) is never "fresh" — there is nothing to serve
+    Iris. This is the freshness assertion the task self-checks after refreshing.
+    """
+    if max_updated_at is None:
+        return False
+    if now is None:
+        now = datetime.now(UTC)
+    if max_updated_at.tzinfo is None:
+        max_updated_at = max_updated_at.replace(tzinfo=UTC)
+    age_s = (now - max_updated_at).total_seconds()
+    return 0 <= age_s <= SITE_CONTENT_FRESHNESS_WINDOW_S
+
+
+async def site_content_refresh(pool: asyncpg.Pool) -> None:
+    """Daily refresh of the site_content RAG snapshot from the vault corpus.
+
+    Re-materializes the public docs/website corpus into site_content (advancing
+    updated_at), then verifies max(updated_at) is back inside the cadence
+    freshness window. A stale watermark after a refresh attempt means the corpus
+    roots were unavailable (e.g. vault unmounted) — logged loudly but never
+    raised, since this RAG-maintenance task must never block greenhouse ops.
+    """
+    try:
+        populator = _load_site_content_populator()
+    except Exception as e:  # noqa: BLE001 — corpus refresh must never crash the loop
+        log.error("site_content_refresh: could not load populator: %s", e)
+        return
+
+    async with pool.acquire() as conn:
+        written = await _refresh_site_content_corpus(conn, populator)
+        max_updated_at = await conn.fetchval("SELECT max(updated_at) FROM site_content")
+
+    if site_content_is_fresh(max_updated_at):
+        log.info(
+            "site_content_refresh: %d rows refreshed; max(updated_at)=%s within %dh window",
+            written,
+            max_updated_at.isoformat() if max_updated_at else "none",
+            SITE_CONTENT_FRESHNESS_WINDOW_S // 3600,
+        )
+    else:
+        log.warning(
+            "site_content_refresh: snapshot still stale after refresh "
+            "(rows touched=%d, max(updated_at)=%s, window=%dh) — corpus roots may be unavailable",
+            written,
+            max_updated_at.isoformat() if max_updated_at else "none",
+            SITE_CONTENT_FRESHNESS_WINDOW_S // 3600,
+        )
+
+
+# ═════════════════════════════════════════════════════════════════
 # 3. SHELLY ENERGY SYNC (every 300s)
 # ═════════════════════════════════════════════════════════════════
 _SHELLY_PREFIX = "sensor.shellyproem50_ac15186daafc_energy_meter"

--- a/tests/test_site_content_refresh.py
+++ b/tests/test_site_content_refresh.py
@@ -1,0 +1,184 @@
+"""Unit tests for the daily site_content RAG-refresh task (issue #43).
+
+Covers:
+  - the corpus walk selects/upserts in-scope vault pages and advances
+    max(updated_at) (the "selects/refreshes" half), and
+  - the freshness assertion that max(updated_at) stays inside the cadence
+    window after a refresh (the "freshness assertion (fixture)" half).
+
+Read/embed side only — no device, no live DB. A FakePool models site_content
+as an in-memory dict so the upsert path runs end-to-end with deterministic
+timestamps.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+TESTS_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_ROOT.parent
+INGESTOR_ROOT = REPO_ROOT / "ingestor"
+if str(INGESTOR_ROOT) not in sys.path:
+    sys.path.insert(0, str(INGESTOR_ROOT))
+
+import tasks  # noqa: E402
+
+
+# ── In-memory site_content backed by a FakePool ─────────────────────────────
+class _FakeConn:
+    """Minimal asyncpg.Connection shim for the site_content upsert path.
+
+    Stores rows as {page_path: (content, updated_at)} and stamps updated_at on
+    every UPDATE/INSERT with the supplied `stamp`, mirroring the
+    `updated_at = now()` / DEFAULT now() behaviour of the real table so
+    max(updated_at) advances on refresh.
+    """
+
+    def __init__(self, store, stamp: datetime):
+        self._store = store
+        self._stamp = stamp
+
+    async def fetchval(self, query, *args):
+        q = " ".join(query.split())
+        if q.startswith("SELECT 1 FROM site_content WHERE page_path"):
+            return 1 if args[0] in self._store else None
+        if q.startswith("SELECT max(updated_at) FROM site_content"):
+            if not self._store:
+                return None
+            return max(ua for _, ua in self._store.values())
+        raise AssertionError(f"unexpected fetchval: {q!r}")
+
+    async def execute(self, query, *args):
+        q = " ".join(query.split())
+        if q.startswith("UPDATE site_content SET content"):
+            page_path, content = args[0], args[1]
+            self._store[page_path] = (content, self._stamp)
+            return "UPDATE 1"
+        if q.startswith("INSERT INTO site_content"):
+            page_path, content = args[0], args[1]
+            self._store[page_path] = (content, self._stamp)
+            return "INSERT 0 1"
+        raise AssertionError(f"unexpected execute: {q!r}")
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class _FakePool:
+    def __init__(self, store, stamp: datetime):
+        self._conn = _FakeConn(store, stamp)
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+@pytest.fixture
+def fixture_corpus(tmp_path: Path) -> Path:
+    """A tiny vault/docs corpus the populator should index into site_content."""
+    docs = tmp_path / "docs"
+    (docs / "greenhouse").mkdir(parents=True)
+    (docs / "greenhouse" / "soil.md").write_text("# Soil\nMoisture snapshot.\n", encoding="utf-8")
+    (docs / "overview.md").write_text("# Overview\nGreenhouse climate controller.\n", encoding="utf-8")
+    # Excluded by SITE_DOC_EXCLUDE_PATTERNS — must NOT be indexed.
+    (docs / "BACKLOG.md").write_text("# Backlog\nNot a RAG page.\n", encoding="utf-8")
+    # Planner playbook lives in its own table — must NOT land in site_content.
+    (docs / "planner").mkdir()
+    (docs / "planner" / "playbook.md").write_text("# Playbook\nPlanner-only.\n", encoding="utf-8")
+    # Empty file — skipped.
+    (docs / "empty.md").write_text("   \n", encoding="utf-8")
+    return tmp_path
+
+
+def _point_populator_at(populator, root: Path) -> None:
+    """Repoint the populator's corpus roots at the fixture tree."""
+    docs = root / "docs"
+    populator.REPO_ROOT = root
+    populator.SITE_DOC_ROOTS = [(docs, root)]
+
+
+@pytest.mark.asyncio
+async def test_site_content_refresh_selects_and_upserts_corpus(fixture_corpus, monkeypatch):
+    stamp = datetime.now(UTC)
+    store: dict[str, tuple[str, datetime]] = {}
+    pool = _FakePool(store, stamp)
+
+    populator = tasks._load_site_content_populator()
+    _point_populator_at(populator, fixture_corpus)
+    monkeypatch.setattr(tasks, "_load_site_content_populator", lambda: populator)
+
+    await tasks.site_content_refresh(pool)
+
+    indexed = set(store.keys())
+    # soil.md + overview.md indexed; BACKLOG excluded, planner/* skipped, empty skipped.
+    assert "docs/greenhouse/soil.md" in indexed
+    assert "docs/overview.md" in indexed
+    assert not any("BACKLOG" in p for p in indexed)
+    assert not any("planner" in p for p in indexed)
+    assert not any("empty" in p for p in indexed)
+    # Every indexed row carries the refresh timestamp.
+    assert all(ua == stamp for _, ua in store.values())
+
+
+@pytest.mark.asyncio
+async def test_site_content_refresh_advances_freshness_watermark(fixture_corpus, monkeypatch):
+    stamp = datetime.now(UTC)
+    # Pre-seed a stale snapshot well outside the cadence window.
+    stale = stamp - timedelta(days=8)
+    store: dict[str, tuple[str, datetime]] = {"docs/overview.md": ("old content", stale)}
+    pool = _FakePool(store, stamp)
+
+    populator = tasks._load_site_content_populator()
+    _point_populator_at(populator, fixture_corpus)
+    monkeypatch.setattr(tasks, "_load_site_content_populator", lambda: populator)
+
+    # Before the refresh the snapshot is stale.
+    assert tasks.site_content_is_fresh(stale, now=stamp) is False
+
+    await tasks.site_content_refresh(pool)
+
+    max_updated = max(ua for _, ua in store.values())
+    assert max_updated == stamp
+    # After the refresh max(updated_at) is back inside the daily cadence window.
+    assert tasks.site_content_is_fresh(max_updated) is True
+
+
+def test_site_content_freshness_window_matches_daily_cadence():
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    # Empty table is never fresh — nothing to serve Iris.
+    assert tasks.site_content_is_fresh(None, now=now) is False
+    # Just-refreshed is fresh.
+    assert tasks.site_content_is_fresh(now, now=now) is True
+    # Inside the daily window (cadence + grace) is fresh.
+    inside = now - timedelta(seconds=tasks.SITE_CONTENT_FRESHNESS_WINDOW_S - 1)
+    assert tasks.site_content_is_fresh(inside, now=now) is True
+    # One second past the window is stale.
+    outside = now - timedelta(seconds=tasks.SITE_CONTENT_FRESHNESS_WINDOW_S + 1)
+    assert tasks.site_content_is_fresh(outside, now=now) is False
+    # Window is the daily cadence plus the grace margin.
+    assert tasks.SITE_CONTENT_FRESHNESS_WINDOW_S == (
+        tasks.SITE_CONTENT_REFRESH_INTERVAL_S + tasks.SITE_CONTENT_FRESHNESS_GRACE_S
+    )
+
+
+def test_naive_watermark_is_treated_as_utc():
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    naive = datetime(2026, 6, 1, 11, 0)  # 1h ago, no tzinfo
+    assert tasks.site_content_is_fresh(naive, now=now) is True
+
+
+def test_task_loop_registers_site_content_refresh():
+    src = (INGESTOR_ROOT / "ingestor.py").read_text()
+    assert '("site_content_refresh", 86400, site_content_refresh)' in src
+    assert "site_content_refresh," in src  # imported from tasks


### PR DESCRIPTION
Closes #43

## What
`site_content` (Iris's semantic-retrieval snapshot of the public vault/docs corpus) had **no scheduled refresh**, so `max(updated_at)` silently drifted stale (7 days at audit time — live was `2026-05-23 23:23` on `2026-05-30`). Public HTML stays fresh, so the RAG lag is easy to miss while it degrades Iris retrieval.

Adds a **daily (86400s) background task `site_content_refresh`** to the ingestor `task_loop`:
- Re-materializes the `docs/` + vault `website/` corpus into `site_content` (each upsert stamps `updated_at = now()`), **reusing the corpus-walk helpers from `scripts/populate-site-content.py`** as the single source of truth for which pages are RAG targets and which are excluded (no forked second copy of the walk logic).
- After refreshing, **self-asserts the freshness invariant**: `max(updated_at)` must land inside the cadence window (24h cadence + 6h grace = **30h**, kept as coupled module constants so the registration interval and the assertion can't drift apart). A stale watermark after a refresh attempt (corpus roots unavailable, e.g. vault unmounted) is logged loudly but **never raised** — RAG maintenance must never block greenhouse ops.

## Acceptance criteria mapping
- *"A scheduled task refreshes site_content from the vault on a defined cadence (daily)"* → `("site_content_refresh", 86400, site_content_refresh)` in `ingestor.py` TASKS; `site_content_refresh()` in `tasks.py`.
- *"max(updated_at) stays within the cadence window"* → `site_content_is_fresh()` freshness assertion, checked by the task post-refresh and unit-tested with a fixture (pre-seeded 8-day-stale snapshot refreshed back inside the window).
- *"Verified by observing a fresh updated_at after the job runs"* → `test_site_content_refresh_advances_freshness_watermark` asserts `max(updated_at)` advances to the refresh stamp and passes the freshness check.

## Scope / safety
- **Read/embed side only.** No device path, no live writer, no `SHADOW_MODE`, no device egress.
- Does **not** touch `verdify_schemas/**`, `mcp/server.py`, or `ingestor/entity_map.py` → **no Rule-7 service restart required**.
- No firmware touch.
- Single-issue, no bundling. No staging-pin / package changes.

## Validation (UTC 2026-06-01T21:49:48Z)
- `make lint` → `All checks passed!`
- `pytest tests/test_site_content_refresh.py` → **5 passed** (FakePool + tmp_path fixture corpus; proves the walk selects/upserts soil.md + overview.md, skips BACKLOG/planner/empty, advances the watermark; window/cadence coupling + naive-tz edges).
- Regression: `tests/test_planner_memory_ingest.py` (7) + `test_site_content_populator_indexes_public_website_markdown` (1) → green.

requested-by: iris (shared territory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)