### PR TITLE
fix(verdify-prod): reconcile verdify-db storageClass to live (synology-iscsi-ssd)

### DIFF
--- a/deploy/k8s/overlays/prod/db-storageclass-iscsi.yaml
+++ b/deploy/k8s/overlays/prod/db-storageclass-iscsi.yaml
@@ -1,0 +1,31 @@
+# PROD storage reconcile: the live prod verdify-db has ALREADY been migrated off
+# the node-pinned local-path PVC onto the proven synology-iscsi-ssd StorageClass
+# (csi.san.synology.com, /volume1 SSD, reclaim=Retain, WaitForFirstConsumer,
+# expandable) — its db-data-verdify-db-0 PVC has been Bound on synology-iscsi-ssd
+# since the gated DB cutover (verified live: 50Gi RWO synology-iscsi-ssd, Bound,
+# 5d+). The base db-statefulset.yaml still pins local-path (shared with the dev/
+# staging pattern), so the prod overlay must restate the volumeClaimTemplate to
+# match the live cluster — otherwise ArgoCD renders local-path, diffs the live
+# STS, and tries to patch the IMMUTABLE volumeClaimTemplates.storageClassName
+# (the StatefulSet "Forbidden: updates to spec for fields other than ..." sync
+# failure). This patch makes git == live so there is NO diff and NO patch attempt.
+#
+# This is a RECONCILE-TO-LIVE git change only; it does NOT touch or recreate the
+# live StatefulSet (git now equals the running spec). Mirrors the staging
+# db-storageclass-iscsi.yaml pattern. The whole volumeClaimTemplate element is
+# restated (kustomize keys volumeClaimTemplates by metadata.name and replaces the
+# matched element) so accessModes + size are preserved alongside the SC.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: verdify-db
+spec:
+  volumeClaimTemplates:
+    - metadata:
+        name: db-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: synology-iscsi-ssd
+        resources:
+          requests:
+            storage: 50Gi

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -90,6 +90,11 @@ components:
   - ../../components/grafana
 
 patches:
+  # PROD DB STORAGE RECONCILE: restate verdify-db's volumeClaimTemplate onto
+  # synology-iscsi-ssd to match the ALREADY-MIGRATED live prod DB (Bound 5d+).
+  # git==live -> no immutable-field StatefulSet patch attempt. See
+  # db-storageclass-iscsi.yaml. Reconcile-to-live only; does NOT recreate the STS.
+  - path: db-storageclass-iscsi.yaml
   # DEVICE-WRITE INTERLOCK (#79): VERDIFY_DEVICE_WRITE_ENABLED=1 — prod only.
   - path: device-write-configmap.yaml
   # #113 publish-all: prod re-emits every flushed telemetry row onto the fan-out


### PR DESCRIPTION
## Reconcile-to-live (lane 4)

The live prod `verdify-db` was already migrated onto `synology-iscsi-ssd` (PVC `db-data-verdify-db-0` Bound 50Gi RWO, 5d+), but the prod overlay still rendered the base `local-path`. That stale diff made ArgoCD repeatedly try to patch the IMMUTABLE `volumeClaimTemplates.storageClassName` on the live StatefulSet → the recurring `StatefulSet ... Forbidden: updates to spec for fields other than ...` sync failure that left `verdify-prod-dark` Degraded/OutOfSync.

Adds `overlays/prod/db-storageclass-iscsi.yaml` (mirrors the staging pattern) + wires it into the prod overlay patches. `kustomize build overlays/prod` renders `synology-iscsi-ssd`; server-side `kubectl diff` of the rendered STS vs live is now **identical (exit 0)**, so ArgoCD stops attempting the forbidden patch and the STS goes Synced.

Reconcile-to-live git change ONLY — git now equals the running spec; does NOT touch, restart, or recreate the live StatefulSet/PVC. No ingestor impact. Passes the promote-diff-guard (changes no digest → structural, per the guard fix in #199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)