### PR TITLE
fix(verdify-prod): bind hermes-iris api_server on 0.0.0.0 (CrashLoop fix)

### DIFF
--- a/deploy/k8s/components/hermes-iris/hermes-iris.yaml
+++ b/deploy/k8s/components/hermes-iris/hermes-iris.yaml
@@ -110,6 +110,27 @@ spec:
             # compose:375 VERDIFY_SLACK_CONFIG=/opt/data/slack.yaml (on the PVC).
             - name: VERDIFY_SLACK_CONFIG
               value: /opt/data/slack.yaml
+            # BIND THE :8642 API SERVER ON 0.0.0.0 (CrashLoop fix, verdify-prod
+            # 2026-06-07). The api_server platform (the /v1/runs listener the
+            # ingestor calls) is auto-enabled because verdify-hermes provides
+            # API_SERVER_KEY (gateway/config.py:1386 `if api_server_enabled or
+            # api_server_key`). But Hermes' DEFAULT_HOST is 127.0.0.1
+            # (gateway/platforms/api_server.py:57) — proven: with only the secret
+            # the gateway binds 127.0.0.1:8642, so the kubelet tcpSocket probe to
+            # the POD IP is refused, fails 3x, SIGTERMs the gateway -> CrashLoop.
+            # On the VM hermes/iris/config.yaml set platforms.api_server.extra
+            # host: 0.0.0.0 (and docker-compose published 127.0.0.1 externally);
+            # in k3s /opt/data is an empty PVC so that config.yaml is absent and
+            # the entrypoint falls back to the cli-config example (no api_server,
+            # default 127.0.0.1). These two env vars are the k8s-native port of
+            # that config.yaml host override — non-secret bind params only; the
+            # ClusterIP Service + allow-hermes-from-ingestor NetworkPolicy keep the
+            # surface in-namespace (never LB, never WAN). API_SERVER_KEY stays the
+            # auth source (in verdify-hermes, never in this repo).
+            - name: API_SERVER_HOST
+              value: "0.0.0.0"
+            - name: API_SERVER_PORT
+              value: "8642"
           securityContext:
             allowPrivilegeEscalation: false
             # hermes writes run state under /opt/data (PVC); root FS can stay RO.


### PR DESCRIPTION
## Root cause
`verdify-hermes-iris` was 0/1 CrashLoopBackOff (21 restarts). #198 fixed command->args; the remaining failure was the **:8642 tcpSocket liveness probe killing an otherwise-healthy gateway** — not a real crash (logs: clean `Hermes Gateway Starting` then `signal=SIGTERM under_systemd=yes`, no bind/crash error).

The api_server platform (the `/v1/runs` listener the ingestor planner path calls) **is** auto-enabled — `verdify-hermes` supplies `API_SERVER_KEY` and `gateway/config.py:1386` enables api_server when that key is set. But Hermes' `DEFAULT_HOST` is `127.0.0.1` (`gateway/platforms/api_server.py:57`). On the VM, `hermes/iris/config.yaml` set `platforms.api_server.extra host: 0.0.0.0`; in k3s `/opt/data` is an **empty PVC** so that config.yaml is absent and the entrypoint falls back to the cli-config example (no api_server stanza, default 127.0.0.1).

**Proven in-image** (same digest):
- secret only -> binds `127.0.0.1:8642` (`/proc/net/tcp` `0100007F:21C2`) -> probe to pod IP refused -> CrashLoop
- `API_SERVER_HOST=0.0.0.0` -> binds `0.0.0.0:8642` (`00000000:21C2`, local connect rc=0) -> probe passes

## Fix
Add `API_SERVER_HOST=0.0.0.0` + `API_SERVER_PORT=8642` as plain (non-secret) env — the k8s-native port of the VM's config.yaml host override. `API_SERVER_KEY` stays the auth source in `verdify-hermes` (never in repo). Surface stays in-namespace via the ClusterIP Service + `allow-hermes-from-ingestor` NetworkPolicy. Probe kept (the gateway genuinely must serve :8642 for the planner->hermes path).

## Scope / validation
- Component change -> applies to `overlays/prod` + `overlays/prod-dark`; `overlays/staging` still excludes hermes-iris (verified).
- `kustomize build` + `kubeconform -strict` pass for prod-dark (33 valid / 0 invalid) and prod.
- hermes-iris is NOT the device writer; live apply + restart is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)