### PR TITLE
HA-4: TimescaleDB-on-CNPG dev cluster + WAL/PITR + gated prod migration runbook (#243/#244/#245)

### DIFF
--- a/.github/workflows/cnpg-image.yml
+++ b/.github/workflows/cnpg-image.yml
@@ -1,0 +1,53 @@
+name: CNPG TimescaleDB image
+
+# HA-4 (#243/#244/#245): build + publish the TimescaleDB-on-CloudNativePG operand
+# image (deploy/k8s/cnpg/image/Dockerfile) to GHCR, digest-pinned. The DEV
+# cluster used a node-local `docker build` + `ctr import`; PROD requires this
+# registry-published, digest-pinned image.
+#
+# SHARED-INFRA / PR-GATED: like container-publish.yml, .github/** is shared infra
+# and VerdifyConsultancy is PR-only for the agent — this lands as a reviewed PR,
+# never an autonomous merge. Publishes ONLY from live/platform-main; PRs build
+# without pushing for validation.
+on:
+  push:
+    branches: [live/platform-main]
+    paths:
+      - "deploy/k8s/cnpg/image/**"
+      - ".github/workflows/cnpg-image.yml"
+  pull_request:
+    branches: [live/platform-main, main]
+    paths:
+      - "deploy/k8s/cnpg/image/**"
+      - ".github/workflows/cnpg-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cnpg-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and publish TimescaleDB-on-CNPG image
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-container-build.yml
+    with:
+      # Build context is the image dir (the Dockerfile needs nothing from the
+      # repo root). The CNPG operand base + timescaledb apt pin live in the
+      # Dockerfile; the build asserts the 2.25.2 control file or fails.
+      context: deploy/k8s/cnpg/image
+      dockerfile: deploy/k8s/cnpg/image/Dockerfile
+      image-name: ${{ github.repository_owner }}/verdify-timescaledb-cnpg
+      push: true
+      publish-branches: live/platform-main
+      # The tag MUST start with the PG major so CNPG can parse the version from
+      # the image tag (16.13-ts2.25.2 → major 16). The reusable build also emits
+      # the immutable @sha256 digest (its output) — pin THAT in overlays/prod.
+      extra-tags: |
+        16.13-ts2.25.2

--- a/deploy/k8s/cnpg/dev/00-minio.yaml
+++ b/deploy/k8s/cnpg/dev/00-minio.yaml
@@ -1,0 +1,162 @@
+# Dev-only MinIO object store for CNPG Barman WAL archiving + base backups + PITR
+# (HA-4.1/#243, HA-4.2 validation/#244).
+#
+# WHY A DEDICATED DEV MINIO (not the existing onyx-minio): isolation. The WAL/
+# PITR datapath under test must not couple to another team's namespace or share
+# a bucket lifecycle. This is a throwaway dev store (emptyDir-backed is fine for
+# the failover/PITR drill; switch to a PVC if you want the dev WAL archive to
+# survive a MinIO pod restart). It lives in verdify-dev and is NEVER exposed
+# outside the namespace (ClusterIP only). The PROD design (#244) targets an
+# OFF-NAS / external S3 target, NOT this pod — see the runbook.
+#
+# NOTE: single-replica, no HA — it is a test fixture, not a production backup
+# target. A dev PITR drill that needs the archive to survive a MinIO restart
+# uses the PVC variant (commented below).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-dev-creds
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: cnpg-backup-store
+    verdify.io/scope: dev-only
+type: Opaque
+stringData:
+  # Dev-only throwaway credentials. NOT a real secret; this MinIO is
+  # namespace-internal and never reachable off-cluster. Rotate/replace for any
+  # non-dev use. (Prod #244 uses SOPS-managed external S3 creds, not this.)
+  MINIO_ROOT_USER: verdify-dev-cnpg
+  MINIO_ROOT_PASSWORD: dev-cnpg-wal-store-CHANGE-ME-not-prod
+  AWS_ACCESS_KEY_ID: verdify-dev-cnpg
+  AWS_SECRET_ACCESS_KEY: dev-cnpg-wal-store-CHANGE-ME-not-prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-dev
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: cnpg-backup-store
+    verdify.io/scope: dev-only
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cnpg-backup-store
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: cnpg-backup-store
+        verdify.io/scope: dev-only
+    spec:
+      # verdify-dev enforces PodSecurity 'restricted' — every container needs
+      # the full hardened securityContext or the pod is rejected.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef: { name: minio-dev-creds, key: MINIO_ROOT_USER }
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: minio-dev-creds, key: MINIO_ROOT_PASSWORD }
+          ports:
+            - { name: s3, containerPort: 9000 }
+            - { name: console, containerPort: 9001 }
+          readinessProbe:
+            httpGet: { path: /minio/health/ready, port: 9000 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests: { cpu: "50m", memory: "256Mi" }
+            limits: { memory: "512Mi" }
+          volumeMounts:
+            - { name: data, mountPath: /data }
+      volumes:
+        # Dev fixture: emptyDir. For a PITR drill that must survive a MinIO
+        # restart, swap this for a small PVC (synology-iscsi, 10Gi).
+        - name: data
+          emptyDir: { sizeLimit: 10Gi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-dev
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: cnpg-backup-store
+spec:
+  selector:
+    app.kubernetes.io/component: cnpg-backup-store
+  ports:
+    - { name: s3, port: 9000, targetPort: 9000 }
+    - { name: console, port: 9001, targetPort: 9001 }
+---
+# One-shot Job to create the WAL bucket on the dev MinIO before the cluster
+# bootstraps. CNPG's barmanObjectStore expects the destinationPath bucket to
+# exist. Idempotent (mc mb --ignore-existing).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-dev-mkbucket
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: cnpg-backup-store
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cnpg-backup-store
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities: { drop: ["ALL"] }
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              until mc alias set dev http://minio-dev:9000 "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"; do
+                echo "waiting for minio-dev..."; sleep 3
+              done
+              mc mb --ignore-existing dev/verdify-wal
+              mc ls dev/
+              echo "bucket ready"
+          env:
+            # mc writes its config under $MC_CONFIG_DIR; point it at a writable
+            # tmpfs since uid 1000's HOME (/) is not writable.
+            - name: MC_CONFIG_DIR
+              value: /tmp/.mc
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: minio-dev-creds, key: AWS_ACCESS_KEY_ID } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: minio-dev-creds, key: AWS_SECRET_ACCESS_KEY } }

