### PR TITLE
fix(#99): repin inert dev verdify-migrate to real digest + auto-repin in bump job

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -67,10 +67,11 @@ on:
     # paths-ignore is the primary, deterministic guard (skip-ci only covers the
     # exact-marker case, not e.g. a hand-edit to the overlay).
     #
-    # overlays/dev (#127): the same bump commit also repins the verdify-planner
-    # digest into overlays/dev/kustomization.yaml. dev is INERT (no ArgoCD app
-    # applied), and that repin must likewise not retrigger this workflow, so the
-    # dev overlay is included in the loop-break paths-ignore.
+    # overlays/dev (#127, #99): the same bump commit also repins the
+    # verdify-planner AND verdify-migrate digests into
+    # overlays/dev/kustomization.yaml. dev is INERT (no ArgoCD app applied), and
+    # that repin must likewise not retrigger this workflow, so the dev overlay is
+    # included in the loop-break paths-ignore.
     paths-ignore:
       - "deploy/k8s/overlays/staging/**"
       - "deploy/k8s/overlays/dev/**"
@@ -481,9 +482,11 @@ jobs:
     # longer hard-requires ANY individual image job's result in the `if:`. The
     # pin() helper below already no-ops on an empty digest, so a failed/skipped
     # image simply keeps its current overlay pin and never blocks the others.
-    # migrate stays in `needs:` ONLY so its digest is readable for the staging
-    # pin when it DOES publish (the staging overlay still references verdify-migrate),
-    # but it is dropped from the `if:` gate so its failure cannot block the bump.
+    # migrate stays in `needs:` so its digest is readable for BOTH the staging
+    # pin (the staging overlay references verdify-migrate) and the overlays/dev
+    # migrate repin (#99 — dev self-heals its migrate pin off a phantom on each
+    # green migrate build, mirroring the staging pin), but it is dropped from the
+    # `if:` gate so its failure cannot block the bump.
     # The planner image is in `needs:` ONLY to read its digest for the dev-overlay
     # repin (#127); the planner is still absent from overlays/staging.
     if: |
@@ -538,31 +541,41 @@ jobs:
           pin "$INGESTOR_DIGEST"
           pin "$MIGRATE_DIGEST"
 
-      - name: Repin planner digest into overlays/dev (#127)
+      - name: Repin planner + migrate digests into overlays/dev (#127, #99)
         env:
           PLANNER_DIGEST: ${{ needs.planner-image.outputs.image_digest }}
+          MIGRATE_DIGEST: ${{ needs.migrate-image.outputs.image_digest }}
         run: |
           set -euo pipefail
-          # AUTO-REPIN THE PLANNER DIGEST IN THE DEV OVERLAY (#127). The dev
-          # overlay carries a placeholder verdify-planner@sha256:0000… pin (no
-          # planner image had ever published). When the planner image publishes
-          # this run, write its real @sha256 digest into overlays/dev so the
-          # placeholder stops being a dead pin. SAFE: dev is INERT — there is NO
-          # verdify-dev ArgoCD Application applied, so this bump deploys nothing.
-          # prod is NEVER touched here (human-gated). The push paths-ignore is
-          # extended to overlays/dev/** so this bump commit does not retrigger
-          # the workflow (same loop-break as overlays/staging).
-          if [ -z "${PLANNER_DIGEST:-}" ]; then
-            echo "no planner digest published this run (job skipped/failed); keeping the existing dev pin."
-            exit 0
-          fi
-          case "$PLANNER_DIGEST" in
-            *@sha256:*) ;;
-            *) echo "refusing non-digest planner image ref: $PLANNER_DIGEST" >&2; exit 1 ;;
-          esac
+          # AUTO-REPIN THE PLANNER + MIGRATE DIGESTS IN THE DEV OVERLAY (#127,
+          # #99). The dev overlay reuses the staging-verified app-image digests
+          # as a known-good baseline, but the planner and migrate pins can drift
+          # to a phantom (a placeholder @sha256:0000… for planner; a deleted
+          # digest for migrate). When either image publishes this run, write its
+          # real @sha256 digest into overlays/dev so neither stays a dead pin.
+          # The dev migrate repin MIRRORS the staging migrate pin above (same
+          # MIGRATE_DIGEST source), so a migrate-impacting (db/**) push now
+          # self-heals BOTH overlays' migrate pin in one bump. SAFE: dev is
+          # INERT — there is NO verdify-dev ArgoCD Application applied, so this
+          # bump deploys nothing. prod is NEVER touched here (human-gated). The
+          # push paths-ignore is extended to overlays/dev/** so this bump commit
+          # does not retrigger the workflow (same loop-break as overlays/staging).
           cd deploy/k8s/overlays/dev
-          kustomize edit set image "$PLANNER_DIGEST"
-          echo "repinned dev planner -> $PLANNER_DIGEST"
+          repin() {
+            local label="$1" ref="$2"
+            if [ -z "$ref" ]; then
+              echo "no $label digest published this run (job skipped/failed); keeping the existing dev pin."
+              return 0
+            fi
+            case "$ref" in
+              *@sha256:*) ;;
+              *) echo "refusing non-digest $label image ref: $ref" >&2; exit 1 ;;
+            esac
+            kustomize edit set image "$ref"
+            echo "repinned dev $label -> $ref"
+          }
+          repin planner "${PLANNER_DIGEST:-}"
+          repin migrate "${MIGRATE_DIGEST:-}"
 
       - name: Validate digest-only render
         run: |

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -62,10 +62,12 @@ patches:
 
 # Image digest pins. Canonical namespace ghcr.io/verdifyconsultancy/verdify-*,
 # immutable @sha256 (NEVER a mutable :latest/:dev tag). The app images reuse the
