### PR TITLE
Harden publish-site-content.sh against outbound HTTPS timeouts (#59)

### DIFF
--- a/scripts/publish-site-content.sh
+++ b/scripts/publish-site-content.sh
@@ -46,11 +46,64 @@ LOG=${VERDIFY_PUBLISH_LOG:-/srv/verdify/state/publish.log}
 LOCK=${VERDIFY_PUBLISH_LOCK:-/var/lock/verdify-site-content-publish.lock}
 PREV_DATE=$(date -d "${DATE} -1 day" +%Y-%m-%d)
 
+# Bounded retry/timeout guard (issue #59). The generators below make outbound
+# HTTPS calls (e.g. update-evidence-snapshots.py hits https://api.verdify.ai).
+# A transient egress timeout used to wedge the whole oneshot unit
+# (verdify-forecast-page / verdify-plan-publish) into a failed state. Each step
+# now runs under a hard wall-clock timeout and is retried a bounded number of
+# times; a step that exhausts its retries is logged loudly and recorded as a
+# failure but does NOT abort the remaining generators, so one flaky upstream
+# does not leave the units failed. The unit exits non-zero at the end iff a
+# step ultimately failed, so genuine breakage is still surfaced to systemd.
+STEP_TIMEOUT=${VERDIFY_PUBLISH_STEP_TIMEOUT:-120}   # seconds per attempt (0 disables)
+STEP_RETRIES=${VERDIFY_PUBLISH_STEP_RETRIES:-3}     # total attempts per step
+STEP_RETRY_DELAY=${VERDIFY_PUBLISH_STEP_RETRY_DELAY:-5} # seconds between attempts
+
 mkdir -p "$(dirname "$LOG")" "$(dirname "$LOCK")"
 
+FAILED_STEPS=()
+
+# run_step COMMAND [ARGS...] — execute one generator with a bounded wall-clock
+# timeout and bounded retries. Records (does not abort on) terminal failures.
 run_step() {
-  echo "[$(date -Is)] $*" | tee -a "$LOG"
-  "$@" 2>&1 | tee -a "$LOG"
+  local attempt rc
+  for ((attempt = 1; attempt <= STEP_RETRIES; attempt++)); do
+    echo "[$(date -Is)] step (attempt ${attempt}/${STEP_RETRIES}, timeout=${STEP_TIMEOUT}s): $*" | tee -a "$LOG"
+    rc=0
+    # Run inside `if` so `set -e`/`pipefail` does not abort the function on a
+    # non-zero step; then read PIPESTATUS[0] — the generator's real exit code,
+    # not tee's — to classify the failure. (A trailing `|| true` would clobber
+    # PIPESTATUS, so we must branch on the pipeline directly.)
+    if [[ "$STEP_TIMEOUT" -gt 0 ]]; then
+      # --kill-after sends SIGKILL 10s after SIGTERM so a wedged HTTPS read that
+      # ignores the term signal cannot hold the unit open indefinitely.
+      if timeout --kill-after=10s "${STEP_TIMEOUT}s" "$@" 2>&1 | tee -a "$LOG"; then
+        rc=0
+      else
+        rc=${PIPESTATUS[0]}
+      fi
+    else
+      if "$@" 2>&1 | tee -a "$LOG"; then
+        rc=0
+      else
+        rc=${PIPESTATUS[0]}
+      fi
+    fi
+    if [[ "$rc" -eq 0 ]]; then
+      return 0
+    fi
+    if [[ "$rc" -eq 124 || "$rc" -eq 137 ]]; then
+      echo "[$(date -Is)] TIMEOUT after ${STEP_TIMEOUT}s (rc=${rc}) on attempt ${attempt}/${STEP_RETRIES}: $*" | tee -a "$LOG" >&2
+    else
+      echo "[$(date -Is)] FAILED (rc=${rc}) on attempt ${attempt}/${STEP_RETRIES}: $*" | tee -a "$LOG" >&2
+    fi
+    if [[ "$attempt" -lt "$STEP_RETRIES" ]]; then
+      sleep "$STEP_RETRY_DELAY"
+    fi
+  done
+  echo "[$(date -Is)] GIVING UP after ${STEP_RETRIES} attempts (last rc=${rc}); continuing remaining steps: $*" | tee -a "$LOG" >&2
+  FAILED_STEPS+=("$*")
+  return 0
 }
 
 {
@@ -81,5 +134,18 @@ run_step() {
     echo "[$(date -Is)] Site content publish complete: reason=${REASON}, date=${DATE}" | tee -a "$LOG"
   else
     echo "[$(date -Is)] Site content generated without rebuild: reason=${REASON}, date=${DATE}" | tee -a "$LOG"
+  fi
+
+  # Surface terminal failures once, at the end. A step that recovered on retry
+  # leaves FAILED_STEPS empty and we exit clean even though a transient timeout
+  # occurred — that is the whole point: a flaky egress no longer wedges the unit.
+  # A step that exhausted its retries exits the unit non-zero so systemd still
+  # records genuine, persistent breakage as a failure.
+  if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
+    echo "[$(date -Is)] publish finished with ${#FAILED_STEPS[@]} failed step(s) after retries:" | tee -a "$LOG" >&2
+    for step in "${FAILED_STEPS[@]}"; do
+      echo "[$(date -Is)]   - ${step}" | tee -a "$LOG" >&2
+    done
+    exit 1
   fi
 } 9>"$LOCK"

--- a/tests/test_publish_site_content_guard.py
+++ b/tests/test_publish_site_content_guard.py
@@ -1,0 +1,185 @@
+"""Behavioral tests for the publish-site-content.sh retry/timeout guard (issue #59).
+
+The two host units verdify-forecast-page and verdify-plan-publish both invoke
+scripts/publish-site-content.sh as a Type=oneshot unit. The script fans out to
+~15 generators, several of which make outbound HTTPS calls (e.g.
+update-evidence-snapshots.py -> https://api.verdify.ai). A single transient
+egress timeout used to abort the whole unit and leave it failed until an
+operator ran `systemctl reset-failed`.
+
+These tests drive the real script with a fake PYTHON dispatcher and a fixture
+SCRIPT_ROOT (so no live DB, no real HTTPS, no device) and assert the guard:
+
+  - retries a step that fails-then-succeeds and exits the unit CLEAN
+    (a transient timeout no longer wedges the unit);
+  - bounds a hung step with a wall-clock timeout and gives up after N attempts
+    rather than hanging the unit forever;
+  - still exits NON-ZERO when a step is persistently broken, so systemd records
+    genuine breakage;
+  - continues running later generators after an earlier one fails (one flaky
+    upstream does not silently drop the rest of the publish).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "publish-site-content.sh"
+
+# Fake PYTHON dispatcher: receives the generator path as $1 and dispatches on its
+# basename to a per-generator behavior driven by env vars set by each test:
+#   FIXTURE_FAIL_ONCE=<basename>   -> exit 1 the first time, 0 thereafter
+#   FIXTURE_FAIL_ALWAYS=<basename> -> always exit 1
+#   FIXTURE_HANG=<basename>        -> sleep far longer than the step timeout
+# A small state dir records attempt counts so fail-once is deterministic.
+FAKE_PYTHON = r"""#!/usr/bin/env bash
+set -euo pipefail
+target="$(basename "${1:-unknown}")"
+state="${FIXTURE_STATE_DIR}/${target}.attempts"
+n=0
+if [[ -f "$state" ]]; then n="$(cat "$state")"; fi
+n=$((n + 1))
+echo "$n" > "$state"
+echo "fake-python ran ${target} (attempt ${n})"
+if [[ "${FIXTURE_HANG:-}" == "$target" ]]; then
+  sleep 30
+fi
+if [[ "${FIXTURE_FAIL_ALWAYS:-}" == "$target" ]]; then
+  echo "fake-python ${target}: simulated persistent HTTPS failure" >&2
+  exit 1
+fi
+if [[ "${FIXTURE_FAIL_ONCE:-}" == "$target" && "$n" -eq 1 ]]; then
+  echo "fake-python ${target}: simulated transient HTTPS timeout" >&2
+  exit 1
+fi
+exit 0
+"""
+
+# The publish script calls a handful of generators via `bash "$SCRIPT_ROOT/..."`
+# directly (not through PYTHON), plus rebuild-site.sh. We run with --no-rebuild
+# so rebuild-site.sh is skipped, and stub the bash-invoked helpers.
+BASH_GENERATORS = (
+    "export-public-sample-dataset.sh",
+    "gather-static-context.sh",
+)
+PY_GENERATORS = (
+    "generate-daily-plan.py",
+    "generate-forecast-page.py",
+    "generate-plans-index.py",
+    "generate-lessons-page.py",
+    "generate-ai-tunables-page.py",
+    "generate-baseline-vs-iris-page.py",
+    "update-evidence-snapshots.py",
+    "render-equipment-page.py",
+    "render-zone-pages.py",
+    "render-crop-profiles.py",
+    "export-hourly-performance-dataset.py",
+)
+
+
+@pytest.fixture
+def harness(tmp_path: Path):
+    """Build a fixture SCRIPT_ROOT + fake PYTHON and return a runner."""
+    script_root = tmp_path / "scripts"
+    script_root.mkdir()
+    # Stub the bash-invoked helpers so the script's `bash "$SCRIPT_ROOT/x.sh"`
+    # calls succeed without touching the real site tooling.
+    for name in BASH_GENERATORS:
+        helper = script_root / name
+        helper.write_text("#!/usr/bin/env bash\necho stub-ok\nexit 0\n", encoding="utf-8")
+        helper.chmod(0o755)
+    # The .py generators are never read by the fake PYTHON, but create empty
+    # placeholders so paths exist and intent is clear.
+    for name in PY_GENERATORS:
+        (script_root / name).write_text("# fixture placeholder\n", encoding="utf-8")
+
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(FAKE_PYTHON, encoding="utf-8")
+    fake_python.chmod(0o755)
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    log = tmp_path / "publish.log"
+    lock = tmp_path / "publish.lock"
+
+    def run(extra_env: dict[str, str], timeout_s: int = 60):
+        env = dict(os.environ)
+        env.update(
+            {
+                "VERDIFY_SCRIPT_ROOT": str(script_root),
+                "PYTHON": str(fake_python),
+                "VERDIFY_PUBLISH_LOG": str(log),
+                "VERDIFY_PUBLISH_LOCK": str(lock),
+                # Fast, deterministic guard knobs for tests.
+                "VERDIFY_PUBLISH_STEP_TIMEOUT": "2",
+                "VERDIFY_PUBLISH_STEP_RETRIES": "3",
+                "VERDIFY_PUBLISH_STEP_RETRY_DELAY": "0",
+                "FIXTURE_STATE_DIR": str(state_dir),
+            }
+        )
+        env.update(extra_env)
+        proc = subprocess.run(
+            ["bash", str(SCRIPT), "--no-rebuild", "--reason", "test"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        combined = proc.stdout + proc.stderr + log.read_text(encoding="utf-8")
+        return proc.returncode, combined, state_dir
+
+    return run
+
+
+def test_clean_run_exits_zero_and_runs_every_step(harness):
+    rc, out, state_dir = harness({})
+    assert rc == 0, out
+    assert "Site content generated without rebuild" in out
+    # No spurious retries on success: each generator runs once per invocation.
+    # generate-daily-plan.py is invoked twice by the script (PREV_DATE + DATE).
+    expected = {name: 1 for name in PY_GENERATORS}
+    expected["generate-daily-plan.py"] = 2
+    for name, count in expected.items():
+        assert (state_dir / f"{name}.attempts").read_text().strip() == str(count), name
+
+
+def test_transient_failure_is_retried_then_unit_exits_clean(harness):
+    # update-evidence-snapshots.py is the real outbound-HTTPS step; fail it once.
+    rc, out, state_dir = harness({"FIXTURE_FAIL_ONCE": "update-evidence-snapshots.py"})
+    assert rc == 0, out  # recovered on retry -> unit NOT wedged
+    assert (state_dir / "update-evidence-snapshots.py.attempts").read_text().strip() == "2"
+    assert "FAILED (rc=1) on attempt 1/3" in out
+    assert "GIVING UP" not in out
+
+
+def test_persistent_failure_exits_nonzero_after_bounded_retries(harness):
+    rc, out, _ = harness({"FIXTURE_FAIL_ALWAYS": "update-evidence-snapshots.py"})
+    assert rc == 1, out  # genuine breakage still surfaced to systemd
+    assert "GIVING UP after 3 attempts" in out
+    assert "publish finished with 1 failed step(s) after retries" in out
+
+
+def test_persistent_failure_does_not_skip_later_generators(harness):
+    # Fail an early generator persistently; a LATER generator must still run.
+    rc, out, state_dir = harness({"FIXTURE_FAIL_ALWAYS": "generate-forecast-page.py"})
+    assert rc == 1, out
+    # generate-forecast-page is step 3; render-crop-profiles is much later.
+    assert (state_dir / "generate-forecast-page.py.attempts").read_text().strip() == "3"
+    assert (state_dir / "render-crop-profiles.py.attempts").read_text().strip() == "1"
+
+
+def test_hung_step_is_bounded_by_timeout_and_does_not_wedge_the_unit(harness):
+    # A generator that hangs (simulated wedged HTTPS read) must be killed by the
+    # wall-clock timeout, retried, and ultimately recorded as failed — the unit
+    # returns instead of hanging forever. Step timeout is 2s x 3 attempts ~= 6s;
+    # the outer subprocess timeout (40s) proves we did not hang.
+    rc, out, _ = harness({"FIXTURE_HANG": "update-evidence-snapshots.py"}, timeout_s=40)
+    assert rc == 1, out
+    assert "TIMEOUT after 2s" in out
+    assert "GIVING UP after 3 attempts" in out


### PR DESCRIPTION
Closes #59

## Root cause
Both failed host oneshot units — `verdify-forecast-page` and `verdify-plan-publish` — invoke `scripts/publish-site-content.sh`. The script fans out to ~15 generators under `set -euo pipefail`. Several make outbound HTTPS calls; confirmed `scripts/update-evidence-snapshots.py` calls `https://api.verdify.ai/api/v1/public/evidence-snapshot` via `urllib.request.urlopen(..., timeout=45)`. Under `set -e` with no per-step wall-clock bound, a single transient egress timeout (or a wedged read that outlives urllib's own timeout) aborts the whole oneshot and leaves the units `failed` until an operator runs `systemctl reset-failed`.

## Change (in-lane, repo-only)
Harden the orchestrator's `run_step`:
- **Hard wall-clock timeout per attempt** — `timeout --kill-after=10s "${STEP_TIMEOUT}s"` (env-tunable `VERDIFY_PUBLISH_STEP_TIMEOUT`, default 120s). `--kill-after` SIGKILLs a step that ignores SIGTERM so a wedged HTTPS read cannot hold the unit open indefinitely.
- **Bounded retries** — `VERDIFY_PUBLISH_STEP_RETRIES` (default 3) with `VERDIFY_PUBLISH_STEP_RETRY_DELAY` between attempts.
- **Clear failure logging** — per-attempt `TIMEOUT`/`FAILED` lines (with rc), plus a final `GIVING UP` + failed-step summary.
- **No-wedge semantics** — a step that exhausts its retries is recorded but does NOT abort the remaining generators. The unit exits non-zero at the end iff a step ultimately failed, so a transient timeout that recovers on retry no longer wedges the unit, while genuine persistent breakage is still surfaced to systemd.
- PIPESTATUS is read via an `if`-branch (not `|| true`, which clobbers it) to capture the generator's real exit code rather than `tee`'s.

## Validation (UTC 2026-06-01T22:22Z)
- `make lint` (ruff over ingestor/api/mcp/scripts/tests/verdify_schemas) — **All checks passed!**
- `shellcheck 0.11.0 scripts/publish-site-content.sh` — **clean**; `bash -n` — **clean**.
- New `tests/test_publish_site_content_guard.py` — **5 passed** — drives the real script with a fake PYTHON dispatcher + fixture SCRIPT_ROOT (no DB, no real HTTPS, no device):
  - clean run exits 0 and runs every step once (no spurious retries);
  - transient fail-once is retried then unit exits **clean** (the wedge fix);
  - persistent failure exits **non-zero** after bounded retries + emits the failed-step summary;
  - persistent early failure does **not** skip later generators;
  - a hung step is bounded by the wall-clock timeout and does not hang the unit.

## Scope / gates
- Touches only `scripts/publish-site-content.sh` (area:web content tooling) + a new test file. No `verdify_schemas/**`, `mcp/server.py`, `ingestor/entity_map.py`, or `firmware/**` — Rule 7 / firmware replay gates do not apply. No infra files (`systemd/`, `traefik/`, `docker-compose.yml`).
- **GATED RESIDUAL (gate:jason):** the host `systemctl reset-failed verdify-forecast-page verdify-plan-publish` + a successful re-run is an OPERATOR action on the iris VM and is NOT performed here. Issue stays OPEN + `blocked` for the host reset and a DEPLOYED re-probe. The egress allowlist/DNS root-cause for `api.verdify.ai` reachability (cf. #67) is host/network-side and remains operator/Nexus-gated.

requested-by: iris (shared territory — area:web tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)