### PR TITLE
ha(verdify-prod): Sprint ha-1 / LANE B — stateless multi-replica + hard spread + PDBs (#230)

### DIFF
--- a/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
+++ b/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
@@ -1,0 +1,116 @@
+# Sprint ha-1 / LANE B (#230) — STATELESS MULTI-REPLICA + HARD HOSTNAME SPREAD.
+#
+# Why a prod-overlay patch (not a base/component edit): base (api/mcp) renders
+# into overlays/staging, and the www/lab components render into overlays/dev, so
+# editing them there would change those instances. These availability changes are
+# a PROD posture, so they are applied here as strategic-merge patches scoped to
+# overlays/prod only. staging/dev keep replicas:1 + their existing strategy.
+#
+# Root cause (incident 2026-06-07): ~11 of 13 verdify-prod pods stacked on node7
+# (the smallest worker, 8c/16G) with nothing telling the scheduler to spread, so
+# a 2-"replica" namespace had the availability of a 1-replica one. The fix:
+#   1. replicas 1 -> 2 (N+1: survive one node loss/drain with >=1 ready endpoint).
+#   2. topologySpreadConstraints hostname maxSkew:1 whenUnsatisfiable:DoNotSchedule
+#      with matchLabelKeys:[pod-template-hash] -> the 2 replicas (and a rolling
+#      update's surging replica) land on 2 DISTINCT of the 4 schedulable workers
+#      (node4/5/6/7). 4 workers >= 2 replicas => the hard constraint is ALWAYS
+#      satisfiable, so DoNotSchedule carries no Pending risk.
+#   3. RollingUpdate maxUnavailable:0, maxSurge:1 -> zero-downtime: scaling and
+#      every future rollout never drops the ready-endpoint count below running.
+#
+# Selectors match each deployment's live spec.selector.matchLabels exactly
+# (www=www, lab=lab-site, api=api, mcp=mcp, traefik name=verdify-traefik).
+# NOT touched here: verdify-ingestor / verdify-setpoint-server (single-writer
+# device path — gated ha-3), grafana (RWO PVC singleton — stays replicas:1).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-www
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: www
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-lab
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: lab-site
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-api
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-mcp
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: mcp

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -46,6 +46,11 @@ resources:
   # www/lab IngressRoutes above (verdify-t2-* are distinctly named) and matches
   # the live verdify-prod cluster exactly. See traefik/ for the full set.
   - traefik
+  # HA Sprint ha-1 / LANE B (#230): PodDisruptionBudgets giving every 2-replica
+  # stateless surface (www/lab/api/mcp) + tier-2 verdify-traefik a disruption
+  # floor (minAvailable:1), and grafana a drain-safe maxUnavailable:1 (RWO PVC
+  # singleton). The incident had ZERO PDBs in verdify-prod. See pdb.yaml.
+  - pdb.yaml
 
 # verdify-planner (#117) + verdify-mqtt fan-out broker (#113) — referenced as
 # Components, NOT added to base, so they never render into overlays/staging (the
@@ -122,6 +127,11 @@ patches:
   - path: ingestor-state-volume.yaml
   # ingestor keeps the base replicas:1 + Recreate (single-writer invariant); no
   # replicas:0 pin here (that is staging's two-writer safety pin).
+  # HA Sprint ha-1 / LANE B (#230): scale www/lab/api/mcp 1->2, hard hostname
+  # spread (DoNotSchedule + matchLabelKeys), zero-downtime rollout. Scoped to
+  # overlays/prod so base (api/mcp -> staging) + the www/lab components (-> dev)
+  # stay at replicas:1. ingestor/setpoint-server are NOT in this patch.
+  - path: ha-stateless-spread.patch.yaml
 
 # Image digest pins. Same canonical namespace as staging
 # (ghcr.io/verdifyconsultancy/verdify-*), pinned to immutable @sha256 digests

--- a/deploy/k8s/overlays/prod/pdb.yaml
+++ b/deploy/k8s/overlays/prod/pdb.yaml
@@ -1,0 +1,98 @@
+# Sprint ha-1 / LANE B (#230) — PodDisruptionBudgets for the verdify-prod
+# stateless surfaces + tier-2 edge.
+#
+# The incident had ZERO PDBs in verdify-prod, so a drain/upgrade/TaintManager
+# eviction could take any surface to zero ready endpoints. These PDBs give every
+# 2-replica surface a disruption FLOOR: a voluntary disruption (drain) evicts one
+# replica, then BLOCKS until its replacement is Ready on another node before the
+# second can go — the surface never hits zero during cluster maintenance.
+#
+#   - www / lab / api / mcp / verdify-traefik: minAvailable: 1 (2-replica surfaces).
+#   - grafana: maxUnavailable: 1 (RWO iSCSI PVC singleton, stays replicas:1).
+#     minAvailable:1 on a 1-replica object would block EVERY node drain forever;
+#     maxUnavailable:1 lets the drain proceed (its HA is fast PVC-reattach
+#     failover, NOT a second replica) — the §2.2 design.
+#
+# Selectors mirror each deployment's live spec.selector.matchLabels exactly.
+# NOT covered: verdify-ingestor / verdify-setpoint-server (gated ha-3 device
+# path — their PDB is authored in that sprint, not here).
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-www
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: www
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: www
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-lab
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: lab-site
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: lab-site
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-api
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-mcp
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: mcp
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mcp
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-traefik
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: edge-traefik
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: verdify-traefik
+---
+# grafana: RWO PVC singleton (replicas:1). maxUnavailable:1 (NOT minAvailable:1)
+# so node drains can proceed; HA is fast reschedule + PVC re-attach failover.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-grafana
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: grafana

--- a/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
+++ b/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
@@ -25,6 +25,14 @@ metadata:
     app.kubernetes.io/component: edge-traefik
 spec:
   replicas: 2
+  # Sprint ha-1 (#230): zero-downtime rollout — never drop a ready edge replica
+  # below the running count during a rollout (the default 25% maxUnavailable
+  # could briefly take the 2-replica tier to 1).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: verdify-traefik
@@ -37,11 +45,17 @@ spec:
     spec:
       serviceAccountName: verdify-traefik
       # Spread the 2 replicas across nodes so a single node loss can't take the
-      # whole verdify edge tier down (now possible on all 7 L2-consistent nodes).
+      # whole verdify edge tier down. Sprint ha-1 (#230): upgraded to HARD
+      # (DoNotSchedule) — 4 schedulable workers >= 2 replicas => always
+      # satisfiable, so the hard guarantee carries no Pending risk.
+      # matchLabelKeys:[pod-template-hash] so a rolling update's surging replica
+      # also lands on a distinct node.
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: verdify-traefik


### PR DESCRIPTION
## Sprint ha-1 / LANE B (#230) — STATELESS MULTI-REPLICA + HARD SPREAD + PDB

Fix for the **2026-06-07 node7-overload flap** that dropped single-replica public surfaces. ~11 of 13 `verdify-prod` pods were stacked on **node7** (smallest worker, 8c/16G) with nothing telling the scheduler to spread, so a node `NotReady` flap → `TaintManagerEviction` briefly took www/lab/api/mcp/grafana to **zero ready endpoints**.

### What changed (scoped to `overlays/prod` only)
Scoping rationale: `base` (api/mcp) renders into `overlays/staging`, and the www/lab **components** render into `overlays/dev`. Editing those would change staging/dev. So all availability changes are prod-overlay strategic-merge patches + a new `pdb.yaml` — **staging/dev keep replicas:1, no spread, no PDB** (verified by `kustomize build`).

- **`ha-stateless-spread.patch.yaml`** — www/lab/api/mcp **1→2 replicas**; `topologySpreadConstraints` hostname `maxSkew:1` `whenUnsatisfiable: DoNotSchedule` + `matchLabelKeys:[pod-template-hash]` (4 schedulable workers ≥ 2 replicas ⇒ always satisfiable ⇒ no Pending risk; a rolling update's surging replica also spreads); `RollingUpdate maxUnavailable:0 / maxSurge:1` (zero-downtime).
- **`traefik/verdify-traefik-deployment.yaml`** — tier-2 spread `ScheduleAnyway`→**`DoNotSchedule`** + `matchLabelKeys`; explicit zero-downtime `RollingUpdate` strategy.
- **`pdb.yaml`** — `minAvailable:1` PDB for www/lab/api/mcp/verdify-traefik; **grafana** PDB `maxUnavailable:1` (RWO iSCSI singleton stays `replicas:1` — `minAvailable:1` on a 1-replica object would block every node drain forever).

### Guardrails honored
- **NOT touched:** `verdify-ingestor` / `verdify-setpoint-server` (single-writer ESP32 device path — gated **ha-3**). Rendered prod build confirms both stay `replicas:1` + `Recreate` with **no** spread. grafana replica count unchanged.
- Additive + zero-downtime; requests/limits unchanged (those are a separate ha-1 lane). No CPU limit set that could throttle a working pod.

### Validation
- `kustomize build overlays/{prod,staging,dev}` all exit 0; staging+dev unchanged.
- prod render: www/lab/api/mcp/traefik = replicas:2, hard spread, RU 0/1; PDBs present; ingestor/setpoint untouched.
- Applied live (verdify-prod-dark is manual-sync; git == live) with the LANE-B chaos test (one-replica-delete per surface, ingestor node excluded) — see PR thread / report.

Design: `root/docs/verdify-ha-architecture-2026-06-07.md` §1.2/§2.1/§2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)