### PR TITLE
docs(backlog): point cycle index at the 2026-06-09 unified replan

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,5 +1,13 @@
 # Backlog — Cycle Index
 
+> **CANONICAL TRACKING (2026-06-09 full replan):** the authoritative live backlog is now
+> GitHub Issues + Org Project **"Iris / Verdify" #1**, rolled up under epic **#286**.
+> The written replan is [`docs/verdify-backlog-replan-2026-06-09.md`](verdify-backlog-replan-2026-06-09.md)
+> (per-issue triage, milestone map, workstreams) with control diagnoses in
+> [`docs/voice-memo-triage-2026-06-09.md`](voice-memo-triage-2026-06-09.md). Greenhouse control
+> work = epic **#287** (req A–E); deploy/agent enablement = epic **#288**. The per-agent
+> `docs/backlog/*.md` files below predate this replan and are historical reference.
+
 Per-agent backlogs live in `docs/backlog/{agent}.md`. This file is the index + "who's on what this cycle."
 
 ## Verdify refocus command (2026-05-15)


### PR DESCRIPTION
Adds a canonical-tracking banner to `docs/BACKLOG.md` pointing at the 2026-06-09 unified replan: GitHub Issues + Org Project "Iris / Verdify" #1 (roll-up epic #286; control work #287; deploy enablement #288), with the written replan + voice-memo triage docs. Marks the per-agent `docs/backlog/*.md` as historical. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)