### PR TITLE
ci(container-publish): treat db/** as migrate-impacting; repin dev planner (#99)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -99,6 +99,7 @@ jobs:
       ingestor_impact: ${{ steps.impact.outputs.ingestor_impact }}
       planner_impact: ${{ steps.impact.outputs.planner_impact }}
       setpoint_impact: ${{ steps.impact.outputs.setpoint_impact }}
+      migrate_impact: ${{ steps.impact.outputs.migrate_impact }}
       reason: ${{ steps.impact.outputs.reason }}
     steps:
       - name: Checkout
@@ -147,6 +148,7 @@ jobs:
           ingestor_impact=false
           planner_impact=false
           setpoint_impact=false
+          migrate_impact=false
           doc_only=true
           any_changed=false
 
@@ -197,6 +199,19 @@ jobs:
             case "$f" in
               scripts/setpoint-server.py|scripts/Dockerfile.setpoint-server|verdify_schemas/*) setpoint_impact=true ;;
             esac
+            # verdify-migrate image (db/Dockerfile.migrate) carries db/schema.sql
+            # (the production pg_dump --schema-only snapshot) + migration 000 + the
+            # inline migrate.sh. A db/-only change (schema.sql / migrations / the
+            # migrate.sh inline script / Dockerfile.migrate) MUST rebuild it so the
+            # staging schema-build hook stays current — historically a db/-only
+            # change left image_publish=false (only api/mcp/ingestor/setpoint paths
+            # set it) so migrations never rebuilt the migrate image and its digest
+            # only ever published via manual workflow_dispatch (where the
+            # bump-staging-digests write-back is skipped, stranding staging on a
+            # phantom pin). This db/** path closes that gap. (#99)
+            case "$f" in
+              db/*) migrate_impact=true ;;
+            esac
           done < "$changed_files"
 
           if [ "$manual" = "true" ]; then
@@ -205,10 +220,11 @@ jobs:
             ingestor_impact=true
             planner_impact=true
             setpoint_impact=true
+            migrate_impact=true
           fi
 
           any_image=false
-          { [ "$api_impact" = "true" ] || [ "$mcp_impact" = "true" ] || [ "$ingestor_impact" = "true" ] || [ "$planner_impact" = "true" ] || [ "$setpoint_impact" = "true" ]; } && any_image=true
+          { [ "$api_impact" = "true" ] || [ "$mcp_impact" = "true" ] || [ "$ingestor_impact" = "true" ] || [ "$planner_impact" = "true" ] || [ "$setpoint_impact" = "true" ] || [ "$migrate_impact" = "true" ]; } && any_image=true
 
           image_publish=false
           if [ "$manual" = "true" ]; then
@@ -222,7 +238,7 @@ jobs:
             reason="no image-impacting files changed; skipping image publish"
           else
             image_publish=true
-            changed="api=$api_impact mcp=$mcp_impact ingestor=$ingestor_impact planner=$planner_impact setpoint=$setpoint_impact"
+            changed="api=$api_impact mcp=$mcp_impact ingestor=$ingestor_impact planner=$planner_impact setpoint=$setpoint_impact migrate=$migrate_impact"
             reason="image-impacting change ($changed)"
           fi
 
@@ -234,6 +250,7 @@ jobs:
             echo "ingestor_impact=$ingestor_impact"
             echo "planner_impact=$planner_impact"
             echo "setpoint_impact=$setpoint_impact"
+            echo "migrate_impact=$migrate_impact"
             echo "reason=$reason"
           } >> "$GITHUB_OUTPUT"
 
@@ -246,6 +263,7 @@ jobs:
             echo "- ingestor_impact: \`$ingestor_impact\`"
             echo "- planner_impact: \`$planner_impact\` (artifact-only; not deployed)"
             echo "- setpoint_impact: \`$setpoint_impact\` (artifact-only; not deployed)"
+            echo "- migrate_impact: \`$migrate_impact\` (db/** schema-build image)"
             echo "- reason: $reason"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -375,9 +393,13 @@ jobs:
     needs: image-impact
     # verdify-migrate (db/Dockerfile.migrate) carries db/schema.sql + migration
     # 000; it is tiny and rebuilt on any publish so the staging schema stays
-    # current. NOTE: a db/-only change (schema.sql / migrations / migrate.sh) does
-    # not yet set image_publish via the api/mcp/ingestor impact paths — add db/**
-    # to the image-impact paths, or use workflow_dispatch, to rebuild it then.
+    # current. A db/-only change (schema.sql / migrations / the inline migrate.sh /
+    # Dockerfile.migrate) now sets migrate_impact -> image_publish via the
+    # image-impact db/** path (#99), so migrations rebuild + republish the migrate
+    # image on a real push (not only via workflow_dispatch, where the
+    # bump-staging-digests write-back is skipped and staging strands on a phantom
+    # pin). The `if:` stays image_publish-gated (rebuild on ANY publish keeps the
+    # staging schema current); migrate_impact guarantees a db/-only push reaches it.
     if: needs.image-impact.outputs.image_publish == 'true' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read

--- a/db/Dockerfile.migrate
+++ b/db/Dockerfile.migrate
@@ -15,6 +15,11 @@ COPY db/schema.sql /db/schema.sql
 COPY db/migrations/000-fresh-schema-hypertable-repair.sql /db/000-fresh-schema-hypertable-repair.sql
 COPY <<'SCRIPT' /usr/local/bin/migrate.sh
 #!/bin/sh
+# Image schema coverage: db/schema.sql is the production pg_dump --schema-only
+# snapshot through migration 156 (155 twin-observability tables + 156
+# planner_lessons canonicalization / active-lessons prune). Replaying it here
+# builds those into a fresh DB; migration 000 then repairs the hypertable catalog.
+# (This comment is a real db/** edit so the migrate image rebuilds on push — #99.)
 # Verdify fresh-DB schema build. Mirrors the documented convention (db/migrations/000
 # header + tests/test_12_fidelity.py + `make db-dump`): replay db/schema.sql (the
 # production pg_dump --schema-only snapshot) with ON_ERROR_STOP=0 (a fresh

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -62,9 +62,10 @@ patches:
 
 # Image digest pins. Canonical namespace ghcr.io/verdifyconsultancy/verdify-*,
 # immutable @sha256 (NEVER a mutable :latest/:dev tag). The app images reuse the
-# staging-verified digests as a known-good baseline; verdify-planner is a
-# PLACEHOLDER digest (no image published yet — gh api returns 404). The digest
-# write-back job owns these once container-publish for verdify-planner is green.
+# staging-verified digests as a known-good baseline; verdify-planner now carries
+# its real published GHCR digest (#99 — the image is published + repo-linked; the
+# bump-staging-digests job auto-repins it on each green planner build). dev is
+# INERT (no ArgoCD app), so this pin deploys nothing.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
     digest: sha256:ce4ca79f9e6442c39558cbe02b1665c3cddc3e269c1867997d4f292f3a5ce8ff
@@ -75,7 +76,7 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
     digest: sha256:7a39c3deb6df2182c7480cdd653bffa6575570bbfd262bf7c9694abcc58badf5
   - name: ghcr.io/verdifyconsultancy/verdify-planner
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:3e51abaec6372c0bed26ef9859a80008261fcd20a1e8ec1e37627304e1c6b637
   # verdify-www (#116): real GHCR digest of the marketing site image built from
   # the upstream verdify-www repo at sha d3720dc (see components/www/www.yaml).
   - name: ghcr.io/verdifyconsultancy/verdify-www


### PR DESCRIPTION
Closes #99

requested-by: iris (shared territory — .github/workflows)

## Problem (verified)

Staging pinned `verdify-migrate@sha256:7a39c3de…badf5`, which **no longer exists in GHCR** (phantom — the orphan was deleted). The only published migrate digest is `sha256:23f5bc7d…d400` (tagged `sha-0d18c448bdc3` / `local-dev` / `branch-live-platform-main`).

Root cause: the `container-publish.yml` `image-impact` job did **not** treat `db/**` changes as migrate-impacting. Only the api/mcp/ingestor/setpoint paths set `image_publish`, so migrations 151–156 never rebuilt the verdify-migrate image on a push. The real digest only ever published via a manual `workflow_dispatch` — where `bump-staging-digests` is skipped — so the staging overlay was never repinned and stranded on the now-deleted orphan. The migrate image was therefore also **stale vs migrations 151–156**.

## Fix

1. **image-impact**: new `migrate_impact` output, set `true` on any `db/**` change (`db/schema.sql`, `db/migrations/**`, the inline `migrate.sh`, `db/Dockerfile.migrate`), mirroring the api/mcp/ingestor/setpoint impact-path pattern. `migrate_impact` folds into `any_image`, so a `db/`-only push now sets `image_publish=true` and rebuilds + republishes the migrate image **on the push path** (not just dispatch). The migrate job `if:` stays `image_publish`-gated (rebuild-on-any-publish keeps the staging schema current); `migrate_impact` guarantees a `db/`-only push reaches it.
   - Loop-break (`overlays/staging` + `overlays/dev` `paths-ignore`) preserved.
   - promote-diff-guard untouched (separate workflow; this PR touches neither `overlays/prod` nor the `prod-promote` label, so it cleanly skips).
   - migrate is **NOT** added to the bump's `if:` coupling — the #78 decouple stays.
2. **db/Dockerfile.migrate**: documentation comment in the inline `migrate.sh` recording that `db/schema.sql` carries the schema through migration 156 (155 twin observability tables + 156 planner_lessons canonicalization). A real, harmless `db/**` edit so **merging this PR rebuilds + republishes the migrate image now**, which lets `bump-staging-digests` repin staging off the phantom. (Note: there is no standalone `db/migrate.sh` — the script is inlined in `Dockerfile.migrate` per the file's single-source-of-record note; the comment lands there.)
3. **overlays/dev**: replace the verdify-planner `sha256:0000…0000` placeholder with the real published + repo-linked digest `sha256:3e51abaec6372c0bed26ef9859a80008261fcd20a1e8ec1e37627304e1c6b637`. dev is **INERT** (no ArgoCD app) so this deploys nothing. verdify-lab placeholder left as-is (not published yet).

## Validation evidence

- `actionlint .github/workflows/container-publish.yml` → **EXIT 0** (run via `rhysd/actionlint` container).
- `kustomize build deploy/k8s/overlays/dev` → renders clean; planner now resolves to `…@sha256:3e51abae…6b637`.
- `kustomize build deploy/k8s/overlays/staging` → renders clean.
- `make lint` (ruff) → **All checks passed**.

## Service-restart note

No `verdify_schemas/`, `ingestor/entity_map.py`, or `mcp/server.py` change — no service bounce required by CLAUDE.md rule 7. The migrate image is consumed only by the ArgoCD PreSync migration hook against the in-cluster `verdify-db`; it never touches the device or the live VM DB.

## Post-merge expectation (the real proof)

On the merge push to `live/platform-main`: container-publish fires (db/** path → `image_publish=true`), the migrate "Publish trusted image" runs on the **push** path, and `bump-staging-digests` repins `overlays/staging` migrate off `7a39c3de…badf5` onto the real published digest via a `[skip ci] bump` commit.