### PR TITLE
fix(ha): API liveness decoupled from DB + graceful drain on serving surfaces (#231)

### DIFF
--- a/deploy/k8s/base/api-deployment.yaml
+++ b/deploy/k8s/base/api-deployment.yaml
@@ -112,21 +112,52 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-          livenessProbe:
-            # /health exists today (api/main.py:911). /health/live + /health/ready
-            # are the gravity convention; switch the probe paths once the api
-            # scope owner adds them in the containerize PR.
+          # GRACEFUL DRAIN (HA #231, Lane C). On SIGTERM the api must stay
+          # listening for ~5s so Traefik/kube-proxy can drop this pod's endpoint
+          # BEFORE uvicorn stops accepting — otherwise a rolling update / drain
+          # can deliver a request to an already-shutting-down replica → a
+          # mid-rollout 503. The preStop sleep + terminationGracePeriodSeconds
+          # below give that drain window (uvicorn then gets ~25s to finish
+          # in-flight requests before SIGKILL).
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
+          # PROBE DECOUPLING (HA #231, Lane C — the "startup gap" fix). /health
+          # (api/main.py:911) does a DB roundtrip (SELECT ... FROM climate, etc).
+          # Using it for LIVENESS meant a slow/cold asyncpg pool or a transient DB
+          # blip flap-RESTARTED the api (incident night). Fixed by separating the
+          # two concerns:
+          #   - livenessProbe  = a cheap process-alive TCP check on :8080 that
+          #     does NOT touch the DB. A DB-less-but-listening pod is NEVER killed.
+          #     (Interim form per the design doc; swaps to GET /health/live once
+          #     the api scope owner adds that no-DB route in the containerize PR.)
+          #   - readinessProbe = stays on /health (DB-coupled is CORRECT here): a
+          #     pod that can't reach the DB is pulled from rotation but NOT killed.
+          #   - startupProbe   = /health with failureThreshold:30 periodSeconds:5
+          #     → up to 150s for pool/DB warmup before liveness arms, so a cold
+          #     start never trips the (now TCP) liveness probe.
+          startupProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: http
             periodSeconds: 30
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+      # Endpoint-drain window for the preStop hooks above (HA #231). 30s is the
+      # k8s default, pinned explicit so it is reviewable and survives a default
+      # change: ~5s endpoint drain + ~25s for uvicorn to finish in-flight work.
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/k8s/base/mcp-deployment.yaml
+++ b/deploy/k8s/base/mcp-deployment.yaml
@@ -85,21 +85,38 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+          # GRACEFUL DRAIN (HA #231, Lane C). preStop sleep so Traefik/kube-proxy
+          # drop this pod's endpoint before the server stops accepting, avoiding a
+          # mid-rollout 503 (same drain contract as www/lab/api).
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           # FastMCP (mcp/server.py) serves the streamable-http MCP protocol at
           # /mcp, not a plain GET /health (the staging proof saw httpGet /health
           # return 404 -> pod never Ready). A tcpSocket probe confirms the process
           # is listening without touching the server.py DANGER surface (handoff
-          # §3.2: no tool-semantic edits to add a /health route).
+          # §3.2: no tool-semantic edits to add a /health route). Liveness here is
+          # ALREADY DB-independent (TCP only), so the api "startup gap" cannot
+          # occur for mcp; the startupProbe below just holds liveness off until the
+          # listener is up so a slow import never trips it.
+          startupProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 15
             periodSeconds: 30
+            failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+      # Endpoint-drain window for the preStop hook above (HA #231); 30s explicit.
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/k8s/components/lab-site/lab-site.yaml
+++ b/deploy/k8s/components/lab-site/lab-site.yaml
@@ -99,6 +99,14 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
+          # GRACEFUL DRAIN (HA #231, Lane C). preStop sleep so Traefik/kube-proxy
+          # drop this pod's endpoint before nginx stops accepting, avoiding a
+          # mid-rollout 503 (same drain contract as api/mcp/www). Static "/" probes
+          # are DB-free already, so only the drain hook + explicit grace are added.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           # Static site served at "/"; use the homepage as the probe target (no
           # dedicated /healthz in a Quartz static build).
           livenessProbe:
@@ -113,6 +121,8 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+      # Endpoint-drain window for the preStop hook above (HA #231); 30s explicit.
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/k8s/components/www/www.yaml
+++ b/deploy/k8s/components/www/www.yaml
@@ -96,6 +96,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+          # GRACEFUL DRAIN (HA #231, Lane C). preStop sleep so Traefik/kube-proxy
+          # drop this pod's endpoint before server.mjs stops accepting, avoiding a
+          # mid-rollout 503 (same drain contract as api/mcp/lab). Probes already
+          # hit the cheap static "/" homepage (no DB), so no liveness decoupling is
+          # needed here — only the drain hook + explicit grace.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           # server.mjs serves the static dist/ from "/" — use the homepage as the
           # liveness/readiness target (no dedicated /healthz in the upstream app).
           livenessProbe:
@@ -110,6 +119,8 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+      # Endpoint-drain window for the preStop hook above (HA #231); 30s explicit.
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
## Sprint ha-1 — Lane C (API probe health, #231)

Fixes the incident-night **"startup gap"** and the **mid-rollout 503** on the stateless Verdify serving surfaces. Part of the [HA first-principles resilience](https://github.com/VerdifyConsultancy/verdify-platform) epic; design doc `root/docs/verdify-ha-architecture-2026-06-07.md` §2.1.

### Problem
1. `verdify-api` used the **same DB-roundtrip `/health`** (`api/main.py:911` — `SELECT … FROM climate`, etc.) for **both liveness and readiness**. A slow/cold asyncpg pool or a transient DB blip therefore **flap-restarted** the api instead of merely pulling it from rotation.
2. **No surface had a `preStop`/graceful-drain window**, so a rolling update or node drain could route a request to an already-terminating replica → a brief 503.

### Change (stateless surfaces ONLY)
**Probe decoupling — `verdify-api`:**
- `livenessProbe` → cheap **`tcpSocket` :8080** (no DB). A DB-less-but-listening pod is pulled from rotation by readiness but **never killed**. Interim form per the design doc; swaps to `GET /health/live` once the api scope owner adds that no-DB route in the containerize PR.
- `readinessProbe` → **stays on `/health`** (DB-coupled is correct here).
- `startupProbe` → `/health`, `failureThreshold:30 periodSeconds:5` (≤150s pool/DB warmup before liveness arms).

**`verdify-mcp`:** liveness was already DB-independent (`tcpSocket`); added a matching `tcpSocket` `startupProbe`.

**Graceful drain — www / lab / api / mcp:**
- `lifecycle.preStop: ["sleep","5"]` so Traefik/kube-proxy drop the endpoint before SIGTERM (`sleep` verified present in all four images).
- `terminationGracePeriodSeconds: 30` pinned explicit (was the implicit default).

### Scope / safety
- **The `verdify-ingestor` / `setpoint-server` device-write path is NOT touched** (gated ha-3). Zero changes to the device/ESP32/DB-write path.
- `api`/`mcp` live in `base/` → changes also render into `overlays/staging`+`dev` (additive, improvement). `www`/`lab` are prod/dev Components. `kustomize build` validated clean on **all four** overlays (prod, prod-dark, staging, dev).
- Applied live to the manual-sync `verdify-prod-dark` app (overlays/prod) additively; git == live.

### Verification
- All `*.verdify.ai` surfaces stayed **200** (mcp serves `/mcp`, not `/`) across the rollout.
- api `RESTARTS` did **not** increase (liveness no longer trips on DB latency).
- Rollout was zero-downtime (preStop drain + `maxUnavailable:0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)