### PR TITLE
fix(db-backup): wait out CNI netpol race (backup had NEVER succeeded) + RPO freshness alarm

### DIFF
--- a/deploy/k8s/components/db-backup/backup-cronjob.yaml
+++ b/deploy/k8s/components/db-backup/backup-cronjob.yaml
@@ -75,6 +75,31 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
+                  # NETPOL-RACE WAIT (why this job had NEVER succeeded):
+                  # the CNI (kube-router) programs the allow-db-from-backup
+                  # ingress rule for a freshly-scheduled pod ASYNCHRONOUSLY.
+                  # For the first ~5-10s of a new pod's life the rule is not
+                  # yet in the dataplane, so a connection to the DB is REJECTed
+                  # (Connection refused). The original script fired pg_dump
+                  # immediately under `set -e`, so it died on that refusal and
+                  # every nightly run (and its backoff retries, each a NEW pod
+                  # hitting the same race) failed. Block until the DB is
+                  # actually reachable before dumping. pg_isready is a cheap
+                  # SELECT-free TCP+startup probe; it does NOT write the DB.
+                  echo "[backup] waiting for ${DB_HOST}:${DB_PORT} to be reachable (CNI netpol-program race)"
+                  ready=0
+                  for attempt in $(seq 1 60); do
+                    if pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -t 3 >/dev/null 2>&1; then
+                      echo "[backup] DB reachable after ${attempt} attempt(s)"
+                      ready=1
+                      break
+                    fi
+                    sleep 2
+                  done
+                  if [ "${ready}" -ne 1 ]; then
+                    echo "[backup] FATAL: ${DB_HOST}:${DB_PORT} never became reachable after 120s" >&2
+                    exit 1
+                  fi
                   ts="$(date -u +%Y%m%dT%H%M%SZ)"
                   out="${BACKUP_DIR}/verdify-${ts}.dump"
                   echo "[backup] pg_dump -Fc ${DB_NAME}@${DB_HOST} -> ${out}"

--- a/deploy/k8s/components/db-backup/backup-freshness-exporter.yaml
+++ b/deploy/k8s/components/db-backup/backup-freshness-exporter.yaml
@@ -1,0 +1,160 @@
+# BACKUP-FRESHNESS EXPORTER (RPO alarm source).
+#
+# WHY: the nightly verdify-db-backup CronJob writes -Fc dumps to the verdify-db-dumps
+# PVC. The cluster has NO kube-state-metrics and NO pushgateway, so there is no native
+# `kube_cronjob_status_last_successful_time` to alert on. This tiny always-on exporter
+# closes that gap by measuring the REAL recovery-point: the mtime of the newest
+# verdify-*.dump on the dumps PVC. It mounts the PVC READ-ONLY and never touches the
+# DB, the device, or the ingestor — it only stat()s files.
+#
+# It exposes, on :8080/metrics:
+#   verdify_db_backup_last_success_timestamp_seconds  -> unix mtime of newest .dump
+#   verdify_db_backup_dump_size_bytes                 -> size of newest .dump
+#   verdify_db_backup_dump_count                      -> number of .dump files retained
+#   verdify_db_backup_exporter_up                     -> 1 if the scan succeeded
+#
+# Prometheus auto-discovers it via the cluster's kubernetes-pods SD job
+# (prometheus.io/scrape=true on the pod). The companion alert
+# VerdifyDBBackupStale (network-infra deploy/observability) fires when
+# (time() - last_success) > 26h, i.e. a nightly backup was missed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-db-backup-exporter
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: db-backup-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: db-backup-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          # python:3.12-alpine: the same tiny public stdlib image the fleet's other
+          # micro-exporters use (e.g. verdify-writer-exporter). The timescaledb image
+          # ships no python3, so it cannot host this. The exporter is pure stdlib; it
+          # opens nothing but local files (the dumps PVC) and a listen socket.
+          image: python:3.12-alpine
+          command:
+            - python3
+            - -c
+            - |
+              import os, glob, http.server, socketserver
+              BACKUP_DIR = os.environ.get("BACKUP_DIR", "/backups")
+              PORT = int(os.environ.get("LISTEN_PORT", "8080"))
+              def scan():
+                  try:
+                      dumps = glob.glob(os.path.join(BACKUP_DIR, "verdify-*.dump"))
+                      if not dumps:
+                          return (0.0, 0, 0, 1)  # up=1 but no dumps yet -> ts=0 trips the alert
+                      newest = max(dumps, key=os.path.getmtime)
+                      st = os.stat(newest)
+                      return (st.st_mtime, st.st_size, len(dumps), 1)
+                  except Exception:
+                      return (0.0, 0, 0, 0)
+              class H(http.server.BaseHTTPRequestHandler):
+                  def log_message(self, *a):
+                      pass
+                  def do_GET(self):
+                      ts, size, count, up = scan()
+                      body = (
+                          "# HELP verdify_db_backup_last_success_timestamp_seconds Unix mtime of the newest verdify DB dump on the dumps PVC.\n"
+                          "# TYPE verdify_db_backup_last_success_timestamp_seconds gauge\n"
+                          f"verdify_db_backup_last_success_timestamp_seconds {ts}\n"
+                          "# HELP verdify_db_backup_dump_size_bytes Size in bytes of the newest verdify DB dump.\n"
+                          "# TYPE verdify_db_backup_dump_size_bytes gauge\n"
+                          f"verdify_db_backup_dump_size_bytes {size}\n"
+                          "# HELP verdify_db_backup_dump_count Number of retained verdify DB dumps.\n"
+                          "# TYPE verdify_db_backup_dump_count gauge\n"
+                          f"verdify_db_backup_dump_count {count}\n"
+                          "# HELP verdify_db_backup_exporter_up 1 if the last dump-dir scan succeeded.\n"
+                          "# TYPE verdify_db_backup_exporter_up gauge\n"
+                          f"verdify_db_backup_exporter_up {up}\n"
+                      ).encode()
+                      self.send_response(200)
+                      self.send_header("Content-Type", "text/plain; version=0.0.4")
+                      self.send_header("Content-Length", str(len(body)))
+                      self.end_headers()
+                      self.wfile.write(body)
+              class S(socketserver.ThreadingMixIn, http.server.HTTPServer):
+                  daemon_threads = True
+                  allow_reuse_address = True
+              with S(("0.0.0.0", PORT), H) as httpd:
+                  httpd.serve_forever()
+          env:
+            - name: BACKUP_DIR
+              value: /backups
+            - name: LISTEN_PORT
+              value: "8080"
+          ports:
+            - name: metrics
+              containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              memory: "64Mi"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          volumeMounts:
+            - name: dumps
+              mountPath: /backups
+              readOnly: true
+      volumes:
+        - name: dumps
+          persistentVolumeClaim:
+            claimName: verdify-db-dumps
+            readOnly: true
+---
+# Let the observability Prometheus scrape the freshness exporter on :8080.
+# default-deny-ingress otherwise blocks it. Matched by the immutable
+# kubernetes.io/metadata.name label (the part-of label on the observability ns
+# is agent-fleet, not observability, so we pin the metadata-name label instead).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backup-exporter-scrape
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-backup-exporter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: db-backup-exporter
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/deploy/k8s/components/db-backup/kustomization.yaml
+++ b/deploy/k8s/components/db-backup/kustomization.yaml
@@ -23,3 +23,7 @@ kind: Component
 resources:
   - dumps-pvc.yaml
   - backup-cronjob.yaml
