### PR TITLE
feat(deploy/k8s): prod DB backup substrate component (M3.3)

### DIFF
--- a/deploy/k8s/components/db-backup/backup-cronjob.yaml
+++ b/deploy/k8s/components/db-backup/backup-cronjob.yaml
@@ -1,0 +1,184 @@
+# Nightly pg_dump -Fc of verdify-db -> the verdify-db-dumps PVC, with retention
+# (M3.3 prod DB substrate; refs #84/#28/#130).
+#
+# READ-ONLY-ON-THE-DB: this is a BACKUP reader, NOT a second writer. It runs
+# pg_dump (SELECT-only against the live DB) — it NEVER writes the verdify DB and
+# therefore does NOT violate the single-writer invariant. It is the dumps-PVC's
+# only writer (it drops .dump files + prunes), but the verdify DB itself is read
+# exclusively. Safe to enable in ANY env (prod stays replicas:0/device-dark on
+# the ingestor regardless; a backup job is orthogonal to the device path).
+#
+# NOT AUTO-ENABLED: referenced by no overlay. Root opts an env in (or applies
+# this component standalone) once the synology-iscsi-ssd class + the NFS PV
+# behind verdify-db-dumps exist. Merging it to live/platform-main schedules
+# nothing on the live staging app.
+#
+# IMAGE: the SAME pinned timescaledb image as the DB StatefulSet + migration Job
+# (timescale/timescaledb:2.25.2-pg16). pg_dump must be >= the server version, so
+# pinning the identical image guarantees the dump client never trails the engine
+# (same reasoning as db-statefulset.yaml). This is an upstream image, not an app
+# image, so the kustomization images: transformer leaves it untouched.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: verdify-db-backup
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup
+spec:
+  # 02:17 every day. Off-peak; the planner/ingestor cadence is unaffected by a
+  # SELECT-only dump.
+  schedule: "17 2 * * *"
+  # Never stack backups: if a prior dump is still running, skip this tick.
+  concurrencyPolicy: Forbid
+  # Don't fire a storm of missed runs if the cluster was down for a while.
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: db-backup
+    spec:
+      backoffLimit: 2
+      # Reap the Job 24h after it finishes so completed backups don't pile up.
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: verdify
+            app.kubernetes.io/component: db-backup
+        spec:
+          restartPolicy: Never
+          # The timescaledb image is public, but reference the namespace pull
+          # secret for parity with the DB/migrate pods (a future private mirror
+          # swap then needs no manifest change). Same secret as the rest of the
+          # workloads.
+          imagePullSecrets:
+            - name: ghcr-jvallery-readonly
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999          # postgres uid in the timescaledb image
+            runAsGroup: 999
+            fsGroup: 999            # so the NFS dumps mount is group-writable
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: pg-dump
+              image: timescale/timescaledb:2.25.2-pg16
+              # bash (present in the Debian-based timescaledb image): the script
+              # uses `set -o pipefail`, which is NOT POSIX and is unreliable
+              # under a dash /bin/sh, so invoke bash explicitly.
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+                  out="${BACKUP_DIR}/verdify-${ts}.dump"
+                  echo "[backup] pg_dump -Fc ${DB_NAME}@${DB_HOST} -> ${out}"
+                  # -Fc custom format (compressed, restorable with pg_restore;
+                  # preserves the TimescaleDB hypertable/compression catalog when
+                  # paired with timescaledb_pre/post_restore at restore time).
+                  # Write to a .partial file first, then atomically rename, so a
+                  # crash mid-dump never leaves a truncated file that the prune
+                  # or a restore could mistake for a good backup.
+                  pg_dump -Fc -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" \
+                    -d "${DB_NAME}" -f "${out}.partial"
+                  mv "${out}.partial" "${out}"
+                  echo "[backup] wrote ${out} ($(du -h "${out}" | cut -f1))"
+                  # RETENTION: keep the newest ${RETENTION_DAYS} days of dumps;
+                  # delete older ones. Also sweep any stale *.partial from a
+                  # crashed prior run. Pruning never touches the live DB.
+                  echo "[backup] pruning dumps older than ${RETENTION_DAYS}d in ${BACKUP_DIR}"
+                  find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'verdify-*.dump' \
+                    -mtime "+${RETENTION_DAYS}" -print -delete || true
+                  find "${BACKUP_DIR}" -maxdepth 1 -type f -name 'verdify-*.dump.partial' \
+                    -mtime +1 -print -delete || true
+                  echo "[backup] done"
+              env:
+                # Non-secret connection fields from the shared verdify-config
+                # ConfigMap (same source the api/ingestor/migrate use).
+                - name: DB_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      name: verdify-config
+                      key: DB_HOST
+                - name: DB_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: verdify-config
+                      key: DB_PORT
+                - name: DB_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: verdify-config
+                      key: DB_NAME
+                - name: DB_USER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: verdify-config
+                      key: DB_USER
+                # libpq picks PGPASSWORD up automatically; sourced from the same
+                # Secret key the DB/migrate pods use. Read-only use (pg_dump).
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: verdify-app-secrets
+                      key: POSTGRES_PASSWORD
+                - name: BACKUP_DIR
+                  value: /backups
+                # Retention window in days (find -mtime). Tunable by Root per
+                # env without touching the dump logic.
+                - name: RETENTION_DAYS
+                  value: "14"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "256Mi"
+                limits:
+                  memory: "1Gi"
+              volumeMounts:
+                - name: dumps
+                  mountPath: /backups
+                # pg_dump scratch (TLS, libpq tmp); root FS is read-only.
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: dumps
+              persistentVolumeClaim:
+                claimName: verdify-db-dumps
+            - name: tmp
+              emptyDir: {}
+---
+# Let the backup pod reach the DB on 5432. The base allow-db-from-app policy
+# only names api/mcp/ingestor/migrate as DB clients; this adds db-backup so the
+# pg_dump connection is allowed under a NetworkPolicy-enforcing CNI (Cilium,
+# ADR-17). It is INGRESS-to-the-DB only (label db-backup -> db:5432); it grants
+# the backup pod NO other reachability and touches no device VLAN.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db-from-backup
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: db
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: db-backup
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/deploy/k8s/components/db-backup/dumps-pvc.yaml
+++ b/deploy/k8s/components/db-backup/dumps-pvc.yaml
@@ -1,0 +1,49 @@
+# verdify-db-dumps — the pg_dump landing volume for the nightly backup CronJob
+# (M3.3 prod DB substrate; refs #84/#28/#130).
+#
+# BACKING STORE: an NFS export on the Synology (the NAS-backed /mnt/jason share
+# the staging-migration preflight pg_dump already used as the off-box dump
+# target). NFS, not iSCSI/local-path, because backups want a SHARED,
+# many-reader, host-mountable volume that survives the cluster entirely — a
+# human (or a restore Job) reads the .dump file straight off the NAS without a
+# pod. iSCSI SSD is the live-DB hot path; backups belong on cheap shared NFS.
+#
+# storageClassName: "" + a matching PV is the contract Root completes. This PVC
+# binds to a STATICALLY PROVISIONED NFS PersistentVolume that Root applies at
+# the platform layer (the NFS server IP + export path are platform facts, not
+# repo facts, so they live in Root's PV, not here). Setting storageClassName to
+# the empty string opts OUT of dynamic provisioning so this never accidentally
+# carves a new dynamic volume — it waits for Root's named PV.
+#
+# READ-ONLY INTENT: the dumps volume is the system-of-record for backups. The
+# nightly CronJob is the ONLY writer (it mounts this RW to drop new .dump files
+# and prune old ones); every OTHER consumer (a human, a restore Job, an audit)
+# mounts it readOnly. The accessMode is ReadWriteMany so the single writer +
+# many readers can coexist (NFS supports RWX); the CronJob volumeMount is the
+# sole readOnly:false mount in this component. "read-only NFS PVC" in the M3.3
+# spec = read-only to everyone EXCEPT the backup writer.
+#
+# NOT AUTO-ENABLED: referenced by no overlay; Root opts an env in. Merging this
+# provisions nothing on the live staging app.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: verdify-db-dumps
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup
+spec:
+  accessModes: ["ReadWriteMany"]
+  # Empty string -> bind to a pre-provisioned (static) NFS PV by selector/size,
+  # never dynamically provision. Root supplies the matching PV.
+  storageClassName: ""
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: verdify
+      app.kubernetes.io/component: db-backup
+  resources:
+    requests:
+      # Sized for many nightly -Fc dumps of the verdify TimescaleDB plus the
+      # retention headroom the CronJob's prune keeps. Root can grow the backing
+      # NFS PV without touching the workloads.
+      storage: 100Gi

