### PR TITLE
fix(ingestor): mount verdify-ha-token so energy + hydro telemetry resumes (cutover regression)

### DIFF
--- a/deploy/k8s/base/ingestor-deployment.yaml
+++ b/deploy/k8s/base/ingestor-deployment.yaml
@@ -129,6 +129,19 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # HA token mounted at the SAME path config.py reads
+            # (HA_TOKEN_FILE=/mnt/agents/shared/credentials/ha_token.txt) so
+            # load_token() works unchanged. The shelly_sync / ha_sensor_sync /
+            # tempest_sync ingestor tasks (energy + hydro + weather telemetry)
+            # fetch from Home Assistant with this token; without it they fail
+            # every run ("[Errno 2] ... ha_token.txt") and the energy table +
+            # climate hydro_* columns go stale (the 2026-06-07 cutover regression).
+            # Real token via the verdify-ha-token Secret (out-of-band SOPS), the
+            # SAME Secret the setpoint-server component mounts; local builds use
+            # the placeholder file.
+            - name: ha-token
+              mountPath: /mnt/agents/shared/credentials
+              readOnly: true
           # No httpGet probe — connect-out worker. A heartbeat/freshness exec or
           # in-process flag probe is the §3.3 design (queries max(ts) FROM climate)
           # with a generous initialDelay so transient DB latency does not restart
@@ -141,3 +154,13 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        # verdify-ha-token Secret is delivered OUT-OF-BAND (SOPS/age, by-name,
+        # like grafana-admin) BEFORE this app reconciles; the prod overlay
+        # ha-token.placeholder.yaml is local-config (build-time only, excluded
+        # from real apply). Same Secret/shape as components/setpoint-server.
+        - name: ha-token
+          secret:
+            secretName: verdify-ha-token
+            items:
+              - key: ha_token.txt
+                path: ha_token.txt

--- a/deploy/k8s/overlays/prod-dark/ha-token.placeholder.yaml
+++ b/deploy/k8s/overlays/prod-dark/ha-token.placeholder.yaml
@@ -1,0 +1,26 @@
+# PLACEHOLDER Home Assistant token Secret for LOCAL VALIDATION ONLY
+# (kustomize build / kubeconform). #118 setpoint-server.
+#
+# THIS IS NOT A REAL CREDENTIAL and MUST NOT be applied to a real cluster. The
+# real verdify-ha-token Secret is provided by the fleet SOPS+age secret backend
+# and applied OUT-OF-BAND by the GitOps secret-delivery step BEFORE this app
+# reconciles (migration doc §3, verdify-ha-token -> HA long-lived token). The
+# setpoint-server mounts it at /mnt/agents/shared/credentials/ha_token.txt — the
+# SAME path scripts/setpoint-server.py:141 load_token() reads — so the code runs
+# unchanged.
+#
+# The config.kubernetes.io/local-config ANNOTATION (NOT a label) makes
+# `kustomize build` EXCLUDE this object from output, so a device-affecting HA
+# token placeholder is never emitted into a real-apply manifest. For a real
+# apply, the SOPS backend provides the Secret; this file is build-time only.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verdify-ha-token
+  labels:
+    app.kubernetes.io/part-of: verdify
+  annotations:
+    config.kubernetes.io/local-config: "true"   # excluded from build output
+type: Opaque
+stringData:
+  ha_token.txt: "PLACEHOLDER_NOT_A_REAL_SECRET"

--- a/deploy/k8s/overlays/prod-dark/kustomization.yaml
+++ b/deploy/k8s/overlays/prod-dark/kustomization.yaml
@@ -43,9 +43,13 @@ resources:
   # ANNOTATION -> EXCLUDED from build output (OpenAI key never emitted). Real
   # verdify-hermes via SOPS out-of-band. See hermes-secret.placeholder.yaml.
   - hermes-secret.placeholder.yaml
