### PR TITLE
feat(ha-1/lane-a): resource governance — PriorityClasses, CPU limits, LimitRange (#226/#227/#229)

### DIFF
--- a/deploy/k8s/overlays/prod/ha-serving-resources.yaml
+++ b/deploy/k8s/overlays/prod/ha-serving-resources.yaml
@@ -1,0 +1,133 @@
+# HA Sprint ha-1 / Lane A (#226/#227/#229) — strategic-merge patches that add
+# verdify-serving priorityClass + a CPU LIMIT (burst containment, NOT a tight
+# throttle) to the STATELESS verdify-prod surfaces. PROD-OVERLAY ONLY — staging
+# and dev never reference this file, and base/components are untouched.
+#
+# Root cause being fixed: these containers carried CPU+mem REQUESTS and mem
+# LIMITS but NO CPU LIMIT, so any one could burst into all of a node's cores and
+# drive load to ~56 (incident). Each CPU limit below is ~8-80x the OBSERVED
+# steady CPU (kubectl top, 2026-06-07) and well above the request, so a healthy
+# pod is NEVER throttled — it only caps pathological runaway.
+#
+# Observed steady CPU (kubectl top -n verdify-prod):
+#   www 1m | lab 1m | api 3m | mcp 3m | planner 19m | grafana 26m(+renderer)
+#   | traefik 2m. Requests are LEFT AS-IS (already sane for scheduling).
+#
+# NOT INCLUDED (device path, gated ha-3): verdify-ingestor, verdify-setpoint-server.
+# Those keep NO CPU limit on purpose (CFS throttling harms device keepalive).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-www
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: www
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m      # ~250x steady 1m; pure caps for a static Node site
+              memory: 256Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-lab
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: lab-site
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 250m      # static nginx; cap runaway only
+              memory: 128Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-api
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: api
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"       # 8x request; ample headroom for asyncpg bursts
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-mcp
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: mcp
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"       # 8x request
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-planner
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: planner
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"       # 8x request; >>observed 19m
+              memory: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-grafana
+spec:
+  template:
+    spec:
+      priorityClassName: verdify-serving
+      containers:
+        - name: grafana
+          resources:
+            requests:
+              cpu: 100m
+              memory: 384Mi   # bump 256->384Mi (observed working set ~768Mi);
+            limits:           # avoids eviction under node pressure (design §2.2)
+              cpu: "1"        # ~38x steady 26m
+              memory: 1Gi     # raise 768Mi->1Gi to match observed working set
+        - name: renderer
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -51,6 +51,16 @@ resources:
   # floor (minAvailable:1), and grafana a drain-safe maxUnavailable:1 (RWO PVC
   # singleton). The incident had ZERO PDBs in verdify-prod. See pdb.yaml.
   - pdb.yaml
+  # HA Sprint ha-1 / Lane A — resource governance (#226/#227/#229).
+  # 4-tier PriorityClasses (cluster-scoped; additive — see priorityclasses.yaml).
+  # The device-writer class is CREATED but NOT assigned to the ingestor here
+  # (that is gated ha-3); verdify-serving IS assigned to the stateless surfaces
+  # via ha-serving-resources.yaml in patches: below.
+  - priorityclasses.yaml
+  # Conservative namespace LimitRange so future pods aren't unbounded. Sets a
+  # mem default + defaultRequest only (NO CPU `default` limit) so it can never
+  # inject a throttling CPU limit into the gated device path. See limitrange.yaml.
+  - limitrange.yaml
 
 # verdify-planner (#117) + verdify-mqtt fan-out broker (#113) — referenced as
 # Components, NOT added to base, so they never render into overlays/staging (the
@@ -125,6 +135,13 @@ patches:
   # live setpoint-dispatcher + MCP-restart logging stops thrashing post-cutover.
   # emptyDir now; durable RWO PVC is the #130 follow-up. See ingestor-state-volume.yaml.
   - path: ingestor-state-volume.yaml
+  # HA Sprint ha-1 / Lane A (#226/#227/#229): add verdify-serving priorityClass +
+  # a CPU LIMIT (burst containment, NOT a tight throttle) + tuned mem to the
+  # STATELESS surfaces (www/lab/api/mcp/planner/grafana). Strategic-merge by
+  # name -> only these deployments + named containers are touched; the device
+  # path (ingestor/setpoint-server) is DELIBERATELY EXCLUDED. See
+  # ha-serving-resources.yaml.
+  - path: ha-serving-resources.yaml
   # ingestor keeps the base replicas:1 + Recreate (single-writer invariant); no
   # replicas:0 pin here (that is staging's two-writer safety pin).
   # HA Sprint ha-1 / LANE B (#230): scale www/lab/api/mcp 1->2, hard hostname

--- a/deploy/k8s/overlays/prod/limitrange.yaml
+++ b/deploy/k8s/overlays/prod/limitrange.yaml
@@ -1,0 +1,52 @@
+# HA Sprint ha-1 / Lane A (#226) — conservative namespace LimitRange for
+# verdify-prod so FUTURE pods are not created completely unbounded.
+#
+# SAFETY DESIGN (why this cannot break or throttle an existing pod):
+#   * We set defaultRequest ONLY (NOT a `default` limit) for CPU. A LimitRange
+#     `default` CPU limit would be INJECTED into any container that lacks one on
+#     its next (re)create — including the GATED device-writer (ingestor /
+#     setpoint-server), where a CPU limit is FORBIDDEN (CFS throttling harms
+#     device keepalive timing). Omitting the CPU `default` guarantees we never
+#     silently cap the writer. The stateless surfaces get their CPU limits
+#     explicitly from their own per-surface patches, not from here.
+#   * The `default` MEMORY limit (1Gi) is HIGH enough that no current
+#     verdify-prod container exceeds it EXCEPT ones that already declare their
+#     own memory limit (api/mcp/planner 1Gi, grafana, hermes 4Gi) — a container
+#     that already sets a limit is untouched by the LimitRange default. So the
+#     only containers that would adopt the 1Gi mem default are tiny ones
+#     (mqtt 2Mi, exporters ~10-20Mi) — no OOM risk.
+#   * NO CPU `max` EITHER. A LimitRange `max.cpu` is ENFORCED by INJECTING that
+#     ceiling as the container's CPU LIMIT when the container declares no CPU
+#     limit of its own (verified by server dry-run: the ingestor template gets
+#     cpu:4 injected). That would silently put a CPU limit on the GATED device
+#     write path (ingestor) on its next restart — forbidden (CFS throttling
+#     harms ESP32 keepalive). So this LimitRange governs MEMORY ceilings only
+#     and intentionally sets NO CPU `default` and NO CPU `max`. The stateless
+#     surfaces get their CPU limits explicitly from ha-serving-resources.yaml.
+#   * mem `max` is well above the largest existing limit (hermes 4Gi) so nothing
+#     running is rejected. min is tiny.
+# Verify after apply: no pod enters OOMKilled / CPUThrottlingHigh, and a server
+# dry-run create of the ingestor template yields NO cpu limit.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: verdify-prod-defaults
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/managed-by: verdify-ha
+spec:
+  limits:
+    - type: Container
+      # Defaults applied only to containers that omit the field. CPU limit is
+      # DELIBERATELY ABSENT (see header) so the device path is never throttled.
+      defaultRequest:
+        cpu: 25m
+        memory: 32Mi
+      default:
+        memory: 1Gi
+      # MEMORY ceiling only — generous, above the largest existing limit
+      # (hermes 4Gi). NO cpu max (would inject a CPU limit into the device path).
+      max:
+        memory: 6Gi
+      min:
+        memory: 8Mi

--- a/deploy/k8s/overlays/prod/priorityclasses.yaml
+++ b/deploy/k8s/overlays/prod/priorityclasses.yaml
@@ -1,0 +1,72 @@
+# HA Sprint ha-1 / Lane A (#229) — 4-tier PriorityClasses for the verdify stack.
+#
+# All four are BELOW system-cluster-critical (2000000000) and
+# system-node-critical (2000001000) so kubelet/CNI/CSI/coredns are NEVER
+# preempted — the precondition for a flapped node to self-heal (design doc
+# §2.4). Eviction/preemption order under node pressure becomes:
+#   batch (1000)  ->  serving (100000)  ->  data-critical (800000000)
+#   ->  device-writer (900000000)  ->  system-*.
+#
+# Cluster-scoped objects. Additive: creating a PriorityClass does NOT mutate any
+# running pod; a pod only adopts a class when its template sets
+# priorityClassName AND the pod is (re)created. The ingestor/setpoint device
+# path is intentionally NOT assigned verdify-device-writer here — that
+# assignment is the GATED ha-3 sprint. This file only CREATES the class.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: verdify-device-writer
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/managed-by: verdify-ha
+value: 900000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Highest verdify tier. Reserved for the single-writer device path
+  (ingestor / setpoint-server) so it is never the pod starved/preempted/evicted
+  under node pressure. CREATED in ha-1; ASSIGNED to the writer only in the gated
+  ha-3 sprint. Below system-* so node-critical daemons always win.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: verdify-data-critical
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/managed-by: verdify-ha
+value: 800000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stateful single-writer data tier (verdify-db / CNPG). Survives node pressure
+  above the stateless serving tier; below the device writer.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: verdify-serving
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/managed-by: verdify-ha
+value: 100000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stateless public-serving surfaces (www / lab / api / mcp / planner / grafana)
+  and the in-namespace tier-2 verdify-traefik. Preempted only after batch; a
+  surviving replica + PDB keep the surface up during eviction.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: verdify-batch
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/managed-by: verdify-ha
+value: 1000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Batch / best-effort (exporters, db-backup, manual jobs). Evicted FIRST under
+  node pressure so no serving/data/device pod is disrupted by a batch spike.

--- a/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
+++ b/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         app.kubernetes.io/component: edge-traefik
     spec:
       serviceAccountName: verdify-traefik
+      # HA ha-1 / Lane A (#229): serving-tier priority so the tier-2 edge proxy
+      # is preempted only after batch, and never starved under node pressure.
+      priorityClassName: verdify-serving
       # Spread the 2 replicas across nodes so a single node loss can't take the
       # whole verdify edge tier down. Sprint ha-1 (#230): upgraded to HARD
       # (DoNotSchedule) — 4 schedulable workers >= 2 replicas => always
@@ -113,6 +116,12 @@ spec:
               cpu: 50m
               memory: 64Mi
             limits:
+              # HA ha-1 / Lane A (#226/#227): cap pathological burst on the
+              # tier-2 proxy. 1 core is ~500x steady (~2m) and far above any
+              # realistic tier-2 load, so CFS throttling never engages in
+              # practice (the design doc's keepalive concern is about TIGHT caps
+              # — this is a runaway ceiling, not a throttle).
+              cpu: "1"
               memory: 256Mi
 ---
 apiVersion: v1


### PR DESCRIPTION
## Sprint ha-1 — Lane A: Resource Governance

Fix for the 2026-06-07 night node7-overload flap. Root cause (design doc §0): the `verdify-prod` stateless surfaces carried CPU+mem **requests** and mem **limits** but **no CPU limit**, so any one pod could burst into all of a node's cores → load ~56 → missed kubelet heartbeat → `NotReady` → `TaintManagerEviction` of single-replica surfaces (www/lab/api/mcp/grafana 503'd).