-# staging-verified digests as a known-good baseline; verdify-planner now carries
-# its real published GHCR digest (#99 — the image is published + repo-linked; the
-# bump-staging-digests job auto-repins it on each green planner build). dev is
-# INERT (no ArgoCD app), so this pin deploys nothing.
+# staging-verified digests as a known-good baseline; verdify-planner and
+# verdify-migrate now carry their real published GHCR digests (#99 — both images
+# are published + repo-linked; the bump-staging-digests job auto-repins BOTH the
+# planner (on each green planner build) and the migrate (on each green migrate
+# build) digest into this dev overlay, so neither self-heals away from a phantom
+# pin again). dev is INERT (no ArgoCD app), so this pin deploys nothing.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
     digest: sha256:ce4ca79f9e6442c39558cbe02b1665c3cddc3e269c1867997d4f292f3a5ce8ff
@@ -74,7 +76,7 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
     digest: sha256:4f141a5901f802e52b37b15a6a92b8d0bc906f3d854066e3ddd52911aa457d0d
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
-    digest: sha256:7a39c3deb6df2182c7480cdd653bffa6575570bbfd262bf7c9694abcc58badf5
+    digest: sha256:aa85ac7ff3839f78620784095df2eea09031810083a486a3995f275fb892d24f
   - name: ghcr.io/verdifyconsultancy/verdify-planner
     digest: sha256:3e51abaec6372c0bed26ef9859a80008261fcd20a1e8ec1e37627304e1c6b637
   # verdify-www (#116): real GHCR digest of the marketing site image built from


### PR DESCRIPTION
## Summary

Clean up the inert dev `verdify-migrate` phantom pin (harmless follow-up to the #99 dev residual). `deploy/k8s/overlays/dev/kustomization.yaml` pinned `verdify-migrate` at the deleted phantom `sha256:7a39c3de…`, which no longer resolves in GHCR. dev is INERT (no `verdify-dev` ArgoCD Application applied), so the dead pin deploys nothing — but it should be correct.

## Changes

1. **`overlays/dev/kustomization.yaml`** — repin `verdify-migrate` to `sha256:aa85ac7f…`, the real published, repo-linked digest that `overlays/staging` already pins. Verified via the org GHCR package API:
   - phantom `sha256:7a39c3de…` → **NOT published**
   - `sha256:aa85ac7f…` → **published**, carries `local-dev` + `branch-live-platform-main` tags (newest version).
2. **`container-publish.yml` `bump-staging-digests`** (PREFERRED option) — extend the existing dev-overlay repin step so it repins **both** the planner (existing #127) **and** the migrate digest into `overlays/dev`, mirroring the staging migrate pin (same `MIGRATE_DIGEST` source). A migrate-impacting (`db/**`) push now self-heals **both** overlays' migrate pin in one bump, so dev never strands on a phantom migrate pin again. The `repin()` helper no-ops on an empty digest, so a skipped/failed migrate job keeps the existing dev pin (same posture as the planner repin).

## Safety

- dev stays INERT: no ArgoCD app, `ingestor` `replicas:0`, `VERDIFY_DEVICE_WRITE_ENABLED=0`, `deny-esp32-egress`.
- prod overlay and the device-write / egress posture are **untouched**; no prod-safety guard weakened. The bump job only ever `cd`s into `overlays/{staging,dev}` — never prod.
- Loop-break unchanged: `overlays/dev/**` is already in the `push` `paths-ignore`, so the bump commit's dev repin does not retrigger the workflow.

## Validation

- `actionlint` — `container-publish.yml` clean (run isolated: exit 0; repo-wide adds 0 new findings vs base; the 2 pre-existing shellcheck info issues are in `ci.yml` + `promote-diff-guard.yml`, not this PR).
- `kustomize build deploy/k8s/overlays/dev` — succeeds; every `verdify-*` image is `@sha256`-pinned (migrate now `aa85ac7f…`).
- `make lint` (ruff) — clean.

References the #99 dev residual. Closes nothing specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