-  # NO ha-token.placeholder.yaml: the verdify-ha-token Secret is consumed ONLY by
-  # the setpoint-server (the grow-light writer), which prod-dark EXCLUDES. A
-  # device-affecting HA token surface is absent from the device-dark shape.
+  # ha-token.placeholder.yaml: the verdify-ha-token Secret is consumed by the
+  # ingestor (shelly_sync / ha_sensor_sync / tempest_sync HA-telemetry tasks —
+  # energy + hydro + weather) which the base now mounts. This is a READ to Home
+  # Assistant on the SERVICES VLAN, NOT a device-VLAN write, so it does not
+  # violate the device-dark posture. local-config ANNOTATION -> excluded from
+  # build output (token never emitted); real Secret via SOPS out-of-band.
+  - ha-token.placeholder.yaml
   # DEVICE-DARK NETWORK HALF: drop all ingestor egress to the greenhouse device
   # VLAN. This REPLACES overlays/prod's allow-ingestor-device-egress — prod-dark
   # carries the DENY and never the allow. See deny-esp32-egress.yaml.


### PR DESCRIPTION
## Root cause (LANE 2 — energy + hydro ingestion stalled at cutover)

The 2026-06-07 17:16Z greenhouse k3s cutover left `deploy/verdify-ingestor` (ns `verdify-prod`) with **no Home Assistant token**. The `energy` table and the `climate` `hydro_*` columns went stale at cutover (last rows `2026-06-07T17:12Z`), while ESP32-sourced climate/diagnostics/setpoint kept ingesting.

This is **case (a): an ingestor task path disabled by missing config in the prod overlay** — not a separate decommissioned job. `energy` (Shelly Pro EM50 panel meter) and `hydro` (YINMIK water tester, written as `hydro_*` columns into the `climate` table) are produced by the in-process ingestor tasks **`shelly_sync`** and **`ha_sensor_sync`** (plus `tempest_sync` for weather), all of which fetch from Home Assistant (`http://192.168.30.107:8123`) using `config.HA_TOKEN_FILE` → `/mnt/agents/shared/credentials/ha_token.txt`.

Live ingestor logs:
```
ERROR Task shelly_sync failed: [Errno 2] No such file or directory: '/mnt/agents/shared/credentials/ha_token.txt'
ERROR Task ha_sensor_sync failed: ... ha_token.txt
ERROR Task tempest_sync failed: ... ha_token.txt
```

Two gaps from the cutover:
1. **Base `ingestor-deployment.yaml` never mounted the HA token.** Only `components/setpoint-server` mounts `verdify-ha-token`; the ingestor (which also needs it) had only the `tmp` volume.
2. **The `verdify-ha-token` Secret was never delivered out-of-band** to `verdify-prod` (no such secret in the namespace).

Source devices are **alive and reachable**: HA at `192.168.30.107:8123` returns HTTP 200 from a k3s pod; the token file exists on the synced share. The only gap was credential delivery + mount.

## Change
- `deploy/k8s/base/ingestor-deployment.yaml`: add the `ha-token` volume + read-only mount at `/mnt/agents/shared/credentials`, referencing the `verdify-ha-token` Secret — the exact proven `components/setpoint-server` pattern. **No image change** (`load_token()` reads the same path).
- `deploy/k8s/overlays/prod-dark/`: add the matching `ha-token.placeholder.yaml` (local-config, build-time only) and update the kustomization note. The HA read is on the **services VLAN, not a device-VLAN write**, so it respects the device-dark posture.

## Validation
- `kustomize build` OK for prod / prod-dark / staging / dev.
- `kubeconform -strict` OK (prod 35 valid / 0 invalid; prod-dark 33 valid / 0 invalid; 2 CRD skips as baseline).
- Placeholder Secret confirmed **excluded** from real-apply output (`config.kubernetes.io/local-config`).

## ⚠️ Deploy is ingestor-affecting (gated — laptop-root)
The ingestor is the **sole live greenhouse writer** (single-writer ESP32 invariant, `strategy: Recreate`). Rollout order:
1. Apply the **real** `verdify-ha-token` Secret out-of-band (SOPS/age, by-name) to `verdify-prod`, key `ha_token.txt` = the real HA long-lived token (source: `/Users/jason/Agents/shared/credentials/ha_token.txt`).
2. Merge + GitOps-reconcile this manifest, then roll the ingestor with the **guarded stop/verify** procedure.
3. Verify `energy` + `climate.hydro_*` rows resume (max(ts) advances; cadence ~5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)