+  # Always-on RPO alarm source: reads the dumps PVC mtime read-only and exports
+  # verdify_db_backup_last_success_timestamp_seconds for the VerdifyDBBackupStale
+  # alert (no kube-state-metrics in this cluster). See its header.
+  - backup-freshness-exporter.yaml


### PR DESCRIPTION
## P0: the greenhouse DB backup had never once succeeded

The `verdify-db-backup` CronJob (ns `verdify-prod`) is the **only** backup of the live greenhouse prod TimescaleDB. Its `lastSuccessfulTime` was empty and its one run had `Failed` — RPO was effectively unbounded.

### Root cause (proven)
kube-router programs the `allow-db-from-backup` ingress NetworkPolicy for a **freshly-scheduled** pod **asynchronously** (~5–10 s lag). The script ran `pg_dump` immediately under `set -euo pipefail`, so the first connection hit the not-yet-programmed policy → **Connection refused** → the job died. Each `backoffLimit` retry was a new pod hitting the same race.

Reproduced live: a fresh `db-backup`-labeled probe got `Connection refused` on attempt 1, then connected on attempt 2 (~5–10 s later); meanwhile the long-lived `api`/`grafana` pods reach the DB fine. So the DB and the allow-rule are correct — it is purely a startup race.

### Fix
- **`backup-cronjob.yaml`** — block on `pg_isready` (cheap, SELECT-free, no DB write) for up to 120 s before `pg_dump`, so the dump only starts once the allow rule is actually in the dataplane.
- **`backup-freshness-exporter.yaml`** (new) — always-on `python:3.12-alpine` micro-exporter that mounts the dumps PVC **read-only** and exports `verdify_db_backup_last_success_timestamp_seconds` (+ size/count/up). No kube-state-metrics/pushgateway in this cluster, so this is the RPO signal. Auto-scraped via the `kubernetes-pods` SD job; an `allow-backup-exporter-scrape` NetworkPolicy lets the observability Prometheus reach `:8080` (matched by the immutable `kubernetes.io/metadata.name=observability` label, since the ns `part-of` label is `agent-fleet`, not `observability`).

### Proof (applied live, then captured here as IaC)
- Manual run `verdify-db-backup-manual-1`: **Complete 1/1, 33 s**, logs `DB reachable after 2 attempt(s)` → wrote `verdify-20260607T202333Z.dump` (137.4M).
- `pg_restore --list`: valid CUSTOM archive, **4971 TOC entries**, PG 16.11, timescaledb/pgcrypto/vector extensions.
- Exporter live: `verdify_db_backup_last_success_timestamp_seconds 1780863841`, scraped by Prometheus under `job="kubernetes-pods"`.
- Off-NAS copies (second failure domain): Mac `~/verdify-db-backups-offnas/` and Proxmox `oro:/root/verdify-db-offnas/`, both SHA256-verified identical.

### Safety
SELECT-only / read-only throughout. Does **not** scale, restart, or touch the `verdify-ingestor` (the live greenhouse writer), the device path, or any ingestor NetworkPolicy.

Companion alert rules (`VerdifyDBBackupStale` >26h, `VerdifyDBBackupExporterDown`) are in a paired `jvallery/network-infra` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)