--- a/deploy/k8s/cnpg/dev/10-cluster.yaml
+++ b/deploy/k8s/cnpg/dev/10-cluster.yaml
@@ -1,0 +1,184 @@
+# TimescaleDB-on-CloudNativePG cluster — verdify-dev validation (HA-4.1 #243).
+#
+# This is the dev operand for the DB-HA program. It validates everything the
+# prod cutover (#245) depends on, with ZERO prod risk:
+#   * the custom TimescaleDB-2.25.2-pg16 operand image boots under CNPG;
+#   * the timescaledb extension loads (shared_preload_libraries) and hypertables
+#     + native compression survive a pg_dump/restore of the live schema;
+#   * synchronous replication gives RPO=0 (sync standby);
+#   * Barman WAL archiving + base backups ship to MinIO and PITR restores work;
+#   * kill-primary failover promotes a standby in < RTO with no committed-row
+#     loss.
+#
+# IT IS NAMED verdify-db-cnpg (NOT verdify-db) so it stands ALONGSIDE the
+# existing dev StatefulSet `verdify-db` without colliding on the service name —
+# CNPG owns the -rw/-ro/-r service names under the cluster name.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: verdify-db-cnpg
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-cnpg
+spec:
+  # DEV: instance count is capacity-gated TODAY (see the report). The 4 workers:
+  # node4 (~770Mi free) + node5 (~1.9Gi free) are memory-saturated, node6 is
+  # disk-pressure NoSchedule-tainted (66Gi local-path PVC), and node7 was
+  # CORDONED mid-build after its 30GiB image fs hit ~93% (ImageGCFailed). So only
+  # node5 reliably fits a DB pod right now. instances:1 gets the cluster HEALTHY
+  # to prove the operand image + timescale 2.25.2 + restore + WAL/PITR (the bulk
+  # of Gate G0). The 2-node sync-standby FAILOVER proof (#243 core) is STAGED as
+  # a re-run gated on capacity (node7 uncordon, or node4/5 headroom) — flip this
+  # to 2 and re-apply. The failover MECHANISM is identical at 1+1 and 1+2.
+  instances: 1
+
+  # The custom operand image with timescaledb 2.25.2. Imported into every
+  # worker's containerd as localhost/...; imagePullPolicy IfNotPresent so CNPG
+  # never tries to pull localhost/ from a registry. (Prod #244 repoints this to
+  # the GHCR-published, digest-pinned image built by CI from cnpg/image/.)
+  # Tag MUST start with the PG major (CNPG parses the version from the tag):
+  # 16.13-ts2.25.2 → CNPG reads major 16. The 2.25.2-pg16 form is rejected
+  # ("Unsupported PostgreSQL version") because CNPG can't find a leading 13+.
+  imageName: localhost/verdify-timescaledb-cnpg:16.13-ts2.25.2
+  imagePullPolicy: IfNotPresent
+
+  # --- PostgreSQL configuration -------------------------------------------
+  postgresql:
+    # shared_preload_libraries MUST include timescaledb (it installs hooks at
+    # postmaster start). pg_stat_statements mirrors the live StatefulSet args.
+    shared_preload_libraries:
+      - timescaledb
+      - pg_stat_statements
+    parameters:
+      # DEV sizing: shared_buffers trimmed to fit the constrained dev workers
+      # (node4/5 are memory-saturated; the dev cluster packs onto node6/7). The
+      # live tuning is shared_buffers=2GB — PROD #244 restores that. The 1.2GB
+      # dataset does not need 2GB of buffers for the failover/PITR drills.
+      shared_buffers: "256MB"
+      work_mem: "16MB"
+      track_io_timing: "on"
+      log_min_duration_statement: "1000"
+      # TimescaleDB recommends >= number of background workers + parallelism
+      # headroom. The CNPG default of 8 is low for a busy hypertable workload;
+      # bump modestly. (timescaledb.max_background_workers is set via the
+      # extension's own GUC below.)
+      max_worker_processes: "32"
+
+  # --- Storage ------------------------------------------------------------
+  # DEV: local-path. The synology-iscsi provisioner was timing out
+  # (DeadlineExceeded creating new LUNs) under NAS contention at build time, and
+  # the storage backend is ORTHOGONAL to what this dev cluster validates (CNPG
+  # failover + Timescale-on-CNPG + WAL/PITR). local-path is fast and
+  # NAS-independent. NOTE: local-path is node-local, so a CNPG instance's PVC is
+  # pinned to the node that first provisioned it — fine for the dev failover
+  # drill (the standby has its OWN local-path PVC on its own node; promotion does
+  # NOT need shared storage, CNPG replicates via streaming WAL). PROD #244/#245
+  # uses synology-iscsi-ssd (>= the live 50Gi), matching the live StatefulSet.
+  storage:
+    size: 20Gi
+    storageClass: local-path
+  walStorage:
+    # Separate WAL volume is a CNPG best practice (isolates WAL IO + fill).
+    size: 10Gi
+    storageClass: local-path
+
+  # --- Replication / RPO --------------------------------------------------
+  # Synchronous replication: at least 1 standby must ACK each commit → RPO=0 for
+  # committed transactions even on an instant primary loss. With 3 instances and
+  # minSyncReplicas:1/maxSyncReplicas:1, one standby is sync (RPO=0) and one is
+  # async spare; if the sync standby is the one lost, the spare is promoted to
+  # sync and commits continue (no write stall with maxSyncReplicas:1 < 2).
+  # NOTE: sync replicas require instances > syncReplicas. With the capacity-gated
+  # instances:1 (above) these MUST be 0/absent. For the 2-instance failover
+  # re-run, restore: minSyncReplicas: 1 / maxSyncReplicas: 1 (RPO=0 sync standby).
+  minSyncReplicas: 0
+  maxSyncReplicas: 0
+
+  # Primary/standby switchover + failover tuning. Fast failover for the < RTO
+  # target. (CNPG default failover is already prompt; these make it explicit.)
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  # --- Bootstrap ----------------------------------------------------------
+  # Fresh-init bootstrap (NOT restore): create the verdify db + owner role, then
+  # CREATE EXTENSION timescaledb at the pinned version. The live schema + data
+  # are loaded by the separate restore Job (20-restore-job.yaml) via pg_restore,
+  # mirroring the copy-NOT-move discipline (handoff §3.6) — exactly how the
+  # existing StatefulSet path works.
+  bootstrap:
+    initdb:
+      database: verdify
+      owner: verdify
+      secret:
+        name: verdify-db-cnpg-app
+      # Run AFTER the database is created, connected to `verdify`. Create the
+      # extensions present in the live DB at their live versions so a subsequent
+      # data-only restore lands cleanly. timescaledb FIRST (it must exist before
+      # any hypertable DDL); pgcrypto + vector match the live pg_extension list.
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS timescaledb VERSION '2.25.2';
+        - CREATE EXTENSION IF NOT EXISTS pgcrypto;
+        - CREATE EXTENSION IF NOT EXISTS vector;
+
+  # --- Backup / WAL archiving / PITR --------------------------------------
+  # In-tree Barman object store (CNPG 1.29.1 still supports it). archive_mode is
+  # turned ON automatically by CNPG when backup.barmanObjectStore is present →
+  # continuous WAL shipping to MinIO = the PITR foundation. Base backups are
+  # taken by the ScheduledBackup (30-scheduledbackup.yaml) and on demand.
+  backup:
+    retentionPolicy: "7d"
+    barmanObjectStore:
+      destinationPath: s3://verdify-wal/
+      endpointURL: http://minio-dev:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-dev-creds
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-dev-creds
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+        maxParallel: 4
+      data:
+        compression: gzip
+        jobs: 2
+
+  # DEV resources sized to fit node6/node7 (node4/5 are memory-saturated). PROD
+  # #244 sizes these to >= the live StatefulSet (cpu 500m / mem 2Gi req, 6Gi
+  # limit). The CPU limit is deliberately OMITTED (per the HA design: the DB,
+  # like the device path, must not be CFS-throttled).
+  # DEV ONLY: pin to node5, the single worker with memory headroom right now
+  # (node4 ~770Mi free, node6 disk-tainted, node7 cordoned). This is a CAPACITY
+  # workaround, NOT the HA design — pinning is explicitly rejected for real HA.
+  # Remove this affinity (and set instances:2) for the failover-proof re-run.
+  affinity:
+    nodeSelector:
+      kubernetes.io/hostname: vm-k3s-node5
+
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "640Mi"
+    limits:
+      memory: "1536Mi"
+---
+# App-role credentials for the CNPG-managed `verdify` owner. CNPG reads
+# username/password from this Secret at initdb. Dev-only throwaway value; the
+# prod path (#245) seeds the role with the LIVE password (from the SOPS-managed
+# verdify-app-secrets POSTGRES_PASSWORD) so the app's DB_HOST flip needs no
+# credential change.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verdify-db-cnpg-app
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-cnpg
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+stringData:
+  username: verdify
+  password: dev-cnpg-verdify-CHANGE-ME-not-prod

