### PR TITLE
ci: in-image import smoke gate before GHCR push (#26 residual)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -283,6 +283,10 @@ jobs:
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
       extra-tags: local-dev
+      # In-image pre-push proof (#26 residual): the shared alerts contract must
+      # import inside the built api image (WORKDIR /app, verdify_schemas/ COPYed
+      # to /app/verdify_schemas) before it can be pushed/digest-pinned.
+      smoke-import: verdify_schemas.alerts
 
   mcp-image:
     name: Build and publish mcp image
@@ -306,6 +310,9 @@ jobs:
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
       extra-tags: local-dev
+      # In-image pre-push proof (#26 residual): WORKDIR /app, verdify_schemas/
+      # COPYed to /app/verdify_schemas — alerts must import before push.
+      smoke-import: verdify_schemas.alerts
 
   ingestor-image:
     name: Build and publish ingestor image
@@ -327,6 +334,11 @@ jobs:
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
       extra-tags: local-dev
+      # In-image pre-push proof (#26 residual): the ingestor image sets
+      # WORKDIR /app/ingestor but COPYs verdify_schemas/ to /app/verdify_schemas,
+      # so the smoke run is pinned to /app to keep the top-level import resolvable.
+      smoke-import: verdify_schemas.alerts
+      smoke-import-workdir: /app
 
   planner-image:
     name: Build and publish planner image
@@ -412,6 +424,10 @@ jobs:
         GIT_SHA=${{ github.sha }}
         GIT_REF=${{ github.ref_name }}
       extra-tags: local-dev
+      # In-image pre-push proof (#26 residual): WORKDIR /app, verdify_schemas/
+      # COPYed to /app/verdify_schemas — alerts must import before push (same
+      # contract closure the setpoint-server's tunable_registry import relies on).
+      smoke-import: verdify_schemas.alerts
 
   # ---------------------------------------------------------------------------
   # In-repo digest write-back into deploy/k8s/overlays/staging (LOCKED DECISION:

--- a/.github/workflows/reusable-container-build.yml
+++ b/.github/workflows/reusable-container-build.yml
@@ -66,6 +66,27 @@ on:
         required: false
         default: ""
         type: string
+      smoke-import:
+        description: >-
+          Optional Python module to import inside the freshly-built image BEFORE
+          push, as a post-build sanity gate (e.g. `verdify_schemas.alerts`). When
+          set, the publish job runs `python -c "import <module>"` against the
+          local image tag and aborts the push on failure, so a missing-/broken
+          shared-contract image never reaches GHCR. Empty (default) skips it —
+          images that do not carry the module (e.g. planner, migrate) leave it
+          unset.
+        required: false
+        default: ""
+        type: string
+      smoke-import-workdir:
+        description: >-
+          Working directory inside the image for the smoke-import run. Defaults to
+          /app, where api/mcp/setpoint COPY verdify_schemas. The ingestor image
+          sets WORKDIR /app/ingestor, so it passes /app here to keep the
+          `verdify_schemas` top-level import resolvable.
+        required: false
+        default: "/app"
+        type: string
 permissions:
   contents: read
 
@@ -288,7 +309,7 @@ jobs:
           fi
           printf "%s" "$password" | docker login "$REGISTRY" --username "$username" --password-stdin
 
-      - name: Build and push image
+      - name: Build image (pre-push)
         env:
           CONTEXT: ${{ inputs.context }}
           DOCKERFILE: ${{ inputs.dockerfile }}
@@ -332,6 +353,36 @@ jobs:
             --label "org.opencontainers.image.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             "$CONTEXT"
 
+      # In-image import smoke gate (#26 residual). When smoke-import is set, run
+      # `python -c "import <module>"` inside the just-built local image BEFORE the
+      # push. This is the pre-push proof the issue's last open AC asks for: the
+      # shared-contract module must import inside the actual runtime image (catches
+      # a missing COPY, a broken sys.path, or an unsatisfied dep) so a broken image
+      # never reaches GHCR — and therefore never gets digest-pinned into
+      # overlays/staging. Skipped (no-op) when smoke-import is empty, e.g. for the
+      # planner image (carries its own contract mirror, not verdify_schemas) and
+      # the migrate image (no Python package). Runs against the primary tag, which
+      # is one of the local tags built above.
+      - name: Smoke-test built image import
+        if: inputs.smoke-import != ''
+        env:
+          PRIMARY_TAG: ${{ needs.metadata.outputs.primary_tag }}
+          SMOKE_IMPORT: ${{ inputs.smoke-import }}
+          SMOKE_WORKDIR: ${{ inputs.smoke-import-workdir }}
+        run: |
+          set -euo pipefail
+          echo "Smoke-testing 'import ${SMOKE_IMPORT}' in ${PRIMARY_TAG} (workdir ${SMOKE_WORKDIR})"
+          docker run --rm \
+            --entrypoint python \
+            --workdir "$SMOKE_WORKDIR" \
+            "$PRIMARY_TAG" \
+            -c "import ${SMOKE_IMPORT}; print('smoke import ok: ${SMOKE_IMPORT}')"
+
+      - name: Push image
+        env:
+          TAGS: ${{ needs.metadata.outputs.tags }}
+        run: |
+          set -euo pipefail
           while IFS= read -r tag; do
             if [ -n "$tag" ]; then
               docker push "$tag"


### PR DESCRIPTION
Closes #26

## Assessment: #26 is largely SUBSUMED by container-publish.yml; this PR authors ONLY the genuine residual

The original #26 body ("only ci.yml exists, no release.yml, no deploy/ dir") is **stale**. The now-live `container-publish.yml` already implements the substance of #26's umbrella CD ACs:

| #26 acceptance criterion | Status in container-publish.yml |
|---|---|
| Builds + pushes immutable `:<sha>` GHCR tags for verdify-{api,mcp,ingestor,…} | **DONE** — `reusable-container-build.yml` builds + pushes `ghcr.io/<owner>/verdify-<c>:sha-<12char>` and captures the `@sha256` digest. |
| Writes the tag bump into overlays/stage only (never prod), with paths-ignore to break the reconcile loop | **DONE** — `bump-staging-digests` job pins `overlays/staging` to the published `@sha256` digests, commits back to `live/platform-main`; `on.push.paths-ignore: deploy/k8s/overlays/{staging,dev}/**` + `[skip ci]` is the loop-break. prod is never auto-bumped. |
| `workflow_run` / Checks-API gating of the merge SHA | **Superseded by design.** Publishing is gated on `push` to `live/platform-main` (which by definition only happens after PR-merge through the CI-required-checks branch protection), not a separate `workflow_run`. Re-adding a `workflow_run` trigger would duplicate the merge gate, not add safety. Recommend NOT implementing. |
| CI verifies `from verdify_schemas import alerts` inside the built image before push | **This was the one open residual** — implemented here. |

Per #26's own triage comment ("Largely SUBSUMED … kept open only to track the residual … the in-image `from verdify_schemas import alerts` import check"), I did **not** duplicate any build/push/bump job. I added only the missing in-image pre-push import gate.

## What this PR does (additive, two files)

- **`reusable-container-build.yml`**: new optional `smoke-import` input (+ `smoke-import-workdir`, default `/app`). When set, the `publish` job builds, then runs `docker run --rm --entrypoint python <local primary tag> --workdir <wd> -c "import <module>"` **before** `docker push`. A failed import aborts the push — so a broken shared-contract image never reaches GHCR and never gets digest-pinned into `overlays/staging`. Empty default ⇒ no-op. The prior single "Build and push" step is split into **Build → Smoke → Push**; the digest-capture step is untouched.
- **`container-publish.yml`**: wire `smoke-import: verdify_schemas.alerts` into the **api / mcp / ingestor / setpoint-server** jobs (all `COPY verdify_schemas/` → `/app/verdify_schemas`). The ingestor job passes `smoke-import-workdir: /app` because its `WORKDIR` is `/app/ingestor`.
- **Deliberately NOT applied** to `planner-image` (carries its own contract mirror, not the shared `verdify_schemas`) or `migrate-image` (no Python package) — matching the workflow's existing artifact-only / no-shared-schema design notes. The `if: inputs.smoke-import != ''` guard makes the step a no-op there.

No new jobs duplicating build/push/bump. No deploy-path change. No firmware/device path.

## Validation (UTC 2026-06-01)

- `actionlint` 1.7.7 on both edited files: **exit 0, no findings**; full-repo `actionlint`: **exit 0**.
- `make lint` (ruff): **All checks passed!**
- `import verdify_schemas.alerts` resolves locally (proxy for the in-image `/app` run).

## Recommendation on #26 closure

The umbrella CD wiring is SUBSUMED by `container-publish.yml`; this PR closes the last unproven AC. With this merged, #26's acceptance criteria are met except the `workflow_run` gating, which I recommend recording as **superseded-by-container-publish** (push-to-`live/platform-main` already is the post-merge gate) rather than implementing. Suggest closing #26 as `state:superseded` once this lands, or relabeling to drop the stale body.

`.github/**` is SHARED INFRA per CLAUDE.md.

requested-by: iris (shared territory)
