### PR TITLE
fix(gitops): verdify-prod-dark git==live — close #263 + capture ingestor/PDB so sync REINFORCES (#262/#263)

### DIFF
--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -89,12 +89,19 @@ patches:
   # repo). lab is NOT in overlays/staging (it is a dev/prod-only Component), so it
   # is EXEMPT from the promote-diff-guard staging-equality check; dev pins the SAME
   # env-agnostic digest as prod (one-digest-across-envs static content).
+  #
+  # 2026-06-07 #263 CONVERGENCE (laptop-root): the prior 92ab47.. pin was the
+  # SYNTHETIC CI temp-vault build (stock "Welcome to Quartz 4" starter). Repointed
+  # to the SAME real vault-built digest overlays/prod already serves on
+  # lab.verdify.ai (bf71018, 121 .md -> 566 static files), so no overlay carries
+  # the synthetic placeholder and a sync can never seed the Quartz manual. The
+  # durable CI-from-real-vault fix is Iris #124 / PR #259.
 images:
 - digest: sha256:ce4ca79f9e6442c39558cbe02b1665c3cddc3e269c1867997d4f292f3a5ce8ff
   name: ghcr.io/verdifyconsultancy/verdify-api
 - digest: sha256:4f141a5901f802e52b37b15a6a92b8d0bc906f3d854066e3ddd52911aa457d0d
   name: ghcr.io/verdifyconsultancy/verdify-ingestor
-- digest: sha256:92ab47073fad5372832274ba591291fd1c209968fd311892f4130bc423b1140b
+- digest: sha256:bf71018f181f4e37e585b8778852eb209875555525c425921663e7744891c973
   name: ghcr.io/verdifyconsultancy/verdify-lab
 - digest: sha256:9824020a0d2fe77191b2c01ca2634c3bcec6031b79d2fef1c3334b2d5665768d
   name: ghcr.io/verdifyconsultancy/verdify-mcp

--- a/deploy/k8s/overlays/prod-dark/kustomization.yaml
+++ b/deploy/k8s/overlays/prod-dark/kustomization.yaml
@@ -112,7 +112,12 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-www
     digest: sha256:633fb18ab3c9a637693094917615c720a09baaef4877cce8dcea0568bca0b467
   # verdify-lab (#124): SAME env-agnostic Quartz digest overlays/prod + dev pin.
+  # 2026-06-07 #263 CONVERGENCE (laptop-root): repointed off the SYNTHETIC 92ab47..
+  # CI temp-vault build to the REAL vault-built bf71018 that overlays/prod serves
+  # on lab.verdify.ai, so no overlay carries the Quartz-starter placeholder. No
+  # ArgoCD app targets overlays/prod-dark today, but keeping it byte-aligned with
+  # overlays/prod means a later (gated) prod-dark adopt can't regress the lab site.
   - name: ghcr.io/verdifyconsultancy/verdify-lab
-    digest: sha256:92ab47073fad5372832274ba591291fd1c209968fd311892f4130bc423b1140b
+    digest: sha256:bf71018f181f4e37e585b8778852eb209875555525c425921663e7744891c973
   # NO verdify-setpoint-server pin: the setpoint-server Component is excluded, so
   # its image never renders here (device-dark has no grow-light writer).

--- a/deploy/k8s/overlays/prod/ingestor-gather-mount.patch.yaml
+++ b/deploy/k8s/overlays/prod/ingestor-gather-mount.patch.yaml
@@ -1,15 +1,20 @@
 # ============================================================================
-# STAGED — NOT WIRED INTO kustomization.yaml. (#211) GATED INGESTOR PATCH.
+# WIRED INTO kustomization.yaml — git==live CAPTURE. (#211/#263) INGESTOR PATCH.
 # ============================================================================
 # This is the verdify-ingestor Deployment patch that makes gather-plan-context.sh
