### PR TITLE
db(g3): recreate compression + retention bg-job policies (parity 5 compressed) [SERIALIZED — DO NOT auto-merge]

### DIFF
--- a/db/migrations/158-compression-retention-policies.sql
+++ b/db/migrations/158-compression-retention-policies.sql
@@ -1,0 +1,218 @@
+-- 158-compression-retention-policies.sql
+-- =============================================================================
+-- G3 (issue #72, #33-family): recreate the TimescaleDB compression + retention
+-- background-job POLICIES so the migrated in-cluster DB matches the live VM.
+--
+-- PARITY TARGET (docs/runbooks/db-copy-not-move.md §"Canonical parity baseline"
+-- + scripts/db-parity.sh): the live VM (TimescaleDB 2.25.2) carries 11 background
+-- jobs and 5 compressed hypertables:
+--
+--   * 11 bg jobs = policy_compression×4 + policy_retention×5
+--                  + refresh_climate_merged×1 + refresh_relay_stuck×1
+--                  (job_ids 1002-1009,1014,1015,1021)
+--   * 5 compressed hypertables: climate, diagnostics, energy, esp32_logs,
+--                               setpoint_snapshot
+--
+-- This migration is G3 and owns ONLY the compression + retention policies — the
+-- policy_compression×4 + policy_retention×5 = 9 of those 11 jobs, plus the
+-- compression-ENABLED flag on all 5 compressed hypertables. The remaining 2 jobs
+-- (refresh_climate_merged / refresh_relay_stuck) are matview-refresh user-defined
+-- actions; on the live VM those run as host-cron (migration 047), are NOT
+-- TimescaleDB compression/retention policies, and are explicitly OUT OF SCOPE for
+-- G3. (If a later migration registers them as TimescaleDB UDA jobs to reach the
+-- full 11, that is a separate, serialized PR.)
+--
+-- WHY THESE ARE NOT IN db/schema.sql: db/schema.sql is a pg_dump snapshot from the
+-- TimescaleDB *Community Edition*. Community pg_dump emits neither create_hypertable
+-- calls (repaired by migrations 000 + 157/G2) NOR add_compression_policy /
+-- add_retention_policy / ALTER TABLE ... SET (timescaledb.compress ...) — the
+-- compression settings and the policy jobs are TimescaleDB *catalog* state, not
+-- table DDL, so they are silently dropped by the dump. The authoritative source
+-- for the exact policies is therefore the repo's own migration history (where the
+-- live policies were originally created) cross-checked against the parity baseline:
+--
+--   * compression policy (compress_after 7d): climate, energy, diagnostics
+--         (migration 050), setpoint_snapshot (migrations 060/149)            -> 4
+--   * retention policy: climate 365d, energy 365d, diagnostics 180d,
+--         esp32_logs 30d (migration 050), setpoint_snapshot 90d (migration 060) -> 5
+--   * compression ENABLED on all 5 (climate, energy, diagnostics, esp32_logs,
+--         setpoint_snapshot). esp32_logs is compression-ENABLED but has NO
+--         compression policy — exactly the 5-compressed / 4-compression-job split
+--         in the parity baseline (esp32_logs shows "3 chunks (0 compressed)":
+--         compression is enabled but nothing auto-compresses it; its 30-day
+--         retention drops chunks before a manual compress would matter).
+--
+-- compress_segmentby / compress_orderby: setpoint_snapshot reuses the exact
+-- settings migration 149 created on the live VM (segmentby 'parameter',
+-- orderby 'ts DESC'). For climate / energy / diagnostics / esp32_logs the live
+-- compress settings are not recoverable from any checked-in artifact (the dump
+-- strips them and migration 050 created the policy without an explicit
+-- ALTER ... SET), so we enable compression with TimescaleDB's safe default
+-- ordering (compress_orderby 'ts DESC', no segmentby). This makes the hypertable
+-- count as compression_enabled (the parity dimension db-parity.sh dimension 8
+-- checks) and lets add_compression_policy register; segmentby is a storage-layout
+-- optimization, not a parity dimension, and can be tuned later without affecting
+-- the job/compressed-set parity this migration restores.
+--
+-- DEPENDENCY ON G2 (migration 157): G2 converts the 15 non-core telemetry tables
+-- (incl. energy, diagnostics, esp32_logs, setpoint_snapshot) from PLAIN tables
+-- back into hypertables. add_compression_policy / add_retention_policy /
+-- ALTER ... SET (timescaledb.compress) only work on a registered hypertable. As of
+-- this PR, G2 (iris/g2-hypertables, migration 157) is NOT YET MERGED into
+-- live/platform-main. This migration is therefore authored as the NEXT number
+-- (158, after 157) and is written to be SAFE whether or not G2 has run: every
+-- table is guarded by a check that it is a *registered hypertable* before any
+-- compression/retention call. If G2 has run (or on the live VM) all 5 are
+-- hypertables and all policies are (re)asserted. If G2 has NOT run, only `climate`
+-- (a core hypertable from migration 000) is touched and the other 4 are skipped
+-- idempotently — so 158 must be applied AFTER 157 to reach full parity. The order
+-- 157 -> 158 is the serialized sequence coordinator approves.
+--
+-- IDEMPOTENCY: ALTER TABLE ... SET (timescaledb.compress...) is a settings UPSERT
+-- (safe to re-run). add_compression_policy / add_retention_policy are called with
+-- if_not_exists => TRUE, so a re-apply (and the LIVE no-op, where these policies
+-- already exist) is a clean no-op — no duplicate jobs. The hypertable guard also
+-- means a missing table is skipped, never an error.
+--
+-- #23 ROLLBACK-REPLAY SAFETY: this migration is NON-self-transactional. It has NO
+-- top-level BEGIN;/COMMIT; and NO commit-forcing statement (no CREATE INDEX
+-- CONCURRENTLY, no VACUUM, no ALTER SYSTEM, no CREATE/DROP DATABASE|TABLESPACE).
+-- All work is inside a single plpgsql DO block. ALTER TABLE ... SET, and the
+-- TimescaleDB add_compression_policy / add_retention_policy functions, all run
+-- inside an ordinary transaction in TimescaleDB 2.x, so this whole migration is
+-- SAFE to wrap in an outer `BEGIN; ... ROLLBACK;` for rollback validation — there
+-- is no inner COMMIT to defeat the rollback. (Verified by
+-- scripts/check_migration_rollback_safety.py: classified safe-to-wrap.)
+--
+-- SCHEMA-CHANGE SERVICE-RESTART NOTE (CLAUDE.md rule 7): this PR touches NONE of
+-- verdify_schemas/**, ingestor/entity_map.py, or mcp/server.py. It only changes
+-- TimescaleDB physical/catalog policy state (compression flag + background policy
+-- jobs); table names, columns, and the logical read/write contract are unchanged.
+-- No service needs to bounce (verdify-mcp / verdify-ingestor keep working). The
+-- policies are background jobs that run server-side on the StatefulSet.
+--
+-- ROLLBACK (documented; for the disposable rollback fixture, NEVER live — on live
+-- these policies are long-standing and dropping them stops compression/retention):
+-- the inverse of each operation, in reverse:
+--
+--   -- remove the 4 compression policies (skips ones not present):
+--   SELECT remove_compression_policy('setpoint_snapshot', if_exists => TRUE);
+--   SELECT remove_compression_policy('diagnostics',       if_exists => TRUE);
+--   SELECT remove_compression_policy('energy',            if_exists => TRUE);
+--   SELECT remove_compression_policy('climate',           if_exists => TRUE);
+--   -- remove the 5 retention policies (skips ones not present):
+--   SELECT remove_retention_policy('setpoint_snapshot', if_exists => TRUE);
+--   SELECT remove_retention_policy('esp32_logs',        if_exists => TRUE);
+--   SELECT remove_retention_policy('diagnostics',       if_exists => TRUE);
+--   SELECT remove_retention_policy('energy',            if_exists => TRUE);
+--   SELECT remove_retention_policy('climate',           if_exists => TRUE);
+--   -- (optionally) disable compression on each — only valid once chunks are
+--   -- decompressed; for the empty fixture tables it is a clean settings reset:
+--   ALTER TABLE setpoint_snapshot SET (timescaledb.compress = false);
+--   ALTER TABLE esp32_logs        SET (timescaledb.compress = false);
+--   ALTER TABLE diagnostics       SET (timescaledb.compress = false);
+--   ALTER TABLE energy            SET (timescaledb.compress = false);
+--   ALTER TABLE climate           SET (timescaledb.compress = false);
+--
+-- The fixture (db/migrations/tests/test-158-compression-retention-policies.sql)
+-- runs this exact rollback on a disposable container and asserts the
+-- compression/retention job count and compressed-hypertable count return to 0.
+-- =============================================================================
+
+DO $$
+DECLARE
+    rec          record;
+    is_ht        boolean;
+BEGIN
+    -- ── Step 1: enable compression on the 5 canonical compressed hypertables ──
+    -- segmentby/orderby per the WHY-block above. esp32_logs is enabled here but
+    -- intentionally gets NO compression policy in step 2 (5 compressed / 4 jobs).
+    FOR rec IN
+        SELECT * FROM (VALUES
+            ('climate'::text,           NULL::text,        'ts DESC'::text),
+            ('energy',                  NULL,              'ts DESC'),
+            ('diagnostics',             NULL,              'ts DESC'),
+            ('esp32_logs',              NULL,              'ts DESC'),
+            ('setpoint_snapshot',       'parameter',       'ts DESC')
+        ) AS t(table_name, segmentby, orderby)
+    LOOP
+        -- Skip if the table is not a registered hypertable in this DB. This is
+        -- the G2-not-yet-merged guard (only climate is a hypertable then) AND the
+        -- defensive guard for a partial schema. It also short-circuits before any
+        -- compression call so nothing runs that could matter on a non-hypertable.
+        SELECT EXISTS (
+            SELECT 1 FROM timescaledb_information.hypertables
+             WHERE hypertable_schema = 'public'
+               AND hypertable_name = rec.table_name
+        ) INTO is_ht;
+
+        IF NOT is_ht THEN
+            RAISE NOTICE '158: % is not a hypertable here (G2 not applied?) — skipping compression enable', rec.table_name;
+            CONTINUE;
+        END IF;
+
+        -- Enable compression (settings UPSERT — idempotent / safe to re-run).
+        IF rec.segmentby IS NULL THEN
+            EXECUTE format(
+                'ALTER TABLE public.%I SET (timescaledb.compress = true, timescaledb.compress_orderby = %L)',
+                rec.table_name, rec.orderby);
+        ELSE
+            EXECUTE format(
+                'ALTER TABLE public.%I SET (timescaledb.compress = true, timescaledb.compress_segmentby = %L, timescaledb.compress_orderby = %L)',
+                rec.table_name, rec.segmentby, rec.orderby);
+        END IF;
+        RAISE NOTICE '158: compression enabled on public.%', rec.table_name;
+    END LOOP;
+
+    -- ── Step 2: (re)create the 4 compression POLICIES (compress_after 7d) ──────
+    -- climate, energy, diagnostics, setpoint_snapshot. NOT esp32_logs.
+    FOR rec IN
+        SELECT * FROM (VALUES
+            ('climate'::text),
+            ('energy'),
+            ('diagnostics'),
+            ('setpoint_snapshot')
+        ) AS t(table_name)
+    LOOP
+        SELECT EXISTS (
+            SELECT 1 FROM timescaledb_information.hypertables
+             WHERE hypertable_schema = 'public' AND hypertable_name = rec.table_name
+        ) INTO is_ht;
+        IF NOT is_ht THEN
+            CONTINUE;
+        END IF;
+
+        -- if_not_exists => idempotent; no duplicate policy_compression job.
+        EXECUTE format(
+            'SELECT add_compression_policy(%L, INTERVAL ''7 days'', if_not_exists => TRUE)',
+            rec.table_name);
+        RAISE NOTICE '158: compression policy ensured on public.% (7d)', rec.table_name;
+    END LOOP;
+
+    -- ── Step 3: (re)create the 5 retention POLICIES (per-table interval) ───────
+    -- climate 365d, energy 365d, diagnostics 180d, esp32_logs 30d,
+    -- setpoint_snapshot 90d — exactly the live intervals (migrations 050 + 060).
+    FOR rec IN
+        SELECT * FROM (VALUES
+            ('climate'::text,         '365 days'::text),
+            ('energy',                '365 days'),
+            ('diagnostics',           '180 days'),
+            ('esp32_logs',            '30 days'),
+            ('setpoint_snapshot',     '90 days')
+        ) AS t(table_name, drop_after)
+    LOOP
+        SELECT EXISTS (
+            SELECT 1 FROM timescaledb_information.hypertables
+             WHERE hypertable_schema = 'public' AND hypertable_name = rec.table_name
+        ) INTO is_ht;
+        IF NOT is_ht THEN
+            CONTINUE;
+        END IF;
+
+        -- if_not_exists => idempotent; no duplicate policy_retention job.
+        EXECUTE format(
+            'SELECT add_retention_policy(%L, INTERVAL %L, if_not_exists => TRUE)',
+            rec.table_name, rec.drop_after);
+        RAISE NOTICE '158: retention policy ensured on public.% (drop_after %)', rec.table_name, rec.drop_after;
+    END LOOP;
+END $$;

--- a/db/migrations/tests/test-158-compression-retention-policies.sql
+++ b/db/migrations/tests/test-158-compression-retention-policies.sql
@@ -1,0 +1,279 @@
+-- Fixture test for migration 158 (G3 — issue #72, #33-family).
+--
+-- Self-contained, self-asserting SQL fixture for a DISPOSABLE throwaway DB only.
+-- REQUIRES TimescaleDB: migration 158 calls add_compression_policy /
+-- add_retention_policy / ALTER TABLE ... SET (timescaledb.compress ...), all of
+-- which only exist on a timescale/timescaledb image (NOT vanilla postgres).
+--
+-- It models the post-G2 in-cluster state the migration targets: the 5 canonical
+-- compressed/retained hypertables (climate, energy, diagnostics, esp32_logs,
+-- setpoint_snapshot) ALREADY exist as registered hypertables (as migrations
+-- 000 + 157/G2 leave them) but carry NO compression settings and NO
+-- compression/retention policy jobs (exactly how a fresh schema build lands them,
+-- because the Community pg_dump strips that catalog state).
+--
+-- Then it:
+--   1. asserts the SETUP precondition (5 hypertables, 0 compression/retention
+--      policy jobs, 0 compressed hypertables),
+--   2. APPLIES migration 158,
+--   3. asserts the PARITY end-state via the TimescaleDB catalogs:
+--        * exactly 4 policy_compression jobs (climate, energy, diagnostics,
+--          setpoint_snapshot — NOT esp32_logs),
+--        * exactly 5 policy_retention jobs (the 5 canonical, intervals correct),
+--        * exactly 5 compressed hypertables (the 5 canonical incl. esp32_logs),
+--   4. proves IDEMPOTENCY (re-applies the migration body inline = no error, still
+--      4 + 5 jobs, still 5 compressed, no duplicate jobs),
+--   5. runs the documented ROLLBACK (remove_compression_policy /
+--      remove_retention_policy + disable compress) and asserts the policy job
+--      counts and compressed-hypertable count return to 0,
+--   6. (cleanup is by container teardown; nothing here touches a live DB).
+--
+-- Every check RAISEs EXCEPTION on failure, so a clean run ending in the final
+-- NOTICE means SETUP + apply + idempotency + rollback all pass.
+--
+-- Run against a DISPOSABLE TimescaleDB throwaway DB, e.g.:
+--   psql -v ON_ERROR_STOP=1 \
+--        -v migration=db/migrations/158-compression-retention-policies.sql \
+--        -f db/migrations/tests/test-158-compression-retention-policies.sql
+-- NEVER run this against the live DB — it creates/drops schema objects + policies.
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- 0. Preconditions: TimescaleDB present; prod owner role exists.
+-- ---------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        RAISE EXCEPTION 'PRECONDITION FAIL: timescaledb extension required for migration 158 fixture';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'verdify') THEN
+        CREATE ROLE verdify;
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Minimal base schema modeling the post-G2 (157) in-cluster state: the 5
+--    canonical compressed/retained tables exist AS hypertables but with NO
+--    compression settings and NO policy jobs. `ts` is the time column on all
+--    (matching db/schema.sql). setpoint_snapshot carries `parameter` so its
+--    segmentby setting is exercised.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE t text;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'climate','energy','diagnostics','esp32_logs','setpoint_snapshot'
+    ]
+    LOOP
+        EXECUTE format('DROP TABLE IF EXISTS public.%I CASCADE', t);
+    END LOOP;
+END
+$$;
+
+CREATE TABLE public.climate           (ts timestamptz NOT NULL, temp_f double precision,         greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.energy            (ts timestamptz NOT NULL, watts double precision,          greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.diagnostics       (ts timestamptz NOT NULL, metric text,                     greenhouse_id text DEFAULT 'vallery');
+CREATE TABLE public.esp32_logs        (ts timestamptz NOT NULL, level text, message text);
+CREATE TABLE public.setpoint_snapshot (ts timestamptz NOT NULL, parameter text, value double precision, greenhouse_id text DEFAULT 'vallery');
+
+-- All 5 are registered hypertables (as migrations 000 + 157/G2 leave them).
+SELECT create_hypertable('public.climate',           'ts');
+SELECT create_hypertable('public.energy',            'ts');
+SELECT create_hypertable('public.diagnostics',       'ts');
+SELECT create_hypertable('public.esp32_logs',        'ts');
+SELECT create_hypertable('public.setpoint_snapshot', 'ts');
+
+DO $$
+DECLARE n_ht int; n_comp_jobs int; n_ret_jobs int; n_compressed int;
+BEGIN
+    SELECT count(*) INTO n_ht
+      FROM timescaledb_information.hypertables WHERE hypertable_schema = 'public';
+    IF n_ht <> 5 THEN
+        RAISE EXCEPTION 'SETUP FAIL: expected 5 hypertables before migration, got %', n_ht;
+    END IF;
+
+    SELECT count(*) INTO n_comp_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression';
+    SELECT count(*) INTO n_ret_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention';
+    SELECT count(*) INTO n_compressed
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND compression_enabled;
+
+    IF n_comp_jobs <> 0 OR n_ret_jobs <> 0 OR n_compressed <> 0 THEN
+        RAISE EXCEPTION 'SETUP FAIL: expected 0 compression jobs / 0 retention jobs / 0 compressed, got %/%/%',
+            n_comp_jobs, n_ret_jobs, n_compressed;
+    END IF;
+
+    RAISE NOTICE 'SETUP OK: 5 hypertables, 0 compression jobs, 0 retention jobs, 0 compressed hypertables.';
+END
+$$;
+
+-- ===========================================================================
+-- 2. APPLY migration 158.
+-- ===========================================================================
+\echo '--- applying migration 158 ---'
+\i :migration
+
+-- ---------------------------------------------------------------------------
+-- 3. Assert the PARITY end-state via the TimescaleDB catalogs:
+--    4 policy_compression jobs (NOT esp32_logs), 5 policy_retention jobs,
+--    5 compressed hypertables. Also assert the exact per-table membership and
+--    the retention intervals.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    n_comp_jobs   int;
+    n_ret_jobs    int;
+    n_compressed  int;
+    comp_set      text[];
+    ret_set       text[];
+    compressed_set text[];
+    expected_comp  text[] := ARRAY['climate','diagnostics','energy','setpoint_snapshot'];
+    expected_ret   text[] := ARRAY['climate','diagnostics','energy','esp32_logs','setpoint_snapshot'];
+    expected_compd text[] := ARRAY['climate','diagnostics','energy','esp32_logs','setpoint_snapshot'];
+BEGIN
+    -- counts
+    SELECT count(*) INTO n_comp_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression';
+    SELECT count(*) INTO n_ret_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention';
+    SELECT count(*) INTO n_compressed
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND compression_enabled;
+
+    IF n_comp_jobs <> 4 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected 4 policy_compression jobs, got %', n_comp_jobs;
+    END IF;
+    IF n_ret_jobs <> 5 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected 5 policy_retention jobs, got %', n_ret_jobs;
+    END IF;
+    IF n_compressed <> 5 THEN
+        RAISE EXCEPTION 'APPLY FAIL: expected 5 compressed hypertables, got %', n_compressed;
+    END IF;
+
+    -- exact membership (compression policies)
+    SELECT array_agg(hypertable_name ORDER BY hypertable_name) INTO comp_set
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression';
+    IF comp_set IS DISTINCT FROM expected_comp THEN
+        RAISE EXCEPTION 'APPLY FAIL: compression-policy set % <> expected % (esp32_logs must NOT have a compression policy)',
+            comp_set, expected_comp;
+    END IF;
+
+    -- exact membership (retention policies)
+    SELECT array_agg(hypertable_name ORDER BY hypertable_name) INTO ret_set
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention';
+    IF ret_set IS DISTINCT FROM expected_ret THEN
+        RAISE EXCEPTION 'APPLY FAIL: retention-policy set % <> expected %', ret_set, expected_ret;
+    END IF;
+
+    -- exact membership (compressed hypertables — the parity dimension 8 set)
+    SELECT array_agg(hypertable_name ORDER BY hypertable_name) INTO compressed_set
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND compression_enabled;
+    IF compressed_set IS DISTINCT FROM expected_compd THEN
+        RAISE EXCEPTION 'APPLY FAIL: compressed-hypertable set % <> expected %', compressed_set, expected_compd;
+    END IF;
+
+    RAISE NOTICE 'APPLY OK: 4 compression jobs %, 5 retention jobs %, 5 compressed hypertables %.',
+        comp_set, ret_set, compressed_set;
+END
+$$;
+
+-- 3b. Assert the retention intervals match the live values (drop_after schedule).
+DO $$
+DECLARE
+    bad text;
+BEGIN
+    -- timescaledb stores the retention interval in jobs.config->>'drop_after'.
+    SELECT string_agg(hypertable_name || '=' || (config->>'drop_after'), ', ' ORDER BY hypertable_name)
+      INTO bad
+      FROM timescaledb_information.jobs
+     WHERE proc_name = 'policy_retention'
+       AND NOT (
+            (hypertable_name = 'climate'           AND (config->>'drop_after')::interval = INTERVAL '365 days') OR
+            (hypertable_name = 'energy'            AND (config->>'drop_after')::interval = INTERVAL '365 days') OR
+            (hypertable_name = 'diagnostics'       AND (config->>'drop_after')::interval = INTERVAL '180 days') OR
+            (hypertable_name = 'esp32_logs'        AND (config->>'drop_after')::interval = INTERVAL '30 days')  OR
+            (hypertable_name = 'setpoint_snapshot' AND (config->>'drop_after')::interval = INTERVAL '90 days')
+       );
+    IF bad IS NOT NULL THEN
+        RAISE EXCEPTION 'APPLY FAIL: retention interval mismatch on %', bad;
+    END IF;
+    RAISE NOTICE 'APPLY OK: retention intervals match live (climate/energy 365d, diagnostics 180d, esp32_logs 30d, setpoint_snapshot 90d).';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. IDEMPOTENCY: re-apply the migration body; must not error and must leave
+--    exactly 4 + 5 jobs and 5 compressed hypertables (no duplicate jobs).
+-- ---------------------------------------------------------------------------
+\echo '--- re-applying migration 158 (idempotency) ---'
+\i :migration
+
+DO $$
+DECLARE n_comp_jobs int; n_ret_jobs int; n_compressed int;
+BEGIN
+    SELECT count(*) INTO n_comp_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression';
+    SELECT count(*) INTO n_ret_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention';
+    SELECT count(*) INTO n_compressed
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND compression_enabled;
+
+    IF n_comp_jobs <> 4 OR n_ret_jobs <> 5 OR n_compressed <> 5 THEN
+        RAISE EXCEPTION 'IDEMPOTENCY FAIL: after re-apply got %/%/% (expected 4 compression jobs / 5 retention jobs / 5 compressed)',
+            n_comp_jobs, n_ret_jobs, n_compressed;
+    END IF;
+    RAISE NOTICE 'IDEMPOTENCY OK: re-apply is a no-op (4 compression jobs, 5 retention jobs, 5 compressed, no duplicates).';
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. ROLLBACK (documented): remove the 4 compression + 5 retention policies and
+--    disable compression on all 5. Assert the job counts and compressed-set
+--    return to 0.
+-- ---------------------------------------------------------------------------
+\echo '--- applying documented rollback (remove policies + disable compress) ---'
+SELECT remove_compression_policy('setpoint_snapshot', if_exists => TRUE);
+SELECT remove_compression_policy('diagnostics',       if_exists => TRUE);
+SELECT remove_compression_policy('energy',            if_exists => TRUE);
+SELECT remove_compression_policy('climate',           if_exists => TRUE);
+
+SELECT remove_retention_policy('setpoint_snapshot', if_exists => TRUE);
+SELECT remove_retention_policy('esp32_logs',        if_exists => TRUE);
+SELECT remove_retention_policy('diagnostics',       if_exists => TRUE);
+SELECT remove_retention_policy('energy',            if_exists => TRUE);
+SELECT remove_retention_policy('climate',           if_exists => TRUE);
+
+ALTER TABLE setpoint_snapshot SET (timescaledb.compress = false);
+ALTER TABLE esp32_logs        SET (timescaledb.compress = false);
+ALTER TABLE diagnostics       SET (timescaledb.compress = false);
+ALTER TABLE energy            SET (timescaledb.compress = false);
+ALTER TABLE climate           SET (timescaledb.compress = false);
+
+DO $$
+DECLARE n_comp_jobs int; n_ret_jobs int; n_compressed int;
+BEGIN
+    SELECT count(*) INTO n_comp_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression';
+    SELECT count(*) INTO n_ret_jobs
+      FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention';
+    SELECT count(*) INTO n_compressed
+      FROM timescaledb_information.hypertables
+     WHERE hypertable_schema = 'public' AND compression_enabled;
+
+    IF n_comp_jobs <> 0 OR n_ret_jobs <> 0 OR n_compressed <> 0 THEN
+        RAISE EXCEPTION 'ROLLBACK FAIL: after revert got %/%/% (expected 0/0/0)',
+            n_comp_jobs, n_ret_jobs, n_compressed;
+    END IF;
+    RAISE NOTICE 'ROLLBACK OK: all compression/retention policies removed, compression disabled (0/0/0).';
+END
+$$;
+
+DO $$ BEGIN RAISE NOTICE 'ALL FIXTURE ASSERTIONS PASSED (setup + apply + idempotency + rollback).'; END $$;


### PR DESCRIPTION
## G3 — recreate compression + retention background-job policies (DB parity)

Refs #72 (G-DB-3 / G-DB-4), #33-family. **SERIALIZED MIGRATION** — one migration per PR, no bundling.

Restores the **policy half** of the DB parity baseline so the migrated in-cluster (k3s/iSCSI) DB matches the live VM. `db/schema.sql` is a TimescaleDB **Community** `pg_dump`, which strips both `create_hypertable` (repaired by `000` + G2/`157`) **and** the catalog policy state (`add_compression_policy` / `add_retention_policy` / `ALTER TABLE ... SET (timescaledb.compress ...)`). Those policies are catalog rows, not table DDL, so they are silently dropped by the dump and must be re-asserted by a migration.

### What this migration does (parity target: 11 bg jobs, 5 compressed)
G3 owns the **compression + retention** 9 of the 11 baseline bg jobs + the compression-enabled flag on all 5 compressed hypertables:

| policy | hypertables | interval |
|---|---|---|
| `policy_compression` ×4 | climate, energy, diagnostics, setpoint_snapshot | compress_after **7d** |
| `policy_retention` ×5 | climate, energy, diagnostics, esp32_logs, setpoint_snapshot | **365d / 365d / 180d / 30d / 90d** |
| compression **enabled** ×5 | climate, energy, diagnostics, **esp32_logs**, setpoint_snapshot | — |

`esp32_logs` is compression-**enabled** but intentionally has **no** compression policy — exactly the **5-compressed / 4-compression-job** split in the parity baseline (`docs/runbooks/db-copy-not-move.md`, `scripts/db-parity.sh`). The other 2 baseline jobs (`refresh_climate_merged` / `refresh_relay_stuck`) are matview host-cron UDAs (migration `047`), **not** compression/retention — **out of scope for G3**.

**Policy source** (NOT in `db/schema.sql`): the repo's own migration history where the live policies were created — `050` (climate/energy/diagnostics compress + retention, esp32_logs retention), `060` (setpoint_snapshot), `149` (setpoint_snapshot compress segmentby=`parameter`) — cross-checked against the parity baseline. `setpoint_snapshot` reuses migration 149's exact `segmentby='parameter', orderby='ts DESC'`; the other 4 enable compression with TimescaleDB's safe default ordering (`orderby ts DESC`, no segmentby — segmentby is a storage-layout choice, not a parity dimension).

### Dependency on G2 (migration 157 — NOT yet merged)
G2 (`iris/g2-hypertables`, migration `157`) converts the 15 non-core telemetry tables (incl. energy, diagnostics, esp32_logs, setpoint_snapshot) back into hypertables. Compression/retention only work on a **registered hypertable**, so this migration is numbered **158** (after 157) and **guards every table** by a registered-hypertable check:
- With G2 applied (or on live): all 5 are hypertables, all policies assert.
- Without G2: only `climate` (core, from `000`) is touched; the other 4 are skipped idempotently.

**Apply order is `157` → `158`.** This is the serialized sequence for coordinator approval.

### Idempotency & #23 rollback-replay safety
- Idempotent: `ALTER ... SET` is a settings UPSERT; `add_compression_policy` / `add_retention_policy` use `if_not_exists => TRUE` (live no-op + clean re-apply, no duplicate jobs).
- **#23 safe-to-wrap**: NON-self-transactional — no top-level `COMMIT`, no `CREATE INDEX CONCURRENTLY` / `VACUUM` / `ALTER SYSTEM`; single `DO` block. Classified `ok (safe-to-wrap)` by `scripts/check_migration_rollback_safety.py`. Proven below: replaying under `BEGIN; ... ROLLBACK;` leaves 0 policy jobs / 0 compressed.
- **Schema-restart note (CLAUDE.md rule 7):** touches none of `verdify_schemas/**`, `ingestor/entity_map.py`, `mcp/server.py`. Only TimescaleDB catalog policy state — **no service needs to bounce**.

### Fixture evidence (disposable `timescale/timescaledb:2.25.2-pg16`, destroyed after)
Container: PostgreSQL 16.11 / TimescaleDB 2.25.2. Loaded the 5 canonical hypertables (post-G2 state) with no policies, applied `158`, asserted end-state via the TimescaleDB catalogs, proved idempotency + rollback, then destroyed the container.

```
SETUP OK: 5 hypertables, 0 compression jobs, 0 retention jobs, 0 compressed hypertables.
--- applying migration 158 ---
APPLY OK: 4 compression jobs {climate,diagnostics,energy,setpoint_snapshot},
          5 retention jobs {climate,diagnostics,energy,esp32_logs,setpoint_snapshot},
          5 compressed hypertables {climate,diagnostics,energy,esp32_logs,setpoint_snapshot}.
APPLY OK: retention intervals match live (climate/energy 365d, diagnostics 180d, esp32_logs 30d, setpoint_snapshot 90d).
--- re-applying migration 158 (idempotency) ---
IDEMPOTENCY OK: re-apply is a no-op (4 compression jobs, 5 retention jobs, 5 compressed, no duplicates).
--- applying documented rollback (remove policies + disable compress) ---
ROLLBACK OK: all compression/retention policies removed, compression disabled (0/0/0).
ALL FIXTURE ASSERTIONS PASSED (setup + apply + idempotency + rollback).
```

`make lint` → `All checks passed!`. `check_migration_rollback_safety.py --check` → `ok (safe-to-wrap)`.

**#23 rollback-replay proof** (separate run, fresh hypertable state, migration wrapped in `BEGIN; ... ROLLBACK;`):
```
jobs BEFORE wrap: 0 / 0
jobs AFTER wrapped-rollback: 0 / 0   (outer ROLLBACK effective — no inner COMMIT)
compressed hypertables AFTER wrapped-rollback: 0
```

### Explicit ROLLBACK (documented; disposable fixture only — NEVER live)
```sql
-- remove the 4 compression policies (skip absent):
SELECT remove_compression_policy('setpoint_snapshot', if_exists => TRUE);
SELECT remove_compression_policy('diagnostics',       if_exists => TRUE);
SELECT remove_compression_policy('energy',            if_exists => TRUE);
SELECT remove_compression_policy('climate',           if_exists => TRUE);
-- remove the 5 retention policies (skip absent):
SELECT remove_retention_policy('setpoint_snapshot', if_exists => TRUE);
SELECT remove_retention_policy('esp32_logs',        if_exists => TRUE);
SELECT remove_retention_policy('diagnostics',       if_exists => TRUE);
SELECT remove_retention_policy('energy',            if_exists => TRUE);
SELECT remove_retention_policy('climate',           if_exists => TRUE);
-- disable compression on each (valid once chunks decompressed; clean reset on empty fixture):
ALTER TABLE setpoint_snapshot SET (timescaledb.compress = false);
ALTER TABLE esp32_logs        SET (timescaledb.compress = false);
ALTER TABLE diagnostics       SET (timescaledb.compress = false);
ALTER TABLE energy            SET (timescaledb.compress = false);
ALTER TABLE climate           SET (timescaledb.compress = false);
```

---

requested-by: iris — **SERIALIZED MIGRATION, awaiting Jason coordinator approval, DO NOT auto-merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
