### PR TITLE
fix(ha): planner 1->2 + hostname spread + PDB (#230)

### DIFF
--- a/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
+++ b/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
@@ -19,9 +19,17 @@
 #      every future rollout never drops the ready-endpoint count below running.
 #
 # Selectors match each deployment's live spec.selector.matchLabels exactly
-# (www=www, lab=lab-site, api=api, mcp=mcp, traefik name=verdify-traefik).
+# (www=www, lab=lab-site, api=api, mcp=mcp, planner=planner, traefik
+# name=verdify-traefik).
 # NOT touched here: verdify-ingestor / verdify-setpoint-server (single-writer
 # device path — gated ha-3), grafana (RWO PVC singleton — stays replicas:1).
+#
+# ha-5 (#230, this commit): verdify-planner added — the last replicas:1
+# stateless serving surface. It is a stateless HTTP service (run state lives in
+# Postgres via PostgresRunStore) reached in-cluster via Hermes/Iris, NOT a
+# device writer, so 1->2 + hard hostname spread is the same safe posture as
+# www/lab/api/mcp. This patch matches the live cluster state applied at the
+# same time, so an ArgoCD sync REINFORCES it rather than reverting.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -114,3 +122,26 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/component: mcp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-planner
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys:
+            - pod-template-hash
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: planner

--- a/deploy/k8s/overlays/prod/pdb.yaml
+++ b/deploy/k8s/overlays/prod/pdb.yaml
@@ -7,7 +7,8 @@
 # replica, then BLOCKS until its replacement is Ready on another node before the
 # second can go — the surface never hits zero during cluster maintenance.
 #
-#   - www / lab / api / mcp / verdify-traefik: minAvailable: 1 (2-replica surfaces).
+#   - www / lab / api / mcp / planner / verdify-traefik: minAvailable: 1
+#     (2-replica surfaces; planner added in ha-5 / #230).
 #   - grafana: maxUnavailable: 1 (RWO iSCSI PVC singleton, stays replicas:1).
 #     minAvailable:1 on a 1-replica object would block EVERY node drain forever;
 #     maxUnavailable:1 lets the drain proceed (its HA is fast PVC-reattach
@@ -55,6 +56,19 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: verdify-planner
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: planner
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: planner
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
## ha-5 / Lane C — #230 planner HA (the last replicas:1 stateless surface)

`verdify-planner` was the only stateless serving surface in `verdify-prod` still at `replicas:1` after ha-1 covered www/lab/api/mcp/traefik. It is a stateless HTTP service (run state lives in Postgres via `PostgresRunStore`) reached in-cluster via Hermes/Iris — **NOT a device writer** — so the same N+1 + hard hostname-spread + PDB posture applies.

### Changes (prod-overlay scoped — planner is a Component referenced by dev+prod; staging/dev untouched)
- `ha-stateless-spread.patch.yaml`: add `verdify-planner` strategic-merge patch — `replicas: 1->2`, `RollingUpdate maxUnavailable:0/maxSurge:1`, `topologySpreadConstraints` hostname `maxSkew:1` `DoNotSchedule` `matchLabelKeys:[pod-template-hash]`.
- `pdb.yaml`: add `verdify-planner` PDB `minAvailable: 1`.

### GitOps safety (git == live, so a sync REINFORCES)
Authored to match the live cluster state applied at the same time. Live now:
- `verdify-planner 2/2` Ready, replicas spread **node4 + node5** (distinct), **0 restarts**.
- PDB `verdify-planner minAvailable:1`, `disruptionsAllowed:1`.
- `kubectl kustomize overlays/prod` renders planner `replicas:2` + spread + PDB; the gated single-writer surfaces (`verdify-ingestor`/`verdify-setpoint-server`) and singletons (grafana/hermes/mqtt) stay `replicas:1` — no over-reach.

A future ArgoCD sync of `verdify-prod-dark` will reinforce, not revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)