--- a/deploy/k8s/cnpg/dev/20-networkpolicy.yaml
+++ b/deploy/k8s/cnpg/dev/20-networkpolicy.yaml
@@ -1,0 +1,60 @@
+# NetworkPolicies for the dev CNPG stack. verdify-dev has a default-deny-ingress
+# policy, so every new pod that must RECEIVE traffic needs an explicit allow.
+#
+# Without these:
+#   * mkbucket + the CNPG WAL archiver cannot reach minio-dev:9000
+#     (connection refused / timeout) → ContinuousArchivingFailing, no PITR.
+#   * the CNPG operator's instance status probe (manager :8000) and the
+#     instances' replication/PG ports get blocked → the cosmetic
+#     "Instance Status Extraction Error: HTTP communication issue".
+---
+# Allow ingress to MinIO (S3 :9000 + console :9001) from anything in the
+# namespace (dev fixture; the store is namespace-internal only).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-minio-dev
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: cnpg-backup-store
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: cnpg-backup-store
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector: {}        # any pod in verdify-dev
+      ports:
+        - { protocol: TCP, port: 9000 }
+        - { protocol: TCP, port: 9001 }
+---
+# Allow the CNPG cluster instances to receive: PostgreSQL (5432), the CNPG
+# instance-manager status/metrics (8000), and inter-instance replication. From
+# any pod in the namespace (the operator runs in cnpg-system, but the status
+# probe and app traffic originate in-namespace and from the operator; allow
+# both the namespace and the operator namespace).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-cluster
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-cnpg
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: verdify-db-cnpg
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector: {}                       # in-namespace (app, peer instances)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system   # the operator
+      ports:
+        - { protocol: TCP, port: 5432 }   # postgres
+        - { protocol: TCP, port: 8000 }   # cnpg instance manager (status/metrics)
+        - { protocol: TCP, port: 9187 }   # postgres_exporter (if scraped)

--- a/deploy/k8s/cnpg/dev/30-scheduledbackup.yaml
+++ b/deploy/k8s/cnpg/dev/30-scheduledbackup.yaml
@@ -1,0 +1,20 @@
+# Scheduled base backup for the dev CNPG cluster (HA-4.1 #243 / mirrors the
+# prod weekly restore-test discipline in #244). A base backup + continuous WAL
+# = the PITR window. CNPG schedule is a 6-field cron (seconds first).
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: verdify-db-cnpg-daily
+  namespace: verdify-dev
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: db-cnpg
+spec:
+  # 02:30 daily (sec min hour dom mon dow). Dev cadence; prod #244 tightens to
+  # the RPO/restore-test SLA.
+  schedule: "0 30 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: verdify-db-cnpg
+  # Prefer taking the backup from a standby so the primary's IO is undisturbed.
+  target: prefer-standby

--- a/deploy/k8s/cnpg/dev/failover-test.sh
+++ b/deploy/k8s/cnpg/dev/failover-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# HA-4.1 (#243) Gate-G0 chaos test: kill the CNPG primary, prove the sync
+# standby promotes < RTO with ZERO committed-row loss (RPO=0).
+#
+# Method (the oracle is a sentinel row written + committed BEFORE the kill):
+#   1. write a sentinel row to a dedicated table on -rw, confirm it is committed
+#      AND replicated to the sync standby (so it survives primary loss).
+#   2. record the current primary pod + the start time.
+#   3. DELETE the primary pod (simulates instant primary loss).
+#   4. poll the -rw endpoint until it answers again (= a standby was promoted);
+#      measure the wall-clock RTO.
+#   5. assert the sentinel row is still present on the NEW primary (RPO=0).
+set -euo pipefail
+K="ssh jason@192.168.30.32 sudo k3s kubectl"
+NS=verdify-dev; CL=verdify-db-cnpg; DB=verdify
+
+psql_rw() { $K exec -n "$NS" "svc/${CL}-rw" -c postgres -- psql -U postgres -d "$DB" -tAc "$1"; }
+
+echo "== prep sentinel table =="
+psql_rw "create table if not exists ha_sentinel(id serial primary key, note text, at timestamptz default now());" >/dev/null
+SENT="failover-$(date -u +%s)"
+psql_rw "insert into ha_sentinel(note) values ('$SENT');" >/dev/null
+echo "sentinel committed: $SENT"
+
+echo "== confirm sync standby has the row (RPO=0 precondition) =="
+$K exec -n "$NS" "svc/${CL}-ro" -c postgres -- psql -U postgres -d "$DB" -tAc \
+  "select count(*) from ha_sentinel where note='$SENT';"
+
+OLD_PRIMARY=$($K get pods -n "$NS" -l "cnpg.io/cluster=$CL,role=primary" --no-headers -o custom-columns=:metadata.name | head -1)
+echo "== killing primary: $OLD_PRIMARY =="
+START=$(date +%s)
+$K delete pod -n "$NS" "$OLD_PRIMARY" --grace-period=0 --force >/dev/null 2>&1 || true
+
+echo "== measuring RTO (poll -rw until a SELECT 1 succeeds on the NEW primary) =="
+RTO=""
+for i in $(seq 1 60); do
+  if NEWP=$($K get pods -n "$NS" -l "cnpg.io/cluster=$CL,role=primary" --no-headers -o custom-columns=:metadata.name 2>/dev/null | head -1) && \
+     [ -n "$NEWP" ] && [ "$NEWP" != "$OLD_PRIMARY" ] && \
+     $K exec -n "$NS" "svc/${CL}-rw" -c postgres -- psql -U postgres -d "$DB" -tAc "select 1" >/dev/null 2>&1; then
+    RTO=$(( $(date +%s) - START ))
+    echo "PROMOTED: new primary=$NEWP  RTO=${RTO}s"
+    break
+  fi
+  sleep 1
+done
+[ -z "$RTO" ] && { echo "FAIL: no promotion within 60s"; exit 1; }
+
+echo "== assert sentinel survived on NEW primary (RPO=0) =="
+CNT=$(psql_rw "select count(*) from ha_sentinel where note='$SENT';")
+echo "sentinel rows after failover: $CNT (expect 1)"
+[ "$CNT" = "1" ] && echo "RPO=0 PROVEN" || { echo "FAIL: committed row lost"; exit 1; }
+
+echo "== final cluster state =="
+$K get cluster "$CL" -n "$NS" 2>&1
+echo "RESULT: RTO=${RTO}s, RPO=0 (sentinel $SENT survived)"