-# runnable in-pod. It is DELIBERATELY NOT listed in overlays/prod/kustomization
-# `patches:` because applying it RESTARTS the verdify-ingestor pod — which is the
-# LIVE single writer to the greenhouse ESP32 (device loop). It must be applied
-# ONLY via laptop-root's guarded stop/verify restart (single-writer Recreate: the
-# old writer is fully torn down before the new one starts — no double-writer), at
-# the gated window. The other three #210-213 ConfigMap pieces (HERMES_URL,
-# gather-script ConfigMap, gather-env, hermes key) are already live/wired and do
-# NOT restart the ingestor by themselves.
+# runnable in-pod. It is now LISTED in overlays/prod/kustomization `patches:`
+# (laptop-root 2026-06-07) BECAUSE the live writer (node4) is ALREADY running this
+# exact shape — install-psql initContainer, gather-script + pgclient mounts,
+# PATH/LD_LIBRARY_PATH + HERMES_IRIS_API_KEY + PGPASSWORD env (deliveries proven).
+# Wiring it makes git == live, so an ArgoCD reconcile of verdify-prod-dark
+# (path overlays/prod) RENDERS the same ingestor it already runs and REINFORCES
+# the plan-delivery path instead of STRIPPING it. The original concern — that
+# *applying* this RESTARTS the live single ESP32 writer — still governs any
+# kubectl-apply / manual sync: that remains a laptop-root guarded stop/verify
+# Recreate at the gated window. But omitting it from git was the LARGER hazard
+# (a naive sync would revert live), which this capture closes. The other #210-213
+# ConfigMap pieces (HERMES_URL, gather-script ConfigMap, gather-env) are already
+# live/wired and do NOT restart the ingestor by themselves.
 #
 # WHAT IT ADDS (all ADDITIVE strategic-merge; base /tmp + ha-token preserved):
 #  1. initContainer `install-psql` — the ingestor image (Debian trixie/glibc) has
@@ -82,6 +87,25 @@ spec:
               value: "/opt/pgclient/bin:/home/appuser/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
             - name: LD_LIBRARY_PATH
               value: "/opt/pgclient/lib"
+            # #212/#213 plan-delivery env (git==live capture, laptop-root 2026-06-07):
+            # HERMES_IRIS_API_KEY authenticates the ingestor's iris_planner POST to
+            # the in-cluster hermes-iris gateway (HERMES_URL in verdify-config).
+            # These two are ALREADY on the LIVE writer pod (node4, deliveries proven)
+            # but were the only env the prod overlay did not render — without them a
+            # sync would strip the auth + PGPASSWORD and break delivery. Captured
+            # here (additive strategic merge, keyed by name) so a sync REINFORCES.
+            - name: HERMES_IRIS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-hermes
+                  key: HERMES_IRIS_API_KEY
+            # PGPASSWORD for the gather script's direct `psql` (its lib reads
+            # $PGPASSWORD); sourced from the same secret/key as POSTGRES_PASSWORD.
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-app-secrets
+                  key: POSTGRES_PASSWORD
           volumeMounts:
             - name: gather-script
               mountPath: /srv/verdify/scripts/gather-plan-context.sh

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -131,6 +131,15 @@ patches:
   # subprocess (not the ingestor app / device path). See
   # gather-script-env-configmap.yaml. (Picked up on the gated restart.)
   - path: gather-script-env-configmap.yaml
+  # #211/#263 GIT==LIVE INGESTOR CAPTURE (laptop-root 2026-06-07): the gather-mount
+  # patch — install-psql initContainer + gather-script/pgclient mounts +
+  # PATH/LD_LIBRARY_PATH + HERMES_IRIS_API_KEY + PGPASSWORD env. The LIVE writer
+  # (node4) ALREADY runs this exact shape (plan deliveries proven), so rendering it
+  # makes a verdify-prod-dark reconcile a NO-OP on the ingestor (REINFORCE, not
+  # revert). Applying it via kubectl/sync still RESTARTS the single ESP32 writer —
+  # that is a laptop-root guarded Recreate at the gated window, NOT an autonomous
+  # action. See ingestor-gather-mount.patch.yaml header.
+  - path: ingestor-gather-mount.patch.yaml
   # #130 ingestor state volume: writable emptyDir at /srv/verdify/state so the
   # live setpoint-dispatcher + MCP-restart logging stops thrashing post-cutover.
   # emptyDir now; durable RWO PVC is the #130 follow-up. See ingestor-state-volume.yaml.

