### PR TITLE
db(g2): hypertable parity repair — convert the 15 missing telemetry tables to hypertables (#72)

### DIFF
--- a/db/migrations/157-hypertable-parity-repair.sql
+++ b/db/migrations/157-hypertable-parity-repair.sql
@@ -1,0 +1,163 @@
+-- 157-hypertable-parity-repair.sql
+-- =============================================================================
+-- G2 (issue #72, #33-family): full TimescaleDB hypertable parity repair.
+--
+-- Problem: db/schema.sql is a pg_dump snapshot. When it is replayed to stand up
+-- an empty in-cluster (k3s) database, the inherited _timescaledb_internal chunk
+-- tables come across but TimescaleDB's hypertable *catalog* rows do not get
+-- reconstructed (pg_dump from the Community edition does not emit the
+-- create_hypertable calls). The result: a table that is "already partitioned"
+-- in the dump's eyes but is ABSENT from timescaledb_information.hypertables, so
+-- in-cluster it lands as a PLAIN table — no chunking, no compression, no
+-- retention. db/migrations/000-fresh-schema-hypertable-repair.sql repairs only
+-- the 4 CORE hypertables (climate, equipment_state, system_state,
+-- weather_forecast). The other 15 of the canonical 19 come out flat.
+--
+-- The canonical 19-hypertable set (parity baseline: docs/runbooks/
+-- db-copy-not-move.md + scripts/db-parity.sh) was derived by diffing
+-- db/schema.sql's hypertables (every public table whose chunks appear as
+-- _hyper_<htid>_<chunkid>_chunk INHERITS (public.<parent>), all on time column
+-- `ts`, plus model_predictions which has no chunks yet but is a hypertable via
+-- migration 072) against the 4 repaired by 000-*. Every one of the 19 uses the
+-- TimescaleDB DEFAULT chunk_time_interval (7 days): the climate chunk CHECK
+-- boundaries in db/schema.sql step exactly 7 days, and no create_hypertable call
+-- anywhere in db/migrations/ specifies a custom chunk_time_interval. So this
+-- migration matches schema.sql's create_hypertable definitions by using the
+-- same time column (`ts`) and the same (default) interval — i.e. no explicit
+-- chunk_time_interval argument.
+--
+-- This migration converts the 15 MISSING telemetry tables into hypertables:
+--   setpoint_changes, diagnostics, energy, esp32_logs, weather_station,
+--   setpoint_plan, irrigation_log, setpoint_snapshot, forecast_deviation_log,
+--   override_events, setpoint_clamps, gpu_power, infra_cpu, climate_action_log,
+--   model_predictions
+-- so that, together with the 4 from 000-*, timescaledb_information.hypertables
+-- reaches the canonical 19. On a REAL production database every one of these is
+-- already a registered hypertable, so this migration is a no-op there.
+--
+-- Each conversion uses:
+--     create_hypertable(<tbl>, 'ts', if_not_exists => TRUE, migrate_data => TRUE)
+-- exactly as 000-* and the original create_hypertable calls do — `if_not_exists`
+-- makes it safe on a table that is already a hypertable; `migrate_data` makes it
+-- safe on a table that already holds rows (e.g. setpoint_snapshot's millions),
+-- moving existing rows into chunks. We additionally guard with the TimescaleDB
+-- catalog (skip tables that are missing or already registered) so re-applies and
+-- the production no-op are clean, and so a table sitting as a partitioned-but-
+-- unregistered shell from the dump gets its orphan _timescaledb_internal chunk
+-- children dropped first (same approach as migration 000).
+--
+-- #23 rollback-replay safety: this migration is NON-self-transactional — it has
+-- NO top-level BEGIN;/COMMIT; and NO commit-forcing statement (no CREATE INDEX
+-- CONCURRENTLY, no VACUUM). All work is in a single plpgsql DO block. It is
+-- therefore SAFE to wrap in an outer `BEGIN; ... ROLLBACK;` for rollback
+-- validation: there is no inner COMMIT to defeat the rollback. create_hypertable
+-- runs fine in psql's implicit autocommit and inside a transaction when the
+-- table is empty (the rollback-replay fixture exercises the empty case). On the
+-- live no-op path the tables are already hypertables, so the guard short-circuits
+-- BEFORE any create_hypertable call — nothing executes that could force a commit.
+-- It is idempotent (catalog guard + if_not_exists => TRUE), so it is safe to
+-- re-run.
+--
+-- Schema-change service-restart note (CLAUDE.md rule 7 does not apply — this PR
+-- touches neither verdify_schemas/** nor ingestor/entity_map.py nor mcp/server.py
+-- — but for completeness): no service needs to bounce. This only changes physical
+-- table topology (plain -> hypertable); table names, columns, and the logical
+-- read/write contract are unchanged, so verdify-mcp / verdify-ingestor keep
+-- working without a restart.
+--
+-- ROLLBACK (documented; for the disposable rollback fixture, NEVER live — on
+-- live these are long-standing hypertables holding the bulk of the DB and must
+-- not be flattened). De-hypertable-ing in place is not a supported TimescaleDB
+-- operation, so the documented rollback reverts each table to PLAIN by copying
+-- its rows into a temp table, dropping the hypertable, recreating the plain
+-- table from the temp copy, and restoring rows. For the empty fixture tables
+-- this collapses to: drop the hypertable wrapper and recreate the bare table.
+-- The fixture (db/migrations/tests/test-157-hypertable-parity-repair.sql) runs a
+-- representative rollback (drop + recreate plain) and asserts the tables revert
+-- to plain (absent from timescaledb_information.hypertables):
+--
+--   -- per missing table T (example for setpoint_snapshot; repeat per table):
+--   --   1. CREATE TEMP TABLE _rb_T AS TABLE public.T;          -- preserve rows
+--   --   2. DROP TABLE public.T;                                -- drops hypertable + chunks
+--   --   3. <recreate public.T with its original plain DDL from db/schema.sql>
+--   --   4. INSERT INTO public.T SELECT * FROM _rb_T;           -- restore rows (now plain)
+--   --   5. DROP TABLE _rb_T;
+--   -- end result: public.T present, holding its rows, ABSENT from
+--   --             timescaledb_information.hypertables (reverted to plain).
+-- =============================================================================
+
+DO $$
+DECLARE
+    target record;
+    child   record;
+    registered boolean;
+BEGIN
+    -- The 15 canonical hypertables NOT covered by migration 000 (000 does
+    -- climate / equipment_state / system_state / weather_forecast). All on `ts`,
+    -- all default chunk_time_interval (7 days) — matching db/schema.sql.
+    FOR target IN
+        SELECT * FROM (VALUES
+            ('setpoint_changes'::text,       'ts'::text),
+            ('diagnostics',                  'ts'),
+            ('energy',                       'ts'),
+            ('esp32_logs',                   'ts'),
+            ('weather_station',              'ts'),
+            ('setpoint_plan',                'ts'),
+            ('irrigation_log',               'ts'),
+            ('setpoint_snapshot',            'ts'),
+            ('forecast_deviation_log',       'ts'),
+            ('override_events',              'ts'),
+            ('setpoint_clamps',              'ts'),
+            ('gpu_power',                    'ts'),
+            ('infra_cpu',                    'ts'),
+            ('climate_action_log',          'ts'),
+            ('model_predictions',           'ts')
+        ) AS t(table_name, time_column)
+    LOOP
+        -- Skip if the table does not exist in this database (defensive: lets the
+        -- migration apply cleanly on a partial/older schema).
+        IF to_regclass(format('public.%I', target.table_name)) IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        -- Skip if it is already a registered hypertable. This is the LIVE no-op
+        -- path AND the idempotent re-apply path; it short-circuits before any
+        -- create_hypertable call, so nothing commit-forcing ever runs on live.
+        SELECT EXISTS (
+            SELECT 1
+            FROM timescaledb_information.hypertables
+            WHERE hypertable_schema = 'public'
+              AND hypertable_name = target.table_name
+        ) INTO registered;
+
+        IF registered THEN
+            CONTINUE;
+        END IF;
+
+        -- Not registered but the dump may have left inherited
+        -- _timescaledb_internal chunk children attached (a "partitioned but
+        -- unregistered" shell). Drop those orphans first so create_hypertable
+        -- starts from a clean parent — same repair pattern as migration 000.
+        FOR child IN
+            SELECT inhrelid::regclass AS child_table
+            FROM pg_inherits
+            WHERE inhparent = format('public.%I', target.table_name)::regclass
+        LOOP
+            EXECUTE format('DROP TABLE IF EXISTS %s CASCADE', child.child_table);
+        END LOOP;
+
+        -- Register the hypertable. Same call shape as migration 000 and the
+        -- original create_hypertable calls: time column `ts`, default chunk
+        -- interval, if_not_exists for safety, migrate_data so a table that
+        -- already holds rows (e.g. setpoint_snapshot) keeps them, routed into
+        -- chunks.
+        EXECUTE format(
+            'SELECT create_hypertable(%L, %L, if_not_exists => TRUE, migrate_data => TRUE)',
+            target.table_name,
+            target.time_column
+        );
+
+        RAISE NOTICE '157: converted public.% to hypertable on %',
+            target.table_name, target.time_column;
+    END LOOP;
+END $$;

--- a/db/migrations/tests/test-157-hypertable-parity-repair.sql
+++ b/db/migrations/tests/test-157-hypertable-parity-repair.sql
@@ -1,0 +1,274 @@
+-- Fixture test for migration 157 (G2 — issue #72, #33-family).
+--
+-- Self-contained, self-asserting SQL fixture for a DISPOSABLE throwaway DB only.
+-- REQUIRES TimescaleDB: migration 157 calls create_hypertable() on the 15
+-- telemetry tables that the schema.sql restore leaves as PLAIN tables, so this
+-- fixture MUST run on a timescale/timescaledb image (NOT vanilla postgres).
+--
+-- It models the exact in-cluster restore situation the migration repairs:
+--   * the 4 CORE tables (climate / equipment_state / system_state /
+--     weather_forecast) are ALREADY hypertables here (as migration 000 leaves
+--     them), to prove migration 157 does not disturb them and that the final
+--     catalog count reaches the canonical 19.
+--   * the 15 OTHER canonical tables are created as PLAIN tables (exactly how
+--     schema.sql lands them in-cluster), one of them (setpoint_snapshot) seeded
+--     with rows so create_hypertable(..., migrate_data => TRUE) is exercised on
+--     a non-empty table and the rows are asserted to survive into chunks.
+--
+-- Then it:
+--   1. APPLIES migration 157,
+--   2. asserts ALL 15 target tables are now registered hypertables AND the total
+--      public hypertable count is exactly 19 (15 new + 4 core),
+--   3. asserts seeded rows survived the migrate_data conversion and now live in
+--      chunks (data integrity of the in-place conversion),
+--   4. proves IDEMPOTENCY (re-applies the migration body inline = no error, still
+--      exactly 19 hypertables, no duplicate registration),
+--   5. runs the documented ROLLBACK for a representative table (drop hypertable
+--      + recreate plain, preserving rows) and asserts it reverts to PLAIN
+--      (present, holding its rows, ABSENT from the hypertable catalog),
+--   6. (cleanup is by container teardown; nothing here touches a live DB).
+--
+-- Every check RAISEs EXCEPTION on failure, so a clean run ending in the final
+-- NOTICE means apply + idempotency + rollback all pass.
+--
+-- Run against a DISPOSABLE TimescaleDB throwaway DB, e.g.:
+--   psql -v ON_ERROR_STOP=1 \
+--        -v migration=db/migrations/157-hypertable-parity-repair.sql \
+--        -f db/migrations/tests/test-157-hypertable-parity-repair.sql
+-- NEVER run this against the live DB — it creates/drops schema objects.
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- 0. Preconditions: TimescaleDB present; prod owner role exists.
+-- ---------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        RAISE EXCEPTION 'PRECONDITION FAIL: timescaledb extension required for migration 157 fixture';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'verdify') THEN
+        CREATE ROLE verdify;
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Minimal base schema modeling the post-schema.sql-restore state.
+--    Clean slate, then create:
+--      * 4 CORE tables AS hypertables (migration 000 already did these),
+--      * 15 OTHER canonical tables as PLAIN tables.
+--    Every canonical table has a `ts timestamptz NOT NULL` time column, matching
+--    db/schema.sql. Extra columns are minimal shape; the migration only cares
+--    about the `ts` dimension.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE t text;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'climate','equipment_state','system_state','weather_forecast',
+        'setpoint_changes','diagnostics','energy','esp32_logs','weather_station',
+        'setpoint_plan','irrigation_log','setpoint_snapshot','forecast_deviation_log',
+        'override_events','setpoint_clamps','gpu_power','infra_cpu',
+        'climate_action_log','model_predictions'
+    ]
+    LOOP
+        EXECUTE format('DROP TABLE IF EXISTS public.%I CASCADE', t);
+    END LOOP;
+END
+$$;
+
+-- A tiny helper macro is not available in psql; create each table explicitly.
+-- Shape: ts + one payload column + greenhouse_id, enough to be realistic.
+CREATE TABLE public.climate                (ts timestamptz NOT NULL, temp_f double precision,  greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.equipment_state        (ts timestamptz NOT NULL, equipment text,           greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.system_state           (ts timestamptz NOT NULL, entity text,              greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.weather_forecast       (ts timestamptz NOT NULL, temp_f double precision,  greenhouse_id text DEFAULT 'vallery');
+
+CREATE TABLE public.setpoint_changes       (ts timestamptz NOT NULL, parameter text,           greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.diagnostics            (ts timestamptz NOT NULL, metric text,              greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.energy                 (ts timestamptz NOT NULL, watts double precision,   greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.esp32_logs             (ts timestamptz NOT NULL, line text,                greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.weather_station        (ts timestamptz NOT NULL, temp_f double precision,  greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.setpoint_plan          (ts timestamptz NOT NULL, parameter text,           greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.irrigation_log         (ts timestamptz NOT NULL, zone text,                greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.setpoint_snapshot      (ts timestamptz NOT NULL, parameter text, value double precision, greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.forecast_deviation_log (ts timestamptz NOT NULL, deviation double precision, greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.override_events        (ts timestamptz NOT NULL, source text,              greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.setpoint_clamps        (ts timestamptz NOT NULL, parameter text,           greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.gpu_power              (ts timestamptz NOT NULL, watts double precision,   greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.infra_cpu              (ts timestamptz NOT NULL, pct double precision,     greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.climate_action_log     (ts timestamptz NOT NULL, climate_action text,      greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.model_predictions      (ts timestamptz NOT NULL, predicted_temp_f double precision, greenhouse_id text DEFAULT 'vallery');
+
+-- The 4 CORE tables are ALREADY hypertables (as migration 000 leaves them).
+SELECT create_hypertable('public.climate',          'ts');
+SELECT create_hypertable('public.equipment_state',  'ts');
+SELECT create_hypertable('public.system_state',     'ts');
+SELECT create_hypertable('public.weather_forecast', 'ts');
+
+-- Seed setpoint_snapshot (a PLAIN table here) with rows BEFORE the migration so
+-- create_hypertable(..., migrate_data => TRUE) is exercised on a NON-EMPTY table
+-- and we can assert the rows survive into chunks.
+INSERT INTO public.setpoint_snapshot (ts, parameter, value)
+SELECT now() - (g || ' hours')::interval, 'temp_c', 20 + g
+FROM generate_series(1, 50) AS g;
+
+DO $$
+DECLARE n int;
+BEGIN
+    -- Sanity: the 15 targets must currently be PLAIN (NOT hypertables) and the 4
+    -- core must already be hypertables, modeling the post-restore state.
+    SELECT count(*) INTO n
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public';
+    IF n <> 4 THEN
+        RAISE EXCEPTION 'SETUP FAIL: expected exactly 4 core hypertables before migration, got %', n;
+    END IF;
+    RAISE NOTICE 'SETUP OK: 4 core hypertables, 15 plain telemetry tables, 50 seeded setpoint_snapshot rows.';
+END
+$$;
+
+-- ===========================================================================
+-- 2. APPLY migration 157.
+-- ===========================================================================
+\echo '--- applying migration 157 ---'
+\i :migration
+
+-- ---------------------------------------------------------------------------
+-- 3. Assert ALL 15 targets are now hypertables AND total = canonical 19.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    expected text[] := ARRAY[
+        'setpoint_changes','diagnostics','energy','esp32_logs','weather_station',
+        'setpoint_plan','irrigation_log','setpoint_snapshot','forecast_deviation_log',
+        'override_events','setpoint_clamps','gpu_power','infra_cpu',
+        'climate_action_log','model_predictions'
+    ];
+    t   text;
+    n   int;
+    tot int;
+BEGIN
+    FOREACH t IN ARRAY expected
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM timescaledb_information.hypertables
+             WHERE hypertable_schema = 'public' AND hypertable_name = t
+        ) THEN
+            RAISE EXCEPTION 'APPLY FAIL: % was not converted to a hypertable', t;
+        END IF;
+    END LOOP;
+
+    SELECT count(*) INTO n
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND hypertable_name = ANY(expected);
+    IF n <> 15 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected 15 newly-converted hypertables, got %', n;
+    END IF;
+
+    SELECT count(*) INTO tot
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public';
+    IF tot <> 19 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected canonical 19 hypertables total (15 + 4 core), got %', tot;
+    END IF;
+
+    RAISE NOTICE 'APPLY OK: all 15 targets are hypertables; total = 19 (parity).';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3b. Assert migrate_data preserved the seeded rows AND they are in chunks.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE rowcount int; chunkcount int;
+BEGIN
+    SELECT count(*) INTO rowcount FROM public.setpoint_snapshot;
+    IF rowcount <> 50 THEN
+        RAISE EXCEPTION 'APPLY FAIL: migrate_data lost rows — setpoint_snapshot has % (expected 50)', rowcount;
+    END IF;
+
+    SELECT count(*) INTO chunkcount
+      FROM timescaledb_information.chunks
+     WHERE hypertable_schema = 'public' AND hypertable_name = 'setpoint_snapshot';
+    IF chunkcount < 1 THEN
+        RAISE EXCEPTION 'APPLY FAIL: setpoint_snapshot rows were not routed into chunks (chunks=%)', chunkcount;
+    END IF;
+
+    RAISE NOTICE 'APPLY OK: migrate_data preserved 50 rows into % chunk(s).', chunkcount;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. IDEMPOTENCY: re-apply the migration body; must not error and must leave
+--    exactly 19 hypertables with no duplicate registration.
+-- ---------------------------------------------------------------------------
+\echo '--- re-applying migration 157 (idempotency) ---'
+\i :migration
+
+DO $$
+DECLARE tot int; rowcount int;
+BEGIN
+    SELECT count(*) INTO tot
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public';
+    IF tot <> 19 THEN
+        RAISE EXCEPTION 'IDEMPOTENCY FAIL: hypertable count is % after re-apply (expected 19)', tot;
+    END IF;
+    SELECT count(*) INTO rowcount FROM public.setpoint_snapshot;
+    IF rowcount <> 50 THEN
+        RAISE EXCEPTION 'IDEMPOTENCY FAIL: re-apply changed setpoint_snapshot row count to % (expected 50)', rowcount;
+    END IF;
+    RAISE NOTICE 'IDEMPOTENCY OK: re-apply is a no-op (19 hypertables, 50 rows, no error).';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. ROLLBACK (representative): the documented revert-to-plain for one table.
+--    Copy rows -> drop hypertable -> recreate plain -> restore rows. Assert the
+--    table is present, holding its rows, and ABSENT from the hypertable catalog.
+-- ---------------------------------------------------------------------------
+\echo '--- applying documented rollback (setpoint_snapshot -> plain) ---'
+CREATE TEMP TABLE _rb_setpoint_snapshot AS TABLE public.setpoint_snapshot;
+DROP TABLE public.setpoint_snapshot;                         -- drops hypertable + chunks
+CREATE TABLE public.setpoint_snapshot (
+    ts            timestamptz NOT NULL,
+    parameter     text,
+    value         double precision,
+    greenhouse_id text DEFAULT 'vallery'
+);
+INSERT INTO public.setpoint_snapshot SELECT * FROM _rb_setpoint_snapshot;
+DROP TABLE _rb_setpoint_snapshot;
+
+DO $$
+DECLARE rowcount int; tot int;
+BEGIN
+    IF to_regclass('public.setpoint_snapshot') IS NULL THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: setpoint_snapshot missing after revert';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM timescaledb_information.hypertables
+         WHERE hypertable_schema = 'public' AND hypertable_name = 'setpoint_snapshot'
+    ) THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: setpoint_snapshot still a hypertable after revert';
+    END IF;
+    SELECT count(*) INTO rowcount FROM public.setpoint_snapshot;
+    IF rowcount <> 50 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: rows lost on revert — % (expected 50)', rowcount;
+    END IF;
+    -- The other 14 reverted-via-the-same-recipe tables stay hypertables here
+    -- (we only exercised one for brevity); total drops from 19 to 18.
+    SELECT count(*) INTO tot
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public';
+    IF tot <> 18 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: expected 18 hypertables after reverting one, got %', tot;
+    END IF;
+    RAISE NOTICE 'ROLLBACK OK: setpoint_snapshot reverted to plain, 50 rows intact, total now 18.';
+END
+$$;
+
+DO $$ BEGIN RAISE NOTICE 'ALL FIXTURE ASSERTIONS PASSED (apply + migrate_data + idempotency + rollback).'; END $$;


### PR DESCRIPTION
## G2 — TimescaleDB hypertable parity repair (issue #72, #33-family)

Converts the **15 telemetry tables that land as PLAIN tables on an in-cluster `db/schema.sql` restore** into TimescaleDB hypertables, so that — together with the 4 the existing `db/migrations/000-fresh-schema-hypertable-repair.sql` repairs — `timescaledb_information.hypertables` reaches the canonical **19** (parity baseline: `docs/runbooks/db-copy-not-move.md` + `scripts/db-parity.sh`).

### Why
`db/schema.sql` is a `pg_dump` snapshot. Replaying it in-cluster brings the inherited `_timescaledb_internal` chunk tables across but does **not** reconstruct TimescaleDB's hypertable catalog rows (the Community-edition dump does not emit `create_hypertable` calls). The result is a table that is "already partitioned" in the dump's eyes but **absent from the hypertable catalog** — i.e. flat, with no chunking / compression / retention. Migration `000-*` repairs only the 4 **core** tables (`climate`, `equipment_state`, `system_state`, `weather_forecast`).

### The missing 15 (this PR)
Derived by diffing `db/schema.sql`'s hypertable set against the 4 covered by `000-*`:

`setpoint_changes`, `diagnostics`, `energy`, `esp32_logs`, `weather_station`, `setpoint_plan`, `irrigation_log`, `setpoint_snapshot`, `forecast_deviation_log`, `override_events`, `setpoint_clamps`, `gpu_power`, `infra_cpu`, `climate_action_log`, `model_predictions`

**Derivation:** every chunk in the dump appears as `_hyper_<htid>_<chunkid>_chunk INHERITS (public.<parent>)`, giving 18 chunk-bearing parents; `model_predictions` is the 19th (created as a hypertable by migration `072-image-observations.sql` but holds no rows yet, so it has no chunks in the dump). All 19 partition on time column **`ts`** and all use the **default `chunk_time_interval` (7 days)** — the `climate` chunk CHECK boundaries in `db/schema.sql` step exactly 7 days, and **no** `create_hypertable` call anywhere in `db/migrations/` specifies a custom interval. So this migration matches `schema.sql`'s definitions by using `ts` + the default interval (no explicit `chunk_time_interval` argument).

> Note: `twin_decisions` / `firmware_twin_divergence` (migration `155`) are **not** in this set — they post-date the `db/schema.sql` snapshot (no `CREATE TABLE` for them in the dump), so they are not part of the canonical-19 schema.sql parity target.

### How
Each conversion uses the same call shape as `000-*` and the original `create_hypertable` calls:
```sql
create_hypertable(<tbl>, 'ts', if_not_exists => TRUE, migrate_data => TRUE)
```
`if_not_exists` makes it safe on a table that is already a hypertable; `migrate_data` makes it safe on a table that already holds rows (e.g. `setpoint_snapshot`'s millions), routing existing rows into chunks. The whole thing is wrapped in one `DO` block that guards on the TimescaleDB catalog (skip missing / already-registered tables; drop orphan dump chunk children first), so it is a **no-op on the live DB** where these are already hypertables.

### #23 rollback-replay safety
- **NON-self-transactional**: no top-level `COMMIT;`, no commit-forcing statement (no `CREATE INDEX CONCURRENTLY`, no `VACUUM`). Single `DO` block.
- `scripts/check_migration_rollback_safety.py --check db/migrations/157-hypertable-parity-repair.sql` -> `ok (safe-to-wrap)`.
- Verified end-to-end: replayed inside `BEGIN; ... ROLLBACK;` on empty tables; after `ROLLBACK` the hypertable count returns to **0** (nothing leaked to a committed state).
- **Idempotent** (catalog guard + `if_not_exists => TRUE`).

### CLAUDE.md rule 7 (service restart)
This PR touches **neither** `verdify_schemas/**`, `ingestor/entity_map.py`, **nor** `mcp/server.py`, so rule 7 does not apply. For completeness: **no service needs to bounce** — only physical table topology changes (plain -> hypertable); table names, columns, and the read/write contract are unchanged, so `verdify-mcp` / `verdify-ingestor` keep working without a restart.

## FIXTURE EVIDENCE
`db/migrations/tests/test-157-hypertable-parity-repair.sql`, run on a **disposable `timescale/timescaledb:2.25.2-pg16` container** (never the live DB; container destroyed after the run):

```
SETUP OK: 4 core hypertables, 15 plain telemetry tables, 50 seeded setpoint_snapshot rows.
157: converted public.setpoint_changes ... model_predictions to hypertable on ts   (15x)
APPLY OK: all 15 targets are hypertables; total = 19 (parity).
APPLY OK: migrate_data preserved 50 rows into 2 chunk(s).
IDEMPOTENCY OK: re-apply is a no-op (19 hypertables, 50 rows, no error).
ROLLBACK OK: setpoint_snapshot reverted to plain, 50 rows intact, total now 18.
ALL FIXTURE ASSERTIONS PASSED (apply + migrate_data + idempotency + rollback).
FIXTURE EXIT: 0
```
The fixture stands the 4 core tables up as hypertables (as `000-*` leaves them) + the 15 targets as plain tables (as `schema.sql` lands them), seeds `setpoint_snapshot` with 50 rows to exercise `migrate_data => TRUE` on a non-empty table, applies, asserts the catalog reaches 19, proves idempotency, then runs the documented rollback and asserts revert-to-plain.

## EXPLICIT ROLLBACK
De-hypertable-ing in place is not a supported TimescaleDB op, so the documented rollback reverts each table to **plain** by preserving its rows, dropping the hypertable, recreating the plain table, and restoring rows. Per target table `T` (example shown for `setpoint_snapshot`; repeat per table):
```sql
CREATE TEMP TABLE _rb_T AS TABLE public.T;          -- preserve rows
DROP TABLE public.T;                                -- drops hypertable + chunks
-- recreate public.T with its original plain DDL from db/schema.sql
INSERT INTO public.T SELECT * FROM _rb_T;           -- restore rows (now plain)
DROP TABLE _rb_T;
-- end state: public.T present, holding its rows, ABSENT from
--            timescaledb_information.hypertables (reverted to plain).
```
For empty target tables this collapses to: drop the hypertable wrapper and recreate the bare table. The fixture exercises the `setpoint_snapshot` case (50 rows) and asserts it reverts to plain with rows intact (total hypertables 19 -> 18).

---

**requested-by: iris — SERIALIZED MIGRATION, awaiting Jason coordinator approval, DO NOT auto-merge**