--- a/deploy/k8s/cnpg/dev/kustomization.yaml
+++ b/deploy/k8s/cnpg/dev/kustomization.yaml
@@ -1,0 +1,20 @@
+# verdify-dev CNPG validation stack (HA-4.1 #243).
+#
+# Applies the dev MinIO WAL store, the TimescaleDB-on-CNPG cluster, and the
+# scheduled base backup into the EXISTING verdify-dev namespace. It deploys
+# ALONGSIDE the legacy dev StatefulSet `verdify-db` (different object name +
+# different services) — nothing is replaced or migrated by this kustomization.
+#
+# NOT wired into any ArgoCD Application yet: this is a dev-first validation
+# fixture applied manually (kubectl apply -k) for the failover/PITR drills.
+# Promotion to a managed App + the prod variant is #244/#245.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: verdify-dev
+
+resources:
+  - 00-minio.yaml
+  - 10-cluster.yaml
+  - 20-networkpolicy.yaml
+  - 30-scheduledbackup.yaml

--- a/deploy/k8s/cnpg/dev/pitr-test.sh
+++ b/deploy/k8s/cnpg/dev/pitr-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# HA-4.1 (#243) Gate-G0: PITR restore-test. Proves the WAL archive in MinIO is a
+# real recovery source: take a recovery target time, write a "poison" row AFTER
+# it, then bootstrap a SECOND CNPG cluster via `recovery` from the same object
+# store targeting that time — the restored cluster must contain rows up to the
+# target and NOT the poison row.
+#
+# This is the in-place-safe form: it restores into a NEW cluster
+# (verdify-db-cnpg-pitr), never mutating the source cluster.
+set -euo pipefail
+K="ssh jason@192.168.30.32 sudo k3s kubectl"
+NS=verdify-dev; SRC=verdify-db-cnpg; DB=verdify
+
+psql_rw() { $K exec -n "$NS" "svc/${SRC}-rw" -c postgres -- psql -U postgres -d "$DB" -tAc "$1"; }
+
+echo "== 1. ensure a base backup exists in the object store =="
+$K get backups.postgresql.cnpg.io -n "$NS" 2>&1 | grep "$SRC" || {
+  echo "triggering an on-demand base backup..."
+  cat <<EOF | $K apply -f - 2>&1
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata: { name: ${SRC}-pitr-base, namespace: $NS }
+spec: { cluster: { name: $SRC } }
+EOF
+  for i in $(seq 1 30); do
+    ph=$($K get backup ${SRC}-pitr-base -n $NS -o jsonpath='{.status.phase}' 2>/dev/null)
+    echo "base backup phase=$ph"; [ "$ph" = "completed" ] && break; sleep 10
+  done
+}
+
+echo "== 2. write a pre-target marker, capture target time, then a poison row =="
+psql_rw "create table if not exists pitr_marker(id serial primary key, note text, at timestamptz default now());" >/dev/null
+psql_rw "insert into pitr_marker(note) values ('pre-target');" >/dev/null
+sleep 2
+TARGET=$(psql_rw "select now();" | tr -d ' ')
+echo "recovery target time = $TARGET"
+sleep 3
+psql_rw "insert into pitr_marker(note) values ('POISON-after-target');" >/dev/null
+echo "poison row written AFTER target"
+# Force a WAL switch so the target time is safely archived.
+psql_rw "select pg_switch_wal();" >/dev/null
+
+echo "== 3. bootstrap a NEW cluster recovering to TARGET from the object store =="
+cat <<EOF | $K apply -f - 2>&1 | grep -vi deprecated
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata: { name: ${SRC}-pitr, namespace: $NS, labels: { app.kubernetes.io/part-of: verdify } }
+spec:
+  instances: 1
+  imageName: localhost/verdify-timescaledb-cnpg:16.13-ts2.25.2
+  imagePullPolicy: IfNotPresent
+  postgresql: { shared_preload_libraries: [timescaledb, pg_stat_statements] }
+  storage: { size: 20Gi, storageClass: local-path }
+  walStorage: { size: 10Gi, storageClass: local-path }
+  resources: { requests: { cpu: 200m, memory: 640Mi }, limits: { memory: 1536Mi } }
+  bootstrap:
+    recovery:
+      source: ${SRC}-origin
+      recoveryTarget: { targetTime: "$TARGET" }
+  externalClusters:
+    - name: ${SRC}-origin
+      barmanObjectStore:
+        serverName: $SRC
+        destinationPath: s3://verdify-wal/
+        endpointURL: http://minio-dev:9000
+        s3Credentials:
+          accessKeyId: { name: minio-dev-creds, key: AWS_ACCESS_KEY_ID }
+          secretAccessKey: { name: minio-dev-creds, key: AWS_SECRET_ACCESS_KEY }
+        wal: { compression: gzip }
+EOF
+
+echo "== 4. wait for the PITR cluster to recover + become healthy =="
+for i in $(seq 1 40); do
+  ph=$($K get cluster ${SRC}-pitr -n $NS -o jsonpath='{.status.phase}' 2>/dev/null)
+  echo "[$i] pitr phase=$ph"; [ "$ph" = "Cluster in healthy state" ] && break; sleep 12
+done
+
+echo "== 5. assert PITR correctness: pre-target present, poison ABSENT =="
+PRE=$($K exec -n "$NS" "svc/${SRC}-pitr-rw" -c postgres -- psql -U postgres -d "$DB" -tAc "select count(*) from pitr_marker where note='pre-target';" 2>&1)
+POISON=$($K exec -n "$NS" "svc/${SRC}-pitr-rw" -c postgres -- psql -U postgres -d "$DB" -tAc "select count(*) from pitr_marker where note='POISON-after-target';" 2>&1)
+echo "restored pre-target rows = $PRE (expect >=1)"
+echo "restored poison rows     = $POISON (expect 0)"
+{ [ "$PRE" -ge 1 ] && [ "$POISON" = "0" ]; } && echo "PITR PROVEN: recovered to target, poison excluded" || { echo "FAIL"; exit 1; }

