### PR TITLE
lane #221: safe firmware/band iteration loop + band-viz dashboard + tuning tooling

### DIFF
--- a/docs/runbooks/verdify-band-tuning-safe.md
+++ b/docs/runbooks/verdify-band-tuning-safe.md
@@ -1,0 +1,169 @@
+# How to Tune a Band Safely (VPD / Temperature / Orchid Time-of-Day)
+
+**Status:** Runbook (lane VerdifyConsultancy/verdify-platform#221). DB-driven; **no firmware flash**.
+**Author:** laptop-root. **Date:** 2026-06-07.
+
+> **Hard gate:** applying a `crop_target_profiles` migration to the **prod** DB
+> (`verdify-prod/verdify-db`) changes the live setpoints the dispatcher pushes to the sole
+> device writer. **Build + test the migration in the dev DB first; the prod apply is
+> laptop-root + Jason gated.** No secrets are printed in this runbook.
+
+---
+
+## 1. Where the bands actually live (the key architectural fact)
+
+The agronomic bands — including what is loosely called the **"orchid time-of-day logic"** —
+are **DB rows, not firmware code**:
+
+```
+crop_target_profiles            fn_band_setpoints(ts)          dispatcher              firmware
+(24 hourly rows × crop)   ──▶   (resolve + interpolate)  ──▶  (push setpoints)  ──▶  (consumes Setpoints)
+  hour_of_day 0..23              picks MAX(min)/MIN(max)        Tier-1 rows             greenhouse_logic.h
+  temp_ideal_min/max             across active crops,           the planner emits        bands only GRADE;
+  vpd_ideal_min/max              linear-interpolates to          per the bands           firmware never
+  temp/vpd_stress_low/high       the minute                                              hardcodes them
+```
+
+- **`crop_target_profiles`** (`db/schema.sql`): one row per `(crop_type, growth_stage,
+  hour_of_day, season, greenhouse_id)`. Columns:
+  `temp_ideal_min/max`, `temp_stress_low/high`, `vpd_ideal_min/max`, `vpd_stress_low/high`,
+  `dli_target_mol`, `source`.
+- **`fn_band_setpoints(target_ts)`** (`db/schema.sql:388`) resolves the band for a moment:
+  `local_hour = EXTRACT(hour FROM ts AT TIME ZONE 'America/Denver')`, takes
+  `MAX(temp_ideal_min), MIN(temp_ideal_max)` etc. across the active crops for that hour, and
+  **linearly interpolates** to the next hour by the minute fraction. So the curve is smooth,
+  not a 24-step staircase.
+- **`fn_band_timeline(...)`** (`db/schema.sql:429`) is the full timeline view (crop band vs
+  projected vs actual vs firmware) the band-viz dashboard renders.
+
+### 1.1 The "orchid time-of-day" curve = the orchid rows of this table
+
+Migration `145-vanda-band-and-join-fix.sql` (`vanda_spec_v1.0`) wrote the orchid 24-hour
+curve. It is a **diurnal sinusoid**:
+
+| | night/trough (h 0–6, 22–23) | peak (h 14–15) |
+|---|---|---|
+| `temp_ideal_min/max` (°F) | 61.0 / 67.0 | 77.8 / 87.8 |
+| `vpd_ideal_min/max` (kPa) | 0.75 / 0.85 | 0.95 / 1.20 |
+| `temp_stress_low/high` | 55 / 100 (flat all day) | 55 / 100 |
+| `vpd_stress_low/high` | 0.50 / 1.50 (flat) | 0.50 / 1.50 |
+
+The temp band climbs ~17°F from pre-dawn to mid-afternoon then falls; VPD tracks it
+(warmer, drier-allowed by day). **This curve IS the orchid time-of-day behavior.** To
+"rip out the orchid time-of-day logic" you do NOT touch the firmware — you re-author these
+rows (e.g. to a flatter curve, or fewer distinct anchors, or align the temp & VPD shoulders).
+
+> **Verification that it is NOT in firmware:** `greenhouse_logic.h` reads `in.local_hour`
+> only for fog-window / night-suppression / dusk-cutoff *gates* (hard rails), never for the
+> crop band itself. The band arrives as resolved `Setpoints` (`sp.temp_high/low`,
+> `sp.vpd_high/low`) from the dispatcher. (`grep local_hour firmware/lib/greenhouse_logic.h`
+> shows only the gate predicates `fog_hour_in_window`, `is_night_hour`, `past_dusk_cutoff`.)
+
+So issues #52 (orchid dormancy/seasonal) and #37 (irrigation default hour) are **different
+surfaces**: #37 *is* a firmware default (`irrig_center_start_hour` in `globals.yaml`), while
+the orchid temp/VPD diurnal band is the DB curve above. Don't conflate them.
+
+---
+
+## 2. The safe tuning loop (DB-only, no OTA)
+
+```
+  edit band  →  migration in DEV DB  →  band-viz dashboard diff  →  replay-grade  →  GATED prod apply
+```
+
+### Step 1 — author the migration
+Add `db/migrations/<next>-<slug>.sql` (next number after `150-vanda-nutrient-recipe.sql`,
+i.e. **151+**). Pattern from `145`: `DELETE FROM crop_target_profiles WHERE crop_type='orchid'
+AND season='spring';` then `INSERT … VALUES` the new 24 rows. Keep it **idempotent**
+(DELETE-then-INSERT on the unique key `(crop_type, growth_stage, hour_of_day, season,
+greenhouse_id)`) and reversible (commit the prior rows as a down-note).
+
+### Step 2 — apply to the DEV DB only
+```bash
+# dev DB = verdify-dev/verdify-db (k3s). NEVER point this at verdify-prod.
+ssh jason@192.168.30.32 \
+  "sudo k3s kubectl -n verdify-dev exec -i statefulset/verdify-db -- \
+   psql -U verdify -d verdify" < db/migrations/151-<slug>.sql
+```
+
+### Step 3 — visualize the change (the band-adjustment dashboard)
+Open the **"Band Tuning — Diurnal Adjustment"** dashboard (`grafana/dashboards/
+band-tuning-diurnal.json`, see §3). It plots, hour-by-hour:
+- the **temp_ideal_min/max** band envelope across the day,
+- the **vpd_ideal_min/max** band envelope across the day,
+- the **band width** (temp_high − temp_low, vpd_high − vpd_low) — so you can see where a
+  band is too tight to be physically achievable,
+- the **resolved `fn_band_setpoints` curve** (what the dispatcher will actually push).
+
+Confirm the new curve looks right *before* any prod apply. Tight bands (small width) are
+the #1 cause of unachievable-compliance churn — watch the width row.
+
+### Step 4 — grade the change against history
+Run the planner/compliance replay against recent telemetry with the dev band active to see
+how compliance moves. (Compliance is graded per-zone against each crop's served band —
+`iris_planner.py` §80% Compliance.) A band that *raises* compliance only because it widened
+the target is not necessarily a win — check temp AND vpd compliance separately.
+
+### Step 5 — GATED prod apply (laptop-root + Jason)
+Same `psql` apply but against `verdify-prod/verdify-db`. **Gate + snapshot first:**
+```bash
+# snapshot the current orchid rows BEFORE applying (rollback artifact)
+ssh jason@192.168.30.32 \
+  "sudo k3s kubectl -n verdify-prod exec -i statefulset/verdify-db -- \
+   pg_dump -U verdify -d verdify -t crop_target_profiles --data-only" \
+   > /tmp/crop_target_profiles.prod.$(date +%Y%m%d%H%M).sql
+# then apply, then re-probe fn_band_setpoints(now()) matches intent
+```
+Record `GREEN at <T>, re-verified at <T+10min>` with the literal
+`SELECT * FROM fn_band_setpoints(now());` output.
+
+---
+
+## 3. The VPD + temperature band-alignment refactor
+
+**Goal (the #225/agronomy ask):** cleaner VPD+temperature band alignment — the temp and VPD
+"shoulders" (the hours where each starts rising/falling) should be coherent, and the orchid
+diurnal swing should be intentional rather than an artifact of the v1.0 anchors.
+
+Concretely, the tooling for Jason to drive this:
+1. **`scripts/band-curve-export.sql`** (ship): dumps the current 24-row curve for a crop as a
+   tidy table (hour, temp_lo, temp_hi, vpd_lo, vpd_hi, temp_width, vpd_width) — the input to
+   a re-author.
+2. **The band-viz dashboard** (§3 / `band-tuning-diurnal.json`): see the curve + widths + the
+   resolved setpoint, dev vs prod side by side.
+3. **A re-author migration template** (DELETE+INSERT 24 rows) — copy `145`'s shape, change
+   the anchors. For "rip out the time-of-day swing," set all 24 hours to the same
+   `temp_ideal_min/max` + `vpd_ideal_min/max` (a flat band); for "align shoulders," shift the
+   VPD-rise hours to match the temp-rise hours.
+
+**Safe-change rules for the band re-author:**
+- Never narrow a band into infeasibility — keep `temp_width ≥ ~6°F` and `vpd_width ≥ ~0.3 kPa`
+  unless you have evidence the zone can hold tighter (planner notes this exact failure mode).
+- Keep `temp_stress_*` / `vpd_stress_*` wider than `*_ideal_*` (the grader gives partial
+  credit through the stress band; collapsing them to the ideal makes every near-miss a zero).
+- Change temp and VPD **together** and re-grade — VPD is a function of temp + RH, so a temp
+  shoulder shift moves the achievable VPD.
+
+---
+
+## 4. Pitfalls
+
+- **`fn_band_setpoints` keys on `season='spring'` (HARDCODED) — but it is now summer.**
+  Verified live 2026-06-07: prod `crop_target_profiles` has BOTH `orchid/spring` (24 rows)
+  AND `orchid/summer` (24 rows), plus `_default/{spring,summer}`, basil, canna, lettuce,
+  pepper. **`fn_band_setpoints` only reads `season='spring'`** (`db/schema.sql:406,412`), so
+  the **summer curve is authored but NOT served** until the function selects the live season.
+  This is itself a band-alignment defect to fix (a firmware-optimization issue): the resolver
+  should pick the active season, not a hardcoded one. A seasonal orchid dormancy curve (#52)
+  has the same dependency — it needs both the rows **and** the resolver change.
+- **The DEV DB `crop_target_profiles` is EMPTY** (verified live 2026-06-07: 0 rows; the
+  fresh-cutover dev DB was not seeded with profiles). So the band-tuning loop's Step 2 (apply
+  the migration to dev) is *also* the dev-seed step — panels 1–4 of the band-viz dashboard are
+  blank in dev until you load the rows, which is the intended author→load→visualize flow.
+  Panel 5 (`fn_band_setpoints`) still resolves in dev via its defaults.
+- **Timezone:** the curve is interpreted in `America/Denver`. A row authored "for hour 14"
+  is 14:00 MDT/MST, not UTC.
+- **Multi-crop intersection:** `fn_band_setpoints` takes `MAX(min)/MIN(max)` across *all*
+  active crops for the hour — so the served band is the *intersection*. Re-authoring the
+  orchid rows alone may not move the served band if another active crop is the binding
+  constraint that hour. Check `v_crop_catalog_with_profiles` for what's active.

--- a/docs/runbooks/verdify-firmware-safe-iteration-loop.md
+++ b/docs/runbooks/verdify-firmware-safe-iteration-loop.md
@@ -1,0 +1,179 @@
+# Verdify Firmware / Band Safe-Iteration Loop
+
+**Status:** Runbook (lane VerdifyConsultancy/verdify-platform#221). SHADOW-first, device-write=0.
+**Author:** laptop-root. **Date:** 2026-06-07.
+**Audience:** Jason + the `verdify-firmware` dev agent.
+
+> **Hard gate (CLAUDE.md / lane #221):** the LIVE prod device-writer ingestor
+> (`verdify-prod/verdify-ingestor`) is the SOLE live ESP32 writer (`192.168.10.111:6053`).
+> **NEVER** flash live firmware, push a live setpoint, or scale/restart its push path
+> without **laptop-root + Jason** confirmation. Everything below bakes a change in
+> dev/shadow *before* the one gated live step.
+
+---
+
+## 0. The big picture — ideate → deploy → validate, safely
+
+```
+                       SHADOW (device-write=0)                 GATED LIVE (Jason)
+  ┌──────────┐   ┌──────────────────────────────────┐   ┌──────────────────────────┐
+  │ idea /   │──▶│ 1. branch + worktree             │──▶│ 6. make firmware-deploy   │
+  │ band edit│   │ 2. replay-diff vs prod corpus     │   │    (compile→OTA→60s soak  │
+  └──────────┘   │ 3. firmware-invariants + tests    │   │     →sensor-health→pass/  │
+                 │ 4. verdify-dev shadow bake        │   │     auto-rollback)        │
+                 │ 5. (firmware) digital-twin bake   │   │ 7. 48h behavioral bake    │
+                 └──────────────────────────────────┘   │ 8. promote-last-good      │
+                                                         └──────────────────────────┘
+```
+
+There are **two surfaces** you iterate on, and they have different safe loops:
+
+| Surface | What it is | Where it lives | Safe loop |
+|---|---|---|---|
+| **Firmware** (FSM control logic) | `firmware/lib/greenhouse_logic.h` + `firmware/greenhouse/*.yaml` | compiled to OTA binary, runs on ESP32 | replay-diff → invariants → twin bake → gated OTA |
+| **Bands** (agronomic targets, incl. the "orchid time-of-day" curve) | `crop_target_profiles` rows (DB) → `fn_band_setpoints` → dispatcher → firmware setpoints | the **DB**, not the firmware | migration in dev DB → band-viz dashboard → gated prod migration. **No OTA needed.** See `verdify-band-tuning-safe.md`. |
+
+The decisive fact: **changing a band does NOT require a firmware flash.** Bands are
+DB-driven; the firmware just consumes the resolved setpoints the dispatcher pushes. So
+most "tuning" iterations never touch the device binary at all.
+
+---
+
+## 1. The shadow lane (device-dark) — verified invariants
+
+The `verdify-dev` namespace is the structurally-safe place to exercise firmware/planner
+changes end-to-end without any path to the device:
+
+- **Ingestor `replicas:0`** in `verdify-dev` (the writer is scaled to zero — no push loop).
+  - Verify: `ssh jason@192.168.30.32 sudo k3s kubectl -n verdify-dev get deploy verdify-ingestor -o jsonpath='{.spec.replicas}'` → `0`.
+- **`deny-esp32-egress` NetworkPolicy** denies egress to `192.168.10.0/24` for
+  `component=ingestor` in `verdify-dev` (so even if an ingestor pod were ever scaled up,
+  it physically cannot reach the ESP32).
+  - Verify: `ssh jason@192.168.30.32 sudo k3s kubectl -n verdify-dev get networkpolicy deny-esp32-egress` exists.
+- **Acceptance for #221:** "dev ns never opens an ESTAB writer to the ESP32" — both
+  invariants above are the enforcement. Re-probe both before any dev exercise.
+
+> Both invariants were **verified live 2026-06-07** (ingestor `0/0`, NetworkPolicy present).
+
+---
+
+## 2. The firmware OTA loop (`make firmware-deploy`) — what it already enforces
+
+The existing target (`Makefile: firmware-deploy`) is a self-protecting deploy:
+
+1. **`scripts/firmware-deploy-preflight.sh`** — refuses OTA while any `critical`/`high`
+   alert is unresolved (override requires `FIRMWARE_DEPLOY_OPERATOR_SIGNOFF=1` +
+   `FIRMWARE_DEPLOY_OVERRIDE_REASON`).
+2. **Dirty-tree refusal** — refuses to flash a dirty worktree unless
+   `ALLOW_DIRTY_FIRMWARE_DEPLOY=1` **and** operator sign-off + reason are set (emergency only).
+3. **Compile + OTA** to `ESP32_DEVICE=192.168.10.111` with a stamped
+   `fw_version=<date>.<sha>`.
+4. **60s soak** for reboot + ingestor reconnect + first diagnostics cycle.
+5. **`sensor-health SINCE='5 minutes'`** decides pass/fail.
+   - **Pass** → archive the binary + advance the *expected-firmware* pin. **Rollback target
+     stays on the prior last-good** (it bakes first).
+   - **Fail** → `scripts/firmware-rollback.sh firmware/artifacts/last-good.ota.bin` flashes
+     last-good back, waits 60s, re-runs sensor-health, exits non-zero.
+
+**This is already a good loop. The two gaps lane #221 closes are:**
+
+- **(A) bake BEFORE the flash** — today the only pre-flash behavioral check is the
+  frozen-corpus replay-diff. The **digital twin (#34)** turns rule-3's file-mtime bake into
+  a *behavioral* bake against today's real telemetry. → §3.
+- **(B) the rollback floor is stale** — `last-good` is the 2026-05-17 binary while the
+  device runs `2026.5.30.1418.aa6518c`. A rollback today drops the device 2 weeks back.
+  → §4 (#35).
+
+### 2.1 VM-era assumption to fix before the next live deploy (gap found 2026-06-07)
+`scripts/firmware-deploy-preflight.sh` and `firmware-rollback.sh` reach the DB via
+`docker exec verdify-timescaledb …` and read secrets from `/srv/greenhouse/esphome/`.
+**Those paths were on the now-powered-off `.150` VM.** The DB is now
+`verdify-prod/verdify-db` (k3s, TimescaleDB 2.25.2-pg16) and esphome secrets must be
+re-homed. **Before any live `make firmware-deploy`, the preflight DB handle + the
+esphome secrets path must be re-pointed at the k3s DB / new tooling host.** This is a
+prerequisite gate, tracked as a firmware-optimization issue.
+
+---
+
+## 3. Digital twin (#34) — deploy it as the pre-flash behavioral bake
+
+The twin runs the **same** `greenhouse_logic.h` the ESP32 compiles, fed the same
+telemetry, and **never actuates** (read-only by construction: no actuation credential, no
+route to ESP32, INSERT-only DB role). Design: `docs/design/firmware-digital-twin.md`.
+
+**Status:** #34 is `state:MERGED` but **not deployed** to k3s. Deploy it as a `verdify-dev`
+(or a dedicated `verdify-twin`) workload. Two twin roles:
+
+- **prod-twin** pinned to the deployed `last-good` → **prod-vs-reality divergence** (the
+  novel signal; catches a firmware-vs-device drift a twin-vs-twin comparison is blind to).
+- **stage-twin** pinned to the **OTA candidate** → shadows live telemetry for the full bake
+  window *before* the binary is flashed (converts the mtime bake into a behavioral bake).
+
+**Deploy checklist (additive, dev-first, no device risk):**
+1. Land the twin runtime (the `--stream` mode on `replay_emit.cpp`, gated so the batch
+   replay-diff path is byte-for-byte unchanged — see design §2.1) + the `twin_decisions`
+   hypertable + `twin_ro` INSERT-only role (#33 / TWIN-6).
+2. **Close the setpoint-coverage gap first (#31 / TWIN-3)** — the differ must walk every
+   `Setpoints` field with an active code path against the dispatcher's pushed keys, or the
+   twin diverges for a *config* reason and the divergence metric is untrustworthy as a gate.
+   This is a **blocker for trusting the gate** (design §2.2).
+3. Fix the **local-hour timezone bug** (`EXTRACT(HOUR … AT TIME ZONE 'America/Denver')`) and
+   apply the **`dt_ms = min(dt_ms, 5000)`** device cap in the live driver (design §2.2/§2.3).
+4. Set the prod-vs-reality alert threshold **≥ `MAX(MIN_HEAT_OFF_MS, MIN_FAN_OFF_MS)`** (the
+   twin predicts FSM *intent*, the device defers by dwell timers — several minutes).
+5. Wire the **prod-vs-reality Grafana panel** (design §6 Phase 1).
+
+**Acceptance (#34):** twin-prod shadows live telemetry through `greenhouse_logic.h`; writes
+`twin_decisions` per tick; the divergence panel renders; read-only by construction.
+
+---
+
+## 4. Refresh the rollback floor (#35) — `make firmware-promote-last-good`
+
+- The live device runs `2026.5.30.1418.aa6518c`; `last-good` is still the 2026-05-17
+  binary. Freeze rule 3 requires a **48h bake** (no `severity='critical'` sensor-health
+  alert) before promotion — that window completed ~2026-06-01.
+- **Promote (gated, Jason):**
+  `make firmware-promote-last-good FW_VERSION=2026.5.30.1418.aa6518c`
+  → advances `firmware/artifacts/last-good.{version,ota.bin,metadata.env}`.
+- **Precondition:** the archived artifacts for `aa6518c` must exist in
+  `firmware/artifacts/` on the tooling host. If they were lost with the `.150` decom,
+  re-archive from the running device first (`make firmware-archive-artifacts`) — do NOT
+  re-flash to produce them.
+- **Gate:** this only changes the *rollback target file*, not the device. Still confirm
+  with Jason because it changes what an auto-rollback would flash.
+
+---
+
+## 5. The staging-device validation harness (alternative / complement to the twin)
+
+If/when a second physical ESP32 (or an ESPHome `host`-platform Tier-2 build — design §2.2)
+is available, a **staging device** lets a candidate binary run a full bake on real hardware
+fed shadow telemetry before the live OTA. Until then, the **Tier-1 twin (§3) is the
+pre-flash bake** and is sufficient for FSM-intent regressions; mister-timing / dwell-timer
+regressions are a Tier-2-only signal (design §2.2 fidelity boundary).
+
+---
+
+## 6. The one-page operator checklist
+
+```
+IDEATE
+  □ branch + git worktree add (isolated lane)
+SHADOW (no device)
+  □ make firmware-replay           # FSM trace vs prod corpus
+  □ make firmware-invariants       # 16 safety invariants
+  □ make firmware-check            # replay-diff vs last deployed ref
+  □ (twin) deploy candidate to stage-twin, watch divergence panel ≥ bake window
+  □ re-probe dev device-dark invariants (ingestor replicas:0 + deny-esp32-egress)
+GATE  → laptop-root + Jason sign-off required past this line
+LIVE (Jason only)
+  □ refresh last-good if stale (§4)
+  □ re-point preflight DB handle + esphome secrets at k3s (§2.1)  ← prereq
+  □ make firmware-deploy           # compile→OTA→60s→sensor-health→pass/auto-rollback
+  □ 48h behavioral bake (no critical sensor-health alert)
+  □ make firmware-promote-last-good FW_VERSION=<new>   # advance rollback floor
+DURABILITY
+  □ re-probe sensor-health + twin divergence ≥10 min after the deploy claim
+    record "GREEN at <T>, re-verified at <T+N>"
+```

--- a/grafana/provisioning/dashboards/json/band-tuning-diurnal.json
+++ b/grafana/provisioning/dashboards/json/band-tuning-diurnal.json
@@ -1,0 +1,416 @@
+{
+  "uid": "band-tuning-diurnal",
+  "title": "Band Tuning \u2014 Diurnal Adjustment",
+  "editable": true,
+  "schemaVersion": 39,
+  "timezone": "America/Denver",
+  "style": "dark",
+  "tags": [
+    "greenhouse",
+    "bands",
+    "tuning",
+    "agronomy"
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": [],
+  "templating": {
+    "list": [
+      {
+        "name": "crop",
+        "label": "Crop",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "verdify-tsdb"
+        },
+        "query": "SELECT DISTINCT crop_type FROM crop_target_profiles ORDER BY 1",
+        "current": {
+          "text": "orchid",
+          "value": "orchid"
+        },
+        "refresh": 1,
+        "includeAll": false
+      },
+      {
+        "name": "season",
+        "label": "Season",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "verdify-tsdb"
+        },
+        "query": "SELECT DISTINCT season FROM crop_target_profiles ORDER BY 1",
+        "current": {
+          "text": "spring",
+          "value": "spring"
+        },
+        "refresh": 1,
+        "includeAll": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now/d",
+    "to": "now/d+1d"
+  },
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "Diurnal temperature band (temp_ideal_min/max) per hour for $crop / $season. The orchid 'time-of-day' swing is this curve. Authored in crop_target_profiles; resolved to setpoints by fn_band_setpoints.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto"
+          },
+          "unit": "fahrenheit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "type": "timeseries",
+      "title": "Temperature ideal band across the day (\u00b0F)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "format": "time_series",
+          "rawSql": "SELECT timestamp '2026-01-01 00:00:00' + (hour_of_day * interval '1 hour') AS time, temp_ideal_min AS \"temp_lo\", temp_ideal_max AS \"temp_hi\" FROM crop_target_profiles WHERE crop_type = '$crop' AND season = '$season' ORDER BY hour_of_day",
+          "refId": "temp"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "Diurnal VPD band (vpd_ideal_min/max) per hour for $crop / $season. Align the VPD shoulders with the temperature shoulders above for a coherent band.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "type": "timeseries",
+      "title": "VPD ideal band across the day (kPa)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "format": "time_series",
+          "rawSql": "SELECT timestamp '2026-01-01 00:00:00' + (hour_of_day * interval '1 hour') AS time, vpd_ideal_min AS \"vpd_lo\", vpd_ideal_max AS \"vpd_hi\" FROM crop_target_profiles WHERE crop_type = '$crop' AND season = '$season' ORDER BY hour_of_day",
+          "refId": "vpd"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "temp_ideal_max - temp_ideal_min per hour. Width < ~6\u00b0F (red threshold) risks unachievable-compliance churn. Watch where the band is too tight to hold.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto"
+          },
+          "unit": "fahrenheit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "temp_width"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 6
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "line"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "type": "timeseries",
+      "title": "Temperature band WIDTH across the day (\u00b0F)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "format": "time_series",
+          "rawSql": "SELECT timestamp '2026-01-01 00:00:00' + (hour_of_day * interval '1 hour') AS time, (temp_ideal_max - temp_ideal_min) AS \"temp_width\" FROM crop_target_profiles WHERE crop_type = '$crop' AND season = '$season' ORDER BY hour_of_day",
+          "refId": "tw"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "vpd_ideal_max - vpd_ideal_min per hour. Width < ~0.30 kPa (red threshold) risks churn.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto"
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vpd_width"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.3
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "line"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "type": "timeseries",
+      "title": "VPD band WIDTH across the day (kPa)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "format": "time_series",
+          "rawSql": "SELECT timestamp '2026-01-01 00:00:00' + (hour_of_day * interval '1 hour') AS time, (vpd_ideal_max - vpd_ideal_min) AS \"vpd_width\" FROM crop_target_profiles WHERE crop_type = '$crop' AND season = '$season' ORDER BY hour_of_day",
+          "refId": "vw"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "What fn_band_setpoints actually resolves hour-by-hour for the next 24h \u2014 the SERVED band = intersection (MAX(min)/MIN(max)) across ALL active crops, smooth-interpolated. If this differs from the $crop curve above, another active crop is the binding constraint that hour.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 5,
+      "type": "timeseries",
+      "title": "Resolved SERVED setpoints fn_band_setpoints() \u2014 next 24h (all active crops)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "format": "time_series",
+          "rawSql": "SELECT g.h AS time, b.temp_low, b.temp_high, b.vpd_low, b.vpd_high FROM generate_series(date_trunc('day', now()), date_trunc('day', now()) + interval '23 hours', interval '1 hour') AS g(h), LATERAL fn_band_setpoints(g.h) AS b ORDER BY g.h",
+          "refId": "served"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "min",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/band-curve-export.sql
+++ b/scripts/band-curve-export.sql
@@ -1,0 +1,71 @@
+-- band-curve-export.sql — dump a crop's 24-hour band curve for safe re-authoring.
+-- Lane VerdifyConsultancy/verdify-platform#221 (band-tuning tooling).
+--
+-- Usage (dev DB — NEVER point this WRITE-side; this is read-only):
+--   ssh jason@192.168.30.32 \
+--     "sudo k3s kubectl -n verdify-dev exec -i statefulset/verdify-db -- \
+--      psql -U verdify -d verdify -v crop=orchid -v season=spring" \
+--      < scripts/band-curve-export.sql
+--
+-- Override the crop/season with -v crop=<name> -v season=<season>
+-- (defaults below if unset).
+
+\if :{?crop}
+\else
+  \set crop 'orchid'
+\endif
+\if :{?season}
+\else
+  \set season 'spring'
+\endif
+
+\echo '── Band curve for crop=' :crop ' season=' :season ' ──'
+
+-- 1. The raw 24-hour curve + computed widths (the re-author input table).
+SELECT
+    hour_of_day                                  AS h,
+    round(temp_ideal_min::numeric, 1)            AS temp_lo,
+    round(temp_ideal_max::numeric, 1)            AS temp_hi,
+    round((temp_ideal_max - temp_ideal_min)::numeric, 1) AS temp_width,
+    round(vpd_ideal_min::numeric, 2)             AS vpd_lo,
+    round(vpd_ideal_max::numeric, 2)             AS vpd_hi,
+    round((vpd_ideal_max - vpd_ideal_min)::numeric, 2)   AS vpd_width,
+    round(temp_stress_low::numeric, 1)           AS temp_stress_lo,
+    round(temp_stress_high::numeric, 1)          AS temp_stress_hi,
+    round(vpd_stress_low::numeric, 2)            AS vpd_stress_lo,
+    round(vpd_stress_high::numeric, 2)           AS vpd_stress_hi,
+    source
+FROM crop_target_profiles
+WHERE crop_type = :'crop'
+  AND season    = :'season'
+ORDER BY hour_of_day;
+
+-- 2. Curve shape summary — peak/trough + swing (the "time-of-day" signature).
+\echo '── Diurnal swing summary (how much the band moves across the day) ──'
+SELECT
+    round(min(temp_ideal_min)::numeric,1) AS temp_lo_min,
+    round(max(temp_ideal_max)::numeric,1) AS temp_hi_max,
+    round((max(temp_ideal_max) - min(temp_ideal_min))::numeric,1) AS temp_total_swing,
+    round(min(vpd_ideal_min)::numeric,2)  AS vpd_lo_min,
+    round(max(vpd_ideal_max)::numeric,2)  AS vpd_hi_max,
+    round((max(vpd_ideal_max) - min(vpd_ideal_min))::numeric,2) AS vpd_total_swing,
+    count(*) AS rows
+FROM crop_target_profiles
+WHERE crop_type = :'crop' AND season = :'season';
+
+-- 3. Feasibility flags — hours where the band may be too tight to hold.
+\echo '── Tight-band warnings (temp_width<6F or vpd_width<0.3kPa = churn risk) ──'
+SELECT hour_of_day AS h,
+       round((temp_ideal_max - temp_ideal_min)::numeric,1) AS temp_width,
+       round((vpd_ideal_max  - vpd_ideal_min)::numeric,2)  AS vpd_width
+FROM crop_target_profiles
+WHERE crop_type = :'crop' AND season = :'season'
+  AND ( (temp_ideal_max - temp_ideal_min) < 6.0
+        OR (vpd_ideal_max - vpd_ideal_min) < 0.30 )
+ORDER BY hour_of_day;
+
+-- 4. What the dispatcher would actually push right now (served = intersection of
+--    all active crops). If this differs from the curve above, another crop is the
+--    binding constraint this hour.
+\echo '── Resolved served setpoints fn_band_setpoints(now()) (all active crops) ──'
+SELECT * FROM fn_band_setpoints(now());


### PR DESCRIPTION
Stands up Jason's **ideate → deploy → validate** capability for greenhouse/firmware/band optimization, **SHADOW-first (device-write=0)**. No firmware flashed; no live device or DB mutated by this PR.

## What this ships
- **`docs/runbooks/verdify-firmware-safe-iteration-loop.md`** — the end-to-end safe loop: replay-diff → invariants → `verdify-dev` shadow → digital-twin bake → **GATED** live OTA (`make firmware-deploy`: dirty-refusal/compile/OTA/60s soak/sensor-health/auto-rollback) → 48h bake → `promote-last-good`. Documents the twin deploy (#34), the stale rollback floor (#35), and the **verified** dev device-dark invariants (ingestor `replicas:0` + `deny-esp32-egress` NetworkPolicy). Flags the VM-era preflight DB handle + esphome secrets path to re-home to k3s.
- **`docs/runbooks/verdify-band-tuning-safe.md`** — "how to tune a band safely". The **orchid time-of-day logic is the 24-row diurnal `crop_target_profiles` curve** resolved by `fn_band_setpoints` — DB-driven, **no firmware flash**. Safe loop: migration in dev DB → band-viz → replay-grade → GATED prod apply (snapshot first). VPD+temp alignment refactor tooling + safe-change rules.
- **`scripts/band-curve-export.sql`** — dump a crop's 24h curve + widths + tight-band warnings + resolved served setpoints.
- **`grafana/.../band-tuning-diurnal.json`** — "Band Tuning — Diurnal Adjustment" dashboard (band envelopes + widths + resolved curve). **SQL verified against the live prod + dev DBs.**

## Live findings (2026-06-07)
- **`fn_band_setpoints` hardcodes `season='spring'`** — but it is summer; the authored `orchid/summer` curve is NOT served. → #253.
- **Dev DB `crop_target_profiles` is empty** — band changes load to dev to visualize. 

## Backlog
Epic **#249** [firmware-optimization] with children **#250-256**.

## Safety
SHADOW (device-write=0) iterations are autonomous. Every **live OTA** and **prod `crop_target_profiles` apply** is **laptop-root + Jason** gated and snapshot-first. Adversarially verified: all referenced make targets / scripts / design docs exist; dashboard SQL runs on live DBs.

Closes part of #221 (the safe-iteration loop design + tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)