### PR TITLE
Validate G5 dual-write: reusable gap/NULL check (SQL + pytest) (#21)

### DIFF
--- a/scripts/check-g5-dualwrite.sql
+++ b/scripts/check-g5-dualwrite.sql
@@ -1,0 +1,168 @@
+-- check-g5-dualwrite.sql — reusable G5 dual-write validation (issue #21)
+--
+-- Asserts that migration 146's graded compliance dual-write populated BOTH
+--   * daily_summary.*_v2 / graded_* columns, and
+--   * daily_zone_compliance rows
+-- gap-free / NULL-free for every COMPLETED daily-summary run, with proxy_flag
+-- set on the center zone (the vpd_avg proxy) and clear elsewhere.
+--
+-- "Completed daily-summary run" = a daily_summary row whose untouched binary
+-- compliance_pct is populated (the nightly/30-min refresh finished). The
+-- additive dual-write (band-compliance design §6.6/§6.7) must then have filled
+-- the v2 surface for the same date. A run that finished the binary calc but
+-- left the v2 surface NULL, or is missing a graded zone, or has the wrong
+-- proxy_flag, is a dual-write defect.
+--
+-- USAGE (read-only — emits violation rows; ZERO rows = clean):
+--   psql ... -v since="'2026-05-29'" -f scripts/check-g5-dualwrite.sql
+--   psql ... -v since="'2026-05-29'" -v until="'2026-05-31'" -f scripts/check-g5-dualwrite.sql
+--   psql ... -f scripts/check-g5-dualwrite.sql            -- defaults below
+--
+-- :since lower-bounds the audited window (inclusive). Default '2026-05-29' is
+-- the first live dual-write day (rows 05-26..05-28 are pre-146 completed runs
+-- with a NULL v2 surface by construction — legitimately out of scope, not a
+-- regression). Pass -v since="'1970-01-01'" to audit the entire history.
+--
+-- :until upper-bounds the audited window (inclusive). Default '9999-12-31'
+-- (open-ended). Use it to audit a closed range, e.g. the verify-later 3+ run
+-- observation window.
+--
+-- :greenhouse defaults to 'vallery'. The graded-zone set is the one
+-- fn_zone_band_grade emits (center/east/north); center is the proxy zone.
+--
+-- SELECT-ONLY. Safe against live, staging, or a disposable test DB. No writes,
+-- no DDL, no transaction control. The companion pytest
+-- (tests/test_g5_dualwrite_validation.py) runs this exact body against a
+-- DISPOSABLE postgres seeded with clean + gapped/NULL days.
+
+\set ON_ERROR_STOP on
+
+\if :{?since}
+\else
+  \set since '''2026-05-29'''
+\endif
+\if :{?until}
+\else
+  \set until '''9999-12-31'''
+\endif
+\if :{?greenhouse}
+\else
+  \set greenhouse '''vallery'''
+\endif
+
+WITH params AS (
+    SELECT :since::date           AS since_date,
+           :until::date           AS until_date,
+           :greenhouse::text      AS greenhouse_id
+),
+-- The zones fn_zone_band_grade emits, with their expected proxy_flag.
+expected_zone(zone, expect_proxy) AS (
+    VALUES ('center', true), ('east', false), ('north', false)
+),
+-- Completed daily-summary runs in scope: binary compliance_pct populated.
+completed AS (
+    SELECT ds.date, ds.greenhouse_id, ds.compliance_pct,
+           ds.compliance_v2_raw_pct, ds.compliance_v2_attributable_pct,
+           ds.compliance_v2_unachievable_frac,
+           ds.graded_temp_compliance_pct, ds.graded_vpd_compliance_pct,
+           ds.graded_stress_hours_heat, ds.graded_stress_hours_cold,
+           ds.graded_stress_hours_vpd_high, ds.graded_stress_hours_vpd_low,
+           ds.feasibility_unknown_min
+      FROM daily_summary ds, params p
+     WHERE ds.date >= p.since_date
+       AND ds.date <= p.until_date
+       AND ds.greenhouse_id = p.greenhouse_id
+       AND ds.compliance_pct IS NOT NULL
+),
+
+-- ── Violation class 1: daily_summary v2 / graded columns NULL on a finished run.
+v_summary_null AS (
+    SELECT c.date, NULL::text AS zone, 'error'::text AS severity,
+           'daily_summary v2 surface NULL on completed run' AS issue,
+           concat_ws(', ',
+             CASE WHEN c.compliance_v2_raw_pct           IS NULL THEN 'compliance_v2_raw_pct' END,
+             CASE WHEN c.compliance_v2_attributable_pct  IS NULL THEN 'compliance_v2_attributable_pct' END,
+             CASE WHEN c.compliance_v2_unachievable_frac IS NULL THEN 'compliance_v2_unachievable_frac' END,
+             CASE WHEN c.graded_temp_compliance_pct      IS NULL THEN 'graded_temp_compliance_pct' END,
+             CASE WHEN c.graded_vpd_compliance_pct       IS NULL THEN 'graded_vpd_compliance_pct' END,
+             CASE WHEN c.graded_stress_hours_heat        IS NULL THEN 'graded_stress_hours_heat' END,
+             CASE WHEN c.graded_stress_hours_cold        IS NULL THEN 'graded_stress_hours_cold' END,
+             CASE WHEN c.graded_stress_hours_vpd_high    IS NULL THEN 'graded_stress_hours_vpd_high' END,
+             CASE WHEN c.graded_stress_hours_vpd_low     IS NULL THEN 'graded_stress_hours_vpd_low' END,
+             CASE WHEN c.feasibility_unknown_min         IS NULL THEN 'feasibility_unknown_min' END
+           ) AS detail
+      FROM completed c
+     WHERE c.compliance_v2_raw_pct           IS NULL
+        OR c.compliance_v2_attributable_pct  IS NULL
+        OR c.compliance_v2_unachievable_frac IS NULL
+        OR c.graded_temp_compliance_pct      IS NULL
+        OR c.graded_vpd_compliance_pct       IS NULL
+        OR c.graded_stress_hours_heat        IS NULL
+        OR c.graded_stress_hours_cold        IS NULL
+        OR c.graded_stress_hours_vpd_high    IS NULL
+        OR c.graded_stress_hours_vpd_low     IS NULL
+        OR c.feasibility_unknown_min         IS NULL
+),
+
+-- ── Violation class 2: a completed run is MISSING a graded zone row entirely.
+v_zone_missing AS (
+    SELECT c.date, ez.zone, 'error'::text AS severity,
+           'daily_zone_compliance row missing for completed run' AS issue,
+           concat('expected zone ', ez.zone, ' has no daily_zone_compliance row') AS detail
+      FROM completed c
+      CROSS JOIN expected_zone ez
+     WHERE NOT EXISTS (
+            SELECT 1 FROM daily_zone_compliance d
+             WHERE d.date = c.date AND d.zone = ez.zone)
+),
+
+-- ── Violation class 3: a present zone row has NULL graded/feasibility columns.
+v_zone_null AS (
+    SELECT d.date, d.zone, 'error'::text AS severity,
+           'daily_zone_compliance row has NULL graded columns' AS issue,
+           concat_ws(', ',
+             CASE WHEN d.raw_compliance_pct          IS NULL THEN 'raw_compliance_pct' END,
+             CASE WHEN d.ctrl_compliance_pct         IS NULL THEN 'ctrl_compliance_pct' END,
+             CASE WHEN d.graded_temp_compliance_pct  IS NULL THEN 'graded_temp_compliance_pct' END,
+             CASE WHEN d.graded_vpd_compliance_pct   IS NULL THEN 'graded_vpd_compliance_pct' END,
+             CASE WHEN d.graded_stress_hours_heat    IS NULL THEN 'graded_stress_hours_heat' END,
+             CASE WHEN d.graded_stress_hours_cold    IS NULL THEN 'graded_stress_hours_cold' END,
+             CASE WHEN d.graded_stress_hours_vpd_high IS NULL THEN 'graded_stress_hours_vpd_high' END,
+             CASE WHEN d.graded_stress_hours_vpd_low IS NULL THEN 'graded_stress_hours_vpd_low' END,
+             CASE WHEN d.unachievable_min            IS NULL THEN 'unachievable_min' END,
+             CASE WHEN d.controller_miss_min         IS NULL THEN 'controller_miss_min' END,
+             CASE WHEN d.proxy_flag                  IS NULL THEN 'proxy_flag' END
+           ) AS detail
+      FROM daily_zone_compliance d
+      JOIN completed c ON c.date = d.date
+      JOIN expected_zone ez ON ez.zone = d.zone
+     WHERE d.raw_compliance_pct          IS NULL
+        OR d.ctrl_compliance_pct         IS NULL
+        OR d.graded_temp_compliance_pct  IS NULL
+        OR d.graded_vpd_compliance_pct   IS NULL
+        OR d.graded_stress_hours_heat    IS NULL
+        OR d.graded_stress_hours_cold    IS NULL
+        OR d.graded_stress_hours_vpd_high IS NULL
+        OR d.graded_stress_hours_vpd_low IS NULL
+        OR d.unachievable_min            IS NULL
+        OR d.controller_miss_min         IS NULL
+        OR d.proxy_flag                  IS NULL
+),
+
+-- ── Violation class 4: proxy_flag wrong for the zone (center must be the proxy).
+v_proxy_wrong AS (
+    SELECT d.date, d.zone, 'error'::text AS severity,
+           'proxy_flag mismatch' AS issue,
+           concat('zone ', d.zone, ' proxy_flag=', d.proxy_flag,
+                  ' expected ', ez.expect_proxy) AS detail
+      FROM daily_zone_compliance d
+      JOIN completed c ON c.date = d.date
+      JOIN expected_zone ez ON ez.zone = d.zone
+     WHERE d.proxy_flag IS DISTINCT FROM ez.expect_proxy
+)
+
+SELECT * FROM v_summary_null
+UNION ALL SELECT * FROM v_zone_missing
+UNION ALL SELECT * FROM v_zone_null
+UNION ALL SELECT * FROM v_proxy_wrong
+ORDER BY date, zone NULLS FIRST, issue;

--- a/tests/test_g5_dualwrite_validation.py
+++ b/tests/test_g5_dualwrite_validation.py
@@ -1,0 +1,318 @@
+"""Reusable G5 dual-write validation check — pytest (issue #21).
+
+Exercises ``scripts/check-g5-dualwrite.sql`` against a DISPOSABLE postgres
+container (NEVER the live ``verdify-timescaledb``). The fixture seeds:
+
+  * two CLEAN completed daily-summary days — full daily_summary ``*_v2`` /
+    graded surface + a daily_zone_compliance row for every graded zone
+    (center/east/north), with proxy_flag set only on center; and
+  * one GAPPED/NULL completed day that reproduces all four dual-write defect
+    classes the check must catch: NULL v2 summary surface, a missing graded
+    zone row, a zone row with a NULL graded column, and a wrong proxy_flag.
+
+It then asserts the check returns ZERO rows over the clean-only window and
+FLAGS every defect over the gap-inclusive window (no bare-green). Fixture
+timestamps are UTC (``...Z``), matching the captured_at the ingestor writes.
+
+The live ">=3 consecutive completed runs" observation is the DEPLOYED /
+verify-later step (no external owner — just time); it is NOT exercised here.
+
+Run: ``pytest tests/test_g5_dualwrite_validation.py -v``
+Requires docker + the ``postgres`` image; skips cleanly if unavailable.
+NEVER touches the live database — it stands up and tears down its own throwaway.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECK_SQL = REPO_ROOT / "scripts" / "check-g5-dualwrite.sql"
+
+# A disposable image only — explicitly NOT the live verdify-timescaledb stack.
+PG_IMAGE = "postgres:16-alpine"
+PG_USER = "verdify"
+PG_DB = "verdify"
+
+# Minimal schema mirroring the live columns the check reads (migration 146).
+SCHEMA_SQL = """
+CREATE TABLE daily_summary (
+    date date NOT NULL,
+    greenhouse_id text DEFAULT 'vallery',
+    compliance_pct double precision,
+    compliance_v2_raw_pct double precision,
+    compliance_v2_attributable_pct double precision,
+    compliance_v2_unachievable_frac double precision,
+    graded_temp_compliance_pct double precision,
+    graded_vpd_compliance_pct double precision,
+    graded_stress_hours_heat double precision,
+    graded_stress_hours_cold double precision,
+    graded_stress_hours_vpd_high double precision,
+    graded_stress_hours_vpd_low double precision,
+    feasibility_unknown_min double precision,
+    PRIMARY KEY (date, greenhouse_id)
+);
+CREATE TABLE daily_zone_compliance (
+    date date NOT NULL,
+    zone text NOT NULL,
+    crop_catalog_id int,
+    raw_compliance_pct double precision,
+    ctrl_compliance_pct double precision,
+    graded_temp_compliance_pct double precision,
+    graded_vpd_compliance_pct double precision,
+    graded_stress_hours_heat double precision,
+    graded_stress_hours_cold double precision,
+    graded_stress_hours_vpd_high double precision,
+    graded_stress_hours_vpd_low double precision,
+    unachievable_min double precision,
+    controller_miss_min double precision,
+    proxy_flag boolean DEFAULT false,
+    captured_at timestamptz DEFAULT now(),
+    PRIMARY KEY (date, zone)
+);
+"""
+
+# Two clean completed days + one gapped/NULL completed day. UTC captured_at.
+SEED_SQL = """
+-- CLEAN: 2026-05-29 / 2026-05-30 — full v2 surface, all three graded zones,
+-- proxy_flag only on center.
+INSERT INTO daily_summary (date, greenhouse_id, compliance_pct,
+    compliance_v2_raw_pct, compliance_v2_attributable_pct, compliance_v2_unachievable_frac,
+    graded_temp_compliance_pct, graded_vpd_compliance_pct,
+    graded_stress_hours_heat, graded_stress_hours_cold,
+    graded_stress_hours_vpd_high, graded_stress_hours_vpd_low, feasibility_unknown_min)
+VALUES
+  ('2026-05-29','vallery', 80.0, 76.3, 85.0, 0.3041, 95.2, 88.0, 1.1, 0.0, 0.5, 0.2, 0.0),
+  ('2026-05-30','vallery', 78.0, 67.5, 75.6, 0.1124, 95.2, 84.0, 0.9, 0.1, 0.4, 0.3, 0.0);
+
+INSERT INTO daily_zone_compliance (date, zone, raw_compliance_pct, ctrl_compliance_pct,
+    graded_temp_compliance_pct, graded_vpd_compliance_pct,
+    graded_stress_hours_heat, graded_stress_hours_cold,
+    graded_stress_hours_vpd_high, graded_stress_hours_vpd_low,
+    unachievable_min, controller_miss_min, proxy_flag, captured_at)
+VALUES
+  ('2026-05-29','center', 76.3, 85.0, 95.2, 88.0, 1.1, 0.0, 0.5, 0.2, 120, 30, true,  '2026-05-30T07:00:00Z'),
+  ('2026-05-29','east',   90.0, 92.0, 96.0, 90.0, 0.2, 0.0, 0.1, 0.0,  10,  5, false, '2026-05-30T07:00:00Z'),
+  ('2026-05-29','north',  88.0, 90.0, 94.0, 89.0, 0.3, 0.0, 0.2, 0.0,  12,  6, false, '2026-05-30T07:00:00Z'),
+  ('2026-05-30','center', 67.5, 75.6, 95.2, 84.0, 0.9, 0.1, 0.4, 0.3, 100, 40, true,  '2026-05-31T07:00:00Z'),
+  ('2026-05-30','east',   85.0, 88.0, 95.0, 86.0, 0.3, 0.0, 0.2, 0.1,  15,  8, false, '2026-05-31T07:00:00Z'),
+  ('2026-05-30','north',  84.0, 87.0, 93.0, 85.0, 0.4, 0.0, 0.2, 0.1,  16,  9, false, '2026-05-31T07:00:00Z');
+
+-- GAPPED/NULL: 2026-05-31 — binary run finished (compliance_pct set) but the
+-- v2 surface is NULL, north zone row is MISSING, east row has a NULL graded
+-- col, and center proxy_flag is WRONG (false). Four defect classes.
+INSERT INTO daily_summary (date, greenhouse_id, compliance_pct,
+    compliance_v2_raw_pct, compliance_v2_attributable_pct, compliance_v2_unachievable_frac,
+    graded_temp_compliance_pct, graded_vpd_compliance_pct,
+    graded_stress_hours_heat, graded_stress_hours_cold,
+    graded_stress_hours_vpd_high, graded_stress_hours_vpd_low, feasibility_unknown_min)
+VALUES
+  ('2026-05-31','vallery', 70.0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO daily_zone_compliance (date, zone, raw_compliance_pct, ctrl_compliance_pct,
+    graded_temp_compliance_pct, graded_vpd_compliance_pct,
+    graded_stress_hours_heat, graded_stress_hours_cold,
+    graded_stress_hours_vpd_high, graded_stress_hours_vpd_low,
+    unachievable_min, controller_miss_min, proxy_flag, captured_at)
+VALUES
+  ('2026-05-31','center', 53.5, 88.9, 86.7, 80.0, 2.0, 0.0, 1.0, 0.5, 300, 50, false, '2026-06-01T07:00:00Z'),
+  ('2026-05-31','east',   80.0, 83.0, NULL, 82.0, 0.5, 0.0, 0.3, 0.2,  20, 12, false, '2026-06-01T07:00:00Z');
+  -- north row deliberately omitted (missing-zone defect)
+"""
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=20).returncode == 0
+    except Exception:
+        return False
+
+
+def _psql(container: str, sql_args: list[str], *, stdin: str | None = None) -> str:
+    """Run psql inside the disposable container; return stdout (raises on error)."""
+    cmd = [
+        "docker",
+        "exec",
+        "-i",
+        container,
+        "psql",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-U",
+        PG_USER,
+        "-d",
+        PG_DB,
+        *sql_args,
+    ]
+    res = subprocess.run(cmd, input=stdin, capture_output=True, text=True, timeout=60)
+    if res.returncode != 0:
+        raise RuntimeError(f"psql failed: {res.stderr.strip()}\nstdout: {res.stdout.strip()}")
+    return res.stdout
+
+
+@pytest.fixture(scope="module")
+def disposable_db():
+    """A throwaway postgres container seeded with the G5 fixture. NEVER live."""
+    if not _docker_available():
+        pytest.skip("docker unavailable — disposable-DB G5 check test skipped")
+    if not CHECK_SQL.exists():
+        pytest.fail(f"check SQL missing: {CHECK_SQL}")
+
+    name = f"g5-dualwrite-test-{uuid.uuid4().hex[:8]}"
+    run = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            name,
+            "-e",
+            f"POSTGRES_USER={PG_USER}",
+            "-e",
+            "POSTGRES_PASSWORD=verdify",
+            "-e",
+            f"POSTGRES_DB={PG_DB}",
+            PG_IMAGE,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if run.returncode != 0:
+        pytest.skip(f"could not start disposable postgres ({PG_IMAGE}): {run.stderr.strip()}")
+
+    try:
+        # Wait for readiness. The postgres image starts a TEMPORARY server to run
+        # init scripts, then shuts it down and restarts the real one, so a single
+        # pg_isready / SELECT can succeed against the throwaway server moments
+        # before it goes down. Require N CONSECUTIVE successful real queries with a
+        # short settle so we only proceed against the final, stable server.
+        consecutive = 0
+        for _ in range(90):
+            probe = subprocess.run(
+                ["docker", "exec", name, "psql", "-U", PG_USER, "-d", PG_DB, "-tAc", "SELECT 1"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            if probe.returncode == 0 and probe.stdout.strip() == "1":
+                consecutive += 1
+                if consecutive >= 3:
+                    break
+            else:
+                consecutive = 0
+            time.sleep(1)
+        else:
+            pytest.skip("disposable postgres did not become stably ready in time")
+
+        _psql(name, ["-q"], stdin=SCHEMA_SQL)
+        _psql(name, ["-q"], stdin=SEED_SQL)
+        # Copy the check into the container so we run the EXACT committed file.
+        subprocess.run(
+            ["docker", "cp", str(CHECK_SQL), f"{name}:/tmp/check.sql"],  # noqa: S108 — container path, not host
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        yield name
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, timeout=60)
+
+
+def _run_check(container: str, *, since: str, until: str) -> list[list[str]]:
+    """Run the check over [since, until]; return violation rows as field lists."""
+    out = _psql(
+        container,
+        [
+            "-v",
+            f"since='{since}'",
+            "-v",
+            f"until='{until}'",
+            "-t",
+            "-A",
+            "-F",
+            "|",
+            "-f",
+            "/tmp/check.sql",  # noqa: S108 — path is inside the disposable container, not host
+        ],
+    )
+    return [line.split("|") for line in out.splitlines() if line.strip()]
+
+
+def test_check_passes_clean_window(disposable_db):
+    """The two clean days produce ZERO violations (gap-free / NULL-free)."""
+    rows = _run_check(disposable_db, since="2026-05-29", until="2026-05-30")
+    assert rows == [], f"expected clean window to be violation-free, got: {rows}"
+
+
+def test_check_flags_gapped_null_day(disposable_db):
+    """The gapped/NULL day trips all four dual-write defect classes."""
+    rows = _run_check(disposable_db, since="2026-05-29", until="2026-05-31")
+
+    # Every flagged row is the gap day, none of the clean days.
+    assert rows, "expected the gapped/NULL day to be flagged, got zero rows (bare-green)"
+    flagged_dates = {r[0] for r in rows}
+    assert flagged_dates == {"2026-05-31"}, f"only the gap day should flag, got dates {flagged_dates}"
+
+    issues = {r[2] for r in rows}  # severity column
+    assert issues == {"error"}, f"all violations should be severity=error, got {issues}"
+
+    by_issue = {r[3]: r for r in rows}  # issue text -> row
+
+    # 1) daily_summary v2 surface NULL on a completed run.
+    assert "daily_summary v2 surface NULL on completed run" in by_issue
+    summary_detail = by_issue["daily_summary v2 surface NULL on completed run"][4]
+    for col in (
+        "compliance_v2_raw_pct",
+        "compliance_v2_attributable_pct",
+        "compliance_v2_unachievable_frac",
+        "graded_temp_compliance_pct",
+        "feasibility_unknown_min",
+    ):
+        assert col in summary_detail, f"{col} should appear in the NULL-surface detail"
+
+    # 2) a graded zone row is missing entirely (north).
+    missing = "daily_zone_compliance row missing for completed run"
+    assert missing in by_issue
+    assert by_issue[missing][1] == "north", "north is the missing zone"
+
+    # 3) a present zone row has a NULL graded column (east.graded_temp...).
+    null_zone = "daily_zone_compliance row has NULL graded columns"
+    assert null_zone in by_issue
+    assert by_issue[null_zone][1] == "east"
+    assert "graded_temp_compliance_pct" in by_issue[null_zone][4]
+
+    # 4) proxy_flag is wrong for center (must be the proxy zone).
+    proxy = "proxy_flag mismatch"
+    assert proxy in by_issue
+    assert by_issue[proxy][1] == "center"
+
+
+def test_proxy_flag_only_center_when_clean(disposable_db):
+    """Clean days set proxy_flag exactly on center — never on east/north."""
+    out = _psql(
+        disposable_db,
+        [
+            "-t",
+            "-A",
+            "-F",
+            "|",
+            "-c",
+            "SELECT zone, proxy_flag FROM daily_zone_compliance "
+            "WHERE date IN ('2026-05-29','2026-05-30') ORDER BY date, zone;",
+        ],
+    )
+    rows = [line.split("|") for line in out.splitlines() if line.strip()]
+    proxy_true = {z for z, f in rows if f == "t"}
+    proxy_false = {z for z, f in rows if f == "f"}
+    assert proxy_true == {"center"}, f"only center should be proxy on clean days, got {proxy_true}"
+    assert proxy_false == {"east", "north"}, f"east/north must not be proxy, got {proxy_false}"


### PR DESCRIPTION
Closes #21

## What

Authors the **reusable check** the acceptance criteria call for: assert `daily_zone_compliance` + `daily_summary` `*_v2`/graded columns are **gap-free / NULL-free** for every completed daily-summary run, with `proxy_flag` set on the **center** (vpd_avg proxy) zone and clear elsewhere.

Two in-lane, no-device, disposable-DB-only deliverables:

### `scripts/check-g5-dualwrite.sql`
SELECT-only, runnable read-only against any DB (live, staging, disposable). For each **completed** run (a `daily_summary` row whose untouched binary `compliance_pct` is populated = the refresh finished) it emits one violation row per defect across four classes; **zero rows = clean**:
1. `daily_summary` v2 surface NULL on a completed run;
2. a graded zone row (center/east/north) **missing** for a completed run;
3. a present zone row with a **NULL graded column**;
4. `proxy_flag` mismatch (center must be the proxy zone).

Window-bounded by `:since`/`:until` psql vars. Default `since=2026-05-29` is the first live dual-write day, so the pre-146 completed runs 05-26..05-28 (NULL v2 surface by construction) are legitimately out of scope; pass `-v since="'1970-01-01'"` to audit all history.

### `tests/test_g5_dualwrite_validation.py`
pytest against a **disposable** `postgres:16-alpine` container — **never** the live `verdify-timescaledb` (stands up and tears down its own throwaway; skips cleanly if docker is unavailable). The fixture seeds **two clean multi-day rows plus one gapped/NULL day** reproducing all four defect classes (UTC `captured_at` timestamps), then asserts:
- the check returns **zero rows** over the clean window;
- the check **FLAGS** every defect over the gap-inclusive window (no bare-green: each defect class is asserted by name + zone);
- on clean days `proxy_flag` is set **exactly** on center.

## Evidence

```
$ ruff check (ingestor/ api/ mcp/ scripts/*.py tests/ verdify_schemas/)
All checks passed!

$ pytest tests/test_g5_dualwrite_validation.py -v
tests/test_g5_dualwrite_validation.py::test_check_passes_clean_window PASSED
tests/test_g5_dualwrite_validation.py::test_check_flags_gapped_null_day PASSED
tests/test_g5_dualwrite_validation.py::test_proxy_flag_only_center_when_clean PASSED
3 passed
```

Disposable-DB run of the check over the gap-inclusive window (the four flagged defect classes):
```
2026-05-31 |        | error | daily_summary v2 surface NULL on completed run      | compliance_v2_raw_pct, compliance_v2_attributable_pct, ...
2026-05-31 | center | error | proxy_flag mismatch                                 | zone center proxy_flag=f expected t
2026-05-31 | east   | error | daily_zone_compliance row has NULL graded columns   | graded_temp_compliance_pct
2026-05-31 | north  | error | daily_zone_compliance row missing for completed run | expected zone north has no daily_zone_compliance row
```
Clean window (05-29..05-30): **0 rows**.

This is precisely the live gap the check is built to catch: 05-26..05-28 are completed runs predating migration 146's dual-write (NULL v2 surface), 05-29+ dual-write cleanly.

## Scope / safety

- **Not a migration** and touches **no shared territory** (no `db/migrations/`, `verdify_schemas/`, `mcp/server.py`, or `ingestor/entity_map.py`) → no Rule-7 restart note and no drift guards apply.
- No device path, no live writer, no SHADOW_MODE, no secrets, no live-DB writes. Tests run on a disposable container only.

## Verify-later (DEPLOYED, time-gated — no external owner, just time)

Run `scripts/check-g5-dualwrite.sql` against **live** across **>=3 consecutive completed daily-summary runs** and confirm zero rows, plus that the center-zone anomalously-low compliance is genuine (`unachievable_min` / `proxy_flag` explains it) rather than a dual-write or zone-weight artifact. This is the steady-state observation step the issue notes; it is not exercised in CI.