### PR TITLE
deploy(lab): repin verdify-lab off 404 placeholder to real GHCR @sha256 (dev+prod) (#124)

### DIFF
--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -80,16 +80,21 @@ patches:
   # verified pullable 2026-06-04 — REPLACES the prior placeholder pin
   # (sha256:5e00bc20…) whose package 404'd. dev pins the SAME env-agnostic digest
   # as staging/prod (one-digest-across-envs static content).
-  # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
-  # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
-  # #99-class relink. The digest write-back flow pins the real GHCR digest once
-  # container-publish for verdify-lab is green. See components/lab-site/lab-site.yaml.
+  # verdify-lab (#124): real GHCR digest of the Quartz research-site image built
+  # from the verdify-site-legacy repo's Dockerfile.k3s (Quartz `npx quartz build`
+  # -> static public/ -> nginx-unprivileged on :8080). Published + repo-linked by
+  # verdify-site-legacy's publish-lab-image.yml workflow (package repository.name
+  # == verdify-site-legacy) and verified pullable 2026-06-04 — REPLACES the prior
+  # all-zeros placeholder pin whose package 404'd (verdify-site was an orphan GHCR
+  # repo). lab is NOT in overlays/staging (it is a dev/prod-only Component), so it
+  # is EXEMPT from the promote-diff-guard staging-equality check; dev pins the SAME
+  # env-agnostic digest as prod (one-digest-across-envs static content).
 images:
 - digest: sha256:ce4ca79f9e6442c39558cbe02b1665c3cddc3e269c1867997d4f292f3a5ce8ff
   name: ghcr.io/verdifyconsultancy/verdify-api
 - digest: sha256:4f141a5901f802e52b37b15a6a92b8d0bc906f3d854066e3ddd52911aa457d0d
   name: ghcr.io/verdifyconsultancy/verdify-ingestor
-- digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+- digest: sha256:92ab47073fad5372832274ba591291fd1c209968fd311892f4130bc423b1140b
   name: ghcr.io/verdifyconsultancy/verdify-lab
 - digest: sha256:9824020a0d2fe77191b2c01ca2634c3bcec6031b79d2fef1c3334b2d5665768d
   name: ghcr.io/verdifyconsultancy/verdify-mcp

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -116,9 +116,15 @@ images:
   # advances it on a content rebuild.
   - name: ghcr.io/verdifyconsultancy/verdify-www
     digest: sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
-  # PLACEHOLDER — no verdify-lab (Quartz research site, #124) image published yet:
-  # verdify-site is an orphan GHCR repo (repo:None) so CI cannot publish it until a
-  # #99-class relink. The digest write-back flow pins the real GHCR digest once
-  # container-publish for verdify-lab is green. See components/lab-site/lab-site.yaml.
+  # verdify-lab (#124): real GHCR digest of the Quartz research-site image built
+  # from the verdify-site-legacy repo's Dockerfile.k3s (Quartz `npx quartz build`
+  # -> static public/ -> nginx-unprivileged on :8080). Published + repo-linked by
+  # verdify-site-legacy's publish-lab-image.yml workflow (package repository.name
+  # == verdify-site-legacy) and verified pullable 2026-06-04 — REPLACES the prior
+  # all-zeros placeholder pin whose package 404'd (verdify-site was an orphan GHCR
+  # repo). lab is a dev/prod-only Component that is ABSENT from overlays/staging,
+  # so it is EXEMPT from the promote-diff-guard staging-equality check (per the
+  # guard's own derived-exemption set); prod pins the SAME env-agnostic digest as
+  # dev (one-digest-across-envs static content). A content rebuild advances it.
   - name: ghcr.io/verdifyconsultancy/verdify-lab
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:92ab47073fad5372832274ba591291fd1c209968fd311892f4130bc423b1140b


### PR DESCRIPTION
Fixes the **#124 orphan**: `verdify-site-legacy` (the Quartz source for `lab.verdify.ai`) now builds + publishes `ghcr.io/verdifyconsultancy/verdify-lab` (its new `Dockerfile.k3s` + `publish-lab-image.yml`, merged as VerdifyConsultancy/verdify-site-legacy#7). The package is **repo-linked on first publish** (`repository.name == verdify-site-legacy`) and pullable.

This PR repins the **dev + prod** lab-site overlays off the all-zeros placeholder (`sha256:0000…0000`, whose package 404'd) to the real published digest:

```
sha256:92ab47073fad5372832274ba591291fd1c209968fd311892f4130bc423b1140b
```
(tags `sha-67f5fa1`, `latest`)

`components/lab-site` already references the correct image name — only the per-overlay digest pin moved. dev + prod pin the **same env-agnostic digest** (one-digest-across-envs static content), matching the verdify-www posture (#190).

## Scope / safety
- **promote-diff-guard EXEMPT (confirmed):** lab is a dev/prod-only Component, **absent from `overlays/staging`**. The guard's staging-tracked set (derived from the staging render) is `api/mcp/ingestor/migrate/www` — `verdify-lab` has **0 occurrences** in the staging render, so the staging-equality check never inspects it. The prod diff is **digest + comment lines only**, so the guard's change-surface containment also passes (simulated locally: both PASS).
- **Inert on merge:** dev has no ArgoCD app; the live ArgoCD app syncs **only `overlays/staging`** (lab is not there). This repin deploys nothing on merge — it is the reviewable target shape, advanced once dev/prod ArgoCD apps exist.
- No device path, no secrets, no manifest/replica/NetworkPolicy changes.

## Validation
- `kustomize build` (dev + prod): OK; `verdify-lab` renders at the real `@sha256` in both; no all-zeros leak for lab (the lone remaining placeholder is the out-of-scope `verdify-setpoint-server` #118).
- `kubeconform -strict -summary -ignore-missing-schemas`: dev **22 valid / 0 invalid**, prod **32 valid / 0 invalid** (skipped = CRDs without schemas).
- `actionlint`: clean (no workflow changes here).
- promote-diff-guard semantics: change-surface PASS + lab-exempt PASS.

## Follow-up — vault→lab content rebuild
`publish-lab-image.yml` ships a **weekly `schedule`** + a **`repository_dispatch: vault-content-update`** hook so a vault edit republishes a fresh `@sha256` (the production content lives in the external vault, not the CI context; the image build seeds from the in-repo `docs/` Quartz tree). This overlay pin advances on that rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)