### PR TITLE
deploy(www): repin verdify-www off 404 placeholder to real GHCR @sha256 (staging+dev+prod)

### DIFF
--- a/deploy/k8s/components/www/www.yaml
+++ b/deploy/k8s/components/www/www.yaml
@@ -5,12 +5,17 @@
 # git sha, using THAT repo's own Dockerfile (Astro static build -> Node runtime).
 # We deliberately do NOT vendor the whole Astro app into /mnt/iris/verdify; the
 # only artifact this monorepo carries is the immutable @sha256 image digest pin
-# (overlays' images: transformer) + these manifests. Rebuild recipe:
+# (overlays' images: transformer) + these manifests. The image now publishes
+# automatically: verdify-www's own .github/workflows/publish-image.yml builds +
+# pushes ghcr.io/verdifyconsultancy/verdify-www on push to its default branch
+# (GITHUB_TOKEN packages:write -> repo-linked). Manual rebuild recipe:
 #   gh repo clone VerdifyConsultancy/verdify-www && cd verdify-www
 #   docker build -t ghcr.io/verdifyconsultancy/verdify-www:sha-$(git rev-parse --short HEAD) .
 #   docker push  ghcr.io/verdifyconsultancy/verdify-www:sha-<sha>   # -> @sha256 digest
-# First image: repo sha d3720dc -> ghcr.io/verdifyconsultancy/verdify-www
-#   @sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+# First REAL published image: repo sha b33f4cd -> ghcr.io/verdifyconsultancy/verdify-www
+#   @sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
+# (this replaced an earlier placeholder pin sha256:5e00bc20… whose package 404'd —
+#  it had never actually been built/pushed to GHCR.)
 #
 # RUNTIME (load-bearing — why NOT a plain nginx static swap): astro.config.mjs is
 # output:"static", BUT the upstream Dockerfile serves dist/ via scripts/server.mjs

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -75,7 +75,11 @@ patches:
 # build) digest into this dev overlay, so neither self-heals away from a phantom
 # pin again). dev is INERT (no ArgoCD app), so this pin deploys nothing.
   # verdify-www (#116): real GHCR digest of the marketing site image built from
-  # the upstream verdify-www repo at sha d3720dc (see components/www/www.yaml).
+  # the upstream verdify-www repo at sha b33f4cd (see components/www/www.yaml).
+  # Published + repo-linked by verdify-www's publish-image.yml workflow and
+  # verified pullable 2026-06-04 — REPLACES the prior placeholder pin
+  # (sha256:5e00bc20…) whose package 404'd. dev pins the SAME env-agnostic digest
+  # as staging/prod (one-digest-across-envs static content).
   # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
   # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
   # #99-class relink. The digest write-back flow pins the real GHCR digest once
@@ -93,5 +97,5 @@ images:
   name: ghcr.io/verdifyconsultancy/verdify-migrate
 - digest: sha256:3e51abaec6372c0bed26ef9859a80008261fcd20a1e8ec1e37627304e1c6b637
   name: ghcr.io/verdifyconsultancy/verdify-planner
-- digest: sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+- digest: sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
   name: ghcr.io/verdifyconsultancy/verdify-www

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -106,11 +106,16 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-setpoint-server
     digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   # verdify-www (#116): real GHCR digest of the marketing site image built from
-  # the upstream verdify-www repo at sha d3720dc (see components/www/www.yaml).
-  # The site is env-agnostic static content + Node runtime, so prod + dev pin the
-  # same known-good digest; the promotion flow advances it on a content rebuild.
+  # the upstream verdify-www repo at sha b33f4cd (see components/www/www.yaml).
+  # Published + repo-linked by verdify-www's publish-image.yml workflow and
+  # verified pullable 2026-06-04 — REPLACES the prior placeholder pin
+  # (sha256:5e00bc20…) whose package 404'd. The site is env-agnostic static
+  # content + Node runtime, so prod + dev + staging pin the SAME known-good
+  # digest; this keeps prod == the current staging www pin, so the
+  # promote-diff-guard staging-tracked equality check passes. The promotion flow
+  # advances it on a content rebuild.
   - name: ghcr.io/verdifyconsultancy/verdify-www