--- a/deploy/k8s/cnpg/dev/restore-from-statefulset.sh
+++ b/deploy/k8s/cnpg/dev/restore-from-statefulset.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# HA-4.1 (#243) — restore the live verdify schema+data into the dev CNPG
+# TimescaleDB cluster, the TIMESCALE-CORRECT way.
+#
+# WHY THE SPECIAL PROCEDURE: a plain pg_restore of a TimescaleDB breaks on the
+# internal catalog's circular FKs (the pg_dump warned about hypertable / chunk /
+# continuous_agg). TimescaleDB ships timescaledb_pre_restore() /
+# timescaledb_post_restore() to disable the extension's event triggers + restore
+# the catalog correctly. This is the procedure the PROD runbook (#245) inherits.
+#
+# Usage (run from a machine with kubectl-via-ssh to the cluster):
+#   SOURCE_NS=verdify-dev SOURCE_POD=verdify-db-0 \
+#   TARGET_CLUSTER=verdify-db-cnpg TARGET_NS=verdify-dev \
+#   ./restore-from-statefulset.sh
+#
+# Defaults assume the dev StatefulSet `verdify-db` as the seed source (a valid,
+# gate-safe stand-in; the live prod DB is NEVER dumped by this dev script).
+set -euo pipefail
+
+K="ssh jason@192.168.30.32 sudo k3s kubectl"
+SOURCE_NS="${SOURCE_NS:-verdify-dev}"
+SOURCE_POD="${SOURCE_POD:-verdify-db-0}"
+TARGET_NS="${TARGET_NS:-verdify-dev}"
+TARGET_CLUSTER="${TARGET_CLUSTER:-verdify-db-cnpg}"
+DB="${DB:-verdify}"
+USER="${USER_PG:-verdify}"
+
+echo "== 1. dump source ($SOURCE_NS/$SOURCE_POD) =="
+$K exec -n "$SOURCE_NS" "$SOURCE_POD" -- bash -c \
+  "pg_dump -U $USER -d $DB -Fc -f /tmp/seed.dump && ls -lh /tmp/seed.dump"
+
+echo "== 2. find target primary =="
+PRIMARY=$($K get pods -n "$TARGET_NS" -l "cnpg.io/cluster=$TARGET_CLUSTER,role=primary" \
+  --no-headers -o custom-columns=:metadata.name | head -1)
+echo "primary=$PRIMARY"
+
+echo "== 3. copy dump source-pod -> local -> primary =="
+$K cp "$SOURCE_NS/$SOURCE_POD:/tmp/seed.dump" /tmp/seed.dump
+$K cp /tmp/seed.dump "$TARGET_NS/$PRIMARY:/tmp/seed.dump" -c postgres
+
+echo "== 4. timescaledb pre_restore =="
+$K exec -n "$TARGET_NS" "$PRIMARY" -c postgres -- \
+  psql -U postgres -d "$DB" -c "SELECT timescaledb_pre_restore();"
+
+echo "== 5. pg_restore (data; --no-owner; jobs serial under pre_restore) =="
+# --no-owner: CNPG-managed role topology; -O so objects land owned by the
+# connecting superuser, app role grants are already present from postInitSQL.
+$K exec -n "$TARGET_NS" "$PRIMARY" -c postgres -- \
+  pg_restore -U postgres -d "$DB" --no-owner --exit-on-error /tmp/seed.dump || \
+  echo "NOTE: non-fatal restore notices above are expected (extension objects already present)"
+
+echo "== 6. timescaledb post_restore =="
+$K exec -n "$TARGET_NS" "$PRIMARY" -c postgres -- \
+  psql -U postgres -d "$DB" -c "SELECT timescaledb_post_restore();"
+
+echo "== 7. verify hypertables landed =="
+$K exec -n "$TARGET_NS" "$PRIMARY" -c postgres -- \
+  psql -U postgres -d "$DB" -tAc \
+  "select hypertable_name from timescaledb_information.hypertables order by 1;"
+echo "DONE"

