### PR TITLE
fix(gitops): dedup verdify-planner PDB — prod overlay render broken by #265+#266 double-merge

### DIFF
--- a/deploy/k8s/overlays/prod/pdb.yaml
+++ b/deploy/k8s/overlays/prod/pdb.yaml
@@ -110,25 +110,3 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana
----
-# verdify-planner: GIT==LIVE CAPTURE (laptop-root 2026-06-07). This PDB EXISTS on
-# the live verdify-prod cluster (minAvailable:1, selector component=planner) but
-# was never in this file — so a verdify-prod-dark reconcile would have PRUNED it.
-# Captured EXACTLY as live (minAvailable:1) so the sync is a no-op REINFORCE, not
-# a prune. NOTE/FOLLOW-UP: the planner Deployment is replicas:1, so minAvailable:1
-# is drain-BLOCKING (same footgun the grafana PDB above avoids via maxUnavailable:1).
-# Switching it to maxUnavailable:1 would be a live BEHAVIOR change on sync, NOT a
-# reinforce, so it is deliberately left == live here and flagged as a follow-up
-# (the planner is not on node4/the ingestor, so this does not affect the writer).
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: verdify-planner
-  labels:
-    app.kubernetes.io/part-of: verdify
-    app.kubernetes.io/component: planner
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: planner


### PR DESCRIPTION
## Problem (durability-gate catch)
PR #265 (Lane A git==live capture) and PR #266 (Lane C planner 1→2 HA) **each** added a `verdify-planner` PodDisruptionBudget to `overlays/prod/pdb.yaml`. After both squash-merged to `live/platform-main`, the overlay had two PDBs with the same id and:

```
kustomize build overlays/prod
error: may not add resource with an already registered id: PodDisruptionBudget.v1.policy/verdify-planner
```

A non-rendering overlay means an ArgoCD sync of `verdify-prod-dark` would **error** — exactly the GitOps hazard we are guarding against.

## Fix
Both PDBs were byte-identical (`minAvailable:1`, selector `component=planner`). Removed the redundant Lane-A capture block; kept the canonical one in the ha-stateless spread section. planner is now `replicas:2`, so the deleted comment's 'replicas:1 drain-blocking footgun' note no longer applies.

## Verification
- `kustomize build overlays/prod` → **SUCCESS**
- exactly **1** `verdify-planner` PDB rendered
- ingestor still `replicas:1` / **no** priorityClassName (gated singleton untouched)
- planner `replicas:2`

Refs #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)