### PR TITLE
fix(overlays/dev): pin ingestor replicas:0 — verdify-dev provably device-dark (#115)

### DIFF
--- a/deploy/k8s/overlays/dev/ingestor-replicas-zero.yaml
+++ b/deploy/k8s/overlays/dev/ingestor-replicas-zero.yaml
@@ -1,21 +1,26 @@
-# DEVICE SAFETY — dev. The ingestor is the only potentially device-touching
-# workload. In dev it runs in #114 SUBSCRIBE mode
-# (VERDIFY_INGEST_SOURCE=mqtt-subscribe, set in env-configmap.yaml): it opens NO
-# aioesphomeapi connection, runs NO occupancy bridge, and the #79 device-write
-# gate (VERDIFY_DEVICE_WRITE_ENABLED=0) bars any push regardless. It is a pure
-# read-only telemetry mirror from prod's fan-out bus into dev's own DB.
+# DEVICE SAFETY — dev (device-dark layer 2 of 3; #115).
 #
-# With subscribe mode landed (#114), dev runs the ingestor at replicas:1. There
-# is no single-writer concern: a subscriber holds no device connection, so the
-# Recreate strategy from base is sufficient and a second subscriber would at
-# worst double-write mirror rows (idempotency is the DB's concern, never the
-# device). replicas:1 keeps it lean.
+# The ingestor is the ONLY potentially device-touching workload. In dev it is
+# configured for #114 SUBSCRIBE mode (VERDIFY_INGEST_SOURCE=mqtt-subscribe, set
+# in env-configmap.yaml) and the #79 device-write gate
+# (VERDIFY_DEVICE_WRITE_ENABLED=0) bars any push regardless — but until the
+# Jason-gated M5 cutover, the WORKLOAD itself stays OFF.
+#
+# Pinned to replicas:0 so verdify-dev is PROVABLY device-dark: no ingestor pod
+# runs at all, so there is no second process anywhere that could hold an ESP32
+# native-API connection and no path by which an ArgoCD selfHeal reconcile could
+# stand one up. This MIRRORS overlays/staging/ingestor-replicas-zero.yaml and
+# upholds the single-writer invariant: prod is the ONE writer; dev/stage stay
+# replicas:0/device-dark until the gated, Jason-confirmed M5 flips them on.
+# A manual `kubectl scale` is NOT durable under selfHeal, which is exactly why
+# this pin lives in git. Flip to replicas:1 (subscribe mode) only at M5 with
+# explicit Jason sign-off.
 #
 # NOTE: filename kept (ingestor-replicas-zero.yaml) to avoid churn in the
-# kustomization patch list; it now pins replicas:1 for subscribe mode.
+# kustomization patch list.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: verdify-ingestor
 spec:
-  replicas: 1
+  replicas: 0

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -17,18 +17,18 @@ kind: Kustomization
 #   - every registry/secrets/<id>.yaml target.namespace
 namespace: verdify-dev
 
-  # Placeholder Secret for local `kustomize build` validation ONLY. The SOPS
-  # backend provides the real verdify-app-secrets out-of-band. See the file.
-  # DEVICE-SAFETY: dev-only egress lock dropping all egress to the greenhouse
-  # device VLAN (192.168.10.0/24) from the ingestor pod. Mirrors staging; the
-  # inverse allow lives ONLY in overlays/prod. See deny-esp32-egress.yaml.
-  # EDGE/WAN: host-route the dev verdify-api on api.k3s.verdify.ai through the
-  # shared apps Traefik (.7.10). dev/stage URLs live on *.k3s.verdify.ai (prod
-  # owns the bare *.verdify.ai hosts). See ingressroute.yaml.
-  # EDGE/WAN: host-route the dev verdify-www on www.k3s.verdify.ai through the
-  # same shared apps Traefik (#116). See www-ingressroute.yaml.
-  # EDGE/WAN: host-route the dev verdify-lab Quartz site on lab.k3s.verdify.ai
-  # through the same shared apps Traefik (#124). See lab-ingressroute.yaml.
+# Placeholder Secret for local `kustomize build` validation ONLY. The SOPS
+# backend provides the real verdify-app-secrets out-of-band. See the file.
+# DEVICE-SAFETY: dev-only egress lock dropping all egress to the greenhouse
+# device VLAN (192.168.10.0/24) from the ingestor pod. Mirrors staging; the
+# inverse allow lives ONLY in overlays/prod. See deny-esp32-egress.yaml.
+# EDGE/WAN: host-route the dev verdify-api on api.k3s.verdify.ai through the
+# shared apps Traefik (.7.10). dev/stage URLs live on *.k3s.verdify.ai (prod
+# owns the bare *.verdify.ai hosts). See ingressroute.yaml.
+# EDGE/WAN: host-route the dev verdify-www on www.k3s.verdify.ai through the
+# same shared apps Traefik (#116). See www-ingressroute.yaml.
+# EDGE/WAN: host-route the dev verdify-lab Quartz site on lab.k3s.verdify.ai
+# through the same shared apps Traefik (#124). See lab-ingressroute.yaml.
 resources:
 - namespace.yaml
 - ../../base
@@ -46,12 +46,18 @@ components:
 - ../../components/www
 - ../../components/lab-site
 
-  # APP_ENV=dev + VERDIFY_DEVICE_WRITE_ENABLED=0 (dev never writes the device).
-  # DEVICE SAFETY: pin the device-touching ingestor OFF until the #114
-  # subscribe-from-prod-MQTT ingest mode lands. dev must never be a 2nd writer.
-  # PER-ENV DB STORAGE (#115): retarget the verdify-db PVC from the base
-  # local-path to the volume1 'synology-iscsi-ssd' StorageClass (laptop-root
-  # gate). dev gets its OWN TimescaleDB StatefulSet on the Synology SSD.
+# APP_ENV=dev + VERDIFY_DEVICE_WRITE_ENABLED=0 + VERDIFY_INGEST_SOURCE=
+# mqtt-subscribe (dev is a read-only telemetry SUBSCRIBER, never writes the
+# device). See env-configmap.yaml.
+# DEVICE SAFETY (single-writer invariant): pin the ingestor workload OFF
+# (replicas:0), mirroring overlays/staging, so verdify-dev is PROVABLY
+# device-dark — no ingestor pod runs until the Jason-gated M5 cutover, and an
+# ArgoCD selfHeal reconcile cannot stand up a second writer. dev must never be a
+# 2nd writer. See ingestor-replicas-zero.yaml.
+# PER-ENV DB STORAGE (#115): retarget the verdify-db PVC from the base
+# local-path to the volume1 'synology-iscsi-ssd' StorageClass (laptop-root
+# gate). dev gets its OWN TimescaleDB StatefulSet on the Synology SSD (NOT
+# prod's DB), seeded by the gated copy-not-move pg_dump restore runbook.
 patches:
 - path: env-configmap.yaml
 - path: ingestor-replicas-zero.yaml


### PR DESCRIPTION
## Summary

Completes/verifies `overlays/dev` (#115): **verdify-dev must be provably device-dark with its own seeded DB.** Audited every required layer; the one real gap was the ingestor workload, which was pinned `replicas:1` (subscribe-mode rationale from #114). For a *provably* device-dark dev instance the workload is pinned **OFF (`replicas:0`)**, mirroring `overlays/staging`.

Refs #115
requested-by: iris

## The fix

- `deploy/k8s/overlays/dev/ingestor-replicas-zero.yaml`: `replicas: 1` → `replicas: 0`. No ingestor pod runs until the Jason-gated M5 cutover, and an ArgoCD selfHeal reconcile cannot stand up a second writer. Subscribe-mode env (`VERDIFY_INGEST_SOURCE=mqtt-subscribe`) stays *staged* for M5; the workload simply doesn't run yet.
- `deploy/k8s/overlays/dev/kustomization.yaml`: tidied two comment blocks that were misindented under `namespace:` / `patches:` (leftover from the staging template) and refreshed the device-safety note. No functional change.

**Single-writer invariant honored:** nothing here enables a 2nd writer; prod stays the ONE writer; dev stays device-dark until the gated M5.

## Three device-dark layers (all verified in the rendered overlay)

| Layer | Where | Status |
|---|---|---|
| 1. `VERDIFY_DEVICE_WRITE_ENABLED="0"` | `env-configmap.yaml` | present |
| 2. ingestor `replicas:0` (SHADOW/mqtt-subscribe, workload off) | `ingestor-replicas-zero.yaml` | **fixed here** |
| 3. `deny-esp32-egress` NetworkPolicy (drops `192.168.10.0/24` via `except`) | `deny-esp32-egress.yaml` | present |

**NO `allow-ingestor-device-egress` / `allow-esp32-egress` in the dev render** — that inverse exists ONLY in `overlays/prod`.

## Already-correct (verified, no change needed)

- **Own seeded DB (not prod):** `verdify-db` StatefulSet in ns `verdify-dev` on `synology-iscsi-ssd` (not prod's DB), seeded by the gated copy-not-move `pg_dump` restore runbook; PreSync migrate Job builds the schema. No `verdify-prod`/`verdify-staging` namespace leaks into the dev render.
- **URLs on `*.k3s.verdify.ai`:** `api.k3s.verdify.ai`, `www.k3s.verdify.ai`, `lab.k3s.verdify.ai` IngressRoutes through the shared apps Traefik.
- **Planner digest real:** `ghcr.io/verdifyconsultancy/verdify-planner@sha256:3e51abae...` (NOT all-zeros). `verdify-lab` stays placeholder all-zeros — that image is genuinely unpublished (orphan GHCR repo), identical posture to `overlays/prod`; out of scope for this item.

## Validation

- `kustomize build deploy/k8s/overlays/dev` → clean
- `kubeconform -strict -ignore-missing-schemas` → **22 Valid / 0 Invalid / 0 Errors** (4 skipped = Traefik IngressRoute/Middleware CRDs, no schema)
- base/staging/prod overlays still build + kubeconform clean (regression)
- `make lint` → clean
- Rendered confirmation: ingestor `replicas:0`, `deny-esp32-egress` present, **zero** `allow-esp32` rules

## INERT-ON-MERGE

No `verdify-dev` ArgoCD Application CR and no `synology-iscsi-ssd` StorageClass exist yet (both Root-created). The live `verdify-local-staging` app syncs ONLY `overlays/staging`, so merging this to `live/platform-main` deploys nothing and does not degrade staging. **Root applies the App CR separately.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)