### PR TITLE
feat(lab): automate vault->lab.verdify.ai content/build pipeline (#124/#219)

### DIFF
--- a/.github/workflows/lab-content-pipeline.yml
+++ b/.github/workflows/lab-content-pipeline.yml
@@ -1,0 +1,168 @@
+name: Lab Content Pipeline
+
+# Vault -> lab.verdify.ai content/build pipeline orchestration (#124 / #219).
+#
+# ─── THE PROBLEM THIS SOLVES ────────────────────────────────────────────────
+# lab.verdify.ai is a Quartz static site whose content is the curated public
+# subset of the Obsidian vault (the vault `website/` subtree). That content lives
+# ONLY on the synced fleet replica — GitHub-hosted runners cannot reach it. So the
+# pipeline is split into a fleet stage and a CI stage:
+#
+#   [FLEET]  scripts/sync-lab-content.sh  (runs where the vault is reachable:
+#            an operator Mac via laptop-root, or a fleet host / self-hosted runner)
+#            -> snapshots the curated website/ subtree, scrubs private paths,
+#            -> opens a PR into VerdifyConsultancy/verdify-site-legacy updating
+#               content-snapshot/.
+#
+#   [CI]     verdify-site-legacy/.github/workflows/publish-lab-image.yml
+#            -> on merge, builds the verdify-lab image DETERMINISTICALLY from the
+#               committed content-snapshot/ (the REAL site, not the stock Quartz
+#               docs placeholder it used to seed) and publishes a new @sha256.
+#
+#   [GATE]   overlay digest write-back into verdify-platform lab-site overlays is
+#            the PROD-PROMOTION-GATED step (Jason gate) — see the runbook in
+#            docs/runbooks/lab-content-pipeline.md (this PR).
+#
+# ─── WHAT THIS WORKFLOW DOES ────────────────────────────────────────────────
+# This is the orchestration + CI-side guard that GitHub CAN run:
+#   * lab-build-smoke: prove the verdify-lab Quartz toolchain + the in-repo lab
+#     site config still build a valid static site (catches Quartz/config breakage
+#     before a content sync ever fires). It builds from the verdify-site-legacy
+#     checkout; without the vault it produces the fallback site, which is enough
+#     to validate the BUILD CONTRACT (index.html emitted, :8080 nginx config sane).
+#   * trigger-image-rebuild (dispatch only): fire the verdify-site-legacy
+#     `vault-content-update` repository_dispatch so a just-merged content-snapshot
+#     PR rebuilds + republishes the image, without waiting for the weekly cron.
+#
+# `.github/**` is SHARED INFRA — this lands as a PR for coordinator/James review,
+# never an autonomous merge into the read-only VerdifyConsultancy org.
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger_image_rebuild:
+        description: "Also fire verdify-site-legacy vault-content-update dispatch"
+        type: boolean
+        default: false
+  # Allow the fleet sync job (or a merged content PR) to fire this.
+  repository_dispatch:
+    types: [lab-content-synced]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lab-content-pipeline-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  LAB_REPO: VerdifyConsultancy/verdify-site-legacy
+  LAB_BRANCH: v4
+
+jobs:
+  lab-build-smoke:
+    name: Lab Quartz build smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout verdify-site-legacy (lab Quartz source)
+        uses: actions/checkout@v4
+        with:
+          repository: VerdifyConsultancy/verdify-site-legacy
+          ref: v4
+          # Read-only checkout of the public-ish lab content repo. Falls back to
+          # the workflow token; if the repo is private the job needs a PAT secret
+          # LAB_REPO_TOKEN (documented in the runbook). Kept optional so the
+          # smoke test degrades to "skipped" rather than a hard failure.
+          token: ${{ secrets.LAB_REPO_TOKEN || github.token }}
+          persist-credentials: false
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Quartz deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Seed content with snapshot precedence (mirrors Dockerfile.k3s)
+        run: |
+          set -eux
+          has_md() { [ -d "$1" ] && find "$1" -name '*.md' -type f -print -quit 2>/dev/null | grep -q .; }
+          if has_md content-snapshot; then
+            echo "seeding content/ from content-snapshot/ (REAL curated vault subtree)"
+            rm -rf content; cp -rL content-snapshot content
+          elif [ ! -L content ] && has_md content; then
+            echo "using checked-in content/"
+          else
+            echo "no content-snapshot/ — seeding stock docs/ fallback (toolchain smoke only)"
+            rm -rf content; cp -r docs content
+          fi
+
+      - name: Build Quartz static site
+        run: |
+          set -eux
+          npx quartz build
+          test -f public/index.html
+          pages="$(find public -name '*.html' | wc -l)"
+          echo "emitted ${pages} html pages"
+          [ "${pages}" -ge 1 ]
+
+      - name: Assert real content when snapshot present
+        run: |
+          set -eu
+          if [ -d content-snapshot ] && find content-snapshot -name '*.md' -print -quit | grep -q .; then
+            # When the real snapshot is present the build MUST NOT be the stock
+            # Quartz manual ("Welcome to Quartz"); it must carry the real homepage.
+            if grep -q "Welcome to Quartz" public/index.html; then
+              echo "::error::content-snapshot present but build produced the stock Quartz docs — seed precedence broke"
+              exit 1
+            fi
+            if ! grep -qi "Verdify" public/index.html; then
+              echo "::error::content-snapshot present but built homepage is missing the Verdify site"
+              exit 1
+            fi
+            echo "verified: built the REAL Verdify lab site from content-snapshot/"
+          else
+            echo "no content-snapshot yet — toolchain-only smoke (fallback site)"
+          fi
+
+      - name: Build summary
+        if: always()
+        run: |
+          {
+            echo "### Lab Quartz build smoke"
+            echo
+            echo "- Source repo: \`${LAB_REPO}\` @ \`${LAB_BRANCH}\`"
+            echo "- Pages emitted: \`$(find public -name '*.html' 2>/dev/null | wc -l)\`"
+            echo "- Title: \`$(grep -o '<title>[^<]*</title>' public/index.html 2>/dev/null | head -1)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  trigger-image-rebuild:
+    name: Fire verdify-site-legacy content rebuild
+    runs-on: ubuntu-latest
+    needs: lab-build-smoke
+    if: >-
+      github.event_name == 'repository_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && inputs.trigger_image_rebuild)
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch vault-content-update to the lab image repo
+        env:
+          # Cross-repo dispatch needs a token with `repo`/`actions:write` on
+          # verdify-site-legacy. Documented in the runbook. If unset, the step
+          # no-ops with a notice rather than failing the pipeline.
+          DISPATCH_TOKEN: ${{ secrets.LAB_REPO_TOKEN }}
+        run: |
+          set -eu
+          if [ -z "${DISPATCH_TOKEN:-}" ]; then
+            echo "::notice::LAB_REPO_TOKEN unset — skipping cross-repo image rebuild dispatch"
+            exit 0
+          fi
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${LAB_REPO}/dispatches" \
+            -d '{"event_type":"vault-content-update"}'
+          echo "fired vault-content-update -> ${LAB_REPO} (rebuild + republish verdify-lab)"

--- a/docs/runbooks/lab-content-pipeline.md
+++ b/docs/runbooks/lab-content-pipeline.md
@@ -1,0 +1,117 @@
+# Runbook: vault -> lab.verdify.ai content/build pipeline (#124 / #219)
+
+Automates the previously-manual rebuild of the `lab.verdify.ai` Quartz research
+site from the **real** curated vault content, replacing the synthetic placeholder
+the CI image used to bake.
+
+## Problem this fixes
+
+- The `verdify-lab` CI image (`verdify-site-legacy/.github/workflows/publish-lab-image.yml`)
+  seeded from the stock Quartz `docs/` tree ("Welcome to Quartz 4"), so the published
+  `@sha256` was **synthetic** — never the real site.
+- The live cluster only served the real site because it was built **manually** against
+  the external vault symlink (image `bf71018…`). The repo/GitOps overlay pin
+  (`92ab470…`, synthetic) therefore **diverged** from what serves live. An ArgoCD
+  reconcile to the repo digest would have replaced the real site with the Quartz manual.
+
+## Architecture (two stages, one gate)
+
+```
+[FLEET] scripts/sync-lab-content.sh        # only stage with vault access
+   rsync curated vault website/ subtree -> content-snapshot/  (scrub private/templates)
+   -> PR into VerdifyConsultancy/verdify-site-legacy (branch v4)
+        |
+        v  (merge)
+[CI]    verdify-site-legacy publish-lab-image.yml
+   build verdify-lab image from committed content-snapshot/  (REAL site, deterministic)
+   -> push ghcr.io/verdifyconsultancy/verdify-lab@sha256:<new>
+        |
+        v
+[GATE]  verdify-platform overlay digest write-back   <-- JASON / prod-promotion gate
+   repin lab-site image digest in deploy/k8s/overlays/{dev,prod,prod-dark}
+   -> ArgoCD sync (gated, one-at-a-time, health-checked)
+```
+
+GitHub-hosted CI **cannot** reach the synced vault (`~/Iris/verdify-vault` /
+`/mnt/iris/verdify-vault`), which is why Stage 1 runs fleet-side.
+
+## Stage 1 — refresh the content snapshot (fleet-side)
+
+Run where the synced vault replica is reachable (an operator Mac via laptop-root, or
+a fleet host / self-hosted runner with the vault mounted):
+
+```bash
+# dry-run first — shows the diff stat, makes no commit/PR
+verdify-platform/scripts/sync-lab-content.sh --dry-run
+
+# open the content PR into verdify-site-legacy
+verdify-platform/scripts/sync-lab-content.sh
+
+# include the ~350MB launch video (Git LFS) when it changes
+verdify-platform/scripts/sync-lab-content.sh --include-video
+```
+
+The script reads ONLY the public `website/` subtree, scrubs `private/`, `templates/`,
+`.obsidian/`, Syncthing/Synology metadata, then PRs `content-snapshot/`.
+
+Schedule (recommended): a weekly fleet cron / RemoteTrigger, plus on-demand after a
+notable vault content edit. (A GitHub `schedule` cannot do this — no vault access.)
+
+## Stage 2 — build + publish (GitHub CI, automatic on merge)
+
+Merging the Stage-1 PR into `verdify-site-legacy@v4` triggers
+`publish-lab-image.yml`, which builds the image from `content-snapshot/` and publishes
+a new immutable `@sha256` (printed in the run summary). To force a rebuild without a
+content change (e.g. weekly), use the workflow's `schedule`/`workflow_dispatch`, or fire
+the `verdify-platform` **Lab Content Pipeline** workflow with `trigger_image_rebuild=true`
+(needs the `LAB_REPO_TOKEN` secret with cross-repo `actions:write`).
+
+`verdify-platform`'s `lab-content-pipeline.yml` `lab-build-smoke` job independently
+proves the Quartz toolchain + lab config still build a valid site (and, when the
+snapshot is present, asserts the build is the REAL Verdify site, not the Quartz manual).
+
+## Stage 3 — overlay digest write-back  [GATED: Jason / prod-promotion]
+
+**Do NOT auto-merge.** Once Stage 2 publishes `verdify-lab@sha256:<new>`:
+
+1. Confirm the digest is pullable and serves the expected content (the Stage-2 run
+   summary prints the digest; the live probe is below).
+2. Repin the lab-site image digest in the overlays:
+
+   ```bash
+   cd verdify-platform/deploy/k8s/overlays/dev
+   kustomize edit set image ghcr.io/verdifyconsultancy/verdify-lab@sha256:<new>
+   # repeat for overlays/prod and overlays/prod-dark (lab pins the SAME
+   # env-agnostic digest across envs — static content).
+   ```
+
+3. Open a PR; the `K8s Manifests` gate (kubeconform) must pass.
+4. **Jason gate:** prod promotion. Merge -> ArgoCD sync the dev overlay first,
+   health-check, then prod, one at a time, re-probe durability.
+
+### Verification probe (live, read-only)
+
+```bash
+ssh jason@192.168.30.32 'POD=$(sudo k3s kubectl get pods -n verdify-prod \
+  -l app.kubernetes.io/component=lab-site -o jsonpath="{.items[0].metadata.name}"); \
+  sudo k3s kubectl exec -n verdify-prod "$POD" -- \
+  sh -c "grep -o \"<title>[^<]*</title>\" /usr/share/nginx/html/index.html | head -1"'
+# EXPECT: <title>Verdify: A Longmont, Colorado AI greenhouse with public telemetry — Verdify Lab</title>
+# (NOT "Welcome to Quartz 4")
+```
+
+## Current divergence to reconcile (as of this PR)
+
+- Live deploy image: `verdify-lab@sha256:bf71018…` (real, manually built).
+- Repo/overlay pin: `verdify-lab@sha256:92ab470…` (synthetic Quartz manual).
+
+After the first Stage-1 -> Stage-2 -> Stage-3 cycle, the repo pin advances to a CI-built
+REAL-content digest and the divergence closes (the repo can reproduce the live site).
+
+## www (#219) — does NOT use this pipeline
+
+`verdify-www` (marketing site, `verdify.ai`) is an **Astro** site whose content is
+authored **directly in the `verdify-www` repo** (`content/` collections), NOT sourced
+from the Obsidian vault. So the vault->site sync is **lab-specific**; www needs no vault
+snapshot and is already CI-reproducible from its own repo. This is noted so a future
+agent does not bolt a vault pipeline onto www.

--- a/scripts/sync-lab-content.sh
+++ b/scripts/sync-lab-content.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# sync-lab-content.sh — Snapshot the curated public vault subtree into the
+# verdify-lab content repo and open a PR (#124 / #219, lane 219).
+#
+# WHY THIS IS FLEET-SIDE (not GitHub-hosted CI): the production lab.verdify.ai
+# content is the curated public subset of the Obsidian vault (the vault `website/`
+# subtree), which lives ONLY on the synced fleet replica
+# (~/Iris/verdify-vault/website on an operator Mac, /mnt/iris/verdify-vault/website
+# on the fleet). GitHub-hosted runners cannot reach it. This script therefore runs
+# WHERE THE VAULT IS (an operator Mac via the laptop-root control plane, or a
+# fleet host / self-hosted runner with the vault mounted) and PUSHES a content
+# snapshot into the build repo. CI then builds the image deterministically from
+# the committed snapshot (no live coupling). This is the durable split:
+#   fleet (vault access)  ->  snapshot PR  ->  GitHub CI (reproducible build).
+#
+# WHAT IT DOES
+#   1. rsync the curated `website/` subtree out of the vault, SCRUBBING private/
+#      templates/Obsidian/Syncthing/metadata paths (privacy curation).
+#   2. Stage it as content-snapshot/ in a checkout of the verdify-lab content repo
+#      (VerdifyConsultancy/verdify-site-legacy, branch v4).
+#   3. If it changed, commit on a branch and open a PR (gh).
+#
+# It never edits the vault. It only reads the public website/ subtree.
+#
+# USAGE
+#   scripts/sync-lab-content.sh [--dry-run] [--no-pr] [--include-video]
+#
+# ENV (overridable)
+#   VAULT_WEBSITE   curated vault subtree (default: first existing of the two below)
+#   LAB_REPO        owner/name of the content/build repo (default verdify-site-legacy)
+#   LAB_BRANCH      base branch of the content repo (default v4)
+#   WORKDIR         scratch checkout dir (default: mktemp)
+set -euo pipefail
+
+DRY_RUN=false
+OPEN_PR=true
+INCLUDE_VIDEO=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --no-pr) OPEN_PR=false; shift ;;
+    --include-video) INCLUDE_VIDEO=true; shift ;;
+    -h|--help) sed -n '1,40p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve the curated vault subtree (operator Mac OR fleet host).
+default_vault=""
+for cand in \
+    "${VAULT_WEBSITE:-}" \
+    "$HOME/Iris/verdify-vault/website" \
+    "/mnt/iris/verdify-vault/website" \
+    "/Users/jason/Iris/verdify-vault/website"; do
+  if [[ -n "$cand" && -d "$cand" ]]; then default_vault="$cand"; break; fi
+done
+VAULT_WEBSITE="${default_vault}"
+if [[ -z "$VAULT_WEBSITE" || ! -d "$VAULT_WEBSITE" ]]; then
+  echo "ERROR: curated vault subtree not found (set VAULT_WEBSITE=.../verdify-vault/website)" >&2
+  echo "       this script MUST run where the synced vault replica is reachable." >&2
+  exit 1
+fi
+
+LAB_REPO="${LAB_REPO:-VerdifyConsultancy/verdify-site-legacy}"
+LAB_BRANCH="${LAB_BRANCH:-v4}"
+WORKDIR="${WORKDIR:-$(mktemp -d -t sync-lab-content.XXXXXX)}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+BRANCH="lab-content/sync-${TS}"
+
+echo "[sync-lab-content] vault subtree : $VAULT_WEBSITE"
+echo "[sync-lab-content] content repo  : $LAB_REPO ($LAB_BRANCH)"
+echo "[sync-lab-content] workdir       : $WORKDIR"
+echo "[sync-lab-content] include video : $INCLUDE_VIDEO"
+
+# Privacy curation: the website/ subtree is already the public subset, but we
+# defensively scrub anything non-public/operational that could ride along.
+RSYNC_EXCLUDES=(
+  --exclude '.obsidian/'
+  --exclude '@eaDir/'
+  --exclude '.DS_Store'
+  --exclude '.stfolder/'
+  --exclude '.stignore'
+  --exclude '.stversions/'
+  --exclude '.sync-conflict-*'
+  --exclude 'private/'
+  --exclude 'templates/'
+  --exclude '.trash/'
+)
+# The ~350MB launch video is LFS-managed via the repo .gitattributes; exclude it
+# from the default text+image snapshot unless --include-video is passed.
+if [[ "$INCLUDE_VIDEO" != true ]]; then
+  RSYNC_EXCLUDES+=( --exclude 'static/video/' )
+fi
+
+# Checkout the content repo.
+git clone --quiet --branch "$LAB_BRANCH" "https://github.com/${LAB_REPO}.git" "$WORKDIR/repo"
+cd "$WORKDIR/repo"
+
+# Replace content-snapshot/ wholesale (rsync --delete) so removed vault pages are
+# dropped from the snapshot too. Preserve repo-managed helper files.
+mkdir -p content-snapshot
+# Keep the generated-marker README and the video placeholder; restore after sync.
+[[ -f content-snapshot/README.snapshot.md ]] && cp content-snapshot/README.snapshot.md /tmp/.snap-readme.$$ || true
+[[ -f content-snapshot/static/video/README.md ]] && { mkdir -p /tmp/.snap-vid.$$; cp content-snapshot/static/video/README.md /tmp/.snap-vid.$$/; } || true
+
+rsync -a --delete "${RSYNC_EXCLUDES[@]}" "$VAULT_WEBSITE"/ content-snapshot/
+
+# Restore generated markers.
+[[ -f /tmp/.snap-readme.$$ ]] && mv /tmp/.snap-readme.$$ content-snapshot/README.snapshot.md || true
+if [[ "$INCLUDE_VIDEO" != true && -d /tmp/.snap-vid.$$ ]]; then
+  mkdir -p content-snapshot/static/video
+  mv /tmp/.snap-vid.$$/README.md content-snapshot/static/video/README.md
+  rm -rf /tmp/.snap-vid.$$
+fi
+
+md_count="$(find content-snapshot -name '*.md' -type f | wc -l | tr -d ' ')"
+file_count="$(find content-snapshot -type f | wc -l | tr -d ' ')"
+echo "[sync-lab-content] snapshot: ${md_count} markdown, ${file_count} files"
+
+# Stage so the change check also catches NEW (untracked) snapshot files —
+# `git diff` alone ignores untracked paths (e.g. the very first snapshot on a
+# branch that has none yet).
+git add -A content-snapshot
+if git diff --cached --quiet -- content-snapshot; then
+  echo "[sync-lab-content] no content change — nothing to do."
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[sync-lab-content] --dry-run: changes detected, not committing. Diff stat:"
+  git diff --cached --stat -- content-snapshot | tail -20
+  exit 0
+fi
+
+# Move the staged snapshot onto a fresh branch and commit.
+git checkout -b "$BRANCH"
+git -c user.name="laptop-root" -c user.email="jason@vallery.net" commit -q -m \
+  "chore(lab): refresh content-snapshot from vault website/ (${TS})
+
+Automated vault->lab content sync (lane 219). ${md_count} markdown pages,
+${file_count} files. Source: curated vault website/ subtree. See
+scripts/sync-lab-content.sh in verdify-platform."
+
+if [[ "$OPEN_PR" == true ]]; then
+  git push -u origin "$BRANCH" --quiet
+  gh pr create --repo "$LAB_REPO" --base "$LAB_BRANCH" --head "$BRANCH" \
+    --title "chore(lab): vault->lab content sync ${TS}" \
+    --body "$(cat <<EOF
+Automated content refresh of the verdify-lab Quartz site (lane #219, part of #124).
+
+- Source: curated vault \`website/\` subtree (the public subset).
+- Snapshot: ${md_count} markdown pages, ${file_count} files.
+- Generated by \`verdify-platform/scripts/sync-lab-content.sh\` running where the
+  synced vault replica is reachable (GitHub CI cannot reach the vault).
+
+On merge, \`.github/workflows/publish-lab-image.yml\` rebuilds
+\`ghcr.io/verdifyconsultancy/verdify-lab\` from this snapshot and publishes a new
+@sha256; the verdify-platform digest write-back PR (gated) then advances the
+lab-site overlay pins.
+EOF
+)"
+else
+  echo "[sync-lab-content] committed on $BRANCH (no PR per --no-pr). Push manually:"
+  echo "  git -C $WORKDIR/repo push -u origin $BRANCH"
+fi
+
+echo "[sync-lab-content] done."


### PR DESCRIPTION
## What

Automates the previously-manual vault->lab.verdify.ai build so the Quartz research site rebuilds from the **real** curated vault content on change — replacing the synthetic Quartz-manual placeholder the CI image baked.

**Pairs with** VerdifyConsultancy/verdify-site-legacy#10 (the content-snapshot + Dockerfile precedence on the build repo).

## The problem

- The `verdify-lab` CI image seeded from stock Quartz `docs/` → published `@sha256` was synthetic.
- The live cluster serves the real site only because it was built **manually** (`bf71018…`); the repo/overlay pin (`92ab470…`) diverged. An ArgoCD reconcile to the repo digest would replace the real site with the Quartz manual.

## Architecture (two stages, one gate)

```
[FLEET] scripts/sync-lab-content.sh   (only stage with vault access)
   curated vault website/ subtree -> content-snapshot/ PR (scrub private/templates)
[CI]    verdify-site-legacy publish-lab-image.yml
   build verdify-lab from content-snapshot/ (REAL, deterministic) -> @sha256
[GATE]  overlay digest write-back   <-- JASON / prod-promotion gate (runbook)
```

GitHub-hosted CI cannot reach the synced vault, hence the fleet stage.

## Changes (all additive)

- **`scripts/sync-lab-content.sh`** — fleet-side snapshot+PR job. Proven against the real vault: 121 markdown / 193 files, change-detected (incl. the untracked first-snapshot case). `--dry-run` / `--no-pr` / `--include-video` (LFS).
- **`.github/workflows/lab-content-pipeline.yml`** — `lab-build-smoke` builds the lab site and, when `content-snapshot/` is present, **asserts it is the REAL Verdify site** (fails on the Quartz manual). Optional cross-repo rebuild dispatch.
- **`docs/runbooks/lab-content-pipeline.md`** — the pipeline + the GATED overlay digest write-back step + live verify probe + the `bf71018`-vs-`92ab470` divergence to reconcile.

## www (#219)

Does **not** use this pipeline — `verdify-www` is an Astro site with content authored in-repo (`content/` collections), not vault-sourced; already CI-reproducible. Documented in the runbook.

Tracker: #124 / #219.

> `.github/**` is shared infra — coordinator/James review before merge into the read-only org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)