Design: `~/Agents/root/docs/verdify-ha-architecture-2026-06-07.md` §2.1, §2.4. Issues #226/#227/#229.

### What this PR does (scoped to `deploy/k8s/overlays/prod` only)
**#229 — `priorityclasses.yaml`** — 4-tier PriorityClasses, all **below** `system-*` so kubelet/CNI/CSI/coredns are never preempted (the precondition for a flapped node to self-heal):
| class | value | use |
|---|---|---|
| `verdify-device-writer` | 900000000 | **CREATED only**; NOT assigned to the ingestor here (gated ha-3) |
| `verdify-data-critical` | 800000000 | db |
| `verdify-serving` | 100000 | www/lab/api/mcp/planner/grafana/traefik |
| `verdify-batch` | 1000 | exporters/backup |

**#227/#226 — `ha-serving-resources.yaml` + traefik edit** — `verdify-serving` priority + a **CPU LIMIT sized from observed steady CPU** (`kubectl top`) with large burst headroom (NOT a throttle): www/lab `250m`, api/mcp/planner `2`, grafana/renderer `1`, traefik `1`. grafana mem req 256→384Mi, lim 768Mi→1Gi (observed working set ~768Mi).

**#226 — `limitrange.yaml`** — conservative `verdify-prod` LimitRange. Governs **memory only**: a 1Gi default + 32Mi defaultRequest + 6Gi max. **Deliberately NO CPU `default` and NO CPU `max`** — a server dry-run proved that a `max.cpu` is *injected* as the container CPU limit on a no-cpu-limit pod, which would silently cap the **gated device-writer** on its next restart (forbidden — CFS throttling harms ESP32 keepalive). Re-verified post-fix: ingestor dry-run yields no CPU limit.

### Guardrail held — device path untouched
- `verdify-ingestor` live spec before==after: `priorityClassName:none, replicas:1, strategy:Recreate, cpu-limit:none`. The **running ingestor pod was never restarted** (same pod name/age throughout).
- `verdify-setpoint-server` is in-manifest but not deployed live → nothing to touch.
- kustomize build proves ingestor + setpoint-server + hermes + mqtt + db deployments are byte-identical before/after.

### Validation
- `kustomize build` + `kubeconform -strict -ignore-missing-schemas`: 58 valid / 0 invalid.
- staging + dev overlays build clean with **zero** PriorityClass objects and zero `verdify-serving` refs (base/components untouched).
- Applied live additively (manual-sync app); git == live. All `*.verdify.ai` surfaces 200 across post-apply re-probes (www/verdify.ai/lab/graphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)