### PR TITLE
verdify-prod: reconcile overlay to PROVEN live cutover shape (egress + state vol)

### DIFF
--- a/deploy/k8s/argocd/STAGED-prod-cutover-flip.md
+++ b/deploy/k8s/argocd/STAGED-prod-cutover-flip.md
@@ -1,0 +1,85 @@
+# STAGED — ArgoCD source flip for the verdify-prod device cutover (DO NOT auto-apply)
+
+Status: STAGED for laptop-root + Jason gate. The device cutover is already LIVE
+(applied imperatively 2026-06-07T17:15Z). This flip makes a future ArgoCD sync
+REINFORCE the live armed shape instead of reverting it.
+
+## Why a naive sync today is DANGEROUS
+
+The live ArgoCD app is `verdify-prod-dark`, sourced from `overlays/prod-dark` and
+currently `OutOfSync` (the namespace was armed imperatively). `argocd app sync
+verdify-prod-dark` against the UNCHANGED dark overlay would REVERT the cutover:
+- `deny-esp32-egress` re-adds `except: 192.168.10.0/24` → ESP32 unreachable
+- `VERDIFY_DEVICE_WRITE_ENABLED` → 0
+- ingestor replicas → 0
+= re-dark the live greenhouse. NEVER sync verdify-prod-dark as-is.
+
+## The flip (laptop-root performs; Jason-gated)
+
+overlays/prod has now been reconciled (this PR) to the PROVEN live shape:
+- `allow-ingestor-device-egress`: broad egress (0.0.0.0/0) + DNS — matches the live
+  patched `deny-esp32-egress` (no regression vs the live ingestor's real egress)
+- `VERDIFY_DEVICE_WRITE_ENABLED: "1"`, ingestor `replicas: 1`
+- `/srv/verdify/state` writable emptyDir volume (#130) — fixes the dispatcher thrash
+
+So a sync of an app pointing at overlays/prod REINFORCES the cutover.
+
+### OPTION A (RECOMMENDED) — in-place repoint of the live app, then rename later
+
+Lowest blast radius: keep the live `verdify-prod-dark` Application object (it already
+owns the namespace + the verdify-db STS adoption) and just repoint its source path.
+`deny-esp32-egress` is NOT in overlays/prod, so after the repoint a sync would try to
+PRUNE it — but `prune` is false and these are MANUAL syncs, so it will show as
+OutOfSync/extra, harmless; laptop-root removes `deny-esp32-egress` explicitly at sync
+time (it is already functionally a no-op: live it is the broad-egress allow). The new
+`allow-ingestor-device-egress` is created additively.
+
+Exact live patch (laptop-root runs, AFTER this PR merges to live/platform-main):
+
+```
+ssh jason@192.168.30.32 sudo k3s kubectl -n argocd patch application verdify-prod-dark \
+  --type merge -p '{"spec":{"source":{"path":"deploy/k8s/overlays/prod"}}}'
+```
+
+Then a CONTROLLED, NON-PRUNING sync (review the diff first; never auto-prune the
+verdify-db STS/PVC or the dumps PVC):
+
+```
+# Preview only — confirm it ADDS allow-ingestor-device-egress + state volume and
+# does NOT scale ingestor to 0 / re-add the except:
+argocd app diff verdify-prod-dark
+# Apply additively (NO --prune). Removes the now-orphan deny-esp32-egress by hand:
+argocd app sync verdify-prod-dark --resource '!networking.k8s.io:NetworkPolicy:deny-esp32-egress'
+ssh jason@192.168.30.32 sudo k3s kubectl -n verdify-prod delete netpol deny-esp32-egress
+```
+
+Optional later (cosmetic): rename the App to `verdify-prod` via the OPTION B object.
+
+### OPTION B — apply verdify-prod app CR, retire verdify-prod-dark (cleaner name)
+
+The repo already carries `deploy/k8s/argocd/apps/verdify-prod.yaml` (source
+overlays/prod, manual sync, prune:false), NOT yet applied to the cluster. To adopt
+under the correctly-named app WITHOUT a destructive re-adopt, both apps must point at
+the SAME live objects; ArgoCD would briefly contend for ownership. Sequence:
+
+```
+# 1. Apply the prod app (manual sync; it will show OutOfSync, do NOT sync yet)
+ssh jason@192.168.30.32 sudo k3s kubectl apply -f deploy/k8s/argocd/apps/verdify-prod.yaml
+# 2. Detach the dark app WITHOUT deleting cluster objects (orphan, not cascade):
+ssh jason@192.168.30.32 sudo k3s kubectl -n argocd patch application verdify-prod-dark \
+  --type merge -p '{"metadata":{"finalizers":null}}'
+ssh jason@192.168.30.32 sudo k3s kubectl -n argocd delete application verdify-prod-dark --cascade=orphan
+# 3. Controlled non-pruning sync of verdify-prod (same diff-review as Option A)
+argocd app sync verdify-prod --resource '!networking.k8s.io:NetworkPolicy:deny-esp32-egress'
+```
+
+RISK: the `--cascade=orphan` + re-adopt window is fiddlier than Option A's single
+patch. Prefer Option A unless Jason wants the clean `verdify-prod` name now.
+
+## HARD pre-checks before EITHER flip (laptop-root)
+1. This PR is merged into `live/platform-main` (ArgoCD reads that ref).
+2. `argocd app diff` reviewed: confirms ADD allow-ingestor-device-egress + state
+   volume; confirms NO ingestor→0, NO except:192.168.10.0/24 re-added, NO DB prune.
+3. Single-writer Recreate means the ingestor pod restarts ONCE (state volume) — the
+   VM writer stays STOPPED, so still exactly one writer across the restart.
+4. Re-probe ESP32 write path + DB freshness AFTER (durability gate, ≥10 min).

--- a/deploy/k8s/overlays/prod/allow-ingestor-device-egress.yaml
+++ b/deploy/k8s/overlays/prod/allow-ingestor-device-egress.yaml
@@ -1,19 +1,36 @@
 # DEVICE-VLAN EGRESS ALLOW (#80) — prod ONLY.
 #
-# This is the SINGLE place the ingestor is permitted to reach the greenhouse
-# device VLAN. It is the network-layer counterpart of VERDIFY_DEVICE_WRITE_ENABLED=1:
-# the production ingestor is the one real single writer, so it CAN open the
-# ESPHome native-API connection to the live ESP32 (192.168.10.111:6053), reach
-# Home Assistant + local MQTT on the services VLAN, and read Frigate/go2rtc
-# occupancy.
+# This is the egress policy that lets the prod ingestor — the ONE real single
+# writer — reach the live greenhouse device + every telemetry source it pulls
+# from. It is the network-layer counterpart of VERDIFY_DEVICE_WRITE_ENABLED=1.
 #
-# Staging carries the inverse (deny-esp32-egress drops 192.168.10.0/24). Only
-# ONE of the two overlays ever grants this — never both, never the base.
+# *** PROVEN CUTOVER SHAPE — broad egress + DNS, NOT a tight per-IP allow-list. ***
+# The 2026-06-07 attended cutover (DECISIONS-LOCKED D9) was applied IMPERATIVELY
+# by patching the prod-dark `deny-esp32-egress` policy to egress 0.0.0.0/0 (i.e.
+# REMOVING the `except: 192.168.10.0/24`) plus an explicit DNS allow. That is the
+# shape proven live: the ingestor opened the ESPHome native-API to the ESP32 and
+# has been the sole writer + telemetry persister since 2026-06-07T17:15Z.
 #
-# GATING (handoff §3.4 / §6): declaring this policy does NOT by itself move the
-# device loop to k3s — it also requires the device-VLAN route, the single-writer
-# cutover choreography, and explicit Jason confirmation. This manifest is the
-# reviewable target shape for prod, not an instruction to cut over.
+# This overlay reconciles overlays/prod to THAT PROVEN SHAPE so a future ArgoCD
+# sync REINFORCES the cutover rather than reverting it. The earlier tight per-IP
+# allow-list (ESP32:6053 / HA:8123,1883 / Frigate:5000,1984 / db:5432 / DNS) was
+# the reviewable pre-cutover target, but it is now known to REGRESS real egress
+# the live ingestor uses and is therefore replaced:
+#   - immich GPU-power metrics  http://192.168.30.108:9400/metrics  (GPU power sync)
+#   - the in-cluster fan-out broker verdify-mqtt:1883 (VERDIFY_MQTT_PUBLISH_ALL=1,
+#     publish-all-configmap.yaml) — prod re-emits every flushed row onto the bus
+#   - and, per DECISIONS-LOCKED D4, the durable story is an ingestor that PULLS
+#     from the IoT VLAN and is EXTENSIBLE to OTHER IoT devices — a fixed per-IP
+#     list would have to be edited for every new source.
+#
+# A broad-egress + scoped-DNS policy still keeps an Egress policyType ATTACHED to
+# the ingestor (so it is not "no egress policy = allow all" by accident — it is a
+# deliberate, declared allow), and it provably covers every destination above
+# with zero regression risk. Ingress to the ingestor stays default-denied by
+# base default-deny-ingress; this policy is Egress-only.
+#
+# Staging carries the inverse (deny-esp32-egress drops 192.168.10.0/24). Only the
+# prod overlay grants device egress — never staging, never the base.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -26,40 +43,18 @@ spec:
       app.kubernetes.io/component: ingestor
   policyTypes: ["Egress"]
   egress:
-    # ESP32 ESPHome native API (greenhouse VLAN) — telemetry + setpoint/occupancy push.
+    # Broad egress: ESP32 greenhouse VLAN (192.168.10.0/24:6053), Home Assistant +
+    # external MQTT broker (192.168.30.107:8123,1883), Frigate/go2rtc
+    # (192.168.30.142:5000,1984), immich GPU metrics (192.168.30.108:9400),
+    # in-cluster verdify-db:5432 + verdify-mqtt fan-out:1883, and any further IoT
+    # telemetry source the ingestor is extended to pull from (D4). This is the
+    # exact shape proven live at the 2026-06-07 cutover.
     - to:
         - ipBlock:
-            cidr: 192.168.10.0/24
-      ports:
-        - protocol: TCP
-          port: 6053
-    # Home Assistant REST + local MQTT (services VLAN).
-    - to:
-        - ipBlock:
-            cidr: 192.168.30.107/32
-      ports:
-        - protocol: TCP
-          port: 8123
-        - protocol: TCP
-          port: 1883
-    # Frigate / go2rtc occupancy (services VLAN).
-    - to:
-        - ipBlock:
-            cidr: 192.168.30.142/32
-      ports:
-        - protocol: TCP
-          port: 5000
-        - protocol: TCP
-          port: 1984
-    # In-cluster DB egress + cluster DNS so the ingestor can still write
-    # TimescaleDB and resolve names once an Egress policy is attached to it.
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/component: db
-      ports:
-        - protocol: TCP
-          port: 5432
+            cidr: 0.0.0.0/0
+    # Cluster DNS so the ingestor resolves in-cluster Service names (verdify-db,
+    # verdify-mqtt, verdify-mcp) once an Egress policy is attached to it. Matches
+    # the explicit DNS allow added in the live cutover patch.
     - to:
         - namespaceSelector: {}
       ports:

--- a/deploy/k8s/overlays/prod/ingestor-state-volume.yaml
+++ b/deploy/k8s/overlays/prod/ingestor-state-volume.yaml
@@ -1,0 +1,39 @@
+# INGESTOR STATE VOLUME (#130) — prod.
+#
+# The prod ingestor runs with readOnlyRootFilesystem:true and the base only mounts
+# an emptyDir at /tmp. The live setpoint dispatcher + MCP-restart paths write to a
+# FIXED path /srv/verdify/state (carried over from the VM host layout):
+#   - /srv/verdify/state/setpoint-dispatcher.log   (every setpoint_dispatch task)
+#   - /srv/verdify/state/mcp-server.log            (every MCP restart attempt)
+# Without a writable mount there the live pod throws, observed post-cutover:
+#   ERROR Task setpoint_dispatch failed: [Errno 2] No such file or directory:
+#     '/srv/verdify/state/setpoint-dispatcher.log'
+#   ERROR MCP server restart failed: [Errno 2] No such file or directory:
+#     '/srv/verdify/state/mcp-server.log'
+# i.e. the dispatcher task and MCP supervisor thrash on every cycle. The device
+# pushes themselves still land (direct-push to ESP32 succeeds) but the logging +
+# MCP-restart bookkeeping fails, so the dispatcher task is marked failed each run.
+#
+# FIX: mount a writable emptyDir at /srv/verdify/state. emptyDir is the MINIMUM
+# that clears the thrash (the logs are diagnostic, lost on pod restart — acceptable
+# for now). #130 tracks the DURABLE follow-up: a small RWO PVC (synology-iscsi-ssd)
+# so the dispatcher/MCP logs survive a restart. Modeled as a strategic-merge patch
+# onto the base ingestor Deployment (adds the volume + volumeMount, /tmp preserved).
+#
+# laptop-root applies the restart that picks this up (single-writer Recreate: the
+# old writer pod is torn down fully before the new one starts — no double-writer).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-ingestor
+spec:
+  template:
+    spec:
+      containers:
+        - name: ingestor
+          volumeMounts:
+            - name: state
+              mountPath: /srv/verdify/state
+      volumes:
+        - name: state
+          emptyDir: {}

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -81,6 +81,10 @@ patches:
   # #113 publish-all: prod re-emits every flushed telemetry row onto the fan-out
   # bus (verdify-mqtt) so dev/stage subscribers mirror it. prod-only env.
   - path: publish-all-configmap.yaml
+  # #130 ingestor state volume: writable emptyDir at /srv/verdify/state so the
+  # live setpoint-dispatcher + MCP-restart logging stops thrashing post-cutover.
+  # emptyDir now; durable RWO PVC is the #130 follow-up. See ingestor-state-volume.yaml.
+  - path: ingestor-state-volume.yaml
   # ingestor keeps the base replicas:1 + Recreate (single-writer invariant); no
   # replicas:0 pin here (that is staging's two-writer safety pin).
 


### PR DESCRIPTION
## Why
The 2026-06-07 attended device cutover (DECISIONS-LOCKED D9) was applied **imperatively**. Live `verdify-prod` now has `VERDIFY_DEVICE_WRITE_ENABLED=1`, `deny-esp32-egress` patched to `0.0.0.0/0`+DNS (the `except:192.168.10.0/24` removed → ESP32 reachable), and `verdify-ingestor` replicas=1. The committed `overlays/prod-dark` still encodes the DARK shape; a naive `argocd app sync verdify-prod-dark` would **re-dark the live greenhouse**. This reconciles `overlays/prod` so a future ArgoCD sync **REINFORCES** the cutover.

## Changes
- **`allow-ingestor-device-egress.yaml`**: replace the tight per-IP allow-list with the **broad `0.0.0.0/0` + scoped-DNS** shape proven live. The old list **regressed** real egress the live ingestor uses — immich GPU metrics (`192.168.30.108:9400`) and the in-cluster fan-out broker (`verdify-mqtt:1883`, `VERDIFY_MQTT_PUBLISH_ALL=1`) — and contradicted D4's extensible-IoT-pull story. **Zero egress regression.**
- **`ingestor-state-volume.yaml` (#130)**: add a writable `emptyDir` at `/srv/verdify/state` so the live setpoint-dispatcher + MCP-restart logging stops thrashing (post-cutover ENOENT on `setpoint-dispatcher.log`/`mcp-server.log`). emptyDir now; durable RWO PVC is the #130 follow-up.
- `overlays/prod` already sets `WRITE_ENABLED=1` + ingestor `replicas:1` (verified in render).
- **`STAGED-prod-cutover-flip.md`**: the ArgoCD app source-flip runbook (`overlays/prod-dark`→`overlays/prod`), exact patch+sync commands, gated for laptop-root + Jason. NOT applied.

## Definitive live ingestor egress (from logs+config)
ESP32 `192.168.10.111:6053`; HA `192.168.30.107:8123`; external MQTT broker `192.168.30.107:1883`; Frigate `192.168.30.142:5000`(+1984); immich GPU `192.168.30.108:9400`; in-cluster `verdify-db:5432`; in-cluster fan-out `verdify-mqtt:1883`; DNS. (MCP is an in-pod localhost subprocess, not egress.)

## Safety
- **NOT synced.** Live ingestor untouched. VM writer stays STOPPED.
- `kustomize build deploy/k8s/overlays/prod` passes; render verified: egress `0.0.0.0/0` no `except`, `replicas:1`, `/srv/verdify/state` mounted, `WRITE_ENABLED=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)