### PR TITLE
[codex] classify Verdify route exposure metadata

### DIFF
--- a/deploy/k8s/components/grafana/graphs-ingressroute.yaml
+++ b/deploy/k8s/components/grafana/graphs-ingressroute.yaml
@@ -19,6 +19,11 @@ metadata:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: grafana
     traefik-tier: verdify
+    agent-fleet.vallery.net/edge: verdify-tier2
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints: [verdify-web]
   routes:

--- a/deploy/k8s/overlays/dev/ingressroute.yaml
+++ b/deploy/k8s/overlays/dev/ingressroute.yaml
@@ -45,6 +45,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: api
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: api-auth-review-required
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/dev/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/dev/lab-ingressroute.yaml
@@ -23,6 +23,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: lab-site
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/dev/www-ingressroute.yaml
+++ b/deploy/k8s/overlays/dev/www-ingressroute.yaml
@@ -24,6 +24,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: www
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/prod-dark/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/prod-dark/lab-ingressroute.yaml
@@ -18,6 +18,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: lab-site
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/prod-dark/www-ingressroute.yaml
+++ b/deploy/k8s/overlays/prod-dark/www-ingressroute.yaml
@@ -22,6 +22,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: www
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/prod/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/prod/lab-ingressroute.yaml
@@ -26,6 +26,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: lab-site
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/prod/traefik/verdify-tier1-apps-forward.yaml
+++ b/deploy/k8s/overlays/prod/traefik/verdify-tier1-apps-forward.yaml
@@ -40,6 +40,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: edge-forward
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/prod/traefik/verdify-traefik-routes.yaml
+++ b/deploy/k8s/overlays/prod/traefik/verdify-traefik-routes.yaml
@@ -43,6 +43,11 @@ metadata:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: www
     traefik-tier: verdify
+    agent-fleet.vallery.net/edge: verdify-tier2
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints: [verdify-web]
   routes:
@@ -64,6 +69,11 @@ metadata:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: lab-site
     traefik-tier: verdify
+    agent-fleet.vallery.net/edge: verdify-tier2
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints: [verdify-web]
   routes:
@@ -85,6 +95,11 @@ metadata:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: api
     traefik-tier: verdify
+    agent-fleet.vallery.net/edge: verdify-tier2
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: api-auth-review-required
 spec:
   entryPoints: [verdify-web]
   routes:
@@ -106,6 +121,11 @@ metadata:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: mcp
     traefik-tier: verdify
+    agent-fleet.vallery.net/edge: verdify-tier2
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: mcp-auth-review-required
 spec:
   entryPoints: [verdify-web]
   routes:

--- a/deploy/k8s/overlays/prod/www-ingressroute.yaml
+++ b/deploy/k8s/overlays/prod/www-ingressroute.yaml
@@ -30,6 +30,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: www
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/staging/ingressroute.yaml
+++ b/deploy/k8s/overlays/staging/ingressroute.yaml
@@ -47,6 +47,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: api
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: api-auth-review-required
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/staging/lab-ingressroute.yaml
+++ b/deploy/k8s/overlays/staging/lab-ingressroute.yaml
@@ -30,6 +30,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: lab-site
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure

--- a/deploy/k8s/overlays/staging/www-ingressroute.yaml
+++ b/deploy/k8s/overlays/staging/www-ingressroute.yaml
@@ -33,6 +33,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: www
+    agent-fleet.vallery.net/edge: vallery-edge
+  annotations:
+    agent-fleet.vallery.net/exposure: public
+    agent-fleet.vallery.net/auth-mode: none
+    agent-fleet.vallery.net/public-dns-gate: intentional-public-content
 spec:
   entryPoints:
     - websecure


### PR DESCRIPTION
## Summary

Adds explicit route exposure metadata to Verdify IngressRoutes without changing routing behavior.

This PR adds:

- `agent-fleet.vallery.net/edge` labels for shared `vallery-edge` routes and Verdify tier-2 routes
- `agent-fleet.vallery.net/exposure: public` annotations
- `agent-fleet.vallery.net/auth-mode: none` annotations matching the current no-edge-auth route state
- `agent-fleet.vallery.net/public-dns-gate` annotations that distinguish intentional public content from API/MCP routes needing auth review

Touched route surfaces:

- `deploy/k8s/overlays/dev`: api, www, lab
- `deploy/k8s/overlays/staging`: api, www, lab target shape
- `deploy/k8s/overlays/prod-dark`: www, lab
- `deploy/k8s/overlays/prod`: www, lab, tier-1 forwarder, tier-2 www/lab/api/mcp, graphs

## Why

The K3s/GitOps audit route matrix found Verdify routes with public hosts, no observed edge auth, and no explicit exposure metadata. This PR does not hide that risk by claiming auth exists. It records the current source truth so the next remediation can focus on API/MCP auth policy instead of first rediscovering which routes are public.

## Validation

```bash
kustomize build deploy/k8s/overlays/dev >/tmp/verdify-dev.yaml
kustomize build deploy/k8s/overlays/staging >/tmp/verdify-staging.yaml
kustomize build deploy/k8s/overlays/prod >/tmp/verdify-prod.yaml
kustomize build deploy/k8s/overlays/prod-dark >/tmp/verdify-prod-dark.yaml
kubeconform -strict -summary -ignore-missing-schemas /tmp/verdify-dev.yaml
kubeconform -strict -summary -ignore-missing-schemas /tmp/verdify-staging.yaml
kubeconform -strict -summary -ignore-missing-schemas /tmp/verdify-prod.yaml
kubeconform -strict -summary -ignore-missing-schemas /tmp/verdify-prod-dark.yaml
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_stream(File.read(f)); puts "yaml OK #{f}" }' <touched-yaml-files>
ruby <rendered-route-metadata-check> # verified all rendered IngressRoutes include edge/exposure/auth-mode
git diff --check
```

Observed locally:

- dev render: 26 resources, valid 22, invalid 0, errors 0, skipped 4
- staging render: 28 resources, valid 25, invalid 0, errors 0, skipped 3
- prod render: 74 resources, valid 65, invalid 0, errors 0, skipped 9
- prod-dark render: 38 resources, valid 36, invalid 0, errors 0, skipped 2
- rendered route metadata check: 15 rendered IngressRoutes all have `edge`, `exposure`, and `auth-mode`

No cluster, Argo, DNS, Cloudflare, UDM, firewall, or router mutation was performed.