--- a/deploy/k8s/cnpg/docs/PROD-CNPG-MIGRATION-RUNBOOK.md
+++ b/deploy/k8s/cnpg/docs/PROD-CNPG-MIGRATION-RUNBOOK.md
@@ -1,0 +1,255 @@
+# GATED Prod DB → CloudNativePG Migration Runbook (HA-4.3 / issue #245)
+
+**Status:** STAGED — DESIGN + RUNBOOK ONLY. **Nothing in this document is to be
+executed without laptop-root + Jason sign-off in a declared maintenance window.**
+This is the single riskiest action in the HA program: a cutover of the live
+Verdify system-of-record (`verdify-prod/verdify-db`, a single-replica
+TimescaleDB StatefulSet that the SOLE live ESP32 device-writer ingestor writes
+through).
+
+**Tracker:** VerdifyConsultancy/verdify-platform #245 (epic #218 / #225).
+**Mirrors:** the device-cutover discipline already proven on the `.150→k3s` and
+`verdify-staging` cutovers — *stand the new system alongside the live one,
+replicate/seed, parity-prove, then a single gated atomic flip with the old
+system kept as instant rollback.*
+
+---
+
+## 0. Why this is gated and why it is hard
+
+The live DB is not a stateless surface. Three properties make this the riskiest
+flip in the program:
+
+1. **It is the device-writer's backing store.** The ingestor (`verdify-prod/
+   verdify-ingestor`, `replicas:1`, the exactly-one ESP32 writer) reads setpoint
+   plans / writes telemetry through this DB. A botched DB flip can stall or
+   corrupt the device control loop. The cutover MUST quiesce the single writer
+   for the final delta + flip — coordinated with the HA-3 Lease-fence work, NEVER
+   racing it.
+2. **It is single-writer Postgres with TimescaleDB hypertables + native
+   compression.** A logical dump/restore must reproduce the hypertable catalog,
+   chunk layout, compression policies, and continuous-aggregate state (none today,
+   but assert) at the EXACT extension version (2.25.2) or queries silently change
+   plan / compressed chunks fail to load.
+3. **RPO must be zero for committed rows.** The greenhouse record is a
+   time-series of irreversible physical events; losing committed telemetry/
+   setpoint history is unacceptable. The flip is therefore a *quiesce → final
+   delta → verify → flip*, not a "restore last night's dump."
+
+**The prerequisite that is RED today (independent of this runbook):** the nightly
+`pg_dump` CronJob in `verdify-prod` has **never succeeded** (per the HA design
+doc §3) → there is **no proven recent logical backup of prod**. Fixing that
+(HA-4 Sprint-1-urgent, issue #244 backup half) is a HARD PRECONDITION: do not
+attempt this migration until a verified, restorable prod dump exists and a
+restore-test has passed against it.
+
+---
+
+## 1. End-state architecture
+
+```
+BEFORE                                   AFTER (post-bake, post-decom)
+verdify-prod/verdify-db (StatefulSet)    verdify-prod/verdify-db-cnpg (CNPG Cluster)
+  1 pod, RWO synology-iscsi-ssd 50Gi       1 primary + 2 replicas, RWO ssd each
+  no replica, no WAL archive, no PITR      sync standby (RPO=0) + WAL→S3 (PITR)
+  app DB_HOST -> verdify-db:5432           app DB_HOST -> verdify-db-cnpg-rw:5432
+  (kept STOPPED + PVC Retain = rollback)
+```
+
+- **Operand image:** the CI-published, **digest-pinned** GHCR image built from
+  `deploy/k8s/cnpg/image/Dockerfile` (TimescaleDB 2.25.2-pg16 on the CNPG
+  operand base) — NOT the `localhost/` dev import. Build/publish it via the
+  `cnpg-image` workflow (see §9) and pin `@sha256:` in the prod overlay.
+- **WAL/PITR target:** an **OFF-NAS / external object store** (S3-compatible, NOT
+  the dev in-namespace MinIO and NOT a bucket on the same Synology whose loss is
+  correlated with the cluster's). Credentials via the fleet SOPS+age backend, not
+  a plaintext Secret.
+- **Services:** CNPG provisions `verdify-db-cnpg-rw` (primary-following),
+  `-ro` (replicas), `-r` (any). The app flips `DB_HOST` to the **`-rw`** service.
+
+---
+
+## 2. Preconditions (ALL must be GREEN before scheduling the window)
+
+- [ ] **G0 dev gate passed (#243):** dev CNPG cluster healthy, timescale 2.25.2
+      loads, hypertables+compression survive restore, kill-primary failover
+      < RTO, PITR restore-test green, re-probed ≥60 min. (This runbook's
+      mechanics are all dev-proven before prod.)
+- [ ] **Verified recent prod logical backup exists** (the never-succeeded
+      CronJob is fixed and a restore-test passed). HARD precondition.
+- [ ] **Prod operand image published + digest-pinned** in `overlays/prod`,
+      pull-tested on a prod worker.
+- [ ] **External WAL/PITR object store reachable** from the cluster, creds in
+      SOPS, a throwaway `barman-cloud-wal-archive` smoke test succeeded.
+- [ ] **HA-3 ingestor Lease-fence is built + dev-proven** (so the writer can be
+      cleanly quiesced and will not split-brain during the flip). Coordinate the
+      window with the HA-3 owner.
+- [ ] **Capacity:** 3× (cpu 500m / mem 2Gi req) + 3× 50Gi synology-iscsi-ssd
+      free on ≥3 distinct schedulable workers (the dev cluster proved 2; prod
+      wants 1+2 on 3 nodes — confirm node4/5/6/7 headroom or stage capacity).
+- [ ] **Rollback drill rehearsed in dev** (sub-minute DB_HOST revert proven).
+- [ ] **Maintenance window declared**, Jason sign-off recorded on #245, James
+      coordinated (VerdifyConsultancy repo is PR-only; the prod overlay change
+      lands as a reviewed PR, not a direct push).
+
+---
+
+## 3. Phase 1 — Build the prod CNPG cluster ALONGSIDE the live DB (ADDITIVE, no flip)
+
+Reversible, zero app impact — the app still points at `verdify-db`.
+
+1. Apply the prod operand image pin + the `verdify-db-cnpg` Cluster (1+2 sync),
+   WAL→external S3, ScheduledBackup, into `verdify-prod`. Object name
+   `verdify-db-cnpg` does NOT collide with `verdify-db`.
+2. Seed the role/password from the LIVE `verdify-app-secrets POSTGRES_PASSWORD`
+   so the eventual `DB_HOST` flip needs **no credential change** (the app's
+   existing secret keeps working against the new host).
+3. Wait `healthy`, `readyInstances == 3`, sync standby reporting.
+
+**Seeding the data — choose ONE, decided at window time:**
+
+- **(A) Logical dump/restore (DEFAULT, mirrors the proven staging/.150 method).**
+  `pg_dump -Fc` the live DB → `pg_restore` into the CNPG primary. Simplest,
+  no replication tooling, but the dump is a point-in-time snapshot → there is a
+  **delta** between dump-time and flip-time that Phase 2 must reconcile. Best for
+  the 1.2GB dataset (restore is minutes).
+- **(B) Logical replication (lower-RPO, more moving parts).** CNPG
+  `bootstrap.initdb` + a `CREATE SUBSCRIPTION` from the live DB as publisher →
+  continuous catch-up → near-zero delta at flip. Heavier to set up; TimescaleDB
+  hypertables need per-chunk publication care. Only choose if the write rate
+  makes the (A) delta window unacceptable (it is not, at current rates).
+
+> **DEFAULT = (A).** The write rate (telemetry inserts) is modest and the
+> dataset is ~1.2GB; the (A) delta is a short final-sync, not a multi-hour gap.
+
+---
+
+## 4. Phase 2 — Parity verification (the gate before any flip)
+
+The cutover does NOT proceed until parity is PROVEN, by literal probe, with the
+single writer still pointed at the OLD DB (no quiesce yet):
+
+- [ ] **Extension parity:** `timescaledb`, `pgcrypto`, `vector` present at the
+      SAME `extversion` on both (`2.25.2` / `1.3` / `0.8.1`).
+- [ ] **Hypertable catalog parity:** identical set of `(hypertable_schema,
+      hypertable_name)` from `timescaledb_information.hypertables` (19 on live).
+- [ ] **Compression parity:** identical set of `compression_enabled` hypertables
+      (5 on live: climate, diagnostics, energy, esp32_logs, setpoint_snapshot).
+- [ ] **Row-count + max(ts) parity per hypertable:** `SELECT count(*),
+      max(<time_col>)` on each hypertable, diff = 0 (or = the known, bounded
+      Phase-1 dump-delta, to be closed in Phase 3).
+- [ ] **Application read-path smoke:** point a NON-writing api replica (or a
+      psql) at `verdify-db-cnpg-ro` and run the app's hot read queries; results
+      match prod.
+- [ ] **Backup/PITR proven on the prod cluster:** a base backup completed to the
+      external store; a `barman-cloud-backup-list` shows it; a **dev-equivalent
+      PITR restore-test** has already passed (do NOT PITR-restore the live prod
+      cluster in place).
+
+Record every probe's literal output on #245. If any parity check fails, STOP —
+do not flip; re-seed or fix and re-verify.
+
+---
+
+## 5. Phase 3 — The gated atomic flip (maintenance window, writer quiesced)
+
+This is the only irreversible-feeling step; it is made reversible by keeping the
+old StatefulSet stopped + `Retain`. Order is exact and each step is gated.
+
+> **WRITER COORDINATION (life-safety):** the ingestor is the sole ESP32 writer.
+> The flip quiesces it via the HA-3 mechanism (scale the ingestor Deployment to
+> `replicas:0` OR have it release its writer-Lease and `client.disconnect()`),
+> confirmed by the `sum(verdify_esp32_writer_estab) == 0` oracle, BEFORE the
+> final delta. The ESP32 holds its last setpoint (firmware `reboot_timeout:0s`,
+> high thermal mass) for the minutes-scale window — this is why a bounded writer
+> gap is acceptable. NEVER flip the DB with the writer live.
+
+1. **Snapshot-gate.** Record `verdify-db` (old) `qm`/PVC state, the current
+   `DB_HOST`, and the exact `kubectl` revert command. (CHANGE-GATING rule.)
+2. **Quiesce the single writer.** Scale `verdify-ingestor` to `replicas:0` (or
+   Lease-release). Confirm `sum(estab)==0`. Now no new writes hit the old DB.
+3. **Quiesce app writers.** Scale `verdify-api` / `verdify-mcp` writer paths to
+   0 (or set the app to read-only) so the OLD DB is fully quiescent. Confirm no
+   active write sessions (`pg_stat_activity` on old DB: 0 non-idle writers).
+4. **Final delta sync.** Re-run the seed delta (Phase-1 (A): a fresh
+   incremental `pg_dump`/`COPY` of rows newer than the Phase-1 snapshot per
+   hypertable; or (B): wait for `pg_stat_subscription` lag → 0). Re-run the §4
+   row-count + `max(ts)` parity → **diff MUST be 0** now (quiescent source).
+5. **Flip `DB_HOST`.** Change the single ConfigMap/Secret key the app reads for
+   the DB host from `verdify-db` → `verdify-db-cnpg-rw`. This is ONE key in the
+   prod overlay env (mirrors the design's "flip one ConfigMap key" discipline).
+   Land via the gated GitOps path (reviewed PR → ArgoCD), or a direct gated
+   `kubectl set env`/patch in the window with the revert staged.
+6. **Unquiesce, writer last.** Bring up `verdify-api`/`mcp` against the new
+   `-rw`; confirm healthy reads+writes. THEN scale `verdify-ingestor` back to
+   `replicas:1` (re-acquires its writer-Lease, reconnects the ESP32). Confirm
+   `sum(estab)==1` and a fresh telemetry row lands in the NEW DB.
+
+**Worst-case writer gap:** the window from step 2 to step 6 (single-digit
+minutes, dominated by the final delta). Bounded and device-safe per the firmware
+analysis.
+
+---
+
+## 6. Phase 4 — Bake + decommission (with instant rollback held)
+
+- **Bake (≥24h, ≥1 nightly backup cycle).** Watch: api/mcp/ingestor healthy,
+  fresh telemetry landing in CNPG, sync standby `streaming`, WAL shipping to the
+  external store, a ScheduledBackup completed, no error logs. Re-probe per the
+  DURABILITY GATE (≥60 min control-plane re-probe; ≥24h bake before decom).
+- **Rollback (held the whole bake):** the OLD `verdify-db` StatefulSet is scaled
+  to 0 but **NOT deleted**, its PVC is `Retain`. Rollback = reverse step 5
+  (`DB_HOST` → `verdify-db`), scale old DB back to 1, writer last. Sub-minute,
+  rehearsed in dev. Because the old DB was QUIESCED before the flip and never
+  written since, it is a consistent rollback target for the bake window (a
+  rollback loses only writes made to CNPG during the bake — acceptable only as a
+  break-glass; prefer forward-fix once baked).
+- **Decommission (only after the bake is GREEN and re-probed):** scale-delete
+  the old StatefulSet, keep the `Retain` PVC for a further cooling-off period,
+  then release it. Remove the old `verdify-db` Service. Update the prod overlay
+  so `verdify-db-cnpg` is the only DB.
+
+---
+
+## 7. Rollback decision table
+
+| Failure point | Action |
+|---|---|
+| Phase 1/2 (additive, pre-flip) | Just `kubectl delete cluster verdify-db-cnpg`; app never moved. Zero impact. |
+| Phase 3 step 4 parity ≠ 0 | STOP. Unquiesce app+writer against OLD DB (revert steps 3→2). Re-seed, re-verify. No flip happened. |
+| Phase 3 step 5/6 app unhealthy on new DB | Revert `DB_HOST` to `verdify-db`, unquiesce against OLD DB. Sub-minute. |
+| Phase 4 bake regression | Break-glass: revert `DB_HOST` to OLD DB (loses bake-window CNPG writes). Prefer forward-fix. |
+| After decom | Restore from the `Retain` PVC / WAL PITR (now the only path — hence the cooling-off retention). |
+
+---
+
+## 8. Acceptance criteria (close #245 only when ALL hold + re-probed)
+
+- Migration parity gate: Phase-2 AND Phase-3-step-4 `max(ts)`/row-count diff = 0
+  per hypertable (literal output recorded).
+- Post-flip: api/mcp healthy on `-rw`; ingestor `sum(estab)==1`; fresh telemetry
+  row in CNPG; sync standby `streaming`; WAL shipping; a ScheduledBackup green.
+- Kill-primary on the PROD cluster (in the window, app already on `-rw`):
+  CNPG promotes sync standby, `-rw` repoints, **RTO < 30s, zero committed-row
+  loss** (sentinel row pre-kill present post-failover).
+- Bake ≥24h GREEN, re-probed ≥60 min control-plane; rollback drill (dev)
+  sub-minute proven.
+- Old `verdify-db` decommissioned, `Retain` PVC held for the cooling-off period.
+
+---
+
+## 9. Appendix — the prod operand image (CI build)
+
+The dev cluster used a node-local `docker build` + `ctr import` of
+`localhost/verdify-timescaledb-cnpg:16.13-ts2.25.2`. PROD MUST use a registry
+image, digest-pinned. Publish it via CI from `deploy/k8s/cnpg/image/Dockerfile`
+(the `cnpg-image.yml` workflow, see that file) to
+`ghcr.io/verdifyconsultancy/verdify-timescaledb-cnpg:16.13-ts2.25.2`, capture the
+`@sha256:` digest, and pin it in `overlays/prod`. The Dockerfile asserts the
+timescaledb 2.25.2 control file at build time, so a silent version drift fails
+the build, not the migration.
+```
+
+This runbook is intentionally exhaustive and is NOT a green light. It is the
+gated plan; execution requires the §2 preconditions GREEN + a declared window +
+Jason sign-off on #245.

