### PR TITLE
deploy(prod): repin verdify-setpoint-server off all-zeros to real GHCR @sha256 — prod overlay renders green (#86 #118)

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -99,12 +99,18 @@ images:
   # so this prod pin is a deliberate in-repo write-back, never CI-mutated.
   - name: ghcr.io/verdifyconsultancy/verdify-planner
     digest: sha256:3e51abaec6372c0bed26ef9859a80008261fcd20a1e8ec1e37627304e1c6b637
-  # PLACEHOLDER — #118 verdify-setpoint-server image not published yet
-  # (scripts/Dockerfile.setpoint-server is new). Real GHCR digest pinned by the
-  # write-back flow once container-publish is green. hermes-agent is deliberately
-  # ABSENT here — its upstream @sha256 is preserved inline (NOT transformer-pinned).
+  # verdify-setpoint-server (#118): real GHCR digest of the grow-light writer +
+  # setpoint-diagnostics image built from scripts/Dockerfile.setpoint-server. The
+  # `branch-live-platform-main` build is published + repo-linked to
+  # VerdifyConsultancy/verdify-platform and verified pullable 2026-06-04 (GHCR
+  # manifest HEAD -> 200) — REPLACES the prior all-zeros placeholder pin.
+  # setpoint-server is a PROD-ONLY device-affecting Component (ABSENT from
+  # overlays/staging), so it is EXEMPT from the promote-diff-guard staging-equality
+  # check per the guard's derived prod-only exemption set. A rebuild advances it.
+  # hermes-agent is deliberately ABSENT from this transformer — its upstream
+  # @sha256 is preserved inline in the component (NOT transformer-pinned).
   - name: ghcr.io/verdifyconsultancy/verdify-setpoint-server
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:73f5599f4a8e6e00c5d6e80847e1cbe3d49cc3e95527d0e53d150ac94b0e2f5a
   # verdify-www (#116): real GHCR digest of the marketing site image built from
   # the upstream verdify-www repo at sha b33f4cd (see components/www/www.yaml).
   # Published + repo-linked by verdify-www's publish-image.yml workflow and


### PR DESCRIPTION
## M4.1-prod-overlay (#86): complete + verify the PROD overlay green at REAL digests

Repins the last `sha256:0000…0000` placeholder in `deploy/k8s/overlays/prod` — the
`verdify-setpoint-server` image (#118) — to its REAL published GHCR digest, so the
authored TARGET prod overlay `kustomize build`s + kubeconforms clean with EVERY
`verdify-*` image pinned to a real `@sha256`.

This is the reviewable TARGET shape and stays **INERT**: no ArgoCD App is applied
(Root-level handover is Jason-gated at M4.1). **No device-writer posture change** —
the prod ingestor keeps its writer shape (`DEVICE_WRITE=1` +
`allow-ingestor-device-egress` + `replicas:1`, Recreate), migrate-as-is until M5.
NO firmware changes.

### Setpoint digest repinned
`ghcr.io/verdifyconsultancy/verdify-setpoint-server`
`sha256:0000…0000` → `sha256:73f5599f4a8e6e00c5d6e80847e1cbe3d49cc3e95527d0e53d150ac94b0e2f5a`

- Resolved read-only via `gh api orgs/VerdifyConsultancy/packages/container/verdify-setpoint-server/versions` — newest version, created 2026-06-02T01:47:37Z, tags `sha-ff2a54652b39` / `branch-live-platform-main` / `local-dev`.
- Package is **repo-linked** to `VerdifyConsultancy/verdify-platform`.
- Verified pullable: GHCR manifest HEAD by digest → **HTTP 200** (2026-06-04).

### Other prod digests confirmed real (no remaining sha256:0000)
api, mcp, ingestor, migrate, planner, **www** (`633fb18a`), **lab** (`92ab4707`) — all real `@sha256`. External pins (timescaledb, mosquitto, hermes-agent) preserved.

### Prod components all render
planner (#117) + mqtt-broker (#113, publish-all) + setpoint-server (#118) +
hermes-iris (#119) + www (#116) + lab (#124), plus base (api/mcp/ingestor/db/migrate)
and the writer-shape ingestor (`VERDIFY_DEVICE_WRITE_ENABLED=1`,
`VERDIFY_MQTT_PUBLISH_ALL=1`, replicas:1). No components added/removed.

### Validation
- `kustomize build deploy/k8s/overlays/prod` → clean (exit 0)
- `kubeconform -strict -ignore-missing-schemas` → **Valid 32 / Invalid 0 / Errors 0** (2 skipped: Traefik IngressRoute CRDs, no schema — expected)
- **No `sha256:0000` remains** in overlays/prod — source, fully-rendered, or referenced components
- promote-diff-guard (simulated locally): change-surface = one `prod/kustomization.yaml` digest line + comment block (permitted); staging-equality loop = all staging-tracked pins (api/mcp/ingestor/migrate/www) unchanged (prod may lag staging) → no fail; setpoint-server is **PROD-ONLY** (absent from overlays/staging) → **EXEMPT** from the derived staging-equality check. fail flag: 0
- `make lint` → All checks passed
- No workflow files touched (actionlint N/A)

refs #86 #118
requested-by: iris

🤖 Generated with [Claude Code](https://claude.com/claude-code)