### PR TITLE
deploy(firmware-ota): SealedSecret shape + sealing runbook for k3s OTA (#301)

### DIFF
--- a/deploy/k8s/SECRETS.md
+++ b/deploy/k8s/SECRETS.md
@@ -70,6 +70,7 @@ Service → Secret → key wiring as authored in `deploy/k8s/{base,components}`:
 | `verdify-app-secrets` | `ESP32_API_KEY` | ingestor (`secretKeyRef`); **device-affecting** | ref-only¹ | ref-only¹ | ✓ |
 | `verdify-app-secrets` | `OPENAI_API_KEY` | planner (`secretKeyRef`, `optional: true`) | ✓ | — | ✓ |
 | `verdify-ha-token` | `ha_token.txt` | setpoint-server (volume mount); **device-affecting** | — | — | ✓ |
+| `verdify-firmware-ota` | `ota_password` | **operator OTA tooling host** (`OTA_PW` env for `make firmware-deploy` / `firmware-rollback.sh`); NOT a pod; **device-affecting**, standalone | — | — | ✓³ |
 | `verdify-hermes` | `OPENAI_API_KEY`, `HERMES_MCP_URL`² | hermes-iris (`envFrom.secretRef`) | — | — | ✓ |
 | `verdify-hermes-slack` | slack channel config | hermes-iris (optional volume mount; **non-secret** channel cfg) | — | — | opt |
 | `ghcr-jvallery-readonly` | `.dockerconfigjson` | all workloads (`imagePullSecrets`) | ✓ | ✓ | ✓ |
@@ -80,6 +81,17 @@ but is never exercised — those envs never connect to the live ESP32.
 
 ² `HERMES_MCP_URL` is the migration doc **R7** gate: it must point at
 `verdify-mcp.verdify-prod.svc:8000` and is repointed at SEAL time, never committed.
+
+³ `verdify-firmware-ota` is the ESPHome OTA password (`firmware/greenhouse.yaml`
+`ota:` → `!secret ota_password`). UNLIKE every other Secret here, **no in-cluster
+workload mounts it** — the operator OTA tooling host reads it into `OTA_PW` for
+`make firmware-deploy` / `scripts/firmware-rollback.sh` (espota2 → ESP32
+`192.168.10.111:3232`, run from a greenhouse-LAN host, NEVER a pod). OTA is never part
+of the k3s cutover (`k3s-cutover-sequence.md` DoD #7). Device-affecting and kept
+STANDALONE (like `verdify-esp32-psk`) so a bulk app-secret re-seal can never touch it;
+the value + canonical source + rotate-vs-carry are **Jason-gated** (a rotation implies
+a re-flash, so the default is carry-existing, no re-flash). Sealing procedure:
+`docs/runbooks/firmware-ota-secret-sealing.md`.
 
 `DB_PASS` / `DB_PASSWORD` / `DB_DSN` / `VERDIFY_DB_DSN` are derived in-manifest from
 `POSTGRES_PASSWORD` + the non-secret connection fields in the `verdify-config`
@@ -115,6 +127,7 @@ For a REAL apply, drop the `- *.placeholder.yaml` lines from the overlay's
 | `overlays/prod/secrets.placeholder.yaml` | `verdify-app-secrets` | prod |
 | `overlays/prod/ha-token.placeholder.yaml` | `verdify-ha-token` | prod |
 | `overlays/prod/hermes-secret.placeholder.yaml` | `verdify-hermes` | prod |
+| `overlays/prod/firmware-ota-secret.placeholder.yaml` | `verdify-firmware-ota` | prod |
 
 `verdify-hermes-slack` (optional, non-secret channel config) and
 `ghcr-jvallery-readonly` (image-pull, delivered out-of-band by Root) have no

--- a/deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml
+++ b/deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml
@@ -1,0 +1,52 @@
+# PLACEHOLDER firmware OTA-password Secret for LOCAL VALIDATION ONLY
+# (kustomize build / kubeconform). See docs/runbooks/firmware-ota-secret-sealing.md.
+#
+# THIS IS NOT A REAL CREDENTIAL and MUST NOT be applied to a real cluster. The real
+# verdify-firmware-ota Secret is provided by the fleet SOPS+age secret backend and
+# applied OUT-OF-BAND by the GitOps secret-delivery step (local-k8s-secret-sync) —
+# NEVER by kustomize/ArgoCD from this repo. kustomize cannot decrypt SOPS, so this
+# file exists ONLY so `kustomize build overlays/prod` / kubeconform yield a complete,
+# lint-able manifest in CI.
+#
+# CONSUMER (the reason this is unusual): NO in-cluster workload mounts this Secret.
+# The ESPHome OTA password (firmware/greenhouse.yaml `ota:` -> !secret ota_password)
+# is consumed by the OPERATOR TOOLING HOST that runs `make firmware-deploy` /
+# scripts/firmware-rollback.sh, fed as the OTA_PW env var read from this Secret:
+#   OTA_PW="$(kubectl -n verdify-prod get secret verdify-firmware-ota \
+#       -o jsonpath='{.data.ota_password}' | base64 -d)"
+# OTA flash (espota2 -> 192.168.10.111:3232) runs from that host, NOT a pod. The
+# Secret is the at-rest home of the value; the env feed is its runtime delivery.
+# OTA is NEVER part of the k3s cutover (k3s-cutover-sequence.md DoD #7).
+#
+# DEVICE-AFFECTING: kept as a STANDALONE Secret (NOT folded into verdify-app-secrets)
+# for the same reason verdify-esp32-psk is standalone — a bulk app-secret re-seal must
+# never touch a device-affecting OTA credential. PROD-ONLY: dev/staging are
+# device-dark and never flash, so there is no dev/staging placeholder.
+#
+# LOCAL-CONFIG INVARIANT (#30 contract): config.kubernetes.io/local-config MUST be an
+# ANNOTATION, not a label. `kustomize build` EXCLUDES objects carrying the ANNOTATION
+# from output; as a LABEL it renders into the manifest and an ArgoCD
+# Secret-blacklisted AppProject rejects the whole sync ("synchronization tasks are not
+# valid"). A device-affecting OTA credential placeholder is therefore NEVER emitted
+# into a real-apply manifest. (Mirrors ha-token.placeholder.yaml.)
+#
+# NAMESPACE-MATCH INVARIANT (#30 contract): the registry secret-meta target.namespace
+# (agent-fleet-control/registry/secrets/verdify-firmware-ota.yaml) MUST be
+# byte-identical to this overlay's namespace (verdify-prod), the base Namespace
+# object, and the ArgoCD Application destination.namespace, or the sealed Secret
+# silently never lands.
+#
+# For a real apply, drop the `- firmware-ota-secret.placeholder.yaml` line from this
+# overlay's kustomization.yaml; the sealed Secret is already in-cluster from the
+# out-of-band delivery step (Jason-gated seal — see the runbook §5).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verdify-firmware-ota
+  labels:
+    app.kubernetes.io/part-of: verdify
+  annotations:
+    config.kubernetes.io/local-config: "true"   # excluded from build output
+type: Opaque
+stringData:
+  ota_password: "PLACEHOLDER_NOT_A_REAL_SECRET"

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -30,6 +30,14 @@ resources:
   # ANNOTATION -> EXCLUDED from build output (OpenAI key never emitted). Real
   # verdify-hermes via SOPS out-of-band. See hermes-secret.placeholder.yaml.
   - hermes-secret.placeholder.yaml
+  # PLACEHOLDER firmware OTA-password Secret for local build ONLY. NO pod mounts it:
+  # the operator OTA tooling host reads verdify-firmware-ota/ota_password into OTA_PW
+  # for `make firmware-deploy` / firmware-rollback.sh (espota2 -> :3232, NOT a pod).
+  # Device-affecting, standalone (cf. verdify-esp32-psk), prod-only. local-config
+  # ANNOTATION -> EXCLUDED from build output. Real value via SOPS out-of-band,
+  # Jason-gated. See docs/runbooks/firmware-ota-secret-sealing.md +
+  # firmware-ota-secret.placeholder.yaml.
+  - firmware-ota-secret.placeholder.yaml
   # DEVICE WRITE PATH: the SINGLE egress allow letting the prod ingestor reach the
   # live device VLAN. See allow-ingestor-device-egress.yaml.
   - allow-ingestor-device-egress.yaml

--- a/docs/runbooks/firmware-ota-secret-sealing.md
+++ b/docs/runbooks/firmware-ota-secret-sealing.md
@@ -1,0 +1,317 @@
+# Firmware OTA Secret Sealing + the k3s Firmware Landing Zone
+
+**Status:** PREP / DESIGN ONLY. Nothing here has been sealed, applied, flashed, or
+pushed to a device. This is a path/name/owner/consumer inventory + the operator
+runbook for sealing the ESPHome **OTA password** into the k3s era. No secret value
+is read, echoed, or sealed by authoring this doc.
+**Author:** firmware agent (sandboxed agent pod, RBAC-less, no device/DB/firmware
+secrets — read-and-author only).
+**Scope owner of the artifacts below:** `deploy/k8s/**` + `docs/runbooks/**` are
+SHARED TERRITORY (coordinator/Jason). This doc + the companion
+`deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml` are PROPOSALS the
+coordinator reviews; the device-affecting seal itself is **Jason-gated**.
+
+> **Hard rule observed throughout:** OTA is NEVER part of the k3s cutover sequence
+> (`k3s-cutover-sequence.md` §0 / DoD #7). The control loop, single-writer, and
+> setpoint paths move to k3s; the **OTA flash path stays an operator-host, human-gated
+> action** (`make firmware-deploy`). This doc re-homes the *credential* and the
+> *toolchain* off the dead `.150` VM — it does NOT move flashing into a pod.
+
+---
+
+## 0. TL;DR — what "sealing the OTA password into k3s" actually means
+
+The OTA password (`ota_password`, the ESPHome `ota:` platform password,
+`firmware/greenhouse.yaml:205-207`) is **not consumed by any in-cluster workload**.
+It is read by the operator's **tooling host** when running:
+
+- `make firmware-deploy` → `scripts/firmware-esphome-worktree.sh … upload` (compile + flash)
+- `scripts/firmware-rollback.sh` (auto-rollback on post-OTA sensor-health failure;
+  reads `OTA_PW` env, else parses the legacy `secrets.yaml`)
+
+So "sealing it into k3s" is **NOT** the same shape as `ESP32_API_KEY` /
+`POSTGRES_PASSWORD` (which a pod mounts via `secretKeyRef`). There is **no pod that
+mounts `ota_password`** today and the cutover design never adds one. The seal exists
+so the operator's OTA tooling can **fetch** the credential from one trusted place
+(the cluster) instead of the powered-off `.150` `secrets.yaml`. Concretely it is:
+
+1. a SOPS+age-sealed **k8s Secret `verdify-firmware-ota`** (key `ota_password`) in the
+   `verdify-prod` namespace, delivered by the same fleet GitOps secret-sync the other
+   Verdify secrets use; **and**
+2. an operator step that, on the OTA tooling host (greenhouse-LAN + `kubectl`),
+   reads that Secret into the `OTA_PW` env right before `make firmware-deploy`.
+
+The Secret is the **at-rest home** of the value; the env feed is the **runtime
+delivery** to the espota2 transport. The two pieces are deliberately split so the
+credential is never on a process CLI or in a committed file.
+
+---
+
+## 1. Where the OTA / ESPHome secrets live, and who consumes them
+
+ESPHome's `secrets.yaml` (formerly `/srv/greenhouse/esphome/secrets.yaml` on `.150`)
+holds several keys, but only TWO are real actuation credentials
+(`docs/design/firmware-digital-twin.md:258`):
+
+| ESPHome secret key | Real actuation path | k3s home today | Consumer of the k3s copy |
+|---|---|---|---|
+| `api_encryption_key` (Noise PSK) | aioesphomeapi native-API `:6053` (setpoint/occupancy push + telemetry) | `verdify-app-secrets/ESP32_API_KEY` (`deploy/k8s/SECRETS.md:70`), DRIFTED at the esphome source — sha `df2784f9` vs runtime-canonical `127f85d0` | **ingestor pod** (`secretKeyRef`), prod only |
+| `ota_password` | ESPHome OTA `:3232` (`esphome upload` / `espota2.run_ota`) | **NOT sealed anywhere** (this doc) | **operator tooling host** (`OTA_PW` env), NOT a pod |
+| `wifi_ssid` / `wifi_password` | compile-time only (baked into the build) | not needed in k3s — build-time, lives in the OTA toolchain's `secrets.yaml` | esphome compile on the tooling host |
+| `cloud_mqtt_*`, `ha_bearer_token`, `shelly_em50_url` | not on the device actuation path | sealed elsewhere / ingestor env | n/a for OTA |
+
+The full template is `firmware/secrets.example.yaml` (CI placeholders only).
+
+**Key distinction (and the reason this is its own doc):** the
+`verdify-secret-sealing-plan.md` + `deploy/k8s/SECRETS.md` cover `ESP32_API_KEY` and
+the app secrets — they do **NOT** cover `ota_password`. The `#254` re-home wired the
+`firmware-rollback.sh` `OTA_PW` env hook but explicitly notes "The ota_password is
+NOT yet in any k3s secret; sealing it is device-affecting and GATED on Jason"
+(commit `87f5610`, `scripts/firmware-rollback.sh:19-25`). This doc closes that gap.
+
+---
+
+## 2. What the `firmware-deploy` preflight kube backend needs
+
+`make firmware-deploy` runs `scripts/firmware-deploy-preflight.sh` with
+`VERDIFY_DB_BACKEND=kube` (Makefile default `FIRMWARE_DB_BACKEND ?= kube`,
+`Makefile:38`). The preflight sources `scripts/lib/psql-verdify.sh` and, in
+`kube-exec` mode, runs every DB guard against the live prod DB via:
+
+```
+<VERDIFY_KUBECTL> exec -n verdify-prod verdify-db-0 -c postgres -- \
+    env PGOPTIONS=-c statement_timeout=5000 psql -U verdify -d verdify -t -A -F '|' -c "<guard SQL>"
+```
+
+Knobs (defaults in `psql-verdify.sh:102-105`):
+
+| Env | Default | Meaning |
+|---|---|---|
+| `VERDIFY_KUBECTL` | `kubectl` | the binary OR a multi-token remote driver, word-split. The proven driver for a tooling host without a local kubeconfig is `ssh jason@192.168.30.32 sudo k3s kubectl` (a node with `k3s kubectl`). |
+| `VERDIFY_DB_NAMESPACE` | `verdify-prod` | DB namespace. |
+| `VERDIFY_DB_POD` | `verdify-db-0` | DB pod (StatefulSet). |
+| `VERDIFY_DB_PGCONTAINER` | `postgres` | container with `psql`. |
+
+The guard SQL it runs (read-only, `statement_timeout=5s`): unresolved
+critical/legacy-high alerts (`alert_log`), climate freshness (`climate`),
+`climate_action_log` freshness + decision-proof completeness, 24h forecast max
+(stress-window warning), the `last-good.ota.bin` 48-hour bake mtime check, and the
+weekly-OTA limit (first-seen `diagnostics.firmware_version` this MDT week). All are
+SELECTs — the preflight never writes.
+
+**Reachability the preflight needs:** the tooling host must be able to run
+`VERDIFY_KUBECTL exec` against the in-cluster headless `verdify-db` Service (it is
+ClusterIP/in-cluster only — `psql-verdify.sh:37`). With the `ssh … sudo k3s kubectl`
+driver, the only network requirement is SSH to the k3s node; the node-local kubectl
+reaches the pod. **This was already proven read-only against `verdify-prod`/
+`verdify-db` in `#254`** — the re-homed preflight evaluated every guard and honored
+`statement_timeout=5s` (commit `87f5610`).
+
+---
+
+## 3. What network reachability the actual OTA flash needs (greenhouse-LAN → ESP32)
+
+OTA is the **espota2** TCP transport to the ESP32, NOT the native-API path:
+
+- target: `ESP32_HOST=192.168.10.111`, `ESP32_OTA_PORT=3232`
+  (`scripts/firmware-rollback.sh:17-18`; deploy uses `--device 192.168.10.111`,
+  `Makefile:393` / `ESP32_DEVICE ?= 192.168.10.111`).
+- This is **port 3232**, distinct from the ingestor's native-API **port 6053**.
+- The OTA flash is **NOT issued from a k3s pod.** The
+  `allow-ingestor-device-egress` NetworkPolicy (prod) and the commented `gated-§3.4`
+  egress placeholder only concern the **ingestor's** `:6053` native-API egress
+  (`deploy/k8s/base/networkpolicy.yaml:130-181`,
+  `deploy/k8s/overlays/prod/allow-ingestor-device-egress.yaml`). **No k8s
+  NetworkPolicy governs OTA** because the flash runs from the operator's tooling
+  host, not a pod.
+
+**So OTA reachability is a HOST-network fact, not a cluster fact:** the OTA tooling
+host must sit on (or be routed to) the greenhouse device VLAN `192.168.10.0/24` and
+reach `192.168.10.111:3232`. The cross-VLAN firewall allow that already exists for
+the k3s node → ESP32 `:6053` (per `allow-ingestor-device-egress.yaml` header +
+`docs/design/verdify-final-migration-2026-05-31.md:210`) does **not** automatically
+cover `:3232` from an arbitrary tooling host — the operator runs OTA from a host with
+device-LAN reachability (historically `.150`, now a re-homed toolchain host).
+
+---
+
+## 4. The sealed-Secret shape (in-repo artifact to author)
+
+Mirror the existing `verdify-ha-token` device-affecting Secret pattern
+(`deploy/k8s/overlays/prod/ha-token.placeholder.yaml`) and the `#30` two invariants
+(`deploy/k8s/SECRETS.md`):
+
+- **New secret name:** `verdify-firmware-ota`, key `ota_password`,
+  `target.namespace: verdify-prod`. Kept **standalone** (NOT folded into
+  `verdify-app-secrets`) for the same reason `verdify-esp32-psk` is standalone — so a
+  bulk app-secret re-seal can never touch a device-affecting OTA credential.
+- **prod-ONLY.** dev/staging are device-dark; they never flash. No dev/staging
+  placeholder.
+- **`config.kubernetes.io/local-config` as an ANNOTATION** (never a label) so
+  `kustomize build` renders ZERO `kind: Secret` — the `#30` invariant that caught a
+  real prod leak (`deploy/k8s/SECRETS.md:124-131`).
+- The in-repo file is a **placeholder for `kustomize build`/`kubeconform` only**; the
+  real ciphertext lives in the fleet registry
+  (`agent-fleet-control/secrets/encrypted/verdify-firmware-ota.enc.yaml`) and is
+  applied out-of-band by the GitOps `local-k8s-secret-sync` step.
+
+Companion file authored alongside this doc:
+`deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml` (lint-only stub).
+
+The matching **fleet registry secret-meta** (authored in `agent-fleet-control`, NOT
+this repo) should be:
+
+```yaml
+# agent-fleet-control/registry/secrets/verdify-firmware-ota.yaml  (NO VALUES)
+id: verdify-firmware-ota
+owner: jason                 # device-affecting; Jason confirms canonical value
+target:
+  namespace: verdify-prod    # MUST byte-match the overlay + Namespace + ArgoCD app
+  name: verdify-firmware-ota
+  keys:
+    - k8s_key: ota_password
+      from_source_key: ota_password
+source:
+  # The canonical OTA password source. Jason confirms which is authoritative:
+  #   - the re-homed esphome secrets.yaml on the OTA toolchain host, OR
+  #   - a value Jason supplies directly at seal time.
+  # NEVER seal from a drifted copy (cf. the api_encryption_key df2784f9 drift).
+  nas_path: <jason-confirmed source path>
+  format: dotenv             # or yaml — matches the chosen source file
+```
+
+> **NOTE — `ota_password` is NOT in any dotenv today.** Unlike `ESP32_API_KEY`
+> (which lives in `/srv/verdify/ingestor/.env`), the OTA password lived only in the
+> esphome `secrets.yaml` on the now-powered-off `.150`. So the seal source is a
+> **Jason decision** at seal time (re-homed `secrets.yaml` vs operator-supplied
+> value), not an existing dotenv key. This is a SEAL-TIME input, not a repo change.
+
+---
+
+## 5. Operator runbook — sealing the OTA password (Jason-gated, device-affecting)
+
+Each step is tagged with the ONLY owner who can perform it. Nothing here is run by
+the agent. This is the small, reviewed sequence the in-repo artifacts make turnkey.
+
+### Preconditions (already in-repo or upstream-merged)
+- `deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml` merged (this PR) so
+  `kustomize build overlays/prod` stays complete + lint-able (renders ZERO Secrets).
+- The fleet registry secret-meta `verdify-firmware-ota.yaml` merged in
+  `agent-fleet-control` (James/laptop-root review; NO value).
+- The `local-k8s-secret-sync` workflow `target` enum extended with a
+  `verdify-prod`/`verdify-firmware-ota` arm (laptop-root — same arm work the cutover
+  doc §2.3 calls out for the new namespace).
+
+### Step A — Jason confirms the canonical OTA password `[GATE: Jason]`
+The OTA password value lived only on `.150`'s esphome `secrets.yaml`. Jason confirms
+the authoritative value and its source (re-homed `secrets.yaml` or a value he
+supplies). **Do NOT seal a drifted copy** — the `api_encryption_key` drift (sha
+`df2784f9` vs canonical `127f85d0`) is the cautionary precedent.
+Confirm: rotate-at-seal vs carry-existing. **A rotation requires a re-flash**
+(the device's `ota:` password is compiled in), which is a full firmware-deploy under
+the freeze rules — so the default is **carry-existing** (seal the value the live
+device already accepts; no re-flash).
+
+### Step B — laptop-root seals the value `[GATE: laptop-root]`
+From the `agent-fleet-control` repo root, pipe-only (value never on the CLI), same
+shape as `verdify-secret-sealing-plan.md §2`:
+
+```bash
+scripts/seal-secret.sh verdify-firmware-ota \
+    --remote jason@vm-docker-iris.servers.vallery.net   # or the re-homed source host
+# -> commits ONLY ciphertext secrets/encrypted/verdify-firmware-ota.enc.yaml
+```
+Seal by **explicit id** — never `--all` (it would attempt the device-affecting
+credential alongside blocked app keys).
+
+### Step C — laptop-root syncs the Secret into the cluster `[GATE: laptop-root]`
+Run the protected `local-k8s-secret-sync` workflow for the `verdify-prod` /
+`verdify-firmware-ota` arm. It SOPS-decrypts on the self-hosted runner and
+`kubectl apply`s the namespaced Secret. Verify:
+`kubectl -n verdify-prod get secret verdify-firmware-ota -o jsonpath='{.data.ota_password}' | base64 -d | wc -c`
+returns a non-zero length (length only — never echo the value).
+
+### Step D — operator feeds `OTA_PW` at deploy time `[GATE: Jason / operator]`
+On the OTA tooling host (greenhouse-LAN + `kubectl` reach), right before a deploy:
+
+```bash
+export OTA_PW="$(<VERDIFY_KUBECTL> -n verdify-prod get secret verdify-firmware-ota \
+    -o jsonpath='{.data.ota_password}' | base64 -d)"
+# <VERDIFY_KUBECTL> may be `kubectl` or `ssh jason@192.168.30.32 sudo k3s kubectl`
+make firmware-deploy        # preflight (kube DB backend) + compile + upload
+#   firmware-rollback.sh consumes the same OTA_PW on auto-rollback
+```
+`firmware-rollback.sh` prefers `OTA_PW` and only falls back to parsing a local
+`secrets.yaml` (`scripts/firmware-rollback.sh:24,45-60`) — so once `OTA_PW` is fed,
+the dead `.150` `secrets.yaml` is no longer on the critical path for rollback.
+
+### Step E — re-home the OTA toolchain (separate gate, see §6)
+`make firmware-deploy` ALSO needs the ESPHome toolchain (`ESPHOME_BIN`,
+`SECRETS_SRC` for the *build-time* wifi/api keys) — that is a host re-home, distinct
+from the OTA-password seal. See §6.
+
+---
+
+## 6. The OTA toolchain re-home (the OTHER half of the landing zone)
+
+Sealing `ota_password` is necessary but NOT sufficient to deploy firmware. The
+`.150` VM also held the ESPHome toolchain + build-time secrets. Two host
+dependencies, both gated on a re-homed tooling host:
+
+| Dependency | Hard-coded default | Re-home env knob | Used by |
+|---|---|---|---|
+| `esphome` binary | `/srv/greenhouse/.venv/bin/esphome` | `ESPHOME_BIN` (`firmware-esphome-worktree.sh:15`, `stage-rollback-floor-refresh.sh:41`) | compile + `upload` |
+| esphome `secrets.yaml` (build-time `wifi_*`, `api_encryption_key`) | `/srv/greenhouse/esphome/secrets.yaml` | `SECRETS_SRC` (`firmware-esphome-worktree.sh:16`) | compile (symlinked to `firmware/secrets.yaml`) |
+| esphome-capable python (espota2) | `/srv/greenhouse/.venv/bin/python` → `python3` | `FIRMWARE_PYTHON` (`firmware-rollback.sh:70-77`) | OTA rollback flash |
+| OTA password | legacy `secrets.yaml` `ota_password` | `OTA_PW` (this doc, §5) | OTA flash + rollback |
+
+The rollback-floor itself is stale and `.150`-bound — `#256` staged the refresh
+(`scripts/stage-rollback-floor-refresh.sh`), but its `PROMOTE=1` path is GATED on
+exactly this toolchain re-home (it needs `ESPHOME_BIN` + `SECRETS_SRC` to recompile
+the floor build; it dry-runs and reports both gates otherwise).
+
+**Re-home options (Jason / laptop-root decision — upstream of this repo):**
+1. **A re-homed tooling VM/host** with device-LAN reachability + the esphome venv +
+   `secrets.yaml`, run `make firmware-deploy` there with `OTA_PW` fed from the
+   sealed Secret (§5). Lowest-change: the existing scripts work unchanged via the
+   `ESPHOME_BIN`/`SECRETS_SRC`/`FIRMWARE_PYTHON`/`OTA_PW` env knobs.
+2. **A one-shot in-cluster OTA Job** scheduled onto a node with device-LAN
+   reachability, mounting `verdify-firmware-ota` + a build-time esphome secret, with
+   an egress NetworkPolicy to `192.168.10.111:3232`. This is a BIGGER change (new
+   image with the esphome toolchain, a new egress allow, an OTA-from-pod posture the
+   cutover doc deliberately avoided) and should NOT be the first move — it is a
+   future option, explicitly out of scope here. The freeze rule "CI never
+   flashes/OTAs" still holds (a Job is not CI, but it is the same "no automated
+   flash" spirit — it stays human-triggered + Jason-gated).
+
+---
+
+## 7. Self-serviceable vs upstream-required (classification)
+
+**Self-serviceable (in-repo, this agent can author + push):**
+- This runbook (`docs/runbooks/firmware-ota-secret-sealing.md`) — SHARED TERRITORY,
+  coordinator-reviewed, but authorable.
+- The placeholder Secret stub
+  `deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml` + its
+  `kustomization.yaml` `resources:` line — SHARED TERRITORY, coordinator-reviewed.
+- An update to `deploy/k8s/SECRETS.md` adding the `verdify-firmware-ota` row.
+
+**Upstream-required (human / cluster-admin / Jason grant — cannot self-serve):**
+- The **actual OTA password value** + the canonical-source decision + rotate-vs-carry
+  + the confirmation that no re-flash happens — **Jason** (device-affecting).
+- Running `seal-secret.sh` + `local-k8s-secret-sync` on the protected runner —
+  **laptop-root**.
+- The fleet registry secret-meta `verdify-firmware-ota.yaml` — **James/laptop-root**
+  (it lives in `agent-fleet-control`, a different repo).
+- The OTA **toolchain re-home host** (esphome venv + build-time `secrets.yaml` +
+  device-LAN reachability) — **Jason/laptop-root**.
+- The `local-k8s-secret-sync` `target` enum arm for `verdify-prod` — **laptop-root**.
+
+---
+
+## 8. What this doc does NOT do
+- No secret value read/echoed/sealed. No `seal-secret.sh` / `kubectl` / sync run.
+- No device touch: no OTA, no flash, no re-flash, no setpoint, no native-API session.
+- No firewall/router/VLAN change. No NetworkPolicy edit.
+- No firmware OTA path added to CI or to the k3s cutover. OTA stays the operator-host,
+  human-gated `make firmware-deploy` path (freeze rule #7 / DoD #7).


### PR DESCRIPTION
Turnkey artifacts for **#301** (seal the ESP32 OTA password into k3s — the hard blocker for all firmware OTA).

## What this adds
- `docs/runbooks/firmware-ota-secret-sealing.md` — full operator sealing runbook.
- `deploy/k8s/overlays/prod/firmware-ota-secret.placeholder.yaml` — **lint-only** shape (`config.kubernetes.io/local-config` → excluded from kustomize build output, **never synced to the cluster**).
- `deploy/k8s/SECRETS.md` + `overlays/prod/kustomization.yaml` — document the standalone `verdify-firmware-ota` secret. **No pod mounts it**; the operator OTA tooling host reads `ota_password` into `OTA_PW` for `make firmware-deploy` / `firmware-rollback.sh` (espota2 → ESP32 `192.168.10.111:3232`, from a greenhouse-LAN host, never a pod).

## Why a PR (not direct)
`deploy/k8s/**` + `SECRETS.md` are **coordinator/shared territory**. This is `requested-by: firmware`, authored from the 2026-06-09 deploy-capability map. Zero runtime effect: the placeholder is excluded from build output and no workload references the secret.

## Residual (human-only, Jason-gated)
Confirm the canonical OTA password value + carry-vs-rotate (a rotate implies a re-flash the freeze rules forbid casually); laptop-root runs the SOPS+age seal. Tracked in #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)