### PR TITLE
db: complete DB parity tooling — refresh backfill ledger + runbook counts (parity-tooling)

### DIFF
--- a/db/ledger/backfill_ledger.sql
+++ b/db/ledger/backfill_ledger.sql
@@ -161,7 +161,13 @@ SELECT stamp_migration('db/migrations/147-reward-swap-and-ladder-reanchor.sql', 
 SELECT stamp_migration('db/migrations/148-plan-accuracy-repoint-plan-journal.sql', 'db/migrations', 148, '873f4fb0a57dc7b2702094d4e7b83bea271f222bf986dcc25729a9b5ab87f928', 'baseline');
 SELECT stamp_migration('db/migrations/149-compress-snapshot-open-alerts-zone-kpis.sql', 'db/migrations', 149, 'bc770faa85973a1d614f1defa5265e603d04736aaf9f52b9fac5aa75316337aa', 'baseline');
 SELECT stamp_migration('db/migrations/150-vanda-nutrient-recipe.sql', 'db/migrations', 150, '89326344502f4d6c28961e002321658b47f6317de44a9bfaa331dd9c7cb487c6', 'baseline');
-SELECT stamp_migration('planner_graph/migrations/001_planner_memory.sql', 'planner_graph/migrations', 1, NULL, 'baseline');
+SELECT stamp_migration('db/migrations/151-backfill-suppressed-sensor-offline-resolved-at.sql', 'db/migrations', 151, '05de42dc96d1f7b9869ca463c30e40eed90bed4ef411c48f17212d5c597f6fa8', 'baseline');
+SELECT stamp_migration('db/migrations/152-kwh-coalesce-sanity-gate.sql', 'db/migrations', 152, 'af6e312cfb8278955e08ea1019d65a93b10fb863c746154ae8bf2de17e421d97', 'baseline');
+SELECT stamp_migration('db/migrations/153-pipeline-health-weather-station-dark-sources.sql', 'db/migrations', 153, '7ccce5af590167f1cb90d6186c0dfd2a77b3889e0fc33e7b6b8d65b0811cf9e3', 'baseline');
+SELECT stamp_migration('db/migrations/154-consolidate-oscillation-views.sql', 'db/migrations', 154, '33cf6059d8df0b4d608f8913c6dce302a7917fa3b2ed8c9e475fecdac6e91375', 'baseline');
+SELECT stamp_migration('db/migrations/155-twin-observability-tables.sql', 'db/migrations', 155, 'bfbf32c08a21f396e5721b9a5c539a93bcd8f81db771055e016fd90923a1223c', 'baseline');
+SELECT stamp_migration('db/migrations/156-prune-active-planner-lessons.sql', 'db/migrations', 156, '2a5177c4e75a60cdc5c907ee52fbfb2bf9e32b1ec361ace7b577bbd55380da44', 'baseline');
+SELECT stamp_migration('planner_graph/migrations/001_planner_memory.sql', 'planner_graph/migrations', 1, 'fadceba8d3f49eaa9e11e53fe9d22888228a9177e2532266732e1aca7cb2dd98', 'baseline');
 COMMIT;
 
--- stamped: 157 db/migrations + 1 planner_graph migration
+-- stamped: 163 db/migrations + 1 planner_graph migration

--- a/docs/runbooks/db-copy-not-move.md
+++ b/docs/runbooks/db-copy-not-move.md
@@ -468,7 +468,7 @@ Key design choices:
   duplicate numbers (`031, 060, 070, 071, 072, 073, 074, 078` each appear twice)
   and gaps (`001, 019, 067` are absent), so an integer `version` cannot
   represent the history. Primary key is `(source, filename)`.
-- **One ledger, two streams.** `source='db/migrations'` (this repo, 157 files)
+- **One ledger, two streams.** `source='db/migrations'` (this repo, 163 files)
   and `source='planner_graph/migrations'` (the `001_planner_memory.sql` migration
   that lives in the separate verdify planner repo). Both coexist in one table.
 - **`sha256` per file** so a restored DB can detect a migration that was
@@ -480,8 +480,8 @@ Key design choices:
 The one-time baseline stamp for the existing prod schema is **generated** (never
 hand-written) by **`scripts/gen-ledger-backfill.sh`**, which reads every
 `db/migrations/*.sql` + the planner migration, computes sha256s, and writes
-**`db/ledger/backfill_ledger.sql`** (158 `stamp_migration` calls:
-157 + 1 planner). Regenerate it after adding any migration.
+**`db/ledger/backfill_ledger.sql`** (164 `stamp_migration` calls:
+163 + 1 planner). Regenerate it after adding any migration.
 
 Rollout (sequenced under IRIS-W008/W010, not in this PR):
 
@@ -495,7 +495,7 @@ psql ... -f db/ledger/backfill_ledger.sql
 ```
 
 Validated on a disposable TimescaleDB fixture (never the live DB): DDL applies,
-158 rows stamped (`seq=31` correctly carries 2 rows — the duplicate-number
+164 rows stamped (`seq=31` correctly carries 2 rows — the duplicate-number
 proof), and re-running the backfill leaves the count unchanged (idempotent).
 
 ---


### PR DESCRIPTION
Completes the DB parity tooling deliverable. Refs #129 / #72. requested-by: iris

## What this is

The 9-dimension read-only parity diff and its supporting artifacts landed in #142:
- `scripts/db-parity.sh` — read-only iris-vs-target diff across 9 dimensions (tables/views, extensions, hypertables, continuous-aggregates, bg jobs, row-counts by RPO window, max timestamps with skew, compression set, restore recency), exit 0 = parity / non-zero on divergence, built on `scripts/lib/psql-verdify.sh`.
- `db/ledger/schema_migrations.sql` — applied-migrations ledger DDL (identity = `(source, filename)` to survive duplicate/gapped migration numbers) + idempotent `stamp_migration()` helper.
- `docs/runbooks/db-copy-not-move.md` — by-hand copy-not-move restore runbook (pre_restore → `pg_restore --data-only` → post_restore → ANALYZE → REFRESH matviews → re-add policies) with the G-DB-4 parity-gate checklist.

This PR closes the residual **drift** in the generated/derived artifacts so the set is self-consistent again.

## Changes

- **`db/ledger/backfill_ledger.sql` regenerated** via `scripts/gen-ledger-backfill.sh`. The committed file was generated at 157 `db/migrations`; migrations 151-156 have since landed, so the script's "DO NOT hand-edit; regenerate after adding migrations" contract was being violated (only 157 of 163 files stamped). Now **163 db/migrations + 1 planner = 164** `stamp_migration` calls. The planner migration is present in this checkout so it now stamps with a real sha256 instead of `NULL`.
- **`docs/runbooks/db-copy-not-move.md`** — the three pinned count references (157 files / 158 calls / 158 rows stamped) updated to **163 / 164 / 164** to match the regenerated artifact.

## Validation

All on **disposable** TimescaleDB containers (`verdify-parity-fixture`, `verdify-parity-divergent`, both removed after). The live `verdify-timescaledb` was **never** touched; every session is read-only via `scripts/lib/psql-verdify.sh`.

- `bash -n` clean on `db-parity.sh`, `lib/psql-verdify.sh`, `gen-ledger-backfill.sh`.
- Ledger DDL + backfill applied to a fixture: **164 rows**; `seq=31` carries **2 distinct filenames** (`031-setpoint-plan` / `031-setpoint-schedule` — the duplicate-number proof); re-applying the backfill is **idempotent** (count stays 164).
- **Self-parity smoke** (iris==target fixture): **exit 0**, `PARITY: all 9 dimensions match`.
- **Divergent fixture** (dropped table, extra hypertable, no compression, no policy job, more in-window rows): **exit 1**, 6 dimensions flagged (base_tables / hypertables / jobs / row-counts-by-scope / max-timestamps / compression).
- `make lint`: All checks passed.

## Safety

- Honors the **single-writer invariant** — read-only tooling only; nothing here enables a 2nd writer. Prod ingestor stays `replicas:0`/device-dark until the Jason-gated M5.
- **migrate-as-is**, no device path, no secrets, no live cluster/DNS access — repo artifacts only.
- `db/ledger/schema_migrations.sql` is a DESIGN ARTIFACT / DDL template, **not** a numbered `db/migrations/NNN-*.sql`. The ledger rollout itself stays sequenced under IRIS-W008/W010, not this PR. #177/M7 unaffected (deferred, design-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)