### PR TITLE
ci(migrations): codify migration rollback-safety guard (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,3 +472,59 @@ jobs:
             exit 1
           fi
           echo "PR body documents service restart"
+
+  migration-rollback-safety:
+    name: Migration rollback-safety guard (no self-committing wrap)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    # Codifies the 2026-05-30 live-commit incident (#23): a SELF-committing
+    # migration (its own top-level COMMIT, or a commit-forcing statement like
+    # CREATE INDEX CONCURRENTLY / VACUUM / ALTER SYSTEM) chained under an outer
+    # BEGIN..ROLLBACK dry-run defeats the rollback and commits to the LIVE DB.
+    # scripts/check_migration_rollback_safety.py classifies each db/migrations
+    # file (stripping comments / string literals / dollar-quoted bodies so a
+    # CONCURRENTLY mentioned only in a comment never trips it). This job flags
+    # any self-committing migration touched in the PR so a reviewer confirms the
+    # apply/rollback tooling is NOT blindly wrapping it. No DB / no device.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Flag self-committing migrations touched in this PR
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          BASE=$(git merge-base HEAD "origin/${BASE_REF}")
+          # Only the real numbered set under db/migrations/ (fixtures/ excluded
+          # by the trailing slash → no subdirectories), changed in this PR.
+          CHANGED=$(git diff --name-only --diff-filter=d "$BASE" HEAD -- 'db/migrations/*.sql' 2>/dev/null || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No db/migrations/*.sql changed in this PR; nothing to guard."
+            exit 0
+          fi
+          echo "Changed migrations:"
+          echo "$CHANGED"
+          # shellcheck disable=SC2086
+          python scripts/check_migration_rollback_safety.py --check $CHANGED
+      - name: Guard self-test (bad fixture must fail, 151-155 must pass)
+        run: |
+          set -euo pipefail
+          if python scripts/check_migration_rollback_safety.py --check db/migrations/fixtures/_self_committing_bad.sql; then
+            echo "::error::guard FAILED to reject the self-committing fixture"
+            exit 1
+          fi
+          python scripts/check_migration_rollback_safety.py --check \
+            db/migrations/151-backfill-suppressed-sensor-offline-resolved-at.sql \
+            db/migrations/152-kwh-coalesce-sanity-gate.sql \
+            db/migrations/153-pipeline-health-weather-station-dark-sources.sql \
+            db/migrations/154-consolidate-oscillation-views.sql \
+            db/migrations/155-twin-observability-tables.sql
+          echo "guard self-test passed"
+      - name: Guard unit tests
+        run: |
+          pip install pytest
+          pytest tests/test_migration_rollback_safety.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,11 +499,14 @@ jobs:
         run: |
           set -euo pipefail
           BASE=$(git merge-base HEAD "origin/${BASE_REF}")
-          # Only the real numbered set under db/migrations/ (fixtures/ excluded
-          # by the trailing slash → no subdirectories), changed in this PR.
-          CHANGED=$(git diff --name-only --diff-filter=d "$BASE" HEAD -- 'db/migrations/*.sql' 2>/dev/null || true)
+          # Only the real numbered set under db/migrations/ — the git pathspec
+          # `db/migrations/*.sql` matches RECURSIVELY, so we explicitly exclude the
+          # db/migrations/fixtures/ tree (the deliberately self-committing guard
+          # fixtures, which are NOT applied migrations).
+          CHANGED=$(git diff --name-only --diff-filter=d "$BASE" HEAD \
+            -- 'db/migrations/*.sql' ':(exclude)db/migrations/fixtures/*' 2>/dev/null || true)
           if [ -z "$CHANGED" ]; then
-            echo "No db/migrations/*.sql changed in this PR; nothing to guard."
+            echo "No applied db/migrations/*.sql changed in this PR; nothing to guard."
             exit 0
           fi
           echo "Changed migrations:"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,38 @@ Rule: if the file listed here is in your diff, pause and ask coordinator.
 4. **Drift guards are the wire protocol.** If `verdify_schemas/tests/test_drift_guards.py` passes, two agents can merge independently — the boundary is intact.
 5. **Hand off by doc, not by DM.** Anything a future session of any agent needs to know goes into that agent's `docs/agents/{name}.md` or a memory file, not into chat.
 
+## Migration safety: never wrap a self-committing migration
+
+**Lesson from the 2026-05-30 live-commit incident (#23).** A migration that owns
+its own top-level `COMMIT;` — or contains a *commit-forcing* statement that
+cannot run inside a transaction block (`CREATE INDEX CONCURRENTLY`, `DROP INDEX
+CONCURRENTLY`, `REINDEX ... CONCURRENTLY`, `VACUUM`, `CREATE/DROP DATABASE`,
+`CREATE/DROP TABLESPACE`, `ALTER SYSTEM`) — must **never** be replayed under an
+outer `BEGIN; … ROLLBACK;` dry-run. The inner `COMMIT` (or commit-forcing
+statement) commits to the **live** database the instant psql reaches it,
+silently defeating the rollback. On 2026-05-30 exactly this happened.
+
+The two shapes (per `docs/runbooks/backlog-closeout-deploy-2026-05-30.md`):
+
+- **Self-transactional** (e.g. 149, 150): own top-level `BEGIN;`/`COMMIT;`.
+  Apply as-is; rollback-validate by swapping the trailing `COMMIT;` for
+  `ROLLBACK;`. **Do NOT wrap in an outer `BEGIN..ROLLBACK`.**
+- **Non-self-transactional** (e.g. 134, 146, 147, 151–155): no top-level
+  `COMMIT`; only DO-block `BEGIN`s. Safe to rollback-validate by wrapping in an
+  outer `BEGIN; … ROLLBACK;`.
+
+The guard is codified, not prose-only:
+
+- `scripts/check_migration_rollback_safety.py` classifies each migration
+  (stripping comments, string literals, and dollar-quoted bodies, so a
+  `CONCURRENTLY` mentioned only in a `--` comment never trips it).
+  `--rollback-wrap FILE` is the preflight `make irrigation-migration-check` /
+  `irrigation-migration-proof` run before piping into psql; it refuses to wrap a
+  self-committing migration. `make migration-rollback-safety` lists the full
+  classification.
+- CI job `migration-rollback-safety` (`.github/workflows/ci.yml`) flags any
+  self-committing migration touched in a PR.
+
 ## Branches & sprints
 
 - Each agent has its own sprint counter. Example: `ingestor/sprint-5-...`, `firmware/sprint-7-...`, `saas/sprint-11-...`.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ REPLAY_CORPUS_TMP ?= /tmp/verdify-replay-overrides.csv
 HERMES_IRIS_RUNTIME_DIR ?= /var/lib/verdify/hermes/iris
 HERMES_IRIS_ENV_FILE ?= /etc/verdify/hermes-iris.env
 
-.PHONY: help test lint format check lighting-audit-static lighting-audit-current lighting-audit-live lighting-audit-complete climate-intent-replay-report climate-authority-post-deploy-proof-plan climate-authority-post-deploy-proof firmware-check firmware-check-worktree firmware-check-all firmware-invariants firmware-replay firmware-replay-worktree firmware-replay-stream-check firmware-audit-traceability-proof firmware-audit-worktree-proof firmware-dwell-preview firmware-deploy firmware-archive-artifacts firmware-promote-last-good smoke hermes-deploy-config hermes-restart hermes-smoke clean irrigation-migration-check irrigation-migration-proof irrigation-field-diagnostics irrigation-field-sensor-health-proof irrigation-stack-software-check irrigation-stack-check irrigation-feedback-check irrigation-feedback-discover irrigation-feedback-discovery-proof irrigation-feedback-work-order irrigation-feedback-work-order-proof irrigation-feedback-clear-stale-retained irrigation-feedback-clear-stale-near-misses irrigation-feedback-watch irrigation-feedback-watch-field irrigation-feedback-watch-field-proof irrigation-feedback-finalize-dry-run irrigation-feedback-finalize-dry-run-proof irrigation-feedback-finalize irrigation-feedback-finalize-proof irrigation-feedback-proof-json irrigation-sensor-health-proof irrigation-stack-proof irrigation-completion-audit irrigation-completion-audit-proof irrigation-acceptance irrigation-full-acceptance irrigation-post-deploy-acceptance-plan irrigation-post-deploy-acceptance
+.PHONY: help test lint format check lighting-audit-static lighting-audit-current lighting-audit-live lighting-audit-complete climate-intent-replay-report climate-authority-post-deploy-proof-plan climate-authority-post-deploy-proof firmware-check firmware-check-worktree firmware-check-all firmware-invariants firmware-replay firmware-replay-worktree firmware-replay-stream-check firmware-audit-traceability-proof firmware-audit-worktree-proof firmware-dwell-preview firmware-deploy firmware-archive-artifacts firmware-promote-last-good smoke hermes-deploy-config hermes-restart hermes-smoke clean migration-rollback-safety irrigation-migration-check irrigation-migration-proof irrigation-field-diagnostics irrigation-field-sensor-health-proof irrigation-stack-software-check irrigation-stack-check irrigation-feedback-check irrigation-feedback-discover irrigation-feedback-discovery-proof irrigation-feedback-work-order irrigation-feedback-work-order-proof irrigation-feedback-clear-stale-retained irrigation-feedback-clear-stale-near-misses irrigation-feedback-watch irrigation-feedback-watch-field irrigation-feedback-watch-field-proof irrigation-feedback-finalize-dry-run irrigation-feedback-finalize-dry-run-proof irrigation-feedback-finalize irrigation-feedback-finalize-proof irrigation-feedback-proof-json irrigation-sensor-health-proof irrigation-stack-proof irrigation-completion-audit irrigation-completion-audit-proof irrigation-acceptance irrigation-full-acceptance irrigation-post-deploy-acceptance-plan irrigation-post-deploy-acceptance
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -223,12 +223,21 @@ grafana-brand-check-live: ## Verify live embedded Grafana panels use Verdify Lab
 site-lint: ## Run cheap lint for public-site content and routes
 	$(PYTHON) scripts/lint_public_site.py
 
+migration-rollback-safety: ## Classify db/migrations as self-committing vs safe-to-wrap (#23 guard)
+	@$(PYTHON) scripts/check_migration_rollback_safety.py --list
+
 irrigation-migration-check: ## Replay irrigation migration 134 inside a rollback transaction
+	@# Preflight (#23): refuse to wrap a self-committing migration in an outer
+	@# BEGIN..ROLLBACK — its own top-level COMMIT / commit-forcing statement would
+	@# defeat the rollback and commit to the LIVE DB (2026-05-30 live-commit incident).
+	@$(PYTHON) scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/134-irrigation-fertigation-canonical.sql
 	@set -o pipefail; . scripts/lib/psql-verdify.sh; { printf 'BEGIN;\n'; cat db/migrations/134-irrigation-fertigation-canonical.sql; printf '\nROLLBACK;\n'; } | verdify_psql_stdin -v ON_ERROR_STOP=1 -q
 	@echo "OK: migration 134 replays cleanly in rollback transaction"
 
 irrigation-migration-proof: ## Replay and persist irrigation migration rollback proof
 	@mkdir -p "$(dir $(IRRIGATION_MIGRATION_PROOF))"
+	@# Preflight (#23): refuse to wrap a self-committing migration (see irrigation-migration-check).
+	@$(PYTHON) scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/134-irrigation-fertigation-canonical.sql
 	@set -o pipefail; . scripts/lib/psql-verdify.sh; { { printf 'BEGIN;\n'; cat db/migrations/134-irrigation-fertigation-canonical.sql; printf '\nROLLBACK;\n'; } | verdify_psql_stdin -v ON_ERROR_STOP=1 -q && echo "OK: migration 134 replays cleanly in rollback transaction"; } 2>&1 | tee "$(IRRIGATION_MIGRATION_PROOF)"
 
 irrigation-field-diagnostics: ## Run non-gating field diagnostics for physical feedback blockers

--- a/db/migrations/fixtures/_concurrently_bad.sql
+++ b/db/migrations/fixtures/_concurrently_bad.sql
@@ -1,0 +1,21 @@
+-- FIXTURE — NOT A REAL MIGRATION. DO NOT APPLY TO ANY DATABASE.
+--
+-- Second guard fixture (issue #23): a migration with NO top-level COMMIT but a
+-- commit-forcing statement that cannot run inside a transaction block. Postgres
+-- runs CREATE INDEX CONCURRENTLY in its own implicit transaction; if you wrap
+-- this file in an outer BEGIN..ROLLBACK it errors out ("CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block") OR, depending on the
+-- replay harness, force-commits surrounding work. Either way it must NOT be
+-- silently wrapped — the guard must refuse it.
+--
+-- Lives under db/migrations/fixtures/ with an underscore prefix so the
+-- non-recursive `ls db/migrations/*.sql` apply loop never runs it.
+
+CREATE TABLE IF NOT EXISTS _guard_fixture_concurrently (
+    id   SERIAL PRIMARY KEY,
+    val  INTEGER NOT NULL DEFAULT 0
+);
+
+-- Commit-forcing: cannot run inside a transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_guard_fixture_val
+    ON _guard_fixture_concurrently (val);

--- a/db/migrations/fixtures/_self_committing_bad.sql
+++ b/db/migrations/fixtures/_self_committing_bad.sql
@@ -1,0 +1,37 @@
+-- FIXTURE — NOT A REAL MIGRATION. DO NOT APPLY TO ANY DATABASE.
+--
+-- Deliberately self-committing migration used by the rollback-safety guard
+-- (scripts/check_migration_rollback_safety.py / tests/test_migration_rollback_safety.py,
+-- issue #23). The underscore prefix keeps it outside the numbered applied set;
+-- it lives under db/migrations/fixtures/ (a subdirectory) so the non-recursive
+-- `ls db/migrations/*.sql` apply loop in CI never picks it up.
+--
+-- This file reproduces the 2026-05-30 live-commit incident shape: a migration
+-- with its OWN top-level COMMIT chained under an outer BEGIN..ROLLBACK dry-run.
+-- When wrapped, the inner COMMIT below commits to the live DB the instant psql
+-- reaches it, defeating the outer ROLLBACK. The guard MUST refuse to wrap this.
+--
+-- The comments below intentionally MENTION commit-forcing statements
+-- (CREATE INDEX CONCURRENTLY, VACUUM) to prove the guard ignores comment text
+-- and only trips on the real top-level COMMIT. The DO block likewise contains a
+-- PL/pgSQL BEGIN ... END that must NOT be mistaken for transaction control.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS _guard_fixture_demo (
+    id   SERIAL PRIMARY KEY,
+    note TEXT NOT NULL DEFAULT 'fixture'  -- not a real CREATE INDEX CONCURRENTLY
+);
+
+-- A dollar-quoted DO block: its BEGIN/END are PL/pgSQL keywords, not txn control.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM _guard_fixture_demo) THEN
+        INSERT INTO _guard_fixture_demo (note) VALUES ('seed');
+    END IF;
+END
+$$;
+
+-- The dangerous line: a real top-level COMMIT. This is what defeats an outer
+-- BEGIN..ROLLBACK and what the guard exists to catch.
+COMMIT;

--- a/scripts/check_migration_rollback_safety.py
+++ b/scripts/check_migration_rollback_safety.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Migration rollback-safety guard (#23).
+
+Codifies the 2026-05-30 live-commit incident: a *self-committing* migration
+chained under an outer ``BEGIN; ... ROLLBACK;`` dry-run defeats the rollback and
+commits to the live database. The distinction was documented in prose only
+(``docs/runbooks/backlog-closeout-deploy-2026-05-30.md``):
+
+  * 146 / 147 are NON-self-transactional (DO-block ``BEGIN``s only, no top-level
+    ``COMMIT``) and are SAFE to rollback-validate by wrapping in an outer
+    ``BEGIN; ... ROLLBACK;``.
+  * 149 / 150 are SELF-transactional (own top-level ``BEGIN;``/``COMMIT;``). The
+    inner ``COMMIT`` commits to live the moment psql reaches it, so they must
+    NEVER be wrapped — to rollback-validate them you swap the trailing
+    ``COMMIT;`` for ``ROLLBACK;`` instead.
+
+A migration is *self-committing* (i.e. unsafe to silently wrap in an outer
+rollback) if, at the TOP LEVEL (outside comments, string literals, and
+dollar-quoted function / DO bodies), it contains:
+
+  * a top-level ``COMMIT;`` / ``COMMIT WORK;`` / ``COMMIT TRANSACTION;``, or
+  * a statement that cannot run inside a transaction block and therefore
+    force-commits the surrounding work:
+      - ``CREATE INDEX CONCURRENTLY`` / ``DROP INDEX CONCURRENTLY``
+      - ``REINDEX ... CONCURRENTLY``
+      - ``VACUUM`` (any form)
+      - ``CREATE DATABASE`` / ``DROP DATABASE``
+      - ``CREATE TABLESPACE`` / ``DROP TABLESPACE``
+      - ``ALTER SYSTEM``
+
+Comments (``--`` and ``/* */``), single/double-quoted string literals, and
+dollar-quoted bodies (``$$ ... $$`` or ``$tag$ ... $tag$`` — the DO blocks and
+function bodies that legitimately use ``BEGIN``/``COMMIT`` as PL/pgSQL
+keywords) are stripped before classification, so a ``CREATE INDEX
+CONCURRENTLY`` mentioned only in a ``--`` comment never trips the guard.
+
+Modes
+-----
+``--list`` (default)
+    Classify every ``db/migrations/*.sql`` and print the result. Exit 0.
+
+``--check FILE [FILE ...]``
+    The CI gate. Exit 1 if any listed file is self-committing. This is what the
+    workflow runs against the migration files touched in a PR: a self-committing
+    migration is flagged so a reviewer confirms the apply/rollback tooling is NOT
+    blindly wrapping it.
+
+``--rollback-wrap FILE``
+    The mode rollback-validation tooling (``make irrigation-migration-check``)
+    calls as a preflight. Exit non-zero — refusing — if the target migration is
+    self-committing, so the rollback replay never wraps a migration whose own
+    top-level COMMIT (or commit-forcing statement) would defeat the outer
+    ROLLBACK.
+
+This module is stdlib-only and does NOT touch the database, the network, or any
+device. It only reads ``.sql`` files off disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+
+# Commit-forcing statements that cannot run inside a transaction block. Matched
+# at the start of a top-level statement (after comment/literal/dollar-quote
+# stripping). Each pattern is anchored with a preceding statement boundary.
+_COMMIT_FORCING = (
+    ("top-level COMMIT", re.compile(r"\bCOMMIT(\s+(WORK|TRANSACTION))?\s*;", re.IGNORECASE)),
+    # NOTE: we deliberately do NOT detect a bare `END;` as transaction control.
+    # `END` is heavily overloaded in SQL (CASE ... END, labeled-block END, the
+    # PL/pgSQL block END) and the transaction-control `END;` synonym for COMMIT
+    # is rare and discouraged. After dollar-quote stripping, a surviving `END;`
+    # is almost always a top-level `CASE ... END;` expression terminator (e.g.
+    # migration 145 line 95), so matching it produces false positives. An
+    # explicit top-level `COMMIT;` plus the commit-forcing DDL below are the
+    # reliable, low-false-positive signals for the 2026-05-30 incident shape.
+    ("CREATE INDEX CONCURRENTLY", re.compile(r"\bCREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY\b", re.IGNORECASE)),
+    ("DROP INDEX CONCURRENTLY", re.compile(r"\bDROP\s+INDEX\s+CONCURRENTLY\b", re.IGNORECASE)),
+    ("REINDEX CONCURRENTLY", re.compile(r"\bREINDEX\b[^;]*\bCONCURRENTLY\b", re.IGNORECASE)),
+    ("VACUUM", re.compile(r"\bVACUUM\b", re.IGNORECASE)),
+    ("CREATE DATABASE", re.compile(r"\bCREATE\s+DATABASE\b", re.IGNORECASE)),
+    ("DROP DATABASE", re.compile(r"\bDROP\s+DATABASE\b", re.IGNORECASE)),
+    ("CREATE TABLESPACE", re.compile(r"\bCREATE\s+TABLESPACE\b", re.IGNORECASE)),
+    ("DROP TABLESPACE", re.compile(r"\bDROP\s+TABLESPACE\b", re.IGNORECASE)),
+    ("ALTER SYSTEM", re.compile(r"\bALTER\s+SYSTEM\b", re.IGNORECASE)),
+)
+
+
+@dataclass
+class Classification:
+    path: Path
+    self_committing: bool
+    reasons: list[str]
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+
+def strip_sql_noise(sql: str) -> str:
+    """Return ``sql`` with comments, string literals, and dollar-quoted bodies
+    replaced by spaces (newlines preserved so line semantics stay stable).
+
+    Dollar-quoted bodies (``$$...$$`` / ``$tag$...$tag$``) are where PL/pgSQL DO
+    blocks and function bodies legitimately use BEGIN/COMMIT/END as control
+    keywords; they must be removed before top-level classification. We walk the
+    string character-by-character because nested quoting rules cannot be done
+    safely with a single regex.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(sql)
+    dollar_tag_re = re.compile(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$")
+    while i < n:
+        ch = sql[i]
+        two = sql[i : i + 2]
+
+        # Line comment: -- ... to end of line
+        if two == "--":
+            j = sql.find("\n", i)
+            if j == -1:
+                out.append(" " * (n - i))
+                break
+            out.append(" " * (j - i))
+            i = j
+            continue
+
+        # Block comment: /* ... */ (Postgres allows nesting)
+        if two == "/*":
+            depth = 1
+            j = i + 2
+            while j < n and depth > 0:
+                if sql[j : j + 2] == "/*":
+                    depth += 1
+                    j += 2
+                elif sql[j : j + 2] == "*/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            segment = sql[i:j]
+            # preserve newlines so line counting downstream stays sane
+            out.append("".join("\n" if c == "\n" else " " for c in segment))
+            i = j
+            continue
+
+        # Dollar-quoted body: $$...$$ or $tag$...$tag$
+        if ch == "$":
+            m = dollar_tag_re.match(sql, i)
+            if m:
+                tag = m.group(0)
+                end = sql.find(tag, m.end())
+                if end == -1:
+                    # Unterminated — treat the rest as a body (defensive).
+                    segment = sql[i:]
+                    out.append("".join("\n" if c == "\n" else " " for c in segment))
+                    break
+                j = end + len(tag)
+                segment = sql[i:j]
+                out.append("".join("\n" if c == "\n" else " " for c in segment))
+                i = j
+                continue
+
+        # Single-quoted string literal (with '' escape)
+        if ch == "'":
+            j = i + 1
+            while j < n:
+                if sql[j] == "'" and sql[j : j + 2] == "''":
+                    j += 2
+                    continue
+                if sql[j] == "'":
+                    j += 1
+                    break
+                j += 1
+            segment = sql[i:j]
+            out.append("".join("\n" if c == "\n" else " " for c in segment))
+            i = j
+            continue
+
+        # Double-quoted identifier (with "" escape) — keep as-is structurally
+        # (identifiers can't contain our keywords as statements), but blank it to
+        # avoid a quoted name like "vacuum_log" matching VACUUM.
+        if ch == '"':
+            j = i + 1
+            while j < n:
+                if sql[j] == '"' and sql[j : j + 2] == '""':
+                    j += 2
+                    continue
+                if sql[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            segment = sql[i:j]
+            out.append("".join("\n" if c == "\n" else " " for c in segment))
+            i = j
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def classify(path: Path) -> Classification:
+    """Classify a single migration file as self-committing or safe-to-wrap."""
+    sql = path.read_text(encoding="utf-8")
+    stripped = strip_sql_noise(sql)
+    reasons: list[str] = []
+    for label, pattern in _COMMIT_FORCING:
+        if pattern.search(stripped):
+            reasons.append(label)
+    return Classification(path=path, self_committing=bool(reasons), reasons=reasons)
+
+
+def discover_migrations() -> list[Path]:
+    if not MIGRATIONS_DIR.is_dir():
+        return []
+    return sorted(p for p in MIGRATIONS_DIR.glob("*.sql") if p.is_file())
+
+
+def _print(line: str) -> None:
+    sys.stdout.write(line + "\n")
+
+
+def cmd_list() -> int:
+    migrations = discover_migrations()
+    if not migrations:
+        _print(f"No migrations found under {MIGRATIONS_DIR}")
+        return 0
+    for path in migrations:
+        c = classify(path)
+        if c.self_committing:
+            _print(f"SELF-COMMITTING (do NOT wrap): {c.name}  [{', '.join(c.reasons)}]")
+        else:
+            _print(f"safe-to-wrap                 : {c.name}")
+    return 0
+
+
+def cmd_check(files: list[str]) -> int:
+    """CI gate: exit 1 if any listed file is self-committing."""
+    bad: list[Classification] = []
+    for f in files:
+        path = Path(f)
+        if not path.is_absolute():
+            path = (REPO_ROOT / f).resolve()
+        if not path.is_file():
+            _print(f"::warning::skipping non-existent file {f}")
+            continue
+        c = classify(path)
+        if c.self_committing:
+            bad.append(c)
+            _print(
+                f"::error::{c.name} is SELF-COMMITTING ({', '.join(c.reasons)}). "
+                "It must NOT be replayed under an outer BEGIN..ROLLBACK dry-run "
+                "(the inner COMMIT / commit-forcing statement defeats the rollback "
+                "and commits to live — 2026-05-30 incident). Apply it as-is and "
+                "rollback-validate by swapping its trailing COMMIT for ROLLBACK."
+            )
+        else:
+            _print(f"ok (safe-to-wrap): {c.name}")
+    return 1 if bad else 0
+
+
+def cmd_rollback_wrap(file: str) -> int:
+    """Preflight for rollback-validation tooling: refuse a self-committing file."""
+    path = Path(file)
+    if not path.is_absolute():
+        path = (REPO_ROOT / file).resolve()
+    if not path.is_file():
+        _print(f"::error::migration not found: {file}")
+        return 2
+    c = classify(path)
+    if c.self_committing:
+        _print(
+            f"REFUSING to wrap {c.name} in an outer BEGIN..ROLLBACK: it is "
+            f"self-committing ({', '.join(c.reasons)}). The inner COMMIT / "
+            "commit-forcing statement would defeat the outer ROLLBACK and commit "
+            "to the live database (2026-05-30 live-commit incident). "
+            "Rollback-validate it by swapping its trailing COMMIT for ROLLBACK "
+            "instead."
+        )
+        return 1
+    _print(f"OK to wrap in BEGIN..ROLLBACK (non-self-transactional): {c.name}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Migration rollback-safety guard (#23): reject self-committing "
+        "migrations being replayed under an outer BEGIN..ROLLBACK."
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="Classify every db/migrations/*.sql (default). Exit 0.",
+    )
+    group.add_argument(
+        "--check",
+        nargs="+",
+        metavar="FILE",
+        help="Exit 1 if any listed migration is self-committing (CI gate).",
+    )
+    group.add_argument(
+        "--rollback-wrap",
+        metavar="FILE",
+        help="Preflight: exit non-zero refusing to wrap a self-committing migration.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return cmd_check(args.check)
+    if args.rollback_wrap:
+        return cmd_rollback_wrap(args.rollback_wrap)
+    return cmd_list()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_migration_rollback_safety.py
+++ b/tests/test_migration_rollback_safety.py
@@ -1,0 +1,179 @@
+"""Tests for the migration rollback-safety guard (#23).
+
+Codifies the 2026-05-30 live-commit incident: a self-committing migration
+chained under an outer ``BEGIN; ... ROLLBACK;`` dry-run defeats the rollback and
+commits to live. These tests pin the guard's behavior so a future edit can't
+silently re-open that hole.
+
+No database, no network, no device — the guard only reads ``.sql`` files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = REPO_ROOT / "scripts" / "check_migration_rollback_safety.py"
+MIGRATIONS = REPO_ROOT / "db" / "migrations"
+FIXTURES = MIGRATIONS / "fixtures"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("check_migration_rollback_safety", GUARD_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module namespace.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load_guard()
+
+
+def _mig(name: str) -> Path:
+    """Resolve a numbered migration by its numeric prefix (e.g. '149')."""
+    matches = sorted(MIGRATIONS.glob(f"{name}-*.sql"))
+    assert matches, f"no migration matching {name}-*.sql"
+    return matches[0]
+
+
+# ── Bad fixtures: the guard must REFUSE / FAIL them ──────────────────────────
+
+
+def test_self_committing_fixture_is_flagged():
+    c = guard.classify(FIXTURES / "_self_committing_bad.sql")
+    assert c.self_committing is True
+    assert any("COMMIT" in r for r in c.reasons)
+
+
+def test_concurrently_fixture_is_flagged():
+    c = guard.classify(FIXTURES / "_concurrently_bad.sql")
+    assert c.self_committing is True
+    assert any("CONCURRENTLY" in r for r in c.reasons)
+
+
+def test_rollback_wrap_refuses_self_committing_fixture():
+    rc = guard.cmd_rollback_wrap(str(FIXTURES / "_self_committing_bad.sql"))
+    assert rc == 1
+
+
+def test_rollback_wrap_refuses_concurrently_fixture():
+    rc = guard.cmd_rollback_wrap(str(FIXTURES / "_concurrently_bad.sql"))
+    assert rc == 1
+
+
+def test_check_fails_on_bad_fixture():
+    rc = guard.cmd_check([str(FIXTURES / "_self_committing_bad.sql")])
+    assert rc == 1
+
+
+# ── Real non-self-transactional migrations (146/147): SAFE to wrap ───────────
+
+
+@pytest.mark.parametrize("num", ["146", "147"])
+def test_non_self_transactional_migrations_are_safe_to_wrap(num):
+    c = guard.classify(_mig(num))
+    assert c.self_committing is False, f"{num} wrongly flagged: {c.reasons}"
+    assert guard.cmd_rollback_wrap(str(_mig(num))) == 0
+
+
+def test_146_with_string_literal_concurrently_is_not_flagged():
+    # 146 contains 'REFRESH MATERIALIZED VIEW CONCURRENTLY ...' inside a COMMENT
+    # ON ... IS '<string literal>'. That is neither a top-level statement nor a
+    # commit-forcing one; the guard must not trip on string-literal text.
+    c = guard.classify(_mig("146"))
+    assert c.self_committing is False
+
+
+# ── Real self-transactional migrations (149/150): own top-level COMMIT ───────
+
+
+@pytest.mark.parametrize("num", ["149", "150"])
+def test_self_transactional_migrations_are_refused(num):
+    c = guard.classify(_mig(num))
+    assert c.self_committing is True, f"{num} should be self-committing"
+    assert "top-level COMMIT" in c.reasons
+    assert guard.cmd_rollback_wrap(str(_mig(num))) == 1
+
+
+# ── The issue's explicit acceptance: 151-155 must PASS the guard ─────────────
+
+
+@pytest.mark.parametrize("num", ["151", "152", "153", "154", "155"])
+def test_151_to_155_pass_the_guard(num):
+    # These mention 'CREATE INDEX CONCURRENTLY' only inside `--` comments and have
+    # no top-level COMMIT, so they are safe to wrap. The guard must NOT trip on
+    # commit-forcing words that appear only in comments.
+    c = guard.classify(_mig(num))
+    assert c.self_committing is False, f"{num} wrongly flagged: {c.reasons}"
+
+
+def test_check_passes_151_to_155_together():
+    files = [str(_mig(n)) for n in ("151", "152", "153", "154", "155")]
+    assert guard.cmd_check(files) == 0
+
+
+def test_145_case_end_is_not_a_false_positive():
+    # 145 line 95 is a top-level `CASE ... END;` expression terminator, not a
+    # transaction-control END. The guard must treat 145 as safe-to-wrap.
+    c = guard.classify(_mig("145"))
+    assert c.self_committing is False, f"145 wrongly flagged: {c.reasons}"
+
+
+# ── Comment / dollar-quote / string stripping unit coverage ──────────────────
+
+
+def test_comment_only_concurrently_not_flagged(tmp_path):
+    f = tmp_path / "x.sql"
+    f.write_text(
+        "-- This migration deliberately avoids CREATE INDEX CONCURRENTLY.\n"
+        "/* and VACUUM is mentioned here too */\n"
+        "CREATE TABLE t (id int);\n"
+    )
+    assert guard.classify(f).self_committing is False
+
+
+def test_dollar_quoted_commit_not_flagged(tmp_path):
+    # A COMMIT keyword inside a DO/function body is PL/pgSQL, not txn control.
+    f = tmp_path / "x.sql"
+    f.write_text("DO $$\nBEGIN\n  -- COMMIT;\n  PERFORM 1;\nEND\n$$;\n")
+    assert guard.classify(f).self_committing is False
+
+
+def test_string_literal_commit_not_flagged(tmp_path):
+    f = tmp_path / "x.sql"
+    f.write_text("INSERT INTO log (msg) VALUES ('we will COMMIT; later');\n")
+    assert guard.classify(f).self_committing is False
+
+
+def test_real_top_level_commit_is_flagged(tmp_path):
+    f = tmp_path / "x.sql"
+    f.write_text("BEGIN;\nCREATE TABLE t (id int);\nCOMMIT;\n")
+    c = guard.classify(f)
+    assert c.self_committing is True
+    assert "top-level COMMIT" in c.reasons
+
+
+def test_vacuum_top_level_is_flagged(tmp_path):
+    f = tmp_path / "x.sql"
+    f.write_text("VACUUM ANALYZE my_table;\n")
+    c = guard.classify(f)
+    assert c.self_committing is True
+    assert "VACUUM" in c.reasons
+
+
+def test_alter_system_is_flagged(tmp_path):
+    f = tmp_path / "x.sql"
+    f.write_text("ALTER SYSTEM SET work_mem = '64MB';\n")
+    c = guard.classify(f)
+    assert c.self_committing is True
+    assert "ALTER SYSTEM" in c.reasons
+
+
+def test_rollback_wrap_missing_file_returns_2(tmp_path):
+    assert guard.cmd_rollback_wrap(str(tmp_path / "nope.sql")) == 2


### PR DESCRIPTION
Closes #23

## What & why

Codifies the **2026-05-30 live-commit incident** (prior attempt produced no PR): a *self-committing* migration chained under an outer `BEGIN; … ROLLBACK;` dry-run defeats the rollback and commits to the **live** DB. The distinction was documented in prose only (`docs/runbooks/backlog-closeout-deploy-2026-05-30.md`). This PR makes it an automated guard + CI gate + Makefile preflight + lesson in `CLAUDE.md`.

A migration is **self-committing** (unsafe to silently wrap) if, at the top level (outside comments, string literals, and dollar-quoted DO/function bodies), it has a `COMMIT;` OR a commit-forcing statement that cannot run in a transaction block: `CREATE/DROP INDEX CONCURRENTLY`, `REINDEX … CONCURRENTLY`, `VACUUM`, `CREATE/DROP DATABASE`, `CREATE/DROP TABLESPACE`, `ALTER SYSTEM`.

## Changes
- **`scripts/check_migration_rollback_safety.py`** — stdlib-only guard. Strips comments/strings/dollar-quotes, then classifies. Modes: `--list` (classify all), `--check FILE...` (CI gate, exit 1 on self-committing), `--rollback-wrap FILE` (preflight: refuse to wrap a self-committing migration). No DB / no network / no device.
- **`.github/workflows/ci.yml`** — new PR-gated job `migration-rollback-safety`: flags self-committing migrations touched in the PR, self-tests the bad fixture, runs the unit tests.
- **`Makefile`** — `irrigation-migration-check` / `irrigation-migration-proof` now run the `--rollback-wrap` preflight before piping into psql (refuses to wrap a self-committing migration). New `make migration-rollback-safety` lists the full classification.
- **`db/migrations/fixtures/_self_committing_bad.sql`** + **`_concurrently_bad.sql`** — deliberately self-committing fixtures the guard must refuse. Underscore-prefixed and in a subdirectory, so the non-recursive `ls db/migrations/*.sql` apply loop (and the guard's own `glob("*.sql")`) never run/classify them.
- **`tests/test_migration_rollback_safety.py`** — 24 tests.
- **`CLAUDE.md`** — writes the lesson into the shared-territory docs.

## Validation (2026-06-01T22:07Z UTC)
- `make lint` (ruff check) — **PASS**; `ruff format --check` (CI parity) — **PASS** (162 files already formatted).
- `pytest tests/test_migration_rollback_safety.py` — **24/24 PASS**.
- Guard behavior verified (`--rollback-wrap`): bad fixtures **refused** (rc=1); **149/150** (own top-level `COMMIT;`) **refused** (rc=1); **146/147/134** (non-self-transactional) **OK to wrap** (rc=0); **151-155** **pass** (`CONCURRENTLY` appears only in `--` comments → not flagged). False-positive guard: **145**'s top-level `CASE … END;` is correctly NOT flagged (bare `END;` detection deliberately dropped to avoid CASE/labeled-block false positives — `COMMIT;` + commit-forcing DDL are the reliable signals).
- `actionlint` (rhysd/actionlint docker image) — **clean on the new job**. The sole finding is a pre-existing `SC2012` in the untouched `schemas` job's apply loop (`ls db/migrations/*.sql`), out of scope for this PR.

## Scope / safety
- Shared territory: `.github/workflows/`, `db/` tooling + fixtures, `Makefile`, `CLAUDE.md`, `scripts/`, `tests/`. **requested-by: iris (shared territory)** — coordinator review.
- No device path, no live writer, no host/DNS/firewall mutation. Guard reads `.sql` files only.
- Does **not** touch `verdify_schemas/**`, `mcp/server.py`, `ingestor/entity_map.py`, or `firmware/**` → CLAUDE.md rules 7/8/9 not engaged; no service restart required by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)