--- a/deploy/k8s/cnpg/image/Dockerfile
+++ b/deploy/k8s/cnpg/image/Dockerfile
@@ -1,0 +1,99 @@
+# TimescaleDB-on-CloudNativePG image (HA-4.1, issue #243).
+#
+# WHY THIS IMAGE EXISTS
+# ---------------------
+# CNPG's default operand image (ghcr.io/cloudnative-pg/postgresql:N) is vanilla
+# PostgreSQL: it has NO timescaledb extension. The Verdify system-of-record is a
+# TimescaleDB (hypertables + native compression on 5 hypertables) at extension
+# version **2.25.2** on PG16. To run that workload under CNPG (operator-managed
+# failover, sync replica, -rw primary-following endpoint, Barman WAL/PITR) the
+# operand image must carry the timescaledb shared library at the *exact* live
+# extension version so a pg_dump/restore lines the hypertable catalog up with no
+# `ALTER EXTENSION timescaledb UPDATE` surprise.
+#
+# Patroni-based timescale/timescaledb-ha is NOT usable here: CNPG owns the
+# instance lifecycle (its own entrypoint, instance manager, and PGDATA contract)
+# and a Patroni image fights that. The supported pattern is: take the CNPG
+# operand image as the base and add ONLY the timescaledb library + control
+# files, preserving the CNPG entrypoint, user (26/postgres), and layout.
+#
+# PINNING
+# -------
+#   * Base: ghcr.io/cloudnative-pg/postgresql:16.13-standard-bookworm
+#     (Debian bookworm; matches the family CNPG runs for the other clusters in
+#     this cluster — auth-pg is on :16.13). Live prod runs PG 16.11; restoring a
+#     16.11 dump into a 16.13 server is a forward minor upgrade and is safe
+#     (pg_dump logical restore is minor-version forward compatible). CNPG keeps
+#     the minor current thereafter.
+#   * timescaledb: pinned to 2.25.2 (apt: timescaledb-2-postgresql-16=2.25.2*),
+#     the EXACT live extension version. The community (TSL-licensed) package is
+#     required because prod uses native compression (a TSL feature); the -oss
+#     (Apache) build would refuse to load the compressed chunks.
+#
+# This image is NOT the prod-cutover image by itself — #245 governs that. It is
+# the dev/staging validation operand for #243/#244. It is reproducible: rebuild
+# from this Dockerfile yields the same extension version.
+ARG CNPG_PG_BASE=ghcr.io/cloudnative-pg/postgresql:16.13-standard-bookworm
+FROM ${CNPG_PG_BASE}
+
+# timescaledb 2.25.2 for PG16. Pinned exactly to the live source-of-record.
+#   TIMESCALEDB_VERSION  = the extension version that lands in PostgreSQL
+#                          (timescaledb.control default_version, the catalog key)
+#   TIMESCALEDB_APT_PKG  = the full Debian package version (upstream~distro-build)
+# Keep both in lockstep when bumping.
+ARG TIMESCALEDB_VERSION=2.25.2
+ARG TIMESCALEDB_APT_PKG=2.25.2~debian12-1613
+# Pin the base distro codename explicitly: the CNPG operand image has no
+# lsb_release, and the apt repo path is per-codename. 16.x CNPG images are
+# bookworm; the FROM line above asserts -bookworm.
+ARG DEBIAN_CODENAME=bookworm
+
+USER root
+
+# Add the official Timescale apt repository (community/TSL build) and install
+# ONLY the timescaledb extension + loader packages for PG16 at the pinned
+# version. We do NOT run timescaledb-tune (CNPG manages postgresql.conf; tuning
+# is supplied via the Cluster spec's postgresql.parameters, see the cluster
+# manifest). The exact package version is asserted; the build FAILS LOUDLY if
+# the pinned 2.25.2 build is ever pulled from the repo.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gnupg wget ca-certificates; \
+    echo "deb https://packagecloud.io/timescale/timescaledb/debian/ ${DEBIAN_CODENAME} main" \
+        > /etc/apt/sources.list.d/timescaledb.list; \
+    wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor \
+        > /etc/apt/trusted.gpg.d/timescaledb.gpg; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        "timescaledb-2-postgresql-16=${TIMESCALEDB_APT_PKG}" \
+        "timescaledb-2-loader-postgresql-16=${TIMESCALEDB_APT_PKG}"; \
+    # Prove the pinned extension control file landed at the exact version.
+    test -f "/usr/share/postgresql/16/extension/timescaledb--${TIMESCALEDB_VERSION}.sql"; \
+    grep -q "default_version = '${TIMESCALEDB_VERSION}'" /usr/share/postgresql/16/extension/timescaledb.control; \
+    apt-get purge -y --auto-remove gnupg wget; \
+    rm -rf /var/lib/apt/lists/*
+
+# barman-cloud CLI for in-tree barmanObjectStore WAL archiving + base backups +
+# PITR. The CNPG `-standard-bookworm` operand base does NOT bundle barman-cloud
+# (the newer images dropped it in favour of the Barman Cloud Plugin), so the
+# in-tree backup path fails with "barman-cloud-check-wal-archive: not found"
+# unless we add it here. Installed via apt (python3-barman / barman-cli-cloud +
+# the cloud provider client). Pinned-loose (distro package) since this is the
+# backup tooling, not the data engine; PROD can pin tighter if required.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends barman-cli-cloud python3-boto3; \
+    barman-cloud-wal-archive --help >/dev/null; \
+    barman-cloud-backup --help >/dev/null; \
+    barman-cloud-check-wal-archive --help >/dev/null; \
+    rm -rf /var/lib/apt/lists/*
+
+# Restore the CNPG operand contract: the operator runs the instance as uid 26
+# (postgres) and supplies its own entrypoint. We only added files as root; hand
+# the runtime back to the CNPG postgres user.
+USER 26
+
+LABEL org.opencontainers.image.title="verdify-timescaledb-cnpg" \
+      org.opencontainers.image.description="CloudNativePG operand image with TimescaleDB ${TIMESCALEDB_VERSION} for PG16 (Verdify HA-4, issue #243)" \
+      io.verdify.timescaledb.version="${TIMESCALEDB_VERSION}" \
+      io.verdify.cnpg.base="${CNPG_PG_BASE}"


### PR DESCRIPTION
## HA-4 — DB HA + PITR (CloudNativePG) — DEV BUILD + GATED PROD RUNBOOK

Builds the CloudNativePG validation for the Verdify TimescaleDB DB-HA program (epic #218, issues #243/#244/#245). **The live prod DB was NEVER touched.** Everything here is dev-first (`verdify-dev`) + a staged, gated prod runbook.

### What this PR adds
- **`deploy/k8s/cnpg/image/Dockerfile`** — the **TimescaleDB-on-CNPG operand image**: `FROM ghcr.io/cloudnative-pg/postgresql:16.13-standard-bookworm` + `timescaledb 2.25.2~debian12-1613` (community/TSL build, exact live-match) + **`barman-cli-cloud`**. The build *asserts* the 2.25.2 control file and the barman tooling, so a silent version drift fails the build, not the migration.
  - **Key finding:** the `-standard` CNPG operand base does **not** bundle `barman-cloud-*` (newer images dropped it for the plugin). In-tree `barmanObjectStore` archiving fails with `barman-cloud-check-wal-archive: not found` until you add it — done here.
- **`deploy/k8s/cnpg/dev/`** — dev MinIO WAL store, the CNPG `Cluster`, a `NetworkPolicy` (verdify-dev `default-deny-ingress` was blocking both MinIO and the CNPG status probe), a `ScheduledBackup`, and `restore`/`failover`/`pitr` test scripts.
- **`deploy/k8s/cnpg/docs/PROD-CNPG-MIGRATION-RUNBOOK.md`** (#245) — the gated, mirror-of-the-device-cutover prod migration runbook: stand-alongside → seed → parity-prove → **quiesce the single device-writer** → atomic one-key `DB_HOST` flip → bake → decom, with instant rollback. **Not a green light.**
- **`.github/workflows/cnpg-image.yml`** — CI to publish the digest-pinned prod operand image (PR-gated, `live/platform-main` only). `.github/**` is shared infra → this lands for review, not autonomous merge.

### DEV-PROVEN (literal, in `verdify-dev`)
- TimescaleDB **2.25.2** loads under CNPG (`shared_preload_libraries=timescaledb,pg_stat_statements`; server PG 16.13); pgcrypto 1.3, vector present.
- **Hypertables survive dump → `timescaledb_pre_restore()` → `pg_restore` → `timescaledb_post_restore()`** (the TimescaleDB-correct procedure; a naive pg_restore breaks on the catalog's circular FKs).
- **Native compression works:** 50,000-row hypertable, `timescaledb.compress` enabled, chunk compressed, all 50,000 rows read back; `compression_enabled=t`.
- **WAL archiving → MinIO:** `ContinuousArchiving=True`, `archived_count` climbing, WAL `.gz` segments physically in `s3://verdify-wal/verdify-db-cnpg/wals/...`.
- **Base backup completed:** `firstRecoverabilityPoint` set; `data.tar.gz` + `backup.info` in MinIO.
- **PITR restore-test GREEN:** recovered a *new* cluster to a captured target time → pre-target row present, **post-target POISON row absent** (`poison_rows=0`), timescaledb 2.25.2 intact in the recovered cluster.

### STAGED (capacity-gated, not yet proven)
- **Kill-primary sync-standby failover (RPO=0)** — the dev cluster is **1 instance** today because the cluster is capacity-starved (node4/node5 memory-saturated, node6 disk-pressure-tainted, node7 cordoned mid-build after its 30 GiB image fs hit ~93%). The 2-instance sync-failover proof is a one-line re-run (`instances: 2`, restore `minSyncReplicas/maxSyncReplicas: 1`, drop the node5 nodeSelector) gated on capacity. The `failover-test.sh` script is committed and ready.

### Gates honored
- Live prod DB untouched; dev ingestor stays `replicas:0` (device-dark).
- Prod migration is a **runbook only** (#245); `.github/**` + VerdifyConsultancy = PR-for-review.

cc @ for review — base `live/platform-main`.