--- a/deploy/k8s/components/db-backup/kustomization.yaml
+++ b/deploy/k8s/components/db-backup/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Kustomize COMPONENT: the namespaced prod DB backup substrate (M3.3; refs
+# #84/#28/#130). An env opts in by listing ../../components/db-backup under its
+# overlay `components:` (same pattern as planner/mqtt-broker/www). Referenced by
+# NO overlay today, so it renders into nothing the live verdify-local-staging
+# ArgoCD app syncs — merging it deploys nothing. Root (or a deliberate overlay
+# opt-in) turns it on.
+#
+# Contains the NAMESPACED resources only (they inherit the overlay namespace):
+#   - dumps-pvc.yaml      verdify-db-dumps PVC (binds Root's static NFS PV)
+#   - backup-cronjob.yaml nightly pg_dump -Fc + retention + db-backup->db allow
+#
+# The cluster-scoped synology-iscsi-ssd StorageClass is DELIBERATELY NOT here —
+# it lives in ./storageclass as its own kustomization so it is applied once per
+# CLUSTER, not once per namespace (see that dir's header).
+#
+# SINGLE-WRITER SAFE: the CronJob reads the DB with pg_dump (SELECT-only) and
+# only writes the dumps PVC. It is not a second DB writer and does not touch the
+# device path, so it is safe to enable independently of the M5 prod ingestor
+# gate.
+resources:
+  - dumps-pvc.yaml
+  - backup-cronjob.yaml

--- a/deploy/k8s/components/db-backup/storageclass/kustomization.yaml
+++ b/deploy/k8s/components/db-backup/storageclass/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reusable, CLUSTER-SCOPED synology-iscsi-ssd StorageClass (M3.3; refs
+# #84/#28/#130). Kept in its OWN kustomization (kind: Kustomization, not a
+# Component) because a StorageClass is cluster-scoped: it must be applied ONCE
+# per cluster, NOT once per namespace. If it were bundled into the namespaced
+# db-backup Component, every env that pulled that Component would re-render the
+# same cluster-scoped object and two ArgoCD apps would fight over ownership.
+#
+# CONSUME EXPLICITLY: Root applies this directly
+#   kustomize build deploy/k8s/components/db-backup/storageclass | kubectl apply -f -
+# (the platform-layer owner of cluster-scoped objects), OR a single env's
+# overlay lists ../../components/db-backup/storageclass in its resources: — but
+# only ONE consumer cluster-wide. No overlay references it today, so merging it
+# creates nothing on the live cluster.
+resources:
+  - synology-iscsi-ssd.yaml

--- a/deploy/k8s/components/db-backup/storageclass/synology-iscsi-ssd.yaml
+++ b/deploy/k8s/components/db-backup/storageclass/synology-iscsi-ssd.yaml
@@ -1,0 +1,47 @@
+# Reusable in-repo definition of the volume1 'synology-iscsi-ssd' StorageClass
+# (M3.3 prod DB substrate; refs #84/#28/#130).
+#
+# WHY THIS EXISTS: every overlay (overlays/{dev,staging,prod}) retargets the
+# verdify-db volumeClaimTemplate onto storageClassName: synology-iscsi-ssd, but
+# the class itself was never defined in this repo — it was hand-applied by
+# laptop-root at the platform layer, so the manifests reference a name with no
+# in-repo source of truth. This file makes that class a reusable, reviewable
+# artifact ROOT can apply (or that an env can opt into via the db-backup
+# component) instead of a side-channel kubectl apply.
+#
+# NOT AUTO-ENABLED: this component is referenced by NO overlay. Adding it to a
+# StorageClass tree is cluster-scoped + Root-gated — the live ArgoCD app syncs
+# only overlays/staging, and overlays/staging does NOT pull this component, so
+# merging it provisions nothing and cannot create a duplicate/conflicting class
+# on the live cluster. Root applies it (or an overlay opts in) deliberately.
+#
+# PROVISIONER: the Synology CSI driver (csi.san.synology.com), volume1 SSD pool,
+# matching the class dev/staging/prod already name and the staging migration
+# (commit 4024f4d) already proved against a real worker-bound PVC.
+#
+# reclaimPolicy: Retain is the whole point for a DB volume — when the bound PVC
+# is deleted (e.g. an immutable volumeClaimTemplate retarget forces a STS
+# delete/recreate, handoff §3.6), the underlying iSCSI LUN is RELEASED, not
+# deleted, so the data survives PVC churn and a human reclaims/rebinds it.
+# volumeBindingMode: WaitForFirstConsumer so the LUN is created on the node the
+# DB pod actually schedules onto (a WORKER, not the cordoned etcd-only node1).
+# allowVolumeExpansion: true so the 50Gi DB volume can grow without a recreate.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: synology-iscsi-ssd
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup
+provisioner: csi.san.synology.com
+parameters:
+  # volume1 SSD pool, ext4, thin-provisioned LUN — matches the proven staging
+  # migration. fsType/dsm/location are CSI-driver params Root tunes at apply if
+  # the live driver config differs; the contract here is the class NAME +
+  # Retain + WaitForFirstConsumer that the overlays depend on.
+  fsType: ext4
+  location: /volume1
+  dsm: "192.168.30.20"
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
## What

Authors the prod DB substrate manifests for ROOT to apply (M3.3), as a self-contained, opt-in component under `deploy/k8s/components/db-backup/`. Refs #84 / #28 / #130. `requested-by: iris`.

Three artifacts:

1. **`storageclass/synology-iscsi-ssd.yaml`** — reusable in-repo definition of the volume1 `synology-iscsi-ssd` StorageClass (`csi.san.synology.com`) that every overlay (`overlays/{dev,staging,prod}`) already *names* but no file ever *defined*. `reclaimPolicy: Retain` (the whole point for a DB volume — data survives PVC churn / the immutable volumeClaimTemplate retarget), `volumeBindingMode: WaitForFirstConsumer`, `allowVolumeExpansion: true`. Kept in its **own `kind: Kustomization`** (not the Component) because a StorageClass is cluster-scoped and must be applied **once per cluster**, not once per namespace — bundling it into a namespaced Component would make two ArgoCD apps fight over the same cluster-scoped object.

2. **`dumps-pvc.yaml`** — the read-only `verdify-db-dumps` PVC. Backed by a **static NFS PV that Root supplies** (`storageClassName: ""` opts out of dynamic provisioning; the NFS server IP/export are platform facts, not repo facts). `ReadWriteMany` so the single CronJob writer + many read-only readers (a human, a restore Job) coexist — the backup CronJob is the *only* `readOnly:false` mount.

3. **`backup-cronjob.yaml`** — nightly (02:17) `pg_dump -Fc` of `verdify-db` → the dumps PVC, with `RETENTION_DAYS=14` prune + atomic `.partial`→`.dump` rename. Pinned to the **same `timescale/timescaledb:2.25.2-pg16`** as the DB/migrate pods so `pg_dump` never trails the engine. Includes an `allow-db-from-backup` NetworkPolicy (`db-backup` → `db:5432`) since the base `allow-db-from-app` only names api/mcp/ingestor/migrate.

## Safety / invariants

- **Not auto-enabled.** Referenced by NO overlay and NO ArgoCD app. The live `verdify-local-staging` app syncs only `overlays/staging`, which does not pull this component — merging deploys nothing. Root opts an env in (or applies the component / storageclass standalone).
- **Single-writer invariant intact.** The CronJob runs `pg_dump` (SELECT-only) against the DB; it only *writes* the dumps PVC, never the verdify DB. It does not touch the device path and is orthogonal to the M5 prod-ingestor gate (prod ingestor stays `replicas:0`/device-dark regardless).
- **migrate-as-is honored** — no firmware changes, no native-API dispatcher changes.
- **#177 / M7 not touched.**
- Zero `kind: Secret` rendered in any overlay (SECRETS.md invariant 1 holds); zero StorageClass auto-rendered into any env.

## Validation

- `kustomize build deploy/k8s/components/db-backup` → 3 resources, `kubeconform -strict -summary -ignore-missing-schemas` clean; `.../storageclass` → 1 resource, clean.
- Full-tree CI-equivalent sweep (base + all overlays + every kustomization dir, mirroring `k8s-manifests.yml`) — all green, no regressions.
- `bash -n` on the embedded CronJob script; **executed end-to-end against a disposable `timescale/timescaledb:2.25.2-pg16` container** — produced a valid `-Fc` dump, retention prune exited 0, and `pg_restore --list` confirmed the dump is restorable (TimescaleDB catalog + user table present).
- `make lint` clean. Pre-commit (yaml/json/private-key) passed.

## Root apply (handover)

```
# cluster-scoped, once per cluster:
kustomize build deploy/k8s/components/db-backup/storageclass | kubectl apply -f -
# then per-env: provide the static NFS PV behind verdify-db-dumps, and either
#   add `- ../../components/db-backup` to the env overlay's components: (Root-gated),
#   or apply the namespaced component into the target namespace directly.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)