### PR TITLE
fix(ingestor): wire HERMES_IRIS_API_KEY — the REAL #213 plan-delivery 401

### DIFF
--- a/deploy/k8s/base/ingestor-deployment.yaml
+++ b/deploy/k8s/base/ingestor-deployment.yaml
@@ -115,6 +115,22 @@ spec:
                 secretKeyRef:
                   name: verdify-app-secrets
                   key: MQTT_PASS
+            # AI-plan gateway auth (#213). iris_planner posts the scheduled +
+            # crop-deviation plan requests to Hermes /v1/runs with
+            # Authorization: Bearer ${HERMES_IRIS_API_KEY}
+            # (ingestor/config.py:59 -> iris_planner.py:1200). Hermes validates
+            # this bearer against its own API_SERVER_KEY; the verdify-hermes
+            # Secret holds the SAME value under both HERMES_IRIS_API_KEY and
+            # API_SERVER_KEY (sha b164964a). Without this wiring the ingestor
+            # sends an EMPTY bearer and Hermes returns its OpenAI-shaped
+            # {"code":"invalid_api_key"} 401 at the auth middleware BEFORE any
+            # OpenAI call — the root cause of the recurring plan_delivery_log
+            # gateway_status=401 (NOT a bad OPENAI_API_KEY / config.yaml drift).
+            - name: HERMES_IRIS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-hermes
+                  key: HERMES_IRIS_API_KEY
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## Root cause (corrects the #213 hypothesis in #223)

The recurring `plan_delivery_log` `gateway_status=401` /
`{"error":{"code":"invalid_api_key",...}}` is **Hermes's OWN gateway-auth rejection**, deliberately mimicking OpenAI's 401 envelope. It is **NOT** an OpenAI error and **NOT** a `config.yaml` / `OPENAI_API_KEY` problem.

The ingestor posts scheduled + crop-deviation plan requests to Hermes `POST /v1/runs` with `Authorization: Bearer ${HERMES_IRIS_API_KEY}` (`ingestor/config.py:59` → `iris_planner.py:1200`). The ingestor Deployment **never wired `HERMES_IRIS_API_KEY` in** (env had only PG/ESP32/MQTT secrets + `envFrom verdify-config`, which carries `HERMES_URL` but not the token). So the ingestor sent an **empty bearer**. Hermes's `_authenticate` middleware (`gateway/platforms/api_server.py:700-708`) `hmac.compare_digest` fails on the empty token and returns its OpenAI-shaped 401 **before any OpenAI call** — which is exactly why hermes logs show no OpenAI error and why `OPENAI_API_KEY` proved valid (a direct gpt-5.5 run completes).

This is why the #223 "fix" (restore config.yaml + seed-config initContainer) appeared to regress: the 22:23Z proof was a **direct** hermes test with the correct `API_SERVER_KEY`; the 22:34Z failure was the **ingestor** path with its empty `HERMES_IRIS_API_KEY`. Different keys, different paths — config drift was never the cause of the ingestor 401.

## Live evidence

| Fact | Value |
|---|---|
| ingestor pod `HERMES_IRIS_API_KEY` | len=0, sha `e3b0c442` (= sha256 of empty string) |
| `verdify-hermes` Secret `HERMES_IRIS_API_KEY` == `API_SERVER_KEY` | sha `b164964a`, len 64 |
| empty bearer → | `HTTP 401` `{"...","code":"invalid_api_key"}` (byte-for-byte the logged body) |
| correct bearer → | `HTTP 202` → run `completed`, output `OK`, gpt-5.5/custom/api.openai.com, ~13.5k tokens |

## Fix (durable, restart- and reseed-surviving)

Add a `secretKeyRef` pulling `HERMES_IRIS_API_KEY` from the `verdify-hermes` Secret into the ingestor container env in the **canonical base manifest** (`deploy/k8s/base/ingestor-deployment.yaml`). The Secret already holds the exact value Hermes validates as `API_SERVER_KEY` (sha `b164964a`).

The LLM-auth side (hermes `config.yaml`: keyless `custom` provider, `gpt-5.5`, `base_url api.openai.com`, auto `OPENAI_API_KEY` pickup; the lone `Bearer ${VERDIFY_MCP_TOKEN}` is scoped to `mcp_servers`, NOT LLM) is already correct and **consistent across the live PVC, the `verdify-hermes-iris-config` seed ConfigMap, and this repo** — verified, no change needed there.

## Durability proof (LLM hop)

- Baseline direct gpt-5.5 run → `completed`, output `OK`.
- **Restart #1** of `verdify-hermes-iris`: seed reseeded gpt-5.5/custom/api.openai.com; direct run → `completed`.
- **Restart #2**: seed reseeded correct config again; empty bearer still `401` (auth invariant); correct bearer → `completed`, output `OK`. (`run_b0d64258...`)

The valid `OPENAI_API_KEY` (sha `5ff89f5a`) has gpt-5.5 access — **no fresh key needed**.

## Live-apply gate

Applying this to the **live** ingestor requires an ingestor pod restart — the ingestor is the live greenhouse **device writer**, so per the guardrail it was **NOT restarted here**. The live env-pickup is gated on Jason. (Base `replicas: 0`; live ingestor is a manual scale-up.)

Closes #213. Refs #210 #211 #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)