### PR TITLE
ci: one-click gated prod-promotion workflow + runbook (#220)

### DIFF
--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,389 @@
+name: Prod Promote
+
+# #220 — ONE-CLICK / ONE-APPROVAL prod-promotion entry point.
+#
+# This is the missing top of the gated commit -> stage -> prod promotion flow.
+# The lower half already exists and is LIVE on live/platform-main:
+#
+#   container-publish.yml   push -> build+publish digest-pinned images ->
+#                           IN-REPO write-back bumps overlays/staging (+ dev)
+#                           digests -> ArgoCD AUTO-SYNCS verdify-local-staging.
+#                           (LOCKED decision: in-repo bump, no cross-repo PR,
+#                           no ArgoCD Image Updater.)
+#   k8s-manifests.yml       renders+kubeconform-validates every overlay.
+#   ci.yml                  the logic/schema/firmware/drift gates.
+#   promote-diff-guard.yml  the REQUIRED check on a prod-promote PR: asserts the
+#                           PR advances ONLY prod image digests, and only to the
+#                           digest staging is CURRENTLY running (no fabricated
+#                           pin, no manifest/replica/device-write/NetPol edit).
+#
+# WHAT WAS MISSING (this file): a button that GENERATES the prod-promote PR so
+# Jason stops hand-editing overlays/prod digests. A maintainer clicks Run
+# workflow (mode=pull-request) -> this job reads the CURRENT staging digests,
+# runs the local promotion gates (Device-Write-Safety-Gate + change-surface
+# self-check), bumps overlays/prod/kustomization.yaml to exactly those digests,
+# and opens a `prod-promote`-labelled PR. promote-diff-guard.yml then enforces
+# the same invariants as a required status check, and a human reviews+merges.
+#
+# *** THE DEVICE-WRITE HUMAN GATE IS PRESERVED ***
+# Merging this PR only changes the prod overlay's image digests in git. It does
+# NOT sync the cluster: the verdify-prod ArgoCD Application is MANUAL-SYNC on
+# purpose (no syncPolicy.automated) precisely because its ingestor is the ONE
+# real ESP32 writer. The new prod digests sit OutOfSync until an operator runs
+# `argocd app sync verdify-prod` AFTER the separate device-VLAN sign-off +
+# single-writer cutover are explicitly approved by Jason. This workflow never
+# calls ArgoCD, never scales/patches the live ingestor, never touches the device.
+#
+# DRY-RUN by default: prints the digest delta and the gate verdicts but opens no
+# PR. mode=pull-request opens the PR. This mirrors the de-noised
+# vast-gitops-dev-test-promotion.yml posture (dispatch-only, dry-run default).
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run prints the promotion delta; pull-request opens the prod-promote PR."
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - pull-request
+      images:
+        description: >-
+          Comma-separated staging-tracked images to promote (subset of:
+          api,mcp,ingestor,migrate,www). Empty = promote EVERY staging-tracked
+          prod pin that currently lags staging. Prod-only images
+          (planner/setpoint-server/lab/mqtt/hermes) are NEVER promoted here.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verdify-prod-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Compute staging->prod digest promotion and open PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      MODE: ${{ github.event.inputs.mode }}
+      IMAGES_INPUT: ${{ github.event.inputs.images }}
+      PROMOTE_BRANCH: gitops/verdify-prod-promote
+      PROD_OVERLAY: deploy/k8s/overlays/prod
+      STAGING_OVERLAY: deploy/k8s/overlays/staging
+      DEV_OVERLAY: deploy/k8s/overlays/dev
+    steps:
+      - name: Checkout live/platform-main
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: live/platform-main
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Install kustomize (pinned v5.4.3)
+        run: |
+          set -euo pipefail
+          KUSTOMIZE_VERSION=v5.4.3
+          curl -sfL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+            | tar xz kustomize
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
+
+      # ── Resolve the EFFECTIVE rendered digest maps (robust to formatting) ────
+      - name: Compute staging-tracked promotion delta
+        id: delta
+        run: |
+          set -euo pipefail
+
+          # image<TAB>digest from the RENDERED overlay (the effective pin, not the
+          # raw source line). Restricted to the canonical verdify-* namespace.
+          render_map() {
+            kustomize build "$1" \
+              | grep -oE 'ghcr\.io/verdifyconsultancy/verdify-[a-z-]+@sha256:[0-9a-f]{64}' \
+              | sed -E 's#^ghcr\.io/verdifyconsultancy/(verdify-[a-z-]+)@(sha256:[0-9a-f]{64})$#\1\t\2#' \
+              | sort -u
+          }
+
+          render_map "$STAGING_OVERLAY" > /tmp/staging.map
+          render_map "$PROD_OVERLAY"    > /tmp/prod.map
+
+          # Snapshot the prod render with image lines STRIPPED — this is the
+          # device-write posture surface (NetworkPolicies, ConfigMaps, replicas,
+          # patches, components). The Device-Write-Safety-Gate later asserts this
+          # is byte-identical after the digest bump (only image: lines may move).
+          kustomize build "$PROD_OVERLAY" \
+            | grep -vE '^\s+image: ghcr\.io/verdifyconsultancy/' \
+            > /tmp/prod.render.base.noimg
+
+          echo "=== staging (current, source of truth for promotable digests) ==="
+          cat /tmp/staging.map
+          echo "=== prod (current pins) ==="
+          cat /tmp/prod.map
+
+          # STAGING-TRACKED set is DERIVED = exactly the images the staging
+          # overlay renders (NOT a hand-maintained allowlist). This is the same
+          # derivation promote-diff-guard.yml uses, so the two can never drift:
+          # only images staging actually runs are promotable; prod-only
+          # Components (planner/setpoint/lab/mqtt/hermes) are absent from staging
+          # and therefore NEVER promoted by this workflow.
+          #
+          # Optional subset filter from the `images` input (api,mcp,...). An
+          # entry is matched against the verdify-<name> suffix.
+          declare -A want=()
+          subset=false
+          if [ -n "${IMAGES_INPUT// /}" ]; then
+            subset=true
+            IFS=',' read -ra parts <<< "$IMAGES_INPUT"
+            for p in "${parts[@]}"; do
+              p="$(echo "$p" | tr -d '[:space:]')"
+              [ -n "$p" ] && want["verdify-${p#verdify-}"]=1
+            done
+          fi
+
+          : > /tmp/promote.pairs   # image<TAB>staging_digest  (the ones to bump)
+          changes=0
+          while IFS="$(printf '\t')" read -r img staging_digest; do
+            [ -n "$img" ] || continue
+            # Skip images prod doesn't even pin (nothing to promote).
+            prod_digest="$(awk -F'\t' -v i="$img" '$1==i{print $2}' /tmp/prod.map)"
+            [ -n "$prod_digest" ] || { echo "skip ${img}: prod does not pin it"; continue; }
+            # Honour the optional subset filter.
+            if [ "$subset" = true ] && [ -z "${want[$img]:-}" ]; then
+              echo "skip ${img}: not in requested subset"
+              continue
+            fi
+            if [ "$prod_digest" = "$staging_digest" ]; then
+              echo "noop ${img}: prod already == staging (${staging_digest})"
+              continue
+            fi
+            echo "PROMOTE ${img}: ${prod_digest} -> ${staging_digest}"
+            printf '%s\t%s\n' "$img" "$staging_digest" >> /tmp/promote.pairs
+            changes=$((changes+1))
+          done < /tmp/staging.map
+
+          echo "changes=${changes}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Prod promotion delta (staging -> prod)"
+            echo
+            if [ "$changes" -eq 0 ]; then
+              echo "No staging-tracked prod pin lags staging — nothing to promote."
+            else
+              echo "| image | prod (current) | -> | staging (promote to) |"
+              echo "|---|---|---|---|"
+              while IFS="$(printf '\t')" read -r img sd; do
+                pd="$(awk -F'\t' -v i="$img" '$1==i{print $2}' /tmp/prod.map)"
+                echo "| \`$img\` | \`${pd}\` | -> | \`${sd}\` |"
+              done < /tmp/promote.pairs
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── DEVICE-WRITE-SAFETY-GATE (static, pre-PR) ────────────────────────────
+      # The live device-write posture lives in the prod overlay as:
+      #   * the device-write interlock ConfigMap patch (VERDIFY_DEVICE_WRITE_ENABLED=1)
+      #   * the allow-ingestor-device-egress NetworkPolicy
+      #   * the ingestor replicas (base replicas:1, NO replicas:0 pin in prod)
+      # A digest promotion MUST NOT alter any of these. This gate proves the
+      # promotion we are about to PR changes ONLY image digest lines, so the
+      # device-write path is byte-identical before/after. (promote-diff-guard.yml
+      # re-asserts this on the PR as the REQUIRED check; running it HERE fails
+      # fast before a PR is ever opened, and documents the invariant at the
+      # promotion source.)
+      - name: Apply the digest bump in place (surgical, comment-preserving)
+        if: ${{ steps.delta.outputs.changes != '0' }}
+        run: |
+          set -euo pipefail
+          # SURGICAL digest replacement (NOT `kustomize edit set image`). The prod
+          # overlay's images: block uses the hand-authored
+          #   - name: ghcr.io/verdifyconsultancy/verdify-<c>
+          #     digest: sha256:<hex>
+          # form, each pin carrying a multi-line rationale comment. `kustomize edit
+          # set image` REWRITES the whole kustomization.yaml — it reflows the
+          # resources/components/patches list indentation (2-space `  - x` -> flush
+          # `- x`). That whitespace reflow is semantically a no-op (the render is
+          # identical) BUT it trips promote-diff-guard.yml's change-surface check,
+          # which requires a promote PR to change ONLY digest/comment/component-ref
+          # lines — so a kustomize-edit PR would be REJECTED by the required gate.
+          # This awk swaps ONLY the digest value on the line immediately following
+          # each targeted `- name:` line, leaving every byte of formatting and
+          # every rationale comment intact, so the PR passes promote-diff-guard.
+          awk '
+            BEGIN {
+              pf=ARGV[1]; delete ARGV[1];
+              while ((getline line < pf) > 0) {
+                n=split(line, a, "\t"); if (n>=2) want[a[1]]=a[2];
+              }
+            }
+            {
+              if ($0 ~ /^[[:space:]]*-?[[:space:]]*name:[[:space:]]*ghcr\.io\/verdifyconsultancy\/verdify-[a-z-]+[[:space:]]*$/) {
+                img=$0; sub(/^.*verdify-/, "verdify-", img); sub(/[[:space:]]*$/, "", img);
+                cur = (img in want) ? want[img] : ""; print; next;
+              }
+              if (cur != "" && $0 ~ /^[[:space:]]*digest:[[:space:]]*sha256:[0-9a-f]{64}[[:space:]]*$/) {
+                sub(/sha256:[0-9a-f]{64}/, cur); cur="";
+              }
+              print;
+            }
+          ' /tmp/promote.pairs "$PROD_OVERLAY/kustomization.yaml" > /tmp/kz.new
+          mv /tmp/kz.new "$PROD_OVERLAY/kustomization.yaml"
+
+          # Prove the surgical edit touched ONLY digest lines (defence-in-depth
+          # against an awk regression; mirrors promote-diff-guard's surface check).
+          NON_DIGEST="$(git diff -- "$PROD_OVERLAY/kustomization.yaml" \
+            | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+            | grep -vE '^[+-][[:space:]]*digest:[[:space:]]*sha256:[0-9a-f]{64}[[:space:]]*$' \
+            || true)"
+          if [ -n "$NON_DIGEST" ]; then
+            echo "::error::surgical digest edit changed non-digest lines (awk bug?):"
+            printf '%s\n' "$NON_DIGEST"
+            exit 1
+          fi
+          echo "Surgical bump applied: only digest lines changed."
+
+      - name: Device-Write-Safety-Gate (render-equality; digests-only)
+        if: ${{ steps.delta.outputs.changes != '0' }}
+        run: |
+          set -euo pipefail
+          # Render the bumped prod overlay with image lines STRIPPED and assert it
+          # is BYTE-IDENTICAL to the pre-bump snapshot. This proves the promotion
+          # changes ONLY image references and leaves the device-write posture —
+          # the VERDIFY_DEVICE_WRITE_ENABLED=1 interlock ConfigMap, the
+          # allow-ingestor-device-egress NetworkPolicy, the ingestor replicas, and
+          # every other manifest — untouched. (`kustomize edit` reflows the source
+          # YAML formatting, so a raw source line-diff is noisy; a RENDER diff is
+          # the semantically correct check, and matches promote-diff-guard.yml's
+          # render-based equality enforcement.)
+          kustomize build "$PROD_OVERLAY" \
+            | grep -vE '^\s+image: ghcr\.io/verdifyconsultancy/' \
+            > /tmp/prod.render.cand.noimg
+
+          if ! diff -u /tmp/prod.render.base.noimg /tmp/prod.render.cand.noimg > /tmp/posture.diff; then
+            echo "::error::Device-Write-Safety-Gate FAILED: the promotion changed non-image manifests in the prod render:"
+            cat /tmp/posture.diff
+            exit 1
+          fi
+
+          # Positive assertions: the device-write interlock + egress-allow must be
+          # present in the bumped render (so a future refactor can't silently drop
+          # them and still pass the equality check on an already-broken baseline).
+          rendered="$(kustomize build "$PROD_OVERLAY")"
+          echo "$rendered" | grep -q 'VERDIFY_DEVICE_WRITE_ENABLED' \
+            || { echo "::error::prod render lost the device-write interlock ConfigMap"; exit 1; }
+          echo "$rendered" | grep -q 'allow-ingestor-device-egress' \
+            || { echo "::error::prod render lost the allow-ingestor-device-egress NetworkPolicy"; exit 1; }
+          echo "Device-Write-Safety-Gate OK: non-image render byte-identical; interlock + egress-allow intact."
+
+      - name: Assert every prod image pin is digest-pinned (no tag leak)
+        if: ${{ steps.delta.outputs.changes != '0' }}
+        run: |
+          set -euo pipefail
+          rendered="$(kustomize build "$PROD_OVERLAY")"
+          if printf '%s' "$rendered" \
+              | grep -E '^\s+image: ghcr.io/verdifyconsultancy/verdify-' \
+              | grep -qv '@sha256:'; then
+            echo "::error::a verdify-* image is not digest-pinned in the promotion candidate"
+            printf '%s' "$rendered" | grep -E '^\s+image: ghcr.io/verdifyconsultancy/verdify-'
+            exit 1
+          fi
+          echo "All promoted prod pins are immutable @sha256 digests."
+
+      - name: Dry-run stop
+        if: ${{ github.event.inputs.mode != 'pull-request' }}
+        run: |
+          echo "DRY-RUN: gates passed; no PR opened. Re-run with mode=pull-request to open the prod-promote PR."
+
+      # ── Open the prod-promote PR (mode=pull-request only) ────────────────────
+      - name: Open prod-promote PR
+        if: ${{ github.event.inputs.mode == 'pull-request' && steps.delta.outputs.changes != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "verdify-promote[bot]"
+          git config user.email "verdify-promote@users.noreply.github.com"
+
+          # The digest bump is ALREADY applied in the worktree (the "Apply the
+          # digest bump in place" step above, gated by the Device-Write-Safety-
+          # Gate). Carry that working-tree edit onto a fresh promotion branch.
+          branch="${PROMOTE_BRANCH}-$(date -u +%Y%m%d%H%M%S)"
+          git checkout -b "$branch"
+
+          if git diff --quiet -- "$PROD_OVERLAY/kustomization.yaml"; then
+            echo "No net change in the prod overlay (unexpected after a non-zero delta); nothing to PR."
+            exit 0
+          fi
+
+          # Build a human-readable promotion body.
+          body_file="$(mktemp)"
+          {
+            echo "## Prod promotion (staging -> prod digests)"
+            echo
+            echo "Generated by the **Prod Promote** workflow (#220). This PR advances"
+            echo "the \`overlays/prod\` image digests to **exactly the digests"
+            echo "\`overlays/staging\` is currently running** — the proven-on-staging set."
+            echo
+            echo "| image | prod (was) | -> | staging (now) |"
+            echo "|---|---|---|---|"
+            while IFS="$(printf '\t')" read -r img sd; do
+              pd="$(awk -F'\t' -v i="$img" '$1==i{print $2}' /tmp/prod.map)"
+              echo "| \`$img\` | \`${pd}\` | -> | \`${sd}\` |"
+            done < /tmp/promote.pairs
+            echo
+            echo "### Gates"
+            echo "- Device-Write-Safety-Gate: PASS (digests-only; interlock + egress-allow intact)."
+            echo "- \`promote-diff-guard\` will re-assert digest-equality + change-surface as the REQUIRED check."
+            echo
+            echo "### Device-write human gate is PRESERVED"
+            echo "Merging this PR changes git only. \`verdify-prod\` is a **manual-sync**"
+            echo "ArgoCD Application; the new digests sit **OutOfSync** until an operator"
+            echo "runs \`argocd app sync verdify-prod\` AFTER the device-VLAN sign-off +"
+            echo "single-writer cutover are explicitly approved by Jason. This PR never"
+            echo "touches the cluster, the live ingestor, or the device."
+            echo
+            echo "Runbook: \`docs/runbooks/prod-promotion.md\`."
+          } > "$body_file"
+
+          commit_file="$(mktemp)"
+          {
+            echo "ci: promote overlays/prod image digests to current staging (#220)"
+            echo
+            echo "In-repo staging->prod digest promotion (locked decision: no cross-repo PR,"
+            echo "no ArgoCD Image Updater). Advances each lagging staging-tracked prod pin to"
+            echo "the digest overlays/staging is currently running. Device-write posture"
+            echo "(interlock ConfigMap + allow-ingestor-device-egress NetPol + ingestor"
+            echo "replicas) is UNCHANGED — digests only. verdify-prod stays manual-sync; this"
+            echo "is a git change only, gated by promote-diff-guard + the human device gate."
+          } > "$commit_file"
+
+          git add "$PROD_OVERLAY/kustomization.yaml"
+          git commit -F "$commit_file"
+
+          git push origin "$branch"
+
+          pr_url="$(gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base live/platform-main \
+            --head "$branch" \
+            --title "ci: prod-promote — advance overlays/prod digests to staging (#220)" \
+            --label prod-promote \
+            --body-file "$body_file")"
+          echo "Opened prod-promote PR: $pr_url"
+          {
+            echo "### Prod-promote PR opened"
+            echo
+            echo "$pr_url"
+            echo
+            echo "Next: \`promote-diff-guard\` must pass, a human reviews+merges, THEN an"
+            echo "operator runs the gated \`argocd app sync verdify-prod\` per the runbook."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nothing to promote
+        if: ${{ github.event.inputs.mode == 'pull-request' && steps.delta.outputs.changes == '0' }}
+        run: echo "No staging-tracked prod pin lags staging; no PR opened."

--- a/docs/runbooks/prod-promotion.md
+++ b/docs/runbooks/prod-promotion.md
@@ -164,9 +164,10 @@ PR; prod SYNCING is the device gate.
 | Gate | Where | What it proves |
 |---|---|---|
 | ci.yml ledger (~12) | CI on every PR/push | lint, schemas+drift, firmware logic/replay-diff, fire-and-forget, restart hygiene |
+| **Device-Write Safety Gate (code)** | **ci.yml** | `tests/test_device_write_gate.py`: the ingestor never drives the ESP32 unless `VERDIFY_DEVICE_WRITE_ENABLED=='1'` (default-deny, layer-3 of the #71 interlock) |
 | k8s-manifests | CI | every overlay renders + kubeconform-valid |
 | container-publish smoke-import | CI, pre-push | the built image imports `verdify_schemas.alerts` before it can be pushed |
-| **Device-Write-Safety-Gate (static)** | **prod-promote.yml** | promotion is digests-only; non-image render byte-identical; interlock + egress-allow intact; all @sha256 |
+| **Device-Write-Safety-Gate (manifest)** | **prod-promote.yml** | promotion is digests-only; non-image render byte-identical; interlock + egress-allow intact; all @sha256 |
 | promote-diff-guard | **required check on the PR** | change-surface containment + a changed prod pin lands on EXACTLY the current staging digest |
 | **smoke (device-dark)** | **operator, post-staging-green (G10)** | api/mcp/db serve; staging ingestor replicas==0; ZERO device-VLAN sockets |
 | **device-monitor (single-writer)** | **operator, post-prod-sync** | EXACTLY ONE pod holds the ESP32 writer connection |

--- a/docs/runbooks/prod-promotion.md
+++ b/docs/runbooks/prod-promotion.md
@@ -1,0 +1,210 @@
+# Prod-promotion runbook — gated commit → stage → prod (#220)
+
+**Owner:** laptop-root · **Tracker:** VerdifyConsultancy/verdify-platform#220 ·
+**Status:** AUTHORED 2026-06-07. The CI/CD lower half (build → publish → staging
+auto-deploy → guards) is LIVE on `live/platform-main`; the one-click prod-promote
+entry point (`.github/workflows/prod-promote.yml`) lands with this runbook.
+
+This is the durable "how an image gets from a merge to live prod" record. It exists
+so Jason **stops hand-editing `overlays/prod` image digests** — promotion is now a
+button plus a gated PR, with the live-device-write step still behind the manual
+ArgoCD sync and the human gate.
+
+---
+
+## 0. The invariant this whole flow protects
+
+There is **exactly ONE** live ESP32 writer (the `verdify-prod` ingestor on
+`vm-k3s-node5`/`192.168.30.36`, the device-write path). Nothing in this pipeline
+may stand up a second writer or restart the live writer without an explicit Jason
+gate. Every automated step below is **device-dark** (staging/dev are
+`ingestor replicas:0` + `VERDIFY_DEVICE_WRITE_ENABLED=0` + `deny-esp32-egress`);
+only the final, manual `argocd app sync verdify-prod` touches the writer, and only
+after the device-VLAN sign-off.
+
+---
+
+## 1. The env/gate flow (what runs where)
+
+```
+ merge to live/platform-main
+        │
+        ▼
+ ┌─────────────────────────── verdify-platform CI (GitHub-hosted) ───────────────────────────┐
+ │ ci.yml                 lint · site-guards · schemas+drift · firmware · firmware-logic ·    │
+ │  (the gate ledger)     replay-diff · no-fire-and-forget · service-restart-drift  (≈12 gates)│
+ │ container-publish.yml  image-impact → build+publish DIGEST-PINNED images to GHCR           │
+ │                        → bump-staging-digests: IN-REPO write-back of overlays/staging       │
+ │                          (+dev) @sha256 pins  [skip ci]  (LOCKED: no cross-repo PR,         │
+ │                          no ArgoCD Image Updater)                                            │
+ │ k8s-manifests.yml      kustomize build + kubeconform every overlay                          │
+ └────────────────────────────────────────────────────────────────────────────────────────────┘
+        │  (staging overlay digests advanced in git)
+        ▼
+ ArgoCD  verdify-local-staging   automated{selfHeal:true, prune:false}  → AUTO-SYNCS staging
+        │
+        ▼
+ ┌── OPERATOR GATE G10 (post-green smoke, device-dark) ──────────────────────────────────────┐
+ │ scripts/k3s-smoke.sh smoke   (READ-ONLY; api /health/detailed, mcp tools/list, db,         │
+ │                               ingestor replicas==0, ZERO device-VLAN sockets)               │
+ └────────────────────────────────────────────────────────────────────────────────────────────┘
+        │  staging is GREEN + smoke-proven on the new digests
+        ▼
+ ┌── ONE-CLICK PROMOTE  (.github/workflows/prod-promote.yml, workflow_dispatch) ──────────────┐
+ │ 1. read CURRENT staging digests (the proven-on-staging set)                                 │
+ │ 2. compute delta = staging-tracked prod pins that LAG staging (api,mcp,ingestor,migrate,www)│
+ │ 3. surgical digest bump of overlays/prod/kustomization.yaml (comment-preserving)            │
+ │ 4. DEVICE-WRITE-SAFETY-GATE: render-equality — non-image render byte-identical;             │
+ │    VERDIFY_DEVICE_WRITE_ENABLED + allow-ingestor-device-egress intact; all @sha256          │
+ │ 5. open a `prod-promote`-labelled PR (mode=pull-request) — or just print (mode=dry-run)     │
+ └────────────────────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌── REQUIRED CHECK on the PR ───────────────────────────────────────────────────────────────┐
+ │ promote-diff-guard.yml   change-surface containment (prod overlay = digests/comments/       │
+ │                          component-refs only) + STAGING-EQUALITY (a changed prod pin must    │
+ │                          land on EXACTLY the current staging digest — no fabricated digest)  │
+ └────────────────────────────────────────────────────────────────────────────────────────────┘
+        │  human reviews + merges the PR  (= the "one approval")
+        ▼
+ ArgoCD  verdify-prod   MANUAL-SYNC (no automated block)  → prod sits OutOfSync on new digests
+        │
+        ▼
+ ┌── JASON GATE (device-write) ──────────────────────────────────────────────────────────────┐
+ │ device-VLAN reachability/latency sign-off + single-writer cutover approval, THEN:           │
+ │   argocd app sync verdify-prod        (operator-initiated, the ONLY step that touches the   │
+ │                                        live writer)                                          │
+ │   scripts/k3s-smoke.sh device-monitor --namespace verdify-prod   (EXACTLY-ONE-writer guard) │
+ └────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**The "one-click / one-approval" of #220** = step "ONE-CLICK PROMOTE" (the button)
++ the human merge of the generated PR (the approval). The live-device sync stays a
+**separate, explicit Jason gate** below it.
+
+---
+
+## 2. ArgoCD app wiring (the env tiers)
+
+| App | Path | syncPolicy | Role |
+|---|---|---|---|
+| `verdify-dev` | `overlays/dev` | `automated{selfHeal,prune}` (intended) | device-dark telemetry SUBSCRIBER; auto. |
+| `verdify-local-staging` | `overlays/staging` | `automated{selfHeal:true, prune:false}` | device-dark; **auto-syncs the digest write-back**. |
+| `verdify-prod` | `overlays/prod` | **manual** (no `automated`) | the ONE writer; `prune:false`; operator-synced behind the Jason gate. |
+| `verdify-prod-dark` | `overlays/prod-dark` | **manual** | device-DARK prod adoption (ingestor replicas:0); M4 proof. |
+
+> Drift note (2026-06-07): the live `verdify-dev` Application is currently
+> **manual-sync** (no `automated` block) even though the in-repo CR declares
+> `automated{selfHeal,prune}`. Re-apply the CR to converge if dev should
+> auto-sync. This does not affect the prod-promote flow.
+
+The staging app already auto-deploys on the in-repo digest bump (verified
+`automated{selfHeal:true}` syncing `overlays/staging` from `live/platform-main`).
+No manual ArgoCD sync is needed to ADVANCE staging — satisfying #220's "no manual
+ArgoCD sync to advance an env" for the dev/stage tier. Prod advancing is the gated
+PR; prod SYNCING is the device gate.
+
+---
+
+## 3. Operator procedure
+
+### 3.1 Promote (the button)
+
+1. Confirm staging is green on the digests you want in prod:
+   ```sh
+   ssh jason@192.168.30.32 'sudo k3s kubectl -n argocd get application verdify-local-staging \
+     -o custom-columns=SYNC:.status.sync.status,HEALTH:.status.health.status'
+   # want: Synced / Healthy
+   ```
+2. Run the **post-green staging smoke** (device-dark gate G10):
+   ```sh
+   KUBECONFIG=/home/jason/.kube/verdify-agent.config scripts/k3s-smoke.sh smoke
+   # exit 0 = GREEN; asserts ingestor replicas==0 + ZERO device-VLAN sockets in staging
+   ```
+3. **Dry-run** the promotion to see the delta + gate verdicts (opens no PR):
+   - GitHub → Actions → **Prod Promote** → Run workflow → `mode=dry-run`.
+   - Read the job summary: the staging→prod digest table + `Device-Write-Safety-Gate OK`.
+4. **Open the PR**: re-run **Prod Promote** with `mode=pull-request`
+   (optionally `images=api,mcp` to promote a subset). It opens a
+   `prod-promote`-labelled PR that advances `overlays/prod` digests to the current
+   staging digests, comment-preserving.
+
+### 3.2 Approve (the merge)
+
+5. On the PR, confirm the **required check** `Promote Diff Guard /
+   promote-diff-guard` is green (change-surface + staging-equality), review the
+   digest table, and **merge**. This is the human approval; it is a git change
+   only — the cluster is untouched.
+
+### 3.3 Sync prod (the Jason device gate — NOT automatic)
+
+6. After merge, prod is **OutOfSync** on the new digests:
+   ```sh
+   ssh jason@192.168.30.32 'sudo k3s kubectl -n argocd get application verdify-prod \
+     -o custom-columns=SYNC:.status.sync.status,HEALTH:.status.health.status'
+   # expect: OutOfSync / Healthy  — this is correct; do NOT auto-sync.
+   ```
+7. **Only after** the device-VLAN reachability/latency sign-off + single-writer
+   cutover are explicitly approved by Jason, an operator runs:
+   ```sh
+   argocd app sync verdify-prod          # operator-initiated; the ONLY device-touching step
+   # NEVER pass --prune (verdify-db StatefulSet + iSCSI PVC must never be reaped)
+   ```
+8. Post-sync, prove the **single-writer invariant** holds:
+   ```sh
+   KUBECONFIG=/home/jason/.kube/verdify-agent.config \
+     scripts/k3s-smoke.sh device-monitor --namespace verdify-prod
+   # asserts EXACTLY ONE pod holds the ESP32 native-API connection (192.168.10.111:6053)
+   ```
+
+---
+
+## 4. The gates, enumerated (#220 acceptance)
+
+| Gate | Where | What it proves |
+|---|---|---|
+| ci.yml ledger (~12) | CI on every PR/push | lint, schemas+drift, firmware logic/replay-diff, fire-and-forget, restart hygiene |
+| k8s-manifests | CI | every overlay renders + kubeconform-valid |
+| container-publish smoke-import | CI, pre-push | the built image imports `verdify_schemas.alerts` before it can be pushed |
+| **Device-Write-Safety-Gate (static)** | **prod-promote.yml** | promotion is digests-only; non-image render byte-identical; interlock + egress-allow intact; all @sha256 |
+| promote-diff-guard | **required check on the PR** | change-surface containment + a changed prod pin lands on EXACTLY the current staging digest |
+| **smoke (device-dark)** | **operator, post-staging-green (G10)** | api/mcp/db serve; staging ingestor replicas==0; ZERO device-VLAN sockets |
+| **device-monitor (single-writer)** | **operator, post-prod-sync** | EXACTLY ONE pod holds the ESP32 writer connection |
+
+CI runners are GitHub-hosted and cannot reach the cluster, so the two
+`k3s-smoke.sh` gates are **operator-run** (read-only; never sync/scale/patch). The
+static Device-Write-Safety-Gate that CAN run hosted (render-equality on the
+promotion) runs in `prod-promote.yml` and is re-asserted by `promote-diff-guard`.
+
+---
+
+## 5. Safety properties (adversarially checked)
+
+- **No second writer, ever.** The promote workflow only edits git; staging/dev are
+  device-dark; prod stays manual-sync. The live writer changes only at step 3.3
+  step 7, behind the Jason gate.
+- **No fabricated digest.** A prod pin can only advance to a digest staging is
+  *currently running* (promote-diff-guard staging-equality, render-derived).
+- **No posture drift.** The Device-Write-Safety-Gate render-equality fails the PR
+  if the bump changed ANY non-image manifest (NetworkPolicy, the
+  `VERDIFY_DEVICE_WRITE_ENABLED` interlock, replicas, patches).
+- **No comment/format churn.** The surgical digest edit changes only `digest:`
+  lines, so the rationale comments survive and `promote-diff-guard`'s
+  change-surface check passes (a `kustomize edit set image` would reflow the file
+  and trip it — that is why this workflow does NOT use it).
+- **Prod-only images are never promoted.** planner/setpoint-server/lab/mqtt/hermes
+  are absent from the staging render, so the derived staging-tracked set excludes
+  them; their prod pins advance only via a separate human-gated write-back.
+- **No DB reaping.** `prune:false` on prod + the runbook ban on `--prune`.
+
+---
+
+## 6. Files
+
+- `.github/workflows/prod-promote.yml` — the one-click promotion entry point (this PR).
+- `.github/workflows/promote-diff-guard.yml` — the required PR gate (already live).
+- `.github/workflows/container-publish.yml` — build/publish + staging digest write-back (already live).
+- `.github/workflows/k8s-manifests.yml` — overlay render/validate (already live).
+- `scripts/k3s-smoke.sh` — the operator smoke + single-writer monitor (already in repo).
+- `deploy/k8s/argocd/apps/verdify-{dev,prod,prod-dark}.yaml` — the ArgoCD Application CRs.
+- `docs/runbooks/k3s-smoke-postgreen.md` — the deeper smoke-script reference.


### PR DESCRIPTION
## What

Adds the **one-click / one-approval prod-promotion** entry point (#220) so Jason stops hand-editing `overlays/prod` image digests — while keeping the live device-write step behind the manual ArgoCD sync + the human gate.

### The missing piece
The CI/CD lower half is already LIVE on `live/platform-main`:
- `container-publish.yml` — build + publish digest-pinned images → **in-repo** `overlays/staging` (+dev) digest write-back (locked decision: no cross-repo PR, no ArgoCD Image Updater).
- ArgoCD `verdify-local-staging` (`automated{selfHeal:true}`) **auto-syncs staging** off that bump.
- `promote-diff-guard.yml` — gates prod-promote PRs (change-surface + staging-equality).
- `k8s-manifests.yml` — renders + kubeconform-validates every overlay.

What was missing: a button to **generate** the prod-promote PR. This adds it.

### `.github/workflows/prod-promote.yml` (`workflow_dispatch`, dry-run default)
1. Reads the **current staging digests** (proven-on-staging set).
2. Computes the **staging-tracked delta** — `api/mcp/ingestor/migrate/www`. Prod-only Components (`planner/setpoint-server/lab/mqtt/hermes`) are **derived-excluded** (absent from the staging render), never promoted here.
3. Applies a **surgical, comment-preserving** digest bump to `overlays/prod/kustomization.yaml`. It does **not** use `kustomize edit set image` — that reflows the file's list indentation and would trip `promote-diff-guard`'s change-surface check; the surgical `awk` changes only `digest:` lines.
4. **Device-Write-Safety-Gate (render-equality):** asserts the non-image render is byte-identical (no NetworkPolicy / `VERDIFY_DEVICE_WRITE_ENABLED` interlock / replica / patch drift), the device-egress allow + interlock are present, and every image is `@sha256`.
5. Opens a `prod-promote`-labelled PR (`mode=pull-request`) or just prints the delta (`mode=dry-run`). Optional `images=api,mcp` subset.

### Device-write human gate PRESERVED
`verdify-prod` is **manual-sync** (no `automated`). Merging the generated PR is a **git change only** — the new digests sit `OutOfSync` until an operator runs `argocd app sync verdify-prod` **after** the Jason device-VLAN / single-writer gate. This pipeline never touches the cluster, the live ingestor, or the device.

### Runbook
`docs/runbooks/prod-promotion.md` — full env/gate flow diagram, the operator procedure (promote → approve → gated sync), and the `k3s-smoke.sh smoke` (G10, device-dark) + `device-monitor` (single-writer) operator gates.

## Verification (run locally against the real overlays)
- Delta correct: api/mcp/ingestor/migrate promoted to staging digests, www noop, prod-only images untouched.
- Device-Write-Safety-Gate: non-image render **byte-identical**; interlock + `allow-ingestor-device-egress` intact; all `@sha256`.
- Surgical bump: **only `digest:` lines change** → passes `promote-diff-guard`'s change-surface check; rationale comments preserved.
- `kustomize build overlays/prod | kubeconform` → 59 valid / 0 invalid after the bump.
- Subset filter (`images=api,mcp`) verified under bash.

## Notes
- `.github/**` is SHARED INFRA → this is a **PR for review, not an autonomous merge**.
- No image build is triggered by this PR (`.github`-only change → `image-impact` stays doc-only).

Refs #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
