### PR TITLE
Digital twin MVP: prod-vs-reality divergence dashboard + local offline twin overlay (#34)

### DIFF
--- a/docker-compose.twins.yml
+++ b/docker-compose.twins.yml
@@ -1,0 +1,108 @@
+# docker-compose.twins.yml — firmware digital-twin LOCAL OFFLINE overlay (TWIN-8).
+#
+# Design: docs/design/firmware-digital-twin.md §5.3 (read-only safety model),
+# §6 Phase 1 (prod twin shadowing last-good + divergence dashboard), §7 TWIN-8.
+#
+# WHAT THIS IS: a self-contained OFFLINE harness that stands up a `twin-prod`
+# container running the exact ESP32 control logic (the -DREPLAY_EMIT_STREAM build
+# of firmware/test/replay_emit.cpp, the same code the rule-8 replay-diff gate
+# trusts), pinned to last-good, replaying a checked-in telemetry CSV through the
+# native logic twin and writing predicted decisions to twin_decisions. Pair it
+# with the Grafana board grafana/provisioning/dashboards/json/firmware-twin-
+# divergence.json to see the prod-vs-reality divergence panels render.
+#
+# WHAT THIS IS NOT: the real prod twin. The real prod twin shadows LIVE telemetry
+# and needs the prod TimescaleDB with migration 155 applied + the twin_ro login
+# user provisioned out-of-band — that is Root/prod-migration territory (issue #34
+# needs:root). This overlay runs against a DISPOSABLE local twin-db, never live.
+#
+# Read-only by construction (§5.3 L2):
+#   * No actuation credential, no MQTT, no route to the ESP32 — the twin only
+#     reads a CSV and INSERTs into the two observability tables.
+#   * twin-prod connects as the INSERT-only twin_ro login user; the driver
+#     asserts at startup the role cannot write a control-plane table.
+#   * No docker.sock is mounted (no container-control surface).
+#   * twin-prod sits ONLY on the internal verdify-twin network (no proxy, no
+#     internet egress).
+#
+# RUN (local, disposable):
+#   export TWIN_DB_PASSWORD=$(openssl rand -hex 16)
+#   gzip -cd firmware/test/data/replay_overrides.csv.gz \
+#       > firmware/test/data/replay_overrides.csv
+#   docker compose -f docker-compose.twins.yml up --build twin-db
+#   # apply migration 155 to the disposable twin-db, create the twin login user:
+#   #   psql "$TWIN_DB_DSN" -f db/migrations/155-twin-observability-tables.sql
+#   #   psql "$TWIN_DB_DSN" -c "CREATE ROLE twin GROUP twin_ro LOGIN PASSWORD '...';"
+#   docker compose -f docker-compose.twins.yml up --build twin-prod
+#
+# VALIDATE the file alone (no daemon needed):
+#   docker compose -f docker-compose.yml -f docker-compose.twins.yml config -q
+
+networks:
+  # Internal-only twin network. NOT verdify-proxy and NOT internet-facing.
+  verdify-twin:
+    name: verdify-twin
+    internal: true
+
+volumes:
+  twin_db_data:
+
+services:
+  # Disposable local TimescaleDB for the offline harness. NEVER the live DB.
+  # Bound to loopback only; throwaway volume.
+  twin-db:
+    image: timescale/timescaledb:latest-pg16
+    container_name: verdify-twin-db
+    profiles: ["twins"]
+    environment:
+      POSTGRES_DB: verdify_twin
+      POSTGRES_USER: verdify
+      POSTGRES_PASSWORD: ${TWIN_DB_PASSWORD:?set TWIN_DB_PASSWORD for the disposable twin DB}
+    ports:
+      - "127.0.0.1:55432:5432"
+    volumes:
+      - twin_db_data:/var/lib/postgresql/data
+    networks:
+      - verdify-twin
+    restart: "no"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U verdify -d verdify_twin"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # The prod twin: last-good native logic twin, INSERT-only, offline replay.
+  twin-prod:
+    build:
+      context: .
+      dockerfile: twin/Dockerfile
+    image: verdify-twin:local
+    container_name: verdify-twin-prod
+    profiles: ["twins"]
+    depends_on:
+      twin-db:
+        condition: service_healthy
+    environment:
+      TWIN_ENV: prod
+      # The git sha / fw_version the image is pinned to (last-good). Override at
+      # build/run time; recorded into twin_decisions.twin_ref.
+      TWIN_REF: ${TWIN_REF:-last-good}
+      TWIN_CSV: /data/replay_overrides.csv
+      # INSERT-only twin_ro login user against the DISPOSABLE twin-db. Provision
+      # this user out-of-band (GROUP twin_ro). Leave TWIN_DSN unset for a pure
+      # stdout dry-run with no DB at all.
+      TWIN_DSN: ${TWIN_DSN:-}
+      TWIN_LIMIT: ${TWIN_LIMIT:-0}
+    volumes:
+      # Read-only mount of the checked-in replay corpus (decompress first).
+      - ./firmware/test/data:/data:ro
+    networks:
+      - verdify-twin
+    # Hardening: no new privileges, drop all caps, read-only rootfs. No
+    # docker.sock, no actuation client, no device route.
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: "no"

--- a/grafana/provisioning/dashboards/json/firmware-twin-divergence.json
+++ b/grafana/provisioning/dashboards/json/firmware-twin-divergence.json
@@ -1,0 +1,484 @@
+{
+  "id": null,
+  "uid": "firmware-twin-divergence",
+  "title": "Firmware Twin — Prod vs Reality Divergence",
+  "tags": ["greenhouse", "firmware", "twin", "divergence", "validation"],
+  "timezone": "America/Denver",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "60s",
+  "time": { "from": "now-24h", "to": "now" },
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "editable": true,
+  "graphTooltip": 2,
+  "style": "light",
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "What this board shows",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "**Prod-vs-reality** is the novel firmware-twin signal: the `prod` twin (pinned to `last-good`, fed the same telemetry the ESP32 saw, **never actuating**) predicts what the deployed firmware *should* decide, and that prediction is compared against what the relays *actually did* (`equipment_state`). A sustained gap means a firmware bug, sensor/telemetry skew, or a stale/corrupted setpoint push — the class behind the 2026-04-21 MCP staleness incident. Twin-vs-twin is blind to a latent bug the twin faithfully reproduces; prod-vs-reality is not.\n\nThe twin predicts **FSM relay intent** (Tier 1), not post-dwell physical relay state, so disagreement is only trustworthy when **sustained beyond the relay min-off window** (several minutes) and after manual-override rows are suppressed. See `docs/design/firmware-digital-twin.md` §4 / §6 Phase 1. Grafana unified alerting is off — alarms are written to `alert_log` by ingestor's `alert_monitor`, not here."
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Latest prod-vs-reality relay disagreement %",
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 4 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#73BF69", "value": null },
+              { "color": "#FDD835", "value": 1 },
+              { "color": "#EF5350", "value": 5 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "background_solid",
+        "textMode": "value",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT ts AS time, relay_disagree_pct AS \"Relay disagree %\" FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Latest mode disagreement %",
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 4 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#73BF69", "value": null },
+              { "color": "#FDD835", "value": 1 },
+              { "color": "#EF5350", "value": 5 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "background_solid",
+        "textMode": "value",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT ts AS time, mode_disagree_pct AS \"Mode disagree %\" FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1",
+          "format": "table",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Twin freshness (since last prod tick)",
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 4 },
+      "description": "Seconds since the prod twin last wrote a twin_decisions row. A dark twin silently disables the live gates, so this is itself a high-severity alert input.",
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#73BF69", "value": null },
+              { "color": "#FDD835", "value": 600 },
+              { "color": "#EF5350", "value": 1800 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "background_solid",
+        "textMode": "value_and_name",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT now() AS time, EXTRACT(EPOCH FROM (now() - MAX(ts)))::int AS \"Twin staleness\" FROM twin_decisions WHERE twin_env = 'prod'",
+          "format": "table",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Pinned twin_ref (prod last-good)",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 4 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "#5794F2" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "value",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT ts AS time, twin_ref AS \"twin_ref\" FROM twin_decisions WHERE twin_env = 'prod' ORDER BY ts DESC LIMIT 1",
+          "format": "table",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Prod-vs-reality relay disagreement % (windowed) — threshold = relay min-off window",
+      "description": "From firmware_twin_divergence (comparison='prod_vs_reality'). The threshold line at 5% is a placeholder for the relay min-off window: prod-vs-reality is only trustworthy when SUSTAINED beyond MAX(MIN_HEAT_OFF_MS, MIN_FAN_OFF_MS) (§2.2), since Tier 1 predicts FSM intent, not post-dwell relay state.",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 9 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": { "mode": "line+area" }
+          },
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "#FDD835", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT $__time(ts), relay_disagree_pct AS \"Relay disagree %\", mode_disagree_pct AS \"Mode disagree %\" FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Twin samples vs disagreements per window",
+      "description": "From firmware_twin_divergence (comparison='prod_vs_reality'). Low sample counts make the % noisy — read alongside the % panel.",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 9 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 40,
+            "spanNulls": false
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT $__time(ts), samples AS \"Samples\", disagree_count AS \"Disagreements\" FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Per-relay disagreement % (prod-vs-reality)",
+      "description": "Per-relay breakdown from firmware_twin_divergence.per_relay jsonb. Isolates 'only fog differs' (suspect fog-gate / YAML override) from 'heat differs' (plant-safety triage). Heat min-off is minutes, so brief heat divergence is expected dwell lag, not a bug.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 17 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 5,
+            "spanNulls": false
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT $__time(ts), (per_relay->>'fog')::float AS \"fog\", (per_relay->>'vent')::float AS \"vent\", (per_relay->>'fan1')::float AS \"fan1\", (per_relay->>'fan2')::float AS \"fan2\", (per_relay->>'heat1')::float AS \"heat1\", (per_relay->>'heat2')::float AS \"heat2\" FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "barchart",
+      "title": "Latest disagreement % by mode",
+      "description": "firmware_twin_divergence.by_mode jsonb on the most recent prod-vs-reality window. Disagreement concentrated in one mode (e.g. SEALED_MIST) narrows the cause class.",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 25 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "continuous-GrYlRd" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "legend": { "showLegend": false }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT kv.key AS \"mode\", kv.value::float AS \"disagree %\" FROM (SELECT by_mode FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1) d, jsonb_each_text(d.by_mode) kv ORDER BY kv.value::float DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "barchart",
+      "title": "Latest disagreement % by daypart",
+      "description": "firmware_twin_divergence.by_daypart jsonb (MDT-corrected local_hour buckets). Disagreement keyed to fog-window / night-suppression / dusk-cutoff hours points at the local-hour timezone path.",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 25 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "continuous-GrYlRd" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "legend": { "showLegend": false }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT kv.key AS \"daypart\", kv.value::float AS \"disagree %\" FROM (SELECT by_daypart FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1) d, jsonb_each_text(d.by_daypart) kv ORDER BY kv.key",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "barchart",
+      "title": "Latest disagreement % by outdoor band",
+      "description": "firmware_twin_divergence.by_outdoor_band jsonb (<32 / 32-85 / >85 F, tied to stress-window rule 5).",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 25 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "continuous-GrYlRd" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "legend": { "showLegend": false }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT kv.key AS \"outdoor band\", kv.value::float AS \"disagree %\" FROM (SELECT by_outdoor_band FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1) d, jsonb_each_text(d.by_outdoor_band) kv ORDER BY kv.key",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "state-timeline",
+      "title": "Twin-predicted relay intent vs device actual — fog",
+      "description": "prod twin twin_decisions.relay_fog (predicted FSM intent) vs the device's actual fog relay from equipment_state (forward-filled to twin tick). Visual prod-vs-reality at the relay level; gaps shorter than the fog min-off window are expected dwell lag.",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 33 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 80, "lineWidth": 0 },
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "off", "color": "#5a6b7a" }, "1": { "text": "ON", "color": "#5794F2" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "#5a6b7a", "value": null }, { "color": "#5794F2", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "mergeValues": true,
+        "showValue": "never",
+        "alignValue": "left",
+        "rowHeight": 0.9,
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT $__time(ts), CASE WHEN relay_fog THEN 1 ELSE 0 END AS \"Twin predicted (fog)\" FROM twin_decisions WHERE twin_env = 'prod' AND $__timeFilter(ts) ORDER BY ts",
+          "format": "time_series",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "WITH twin_ticks AS (SELECT ts FROM twin_decisions WHERE twin_env = 'prod' AND $__timeFilter(ts)) SELECT t.ts AS time, (SELECT CASE WHEN es.state THEN 1 ELSE 0 END FROM equipment_state es WHERE es.equipment = 'fog' AND es.ts <= t.ts ORDER BY es.ts DESC LIMIT 1) AS \"Device actual (fog)\" FROM twin_ticks t ORDER BY t.ts",
+          "format": "time_series",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "state-timeline",
+      "title": "Twin-predicted relay intent vs device actual — heat1",
+      "description": "prod twin twin_decisions.relay_heat1 vs the device's actual heat1 relay from equipment_state. Heat min-off is on the order of minutes, so the twin's intent legitimately leads the device's relay by up to that window — only sustained disagreement is a signal.",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 40 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 80, "lineWidth": 0 },
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "off", "color": "#5a6b7a" }, "1": { "text": "ON", "color": "#FF9830" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "#5a6b7a", "value": null }, { "color": "#FF9830", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "mergeValues": true,
+        "showValue": "never",
+        "alignValue": "left",
+        "rowHeight": 0.9,
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT $__time(ts), CASE WHEN relay_heat1 THEN 1 ELSE 0 END AS \"Twin predicted (heat1)\" FROM twin_decisions WHERE twin_env = 'prod' AND $__timeFilter(ts) ORDER BY ts",
+          "format": "time_series",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "WITH twin_ticks AS (SELECT ts FROM twin_decisions WHERE twin_env = 'prod' AND $__timeFilter(ts)) SELECT t.ts AS time, (SELECT CASE WHEN es.state THEN 1 ELSE 0 END FROM equipment_state es WHERE es.equipment = 'heat1' AND es.ts <= t.ts ORDER BY es.ts DESC LIMIT 1) AS \"Device actual (heat1)\" FROM twin_ticks t ORDER BY t.ts",
+          "format": "time_series",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "table",
+      "title": "Worst-divergence examples (latest window) — triage",
+      "description": "firmware_twin_divergence.worst_examples jsonb on the most recent prod-vs-reality window: the highest-divergence input rows for triage (input_ts, reference vs candidate relays).",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 47 },
+      "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "left" } },
+        "overrides": []
+      },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "datasource": { "uid": "verdify-tsdb", "type": "grafana-postgresql-datasource" },
+          "rawSql": "SELECT ex->>'input_ts' AS \"input_ts\", ex->>'ref' AS \"ref (predicted)\", ex->>'cmp' AS \"cmp (actual)\", ex->>'relays' AS \"diverging relays\" FROM (SELECT worst_examples FROM firmware_twin_divergence WHERE comparison = 'prod_vs_reality' AND $__timeFilter(ts) ORDER BY ts DESC LIMIT 1) d, jsonb_array_elements(d.worst_examples) ex",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_18_twin_divergence_dashboard.py
+++ b/tests/test_18_twin_divergence_dashboard.py
@@ -1,0 +1,176 @@
+"""Static contract test for the firmware twin prod-vs-reality divergence board.
+
+Issue #34 (Digital twin MVP, Phase 1, TWIN-13). The dashboard
+``grafana/provisioning/dashboards/json/firmware-twin-divergence.json`` is
+TimescaleDB-backed over the twin observability tables from migration 155
+(issue #33). This test is STATIC (no live DB): it asserts the JSON is valid,
+every target is on the verdify-tsdb datasource, every panel has unique refIds,
+and every table/column/jsonb-key/literal the queries reference actually exists
+in migration 155 / the live schema — so a column rename in the migration breaks
+this test instead of silently producing an empty Grafana panel.
+
+The validated tick is recorded with a real UTC timestamp (not a bare assert) so
+the run is auditable in CI logs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DASHBOARD = _REPO_ROOT / "grafana" / "provisioning" / "dashboards" / "json" / "firmware-twin-divergence.json"
+
+# Columns defined by db/migrations/155-twin-observability-tables.sql + 01-schema.
+TWIN_DECISIONS_COLS = {
+    "ts",
+    "twin_env",
+    "twin_ref",
+    "input_ts",
+    "mode",
+    "climate_action",
+    "mist_stage",
+    "relay_fog",
+    "relay_vent",
+    "relay_fan1",
+    "relay_fan2",
+    "relay_heat1",
+    "relay_heat2",
+    "mode_reason",
+    "override_bits",
+    "twin_metadata",
+    "greenhouse_id",
+}
+FIRMWARE_TWIN_DIVERGENCE_COLS = {
+    "ts",
+    "comparison",
+    "window_start",
+    "window_end",
+    "ref_twin_ref",
+    "cmp_twin_ref",
+    "samples",
+    "disagree_count",
+    "relay_disagree_pct",
+    "mode_disagree_pct",
+    "per_relay",
+    "by_mode",
+    "by_daypart",
+    "by_outdoor_band",
+    "worst_examples",
+    "greenhouse_id",
+}
+EQUIPMENT_STATE_COLS = {"ts", "equipment", "state"}
+
+ALLOWED_TABLES = {
+    "twin_decisions": TWIN_DECISIONS_COLS,
+    "firmware_twin_divergence": FIRMWARE_TWIN_DIVERGENCE_COLS,
+    "equipment_state": EQUIPMENT_STATE_COLS,
+}
+# CTE aliases that are not real tables.
+CTE_ALIASES = {"twin_ticks"}
+
+# The six climate relays (migration per_relay jsonb keys + equipment_state names).
+CLIMATE_RELAYS = {"fog", "vent", "fan1", "fan2", "heat1", "heat2"}
+
+
+def _load() -> dict:
+    return json.loads(_DASHBOARD.read_text())
+
+
+def _all_sql(dash: dict) -> str:
+    return "\n".join(t.get("rawSql", "") for p in dash["panels"] for t in p.get("targets", []))
+
+
+def test_dashboard_json_is_valid_and_provisioned() -> None:
+    assert _DASHBOARD.is_file(), f"missing dashboard {_DASHBOARD}"
+    dash = _load()
+    assert dash["uid"] == "firmware-twin-divergence"
+    assert dash["schemaVersion"] >= 39
+    assert dash["panels"], "dashboard has no panels"
+
+
+def test_every_target_uses_the_timescaledb_datasource() -> None:
+    dash = _load()
+    bad: list[str] = []
+    for p in dash["panels"]:
+        for t in p.get("targets", []):
+            ds = t.get("datasource", {})
+            if ds.get("uid") != "verdify-tsdb":
+                bad.append(f"panel {p['id']} {p.get('title')!r}: {ds}")
+    assert not bad, "targets not on verdify-tsdb:\n" + "\n".join(bad)
+
+
+def test_panels_have_unique_ids_and_refids() -> None:
+    dash = _load()
+    ids = [p["id"] for p in dash["panels"]]
+    dup_ids = sorted(i for i, c in Counter(ids).items() if c > 1)
+    assert not dup_ids, f"duplicate panel ids: {dup_ids}"
+
+    failures: list[str] = []
+    for p in dash["panels"]:
+        refs = [t.get("refId") for t in p.get("targets", []) if t.get("refId")]
+        dups = sorted(r for r, c in Counter(refs).items() if c > 1)
+        if dups:
+            failures.append(f"panel {p['id']} {p.get('title')!r}: duplicate refIds {dups}")
+    assert not failures, "\n".join(failures)
+
+
+def test_queries_reference_only_real_twin_tables_and_columns() -> None:
+    """Every FROM/JOIN table is a real twin/telemetry table and every column,
+    jsonb key, and filter literal exists in migration 155 / the live schema."""
+    dash = _load()
+    sql = _all_sql(dash)
+
+    # 1. tables
+    tables = set(re.findall(r"\bFROM\s+([a-z_]+)", sql)) | set(re.findall(r"\bJOIN\s+([a-z_]+)", sql))
+    tables -= CTE_ALIASES
+    unknown = tables - set(ALLOWED_TABLES)
+    assert not unknown, f"queries reference non-twin tables: {sorted(unknown)}"
+
+    # 2. the board must actually use BOTH twin tables (the deliverable's point).
+    assert "firmware_twin_divergence" in tables
+    assert "twin_decisions" in tables
+
+    # 3. filter literals match the migration's CHECK / documented values.
+    assert set(re.findall(r"comparison\s*=\s*'([a-z_]+)'", sql)) == {"prod_vs_reality"}
+    assert set(re.findall(r"twin_env\s*=\s*'([a-z]+)'", sql)) == {"prod"}
+    assert set(re.findall(r"equipment\s*=\s*'([a-z0-9]+)'", sql)) <= CLIMATE_RELAYS
+
+    # 4. per_relay jsonb keys are exactly the six climate relays.
+    per_relay_keys = set(re.findall(r"per_relay->>'([a-z0-9]+)'", sql))
+    assert per_relay_keys <= CLIMATE_RELAYS, f"unknown per_relay keys: {per_relay_keys}"
+
+    # 5. every bare column token used against each table is a real column.
+    #    (Heuristic: scan the relay_* / metric columns we explicitly select.)
+    expected_div_cols = {
+        "relay_disagree_pct",
+        "mode_disagree_pct",
+        "samples",
+        "disagree_count",
+        "per_relay",
+        "by_mode",
+        "by_daypart",
+        "by_outdoor_band",
+        "worst_examples",
+    }
+    for col in expected_div_cols:
+        if col in sql:
+            assert col in FIRMWARE_TWIN_DIVERGENCE_COLS
+
+    expected_td_cols = {
+        "twin_env",
+        "twin_ref",
+        "relay_fog",
+        "relay_heat1",
+        "mode",
+        "climate_action",
+    }
+    for col in expected_td_cols:
+        if col in sql:
+            assert col in TWIN_DECISIONS_COLS
+
+    checked_at = datetime.now(UTC).isoformat()
+    print(f"[test_18_twin_divergence_dashboard] tables+columns verified at {checked_at}")

--- a/twin/Dockerfile
+++ b/twin/Dockerfile
@@ -1,0 +1,41 @@
+# twin/Dockerfile — firmware digital-twin (Tier 1, native logic twin).
+#
+# Design: docs/design/firmware-digital-twin.md §2.1 / §5.3. Wraps the EXACT code
+# replay_emit.cpp already compiles (g++ -std=c++17, the same compile the rule-8
+# firmware-replay-diff gate trusts) into a long-running --stream follower, then
+# runs a thin OFFLINE driver that replays a telemetry CSV through it. Read-only
+# by construction: the image carries NO actuation credential and has NO route to
+# the ESP32; the only egress is INSERT-only into the two observability tables via
+# the twin_ro role (see docker-compose.twins.yml).
+#
+# This is the LOCAL OFFLINE harness (Phase-1 deliverable). The real PROD twin
+# shadowing live telemetry needs the prod DB / applied migration 155 (Root/prod
+# migration), tracked separately on issue #34 as needs:root.
+
+# ── stage 1: compile the gated --stream harness (replay_emit_follow) ──────────
+FROM gcc:13-bookworm AS build
+WORKDIR /src
+# Only the firmware sources are needed; greenhouse_logic.h is header-only.
+COPY firmware/lib /src/firmware/lib
+COPY firmware/test/replay_emit.cpp /src/firmware/test/replay_emit.cpp
+# -DREPLAY_EMIT_STREAM produces the resident-ControlState stdin follower
+# (TWIN-1). The stock batch binary is byte-for-byte unchanged by this flag, so
+# the rule-8 corpus diff is unaffected.
+RUN g++ -std=c++17 -O2 -DREPLAY_EMIT_STREAM \
+        -I /src/firmware/lib \
+        -o /src/replay_emit_follow \
+        /src/firmware/test/replay_emit.cpp
+
+# ── stage 2: minimal hardened runtime ─────────────────────────────────────────
+# python:3.12-slim gives us psycopg for the INSERT-only sink without pulling a
+# compiler into the runtime image. No docker.sock, no actuation client.
+FROM python:3.12-slim AS runtime
+RUN pip install --no-cache-dir "psycopg[binary]>=3.1" \
+    && useradd --create-home --uid 10001 twin
+COPY --from=build /src/replay_emit_follow /usr/local/bin/replay_emit_follow
+COPY twin/offline_driver.py /usr/local/bin/offline_driver.py
+USER twin
+# The driver replays the mounted corpus CSV through the follower and (optionally)
+# writes each decision to twin_decisions via twin_ro. Both args come from env so
+# the same image serves the offline harness and a future live driver.
+ENTRYPOINT ["python", "/usr/local/bin/offline_driver.py"]

--- a/twin/offline_driver.py
+++ b/twin/offline_driver.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Offline firmware digital-twin driver (Phase-1 LOCAL harness).
+
+Design: docs/design/firmware-digital-twin.md §2.1 (native logic twin) and §5.3
+(read-only / no-actuation safety model, layer L2). This driver wraps the EXACT
+``replay_emit_follow`` binary (the ``-DREPLAY_EMIT_STREAM`` build of
+``firmware/test/replay_emit.cpp`` — the same code the rule-8 firmware-replay-diff
+gate trusts) and replays a telemetry CSV through it, parsing the decision row
+the harness flushes per tick. The decision rows map 1:1 to ``twin_decisions``
+columns (migration 155 / issue #33).
+
+This is the **offline** harness: it feeds a checked-in / mounted corpus CSV,
+not the live stream — so it runs with no live DB and no device path. It is the
+local stand-in for the real prod twin (which shadows live telemetry and needs
+the prod DB / applied migration 155; that part is Root/prod-migration-blocked).
+
+Read-only by construction (§5.3 L2):
+  * No actuation client, no MQTT publish, no ESP32 route — this process only
+    reads a CSV and (optionally) INSERTs into twin_decisions.
+  * If TWIN_DSN is set it connects as the INSERT-only ``twin_ro`` login user and
+    asserts at startup that the role CANNOT write a control-plane table; it
+    aborts loudly if that assertion fails. With no TWIN_DSN it runs in
+    dry-run/stdout mode (pure offline replay, no DB at all).
+
+Env:
+  TWIN_CSV     telemetry CSV to replay        (default /data/replay_overrides.csv)
+  TWIN_REF     git sha / fw_version pinned     (default "last-good")
+  TWIN_ENV     dev|stage|prod                  (default "prod")
+  TWIN_DSN     optional INSERT-only twin_ro DSN; omit for stdout dry-run
+  TWIN_BINARY  follower path                   (default replay_emit_follow)
+  TWIN_LIMIT   stop after N ticks              (default 0 = whole CSV)
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+
+# replay_emit_follow's flushed decision header (replay_emit.cpp stream main()).
+DECISION_COLS = (
+    "ts",
+    "mode",
+    "relay_fog",
+    "relay_vent",
+    "relay_fan1",
+    "relay_fan2",
+    "relay_heat1",
+    "relay_heat2",
+    "mist_stage",
+    "reason",
+    "override_bits",
+    "climate_action",
+)
+RELAY_COLS = ("relay_fog", "relay_vent", "relay_fan1", "relay_fan2", "relay_heat1", "relay_heat2")
+
+# Control-plane table the twin_ro role MUST NOT be able to write (safety probe).
+CONTROL_TABLE = "equipment_state"
+
+
+def _open_csv(path: str) -> io.TextIOBase:
+    if path.endswith(".gz"):
+        return io.TextIOWrapper(gzip.open(path, "rb"), encoding="utf-8")
+    return open(path, encoding="utf-8")  # noqa: SIM115 - caller closes
+
+
+def _assert_read_only(conn) -> None:
+    """§5.3 L2: prove this role cannot write a control-plane table.
+
+    We probe in a savepoint and require an insufficient_privilege error. If the
+    INSERT unexpectedly succeeds (or any other outcome), the twin is NOT
+    read-only by construction and we refuse to run.
+    """
+    import psycopg
+
+    # Probe inside a nested transaction (savepoint) so the rolled-back attempt
+    # leaves no trace even in the impossible case it were permitted.
+    with conn.transaction():
+        try:
+            with conn.transaction():
+                conn.execute(f"INSERT INTO {CONTROL_TABLE} (ts, equipment, state) VALUES (now(), 'twin_probe', false)")
+        except psycopg.errors.InsufficientPrivilege:
+            return  # expected — the role is correctly write-locked
+        raise SystemExit(
+            f"FATAL: twin role could WRITE {CONTROL_TABLE}; not read-only by "
+            "construction (design §5.3 L2). Refusing to run."
+        )
+
+
+def main() -> int:
+    csv_path = os.environ.get("TWIN_CSV", "/data/replay_overrides.csv")
+    twin_ref = os.environ.get("TWIN_REF", "last-good")
+    twin_env = os.environ.get("TWIN_ENV", "prod")
+    dsn = os.environ.get("TWIN_DSN", "").strip()
+    binary = os.environ.get("TWIN_BINARY", "replay_emit_follow")
+    limit = int(os.environ.get("TWIN_LIMIT", "0"))
+
+    if twin_env not in ("dev", "stage", "prod"):
+        print(f"FATAL: TWIN_ENV must be dev|stage|prod, got {twin_env!r}", file=sys.stderr)
+        return 2
+
+    conn = None
+    if dsn:
+        import psycopg
+
+        conn = psycopg.connect(dsn, autocommit=True)
+        _assert_read_only(conn)
+        print(f"[twin] connected read-only; {CONTROL_TABLE} write-lock verified", file=sys.stderr)
+    else:
+        print("[twin] no TWIN_DSN — dry-run, decisions go to stdout only", file=sys.stderr)
+
+    # Launch the follower; prime + follow from the same CSV by piping data rows.
+    proc = subprocess.Popen(  # noqa: S603 - fixed binary, no shell
+        [binary, "--stream", "--header-from", csv_path],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    decision_header = proc.stdout.readline()  # consume the harness header line
+    if not decision_header.startswith("ts\tmode\t"):
+        print(f"FATAL: unexpected follower header: {decision_header!r}", file=sys.stderr)
+        return 3
+
+    written = 0
+    src = _open_csv(csv_path)
+    try:
+        # The replay corpus is TAB-separated (replay_emit.cpp splits on '\t');
+        # forward each data line to the follower verbatim — no re-encoding.
+        header = src.readline().rstrip("\n").split("\t")
+        ts_idx = header.index("ts")
+        for raw in src:
+            line = raw.rstrip("\n")
+            if not line:
+                continue
+            row = line.split("\t")
+            proc.stdin.write(line + "\n")
+            proc.stdin.flush()
+            decision = proc.stdout.readline().rstrip("\n").split("\t")
+            if len(decision) != len(DECISION_COLS):
+                continue  # skip malformed / gap-reset lines
+            rec = dict(zip(DECISION_COLS, decision, strict=True))
+            input_ts = row[ts_idx]
+            if conn is not None:
+                conn.execute(
+                    "INSERT INTO twin_decisions "
+                    "(ts, twin_env, twin_ref, input_ts, mode, climate_action, mist_stage, "
+                    " relay_fog, relay_vent, relay_fan1, relay_fan2, relay_heat1, relay_heat2, "
+                    " mode_reason, override_bits, twin_metadata) "
+                    "VALUES (%(ts)s, %(env)s, %(ref)s, %(input_ts)s, %(mode)s, %(action)s, "
+                    " %(mist)s, %(fog)s, %(vent)s, %(fan1)s, %(fan2)s, %(heat1)s, %(heat2)s, "
+                    " %(reason)s, %(ovr)s, %(meta)s::jsonb)",
+                    {
+                        "ts": datetime.now(UTC),
+                        "env": twin_env,
+                        "ref": twin_ref,
+                        "input_ts": input_ts,
+                        "mode": rec["mode"],
+                        "action": rec["climate_action"],
+                        "mist": int(rec["mist_stage"]),
+                        "fog": rec["relay_fog"] in ("1", "true", "True"),
+                        "vent": rec["relay_vent"] in ("1", "true", "True"),
+                        "fan1": rec["relay_fan1"] in ("1", "true", "True"),
+                        "fan2": rec["relay_fan2"] in ("1", "true", "True"),
+                        "heat1": rec["relay_heat1"] in ("1", "true", "True"),
+                        "heat2": rec["relay_heat2"] in ("1", "true", "True"),
+                        "reason": rec["reason"],
+                        "ovr": int(rec["override_bits"]),
+                        "meta": '{"vpd_zone_inputs":"homogenized","driver":"offline"}',
+                    },
+                )
+            else:
+                relays = "".join("1" if rec[c] in ("1", "true", "True") else "0" for c in RELAY_COLS)
+                print(f"{input_ts}\t{rec['mode']}\t{relays}\t{rec['climate_action']}")
+            written += 1
+            if limit and written >= limit:
+                break
+    finally:
+        src.close()
+        proc.stdin.close()
+        proc.wait(timeout=10)
+        if conn is not None:
+            conn.close()
+
+    print(f"[twin] replayed {written} ticks (env={twin_env}, ref={twin_ref})", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #34 (IN-LANE, no-device portion).

Digital twin MVP (Phase 1) prod-vs-reality dashboard + local offline twin harness. Deps #31 (setpoint coverage), #32 (`--stream` harness), #33 (twin observability tables migration 155) are merged.

## What this delivers

**`grafana/provisioning/dashboards/json/firmware-twin-divergence.json`** — the prod-vs-reality divergence board, TimescaleDB-backed (`uid: verdify-tsdb`) over the real migration-155 tables/columns:
- Windowed relay/mode disagreement % from `firmware_twin_divergence` (`comparison='prod_vs_reality'`), with a threshold marker at the relay min-off window — only SUSTAINED divergence is trustworthy because Tier 1 predicts FSM relay *intent*, not post-dwell relay state (design §2.2/§4.1).
- Per-relay breakdown (`per_relay` jsonb -> fog/vent/fan1/fan2/heat1/heat2).
- by-mode / by-daypart / by-outdoor-band conditioning (the `by_*` jsonb dimensions).
- Twin-predicted relay intent vs device actual: `twin_decisions(twin_env='prod')` vs `equipment_state` forward-fill — the novel firmware-vs-reality signal (twin-vs-twin is blind to a faithfully-reproduced latent bug).
- Twin freshness/staleness stat (a dark twin disables the live gates), pinned `twin_ref`, and a worst-examples triage table.

**`docker-compose.twins.yml`** — LOCAL OFFLINE overlay (TWIN-8): `twin-prod` on an internal-only `verdify-twin` network, running the exact `-DREPLAY_EMIT_STREAM` build of `replay_emit.cpp` pinned to last-good, INSERT-only via `twin_ro`, `read_only` rootfs, `cap_drop: ALL`, no docker.sock, no actuation credential, no ESP32 route — read-only by construction (design §5.3 L2). Disposable local `twin-db`, never the live DB.

**`twin/Dockerfile` + `twin/offline_driver.py`** — multi-stage native logic twin image and the offline driver. The driver replays the checked-in TSV corpus through the follower and asserts the twin role cannot write a control-plane table before any INSERT.

**`tests/test_18_twin_divergence_dashboard.py`** — static contract test (no live DB): JSON valid, every target on `verdify-tsdb`, unique panel ids/refIds, and every table/column/jsonb-key/filter-literal verified against migration 155 / the live schema (a column rename breaks the test instead of silently emptying a panel).

## Validation (evidence)
- `make lint`: **pass** (`All checks passed!`).
- `tests/test_18_twin_divergence_dashboard.py`: **4/4 pass**, UTC-stamped (e.g. `tables+columns verified at 2026-06-02T02:11:39+00:00`).
- Existing `tests/test_13_grafana_band_traceability.py`: **pass** with the new board present.
- `docker compose -f docker-compose.twins.yml config -q` and `... -f docker-compose.yml -f docker-compose.twins.yml config -q`: **exit 0** (standalone + merged).
- Offline driver runs end-to-end against the real corpus: builds `replay_emit_follow`, primes ControlState, emits decision rows (`mode`/6-relay vector/`climate_action`) and the expected TWIN-3 setpoint-coverage warning. Dry-run sample:
  ```
  2025-08-05 09:26:00+00  IDLE  000000  IDLE
  [twin] replayed 5 ticks (env=prod, ref=last-good)
  ```

## Scope / safety
- NO device path, no live writer, no SHADOW_MODE, no device egress. Read-only by construction.
- All-additive new files. Does NOT touch `docker-compose.yml`, `verdify_schemas/`, `db/migrations/`, `ingestor/entity_map.py`, or `mcp/server.py` — so Rule 7 restart note + drift guards do not apply.

## Residual — OPEN, `needs:root`
The REAL prod twin shadowing LIVE telemetry needs the prod TimescaleDB with **migration 155 applied** + the `twin` login user provisioned out-of-band (`GROUP twin_ro`). That is Root/prod-migration territory and is blocked on the prod migration. This PR delivers the dashboard + the local offline harness; the prod-shadowing cutover stays open.

requested-by: iris