--- a/deploy/k8s/overlays/prod/pdb.yaml
+++ b/deploy/k8s/overlays/prod/pdb.yaml
@@ -96,3 +96,25 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana
+---
+# verdify-planner: GIT==LIVE CAPTURE (laptop-root 2026-06-07). This PDB EXISTS on
+# the live verdify-prod cluster (minAvailable:1, selector component=planner) but
+# was never in this file — so a verdify-prod-dark reconcile would have PRUNED it.
+# Captured EXACTLY as live (minAvailable:1) so the sync is a no-op REINFORCE, not
+# a prune. NOTE/FOLLOW-UP: the planner Deployment is replicas:1, so minAvailable:1
+# is drain-BLOCKING (same footgun the grafana PDB above avoids via maxUnavailable:1).
+# Switching it to maxUnavailable:1 would be a live BEHAVIOR change on sync, NOT a
+# reinforce, so it is deliberately left == live here and flagged as a follow-up
+# (the planner is not on node4/the ingestor, so this does not affect the writer).
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-planner
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: planner
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: planner


### PR DESCRIPTION
## LANE A — GitOps convergence (sprint ha-5)

Makes the **verdify-prod-dark** ArgoCD app (renders `overlays/prod`) **git==live** so a future reconcile is a no-op REINFORCE, not a REVERT. Adversarially verified against the live `verdify-prod` cluster.

### #263 — lab-site digest revert hazard (finish convergence)
`overlays/prod` already pins the REAL vault-built `bf71018` that **lab.verdify.ai serves** (verified HTTP 200 + real content "Verdify: A Longmont, Colorado AI greenhouse…"). The SYNTHETIC Quartz-starter digest `92ab470` still lingered in:
- `overlays/dev/kustomization.yaml` → repointed to `bf71018`
- `overlays/prod-dark/kustomization.yaml` → repointed to `bf71018`

Now **no overlay** can seed the "Welcome to Quartz 4" placeholder on a sync. Durable CI-from-real-vault fix stays Iris #124 / PR #259.

### Ingestor git==live capture (the core revert hazard)
`overlays/prod` did NOT render the live writer's plan-delivery wiring (`ingestor-gather-mount.patch.yaml` was staged-but-unwired; `HERMES_IRIS_API_KEY`/`PGPASSWORD` env absent). A sync would have **stripped them from the live node4 writer**. Fixed:
- wired `ingestor-gather-mount.patch.yaml` into `overlays/prod/kustomization`
- added `HERMES_IRIS_API_KEY` + `PGPASSWORD` to that patch

**Rendered ingestor now MATCHES live EXACTLY** — image, replicas:1/Recreate, `install-psql` init, gather-script+pgclient mounts, PATH/LD_LIBRARY_PATH, all 9 env. A reconcile is a no-op on the ingestor.

> APPLYING this patch still RESTARTS the single ESP32 writer — that remains a laptop-root guarded Recreate at the gated window, **never autonomous**. This PR only changes git, not live.

### PDB git==live capture
The live `verdify-planner` PDB (`minAvailable:1`) existed on-cluster but was missing from `pdb.yaml` — a reconcile would have PRUNED it. Captured == live. Flagged follow-up: it is drain-blocking on the replicas:1 planner (grafana avoids this via `maxUnavailable:1`); left == live to keep the sync a reinforce.

### Adversarial git==live verification
| Resource | git==live |
|---|---|
| ingestor: image / replicas / strategy / volumes / initContainers | MATCH |
| ingestor: all 9 env (incl HERMES_IRIS_API_KEY, PGPASSWORD) | MATCH |
| ingestor: all 6 volumeMounts (gather-script subPath, pgclient) | MATCH |
| lab digest (prod) | MATCH (bf71018) |
| stateless www/lab/api/mcp: replicas:2 + hostname DoNotSchedule spread | MATCH |
| all 7 PDBs (incl planner) | MATCH |

**The live verdify-ingestor (node4) was NOT touched — read-only verification only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)