### PR TITLE
fix(db-backup): retry pg_dump on kube-router netpol race — staging nightly backup green (#273)

### DIFF
--- a/deploy/k8s/components/db-backup/backup-cronjob.yaml
+++ b/deploy/k8s/components/db-backup/backup-cronjob.yaml
@@ -75,42 +75,57 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
-                  # NETPOL-RACE WAIT (why this job had NEVER succeeded):
-                  # the CNI (kube-router) programs the allow-db-from-backup
-                  # ingress rule for a freshly-scheduled pod ASYNCHRONOUSLY.
-                  # For the first ~5-10s of a new pod's life the rule is not
-                  # yet in the dataplane, so a connection to the DB is REJECTed
-                  # (Connection refused). The original script fired pg_dump
-                  # immediately under `set -e`, so it died on that refusal and
-                  # every nightly run (and its backoff retries, each a NEW pod
-                  # hitting the same race) failed. Block until the DB is
-                  # actually reachable before dumping. pg_isready is a cheap
-                  # SELECT-free TCP+startup probe; it does NOT write the DB.
-                  echo "[backup] waiting for ${DB_HOST}:${DB_PORT} to be reachable (CNI netpol-program race)"
-                  ready=0
-                  for attempt in $(seq 1 60); do
-                    if pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -t 3 >/dev/null 2>&1; then
-                      echo "[backup] DB reachable after ${attempt} attempt(s)"
-                      ready=1
-                      break
-                    fi
-                    sleep 2
-                  done
-                  if [ "${ready}" -ne 1 ]; then
-                    echo "[backup] FATAL: ${DB_HOST}:${DB_PORT} never became reachable after 120s" >&2
-                    exit 1
-                  fi
+                  # NETPOL-RACE: the CNI (kube-router) programs the
+                  # allow-db-from-backup ingress rule for a freshly-scheduled pod
+                  # ASYNCHRONOUSLY. For the first seconds of a new pod's life the
+                  # rule is not yet in the dataplane, so a connection to the DB is
+                  # REJECTed (Connection refused).
+                  #
+                  # A `pg_isready` gate is NOT sufficient (proven #273): pg_isready
+                  # can return rc=0 on one short probe while the very NEXT
+                  # connection — the pg_dump — still races a not-yet-fully-programmed
+                  # dataplane and gets `Connection refused`, leaving a 0-byte
+                  # .partial. Every nightly run did exactly that. The only reliable
+                  # readiness signal is a SUCCESSFUL pg_dump itself, so RETRY THE
+                  # DUMP (not just a probe) until it connects, with the same
+                  # write-partial-then-atomic-rename safety.
                   ts="$(date -u +%Y%m%dT%H%M%SZ)"
                   out="${BACKUP_DIR}/verdify-${ts}.dump"
-                  echo "[backup] pg_dump -Fc ${DB_NAME}@${DB_HOST} -> ${out}"
                   # -Fc custom format (compressed, restorable with pg_restore;
                   # preserves the TimescaleDB hypertable/compression catalog when
                   # paired with timescaledb_pre/post_restore at restore time).
-                  # Write to a .partial file first, then atomically rename, so a
-                  # crash mid-dump never leaves a truncated file that the prune
-                  # or a restore could mistake for a good backup.
-                  pg_dump -Fc -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" \
-                    -d "${DB_NAME}" -f "${out}.partial"
+                  echo "[backup] pg_dump -Fc ${DB_NAME}@${DB_HOST} -> ${out} (with netpol-race retry)"
+                  dumped=0
+                  for attempt in $(seq 1 30); do
+                    # cheap pre-probe just to log progress; the dump is the gate.
+                    pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -t 3 >/dev/null 2>&1 || true
+                    # A fresh .partial each attempt; a refused connection leaves a
+                    # 0-byte file we overwrite next loop, never a truncated good name.
+                    if pg_dump -Fc -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" \
+                         -d "${DB_NAME}" -f "${out}.partial" 2> /tmp/pg_dump.err; then
+                      dumped=1
+                      echo "[backup] pg_dump succeeded on attempt ${attempt}"
+                      break
+                    fi
+                    # Only swallow the transient connection-refused race; any other
+                    # pg_dump error (auth, disk, corruption) must fail loudly.
+                    if grep -qiE 'connection.*(refused|reset|timed out)|could not connect|server closed the connection' /tmp/pg_dump.err; then
+                      echo "[backup] attempt ${attempt}: DB not reachable yet (netpol race), retrying in 2s"
+                      sleep 2
+                      continue
+                    fi
+                    echo "[backup] FATAL: pg_dump failed with a non-transient error:" >&2
+                    cat /tmp/pg_dump.err >&2
+                    exit 1
+                  done
+                  if [ "${dumped}" -ne 1 ]; then
+                    echo "[backup] FATAL: pg_dump never connected after 30 attempts (~60s+):" >&2
+                    cat /tmp/pg_dump.err >&2
+                    rm -f "${out}.partial" || true
+                    exit 1
+                  fi
+                  # Atomic publish: rename the completed .partial to its final name
+                  # so the prune / a restore never sees a truncated file.
                   mv "${out}.partial" "${out}"
                   echo "[backup] wrote ${out} ($(du -h "${out}" | cut -f1))"
                   # RETENTION: keep the newest ${RETENTION_DAYS} days of dumps;


### PR DESCRIPTION
## #273 — staging nightly backup Failing (VerdifyDBBackupStale, age ~54.5h)

### Root cause (reproduced live in `verdify-staging`)
The prior fix gated on `pg_isready` before `pg_dump`. But a passing pg_isready probe is **not** a sufficient readiness signal under kube-router: the CNI programs the `allow-db-from-backup` ingress rule for a freshly-scheduled pod asynchronously, so pg_isready's single short TCP probe can return rc=0 while the **very next** connection — the pg_dump — still races a not-yet-programmed dataplane and gets `Connection refused`. Under `set -e` that killed the run, leaving a **0-byte `*.partial`**. Each of the 3 backoff retries was a fresh pod hitting the same race → every nightly run failed and the dumps PVC accrued only 0-byte partials (08:17 ×3/night).

### Fix
Make a **successful pg_dump the readiness gate**:
- Retry `pg_dump` itself (up to 30× / ~60s+) on *transient* connection errors only (`refused|reset|timed out|could not connect|server closed`).
- **Fail loudly** on any non-transient pg_dump error (auth / disk / corruption) — no silent green.
- Keep the write-`.partial`-then-atomic-`mv` safety; clean up the partial on give-up.

This component is referenced by **both** the staging and prod overlays, so the same race-hardening lands for the prod nightly backup too.

### Proof (live, verdify-staging)
A Job rendered from the fixed template logged:
```
[backup] attempt 1: DB not reachable yet (netpol race), retrying in 2s
[backup] pg_dump succeeded on attempt 2
[backup] wrote /backups/verdify-20260608T040300Z.dump (52.2M)
```
- Real 54,701,240-byte `.dump` written + atomically renamed; stale 0-byte partials swept.
- Prometheus `time() - verdify_db_backup_last_success_timestamp_seconds` for ns `verdify-staging` dropped **~196000s → ~330s**.
- **`VerdifyDBBackupStale` cleared** (0 backup alerts firing).

### Validation
- `kubectl kustomize deploy/k8s/overlays/staging` → GREEN
- `kubectl kustomize deploy/k8s/overlays/prod` → GREEN
- rendered script passes `bash -n`

Single-file change. Closes #273.