-    digest: sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+    digest: sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
   # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
   # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
   # #99-class relink. The digest write-back flow pins the real GHCR digest once

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -94,9 +94,13 @@ patches:
 # package is removed so CI can publish it repo-linked), the digest write-back job
 # (k8s-manifests.yml, no cross-repo PR / no ArgoCD Image Updater) will own these.
   # verdify-www (#116): real GHCR digest of the marketing site image built from
-  # the upstream verdify-www repo at sha d3720dc (see components/www/www.yaml).
-  # Verified pullable via the org GHCR package API 2026-05-31 (the ONLY non-app
-  # image pinned here; the env-agnostic static content matches dev/prod's pin).
+  # the upstream verdify-www repo at sha b33f4cd (see components/www/www.yaml).
+  # Published + repo-linked by verdify-www's own publish-image.yml workflow
+  # (GITHUB_TOKEN packages:write) and verified pullable via the org GHCR package
+  # API 2026-06-04 — this REPLACES the prior placeholder pin (sha256:5e00bc20…)
+  # whose package never existed (404). The ONLY non-app image pinned here; the
+  # env-agnostic static content matches dev/prod's identical pin (so the
+  # promote-diff-guard staging==prod equality holds for this staging-tracked image).
 images:
 - digest: sha256:005e1893d294d82949f7ed802ab790cdd53aba5ec02d179847e9e87bbd4f1c8e
   name: ghcr.io/verdifyconsultancy/verdify-api
@@ -106,5 +110,5 @@ images:
   name: ghcr.io/verdifyconsultancy/verdify-mcp
 - digest: sha256:4d8a560f016f5229d4451d94964fe0e7a8d14a6b4f34c6603122e61f5f1b3a54
   name: ghcr.io/verdifyconsultancy/verdify-migrate
-- digest: sha256:5e00bc2080ee03fe7f21517d326acf0a89f93baefc0b27fcb481bab59ab7c58a
+- digest: sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
   name: ghcr.io/verdifyconsultancy/verdify-www


### PR DESCRIPTION
## What

Repins `ghcr.io/verdifyconsultancy/verdify-www` in all three overlays that carry it — **staging + dev + prod** — from the 404 placeholder (`sha256:5e00bc20…`) to the real, published, repo-linked digest:

```
sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
```

(verdify-www repo sha `b33f4cd`; tags `sha-b33f4cd` + `latest`; OCI image index, `linux/amd64`.)

## Why

The www overlays pinned a placeholder digest that **404'd** — the `verdify-www` GHCR package had never actually been built/pushed (#116). verdify-www now publishes its own image via a new `.github/workflows/publish-image.yml` (merged upstream: VerdifyConsultancy/verdify-www#5), pushed with the in-job `GITHUB_TOKEN` (`packages: write`) so the package is **repo-linked** to `verdify-www` on first publish. This PR pins the resulting real digest.

## Staging-tracked, one digest across envs

`www` is a **staging-tracked** image (shared by staging/dev/prod), so all three pin the **identical** env-agnostic static-content digest. Keeping `prod == current staging` for www is exactly what the promote-diff-guard requires.

## Validation

- `kustomize build` of **staging, dev, prod** all render the new www digest; every `verdify-*` image remains `@sha256`-pinned (no mutable-tag leak).
- `kubeconform -strict -ignore-missing-schemas` on all three overlay renders: **0 invalid, 0 errors** (skips = CRDs like IngressRoute, expected).
- `actionlint`: clean (no workflow changes here; verified the verdify-www publish workflow separately).
- **promote-diff-guard semantics simulated locally against `live/platform-main` merge-base:**
  - Change-surface containment: the prod overlay touches **only** `kustomization.yaml`, and within it only `digest:`/comment/blank lines changed -> PASS.
  - Staging-tracked equality: the only prod pin this PR advances is **www**, landing exactly on the current staging www digest. api/mcp/ingestor/migrate prod pins are **unchanged** -> allowed to lag -> PASS.
- Digest verified pullable via `docker buildx imagetools inspect`; GHCR package `repository == verdify-www` (repo-linked confirmed via `gh api orgs/VerdifyConsultancy/packages/container/verdify-www`).

## Scope / safety

- Pure web tier, stateless, no device path, no PVC, no secrets. No manifest/replica/NetworkPolicy/interlock changes — digest pins + rationale comments only.
- DEC-WWW (k3s-vs-CloudRun retirement) is **not** decided here; the verdify-www publish workflow is additive to its existing Cloud Run deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)