### PR TITLE
Dashboards v2: solar-noon band alignment, zone + delta panels, gh_* telemetry, query caching

### DIFF
--- a/db/migrations/165-band-solar-noon-repoint.sql
+++ b/db/migrations/165-band-solar-noon-repoint.sql
@@ -1,0 +1,135 @@
+-- 165-band-solar-noon-repoint.sql
+-- ============================================================================
+-- Re-point the served house band onto the firmware-v2 deterministic solar
+-- curve so the dashboard band (and the legacy dispatcher band) peak at SOLAR
+-- NOON, matching the firmware on-chip band — fixes the ~2h offset the owner
+-- sees on the Temp/VPD compliance panels.
+--
+-- ROOT CAUSE (audited 2026-06-11): fn_center_band_setpoints shapes its diurnal
+-- curve via fn_diurnal_interp(target_ts, night, day), which sets
+-- `peak := solar_noon + 2.0` ("thermal lag"). That +2h pushes the band peak to
+-- ~15:00 MDT while solar noon (and the firmware on-chip band, and the solar
+-- actuals) peak at ~13:00. fn_crop_band_value('house', series, ts) [migration
+-- 164] is the exact mirror of firmware greenhouse_solar.h band_value_at_phase()
+-- at this site (lat 40.167, lon -105.102) and peaks at solar noon with no +2h.
+--
+-- This CREATE OR REPLACE keeps the (temp_low, temp_high, vpd_low, vpd_high)
+-- OUT signature UNCHANGED — every one of the 30+ consumers (fn_band_timeline,
+-- fn_house_vpd_control_band, the panels) is non-breaking. The firmware already
+-- runs solar-noon-anchored (sw_onchip_band_enabled on-chip band, OTA'd
+-- 2026-06-11), and ignores the dispatcher's pushed band, so removing the +2h
+-- from the served band changes the dashboard (correct) and the now-inert legacy
+-- push (no control effect).
+--
+-- The old crop_target_profiles endpoint read is kept ONLY as a COALESCE
+-- last-resort fallback (if the house crop_band_anchors rows are ever missing),
+-- so the band is never NULL.
+--
+-- SAFETY: non-self-transactional (CREATE OR REPLACE only). Rollback-validate by
+-- wrapping in an outer BEGIN; ... ROLLBACK;. Idempotent.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_center_band_setpoints(target_ts timestamp with time zone)
+ RETURNS TABLE(temp_low double precision, temp_high double precision, vpd_low double precision, vpd_high double precision)
+ LANGUAGE plpgsql
+ STABLE ROWS 1
+AS $function$
+DECLARE
+    v_season text;
+    night_tl double precision; night_th double precision; night_vl double precision; night_vh double precision;
+    day_tl double precision; day_th double precision; day_vl double precision; day_vh double precision;
+    -- firmware-v2 deterministic band (solar-noon-anchored, fn_crop_band_value)
+    band_tl double precision; band_th double precision; band_vl double precision; band_vh double precision;
+BEGIN
+    v_season := fn_current_season();
+
+    -- ── PRIMARY: the firmware-v2 deterministic house band (solar-phase) ──────
+    -- Exact mirror of the on-chip band the ESP32 enforces. Peaks at solar noon.
+    band_tl := fn_crop_band_value('house', 'temp_low',  target_ts);
+    band_th := fn_crop_band_value('house', 'temp_high', target_ts);
+    band_vl := fn_crop_band_value('house', 'vpd_low',   target_ts);
+    band_vh := fn_crop_band_value('house', 'vpd_high',  target_ts);
+
+    -- ── FALLBACK endpoints from the active orchid (center) profile rows ──────
+    -- Only used if the house anchors are missing (band_* NULL). Keeps the
+    -- legacy day/night-endpoint + fn_diurnal_interp shape as a safety net so no
+    -- hour ever returns NULL.
+    IF band_tl IS NULL OR band_th IS NULL OR band_vl IS NULL OR band_vh IS NULL THEN
+        SELECT avg(p.temp_ideal_min) FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+               avg(p.temp_ideal_max) FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+               avg(p.vpd_ideal_min)  FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+               avg(p.vpd_ideal_max)  FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+               avg(p.temp_ideal_min) FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+               avg(p.temp_ideal_max) FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+               avg(p.vpd_ideal_min)  FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+               avg(p.vpd_ideal_max)  FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15)
+          INTO night_tl, night_th, night_vl, night_vh, day_tl, day_th, day_vl, day_vh
+          FROM crop_target_profiles p
+          JOIN crops c ON c.crop_catalog_id = p.crop_catalog_id
+                      AND c.is_active
+                      AND c.greenhouse_id = p.greenhouse_id
+         WHERE p.crop_catalog_id = 9            -- orchid
+           AND p.greenhouse_id = 'vallery'
+           AND p.season = v_season;
+
+        IF night_tl IS NULL OR day_tl IS NULL THEN
+            SELECT avg(p.temp_ideal_min) FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+                   avg(p.temp_ideal_max) FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+                   avg(p.vpd_ideal_min)  FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+                   avg(p.vpd_ideal_max)  FILTER (WHERE p.hour_of_day BETWEEN 0 AND 5),
+                   avg(p.temp_ideal_min) FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+                   avg(p.temp_ideal_max) FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+                   avg(p.vpd_ideal_min)  FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15),
+                   avg(p.vpd_ideal_max)  FILTER (WHERE p.hour_of_day BETWEEN 13 AND 15)
+              INTO night_tl, night_th, night_vl, night_vh, day_tl, day_th, day_vl, day_vh
+              FROM crop_target_profiles p
+              JOIN crops c ON c.crop_catalog_id = p.crop_catalog_id
+                          AND c.is_active
+                          AND c.greenhouse_id = p.greenhouse_id
+             WHERE p.crop_catalog_id = 9
+               AND p.greenhouse_id = 'vallery'
+               AND p.season = 'spring';
+        END IF;
+
+        night_tl := COALESCE(night_tl, 61.0); night_th := COALESCE(night_th, 67.0);
+        night_vl := COALESCE(night_vl, 0.75);  night_vh := COALESCE(night_vh, 0.85);
+        day_tl   := COALESCE(day_tl, 77.4);    day_th   := COALESCE(day_th, 87.3);
+        day_vl   := COALESCE(day_vl, 0.94);    day_vh   := COALESCE(day_vh, 1.19);
+
+        band_tl := COALESCE(band_tl, fn_diurnal_interp(target_ts, night_tl, day_tl));
+        band_th := COALESCE(band_th, fn_diurnal_interp(target_ts, night_th, day_th));
+        band_vl := COALESCE(band_vl, fn_diurnal_interp(target_ts, night_vl, day_vl));
+        band_vh := COALESCE(band_vh, fn_diurnal_interp(target_ts, night_vh, day_vh));
+    END IF;
+
+    temp_low  := band_tl;
+    temp_high := band_th;
+    vpd_low   := band_vl;
+    vpd_high  := band_vh;
+    RETURN NEXT;
+END;
+$function$;
+
+DO $$
+DECLARE
+    peak_hour integer;
+    v_noon double precision;
+BEGIN
+    -- Verify the band now peaks at SOLAR NOON (~13:00 MDT), not 15:00.
+    SELECT hr INTO peak_hour
+    FROM (
+        SELECT h.hr,
+               (fn_center_band_setpoints(
+                   (date_trunc('day', now() AT TIME ZONE 'America/Denver') + (h.hr || ' hours')::interval)
+                   AT TIME ZONE 'America/Denver')).temp_high AS th
+        FROM generate_series(0, 23) h(hr)
+    ) s
+    ORDER BY th DESC NULLS LAST
+    LIMIT 1;
+    v_noon := (fn_solar_sunrise_hour(now()) + fn_solar_sunset_hour(now())) / 2.0;
+    RAISE NOTICE 'migration 165 OK: band temp_high peaks at hour % (solar noon ~%h). Expect peak within 1h of solar noon.',
+        peak_hour, round(v_noon::numeric, 1);
+    IF peak_hour > round(v_noon)::int + 1 OR peak_hour < round(v_noon)::int - 1 THEN
+        RAISE WARNING 'migration 165: band peak hour % is >1h from solar noon %h — review fn_crop_band_value house anchors', peak_hour, round(v_noon::numeric,1);
+    END IF;
+END $$;

--- a/db/migrations/166-firmware-v2-telemetry-columns.sql
+++ b/db/migrations/166-firmware-v2-telemetry-columns.sql
@@ -1,0 +1,209 @@
+-- 166-firmware-v2-telemetry-columns.sql
+-- =============================================================================
+-- Firmware v2 (#327): land the on-chip telemetry the ESP32 now publishes so the
+-- dashboards-v2 solar-band panels can graph the per-zone target/delta lines and
+-- the house thermal/VPD band that the firmware enforces on-chip (OTA'd
+-- 2026-06-11). This is the DB-side data layer only — the new ESPHome object_ids
+-- already flow off the chip; the ingestor mapping lands alongside this migration
+-- (ingestor/entity_map.py), and the dashboards consume the columns.
+--
+-- WHAT THE CHIP PUBLISHES (firmware/greenhouse/hardware.yaml "Firmware-v2
+-- EVIDENCE SURFACE"):
+--   NUMERIC (sensor, published every 60s) -> climate columns:
+--     gh_solar_phase            -> solar_phase          (dimensionless [0,4))
+--     gh_solar_sunrise_min      -> solar_sunrise_min    (minutes, local)
+--     gh_solar_noon_min         -> solar_noon_min       (minutes, local)
+--     gh_solar_sunset_min       -> solar_sunset_min     (minutes, local)
+--     gh_house_temp_target      -> house_temp_target_f  (°F)
+--     gh_house_temp_delta       -> house_temp_delta_f   (°F)
+--     gh_house_vpd_target       -> house_vpd_target     (kPa)
+--     gh_house_vpd_delta        -> house_vpd_delta      (kPa)
+--     gh_zone_vpd_target_{zone} -> vpd_target_{zone}    (kPa; center/south/west/east)
+--     gh_zone_vpd_delta_{zone}  -> vpd_delta_{zone}     (kPa; center/south/west/east)
+--   TEXT (text_sensor, publish-on-change) -> diagnostics columns:
+--     gh_zone_wet_granted       -> zone_wet_granted     (which zone the arbiter wet)
+--     gh_band_source            -> band_source          (on-chip solar curve vs other)
+--
+-- Live table shapes (inspected on dev — a nightly prod replica — 2026-06-11):
+--   climate:      TimescaleDB hypertable. Gains 16 nullable numeric columns.
+--   diagnostics:  TimescaleDB hypertable. Gains 2 nullable text columns.
+--   sensor_registry: PK (sensor_id); columns sensor_id, entity_id, type, zone,
+--     position, source_table, source_column, unit, expected_interval_s (NOT NULL,
+--     CHECK > 0), active (default true), notes, ... . Convention observed live:
+--     sensor_id = 'climate.<col>' for climate rows and 'diag.<col>' for
+--     diagnostics rows; entity_id = the ESPHome object_id (sanitized friendly
+--     NAME, not the YAML id:). 18 registry rows are inserted (16 numeric + 2
+--     text) so the staleness/coverage tooling tracks the new surfaces.
+--
+-- Compressed-hypertable note: every ADD COLUMN below is nullable with NO
+-- default — metadata-only, which TimescaleDB permits on hypertables with
+-- compressed chunks (no chunk rewrite). No new indexes: the columns are sparse
+-- until the ingestor mapping is live, and dashboard access paths stay (ts) via
+-- the existing hypertable indexes.
+--
+-- #23 rollback-replay safety: NON-self-transactional — no top-level
+-- BEGIN;/COMMIT; and no commit-forcing statement (plain ALTER TABLE ... ADD
+-- COLUMN / INSERT / COMMENT are all transactional). SAFE to wrap in an outer
+-- `BEGIN; ... ROLLBACK;` for rollback validation. Idempotent: ADD COLUMN IF NOT
+-- EXISTS + INSERT ... ON CONFLICT (sensor_id) DO NOTHING.
+--
+-- RESTARTS (CLAUDE.md rule 7): this migration does not touch verdify_schemas/**,
+-- ingestor/entity_map.py, or mcp/server.py — no restart obligation from the SQL
+-- itself. (The companion entity_map.py change in this PR carries its own
+-- restart note: bounce verdify-ingestor so the new CLIMATE_MAP/DIAGNOSTIC_MAP
+-- entries load at startup.)
+--
+-- ROLLBACK (documented; for a disposable validation DB, never live):
+--   ALTER TABLE public.diagnostics DROP COLUMN IF EXISTS band_source;
+--   ALTER TABLE public.diagnostics DROP COLUMN IF EXISTS zone_wet_granted;
+--   ALTER TABLE public.climate DROP COLUMN IF EXISTS vpd_delta_east;
+--   ... (each climate column) ...
+--   DELETE FROM public.sensor_registry WHERE sensor_id IN (
+--     'climate.solar_phase', ..., 'diag.zone_wet_granted', 'diag.band_source');
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 166.1  climate: 16 firmware-v2 numeric telemetry columns (all nullable)
+-- ─────────────────────────────────────────────────────────────────────
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS solar_phase        double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS solar_sunrise_min  integer;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS solar_noon_min     integer;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS solar_sunset_min   integer;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS house_temp_target_f double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS house_temp_delta_f  double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS house_vpd_target   double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS house_vpd_delta    double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_target_center  double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_target_south   double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_target_west    double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_target_east    double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_delta_center   double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_delta_south    double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_delta_west     double precision;
+ALTER TABLE public.climate ADD COLUMN IF NOT EXISTS vpd_delta_east     double precision;
+
+COMMENT ON COLUMN public.climate.solar_phase IS
+'Firmware-v2 on-chip solar phase in [0,4): 0=sunrise, 1=solar noon, 2=sunset, '
+'3=solar midnight (contract B1). Mirror of fn_solar_phase().';
+COMMENT ON COLUMN public.climate.solar_sunrise_min IS
+'Firmware-v2 sunrise time, minutes after local midnight (America/Denver).';
+COMMENT ON COLUMN public.climate.solar_noon_min IS
+'Firmware-v2 solar-noon time, minutes after local midnight (America/Denver).';
+COMMENT ON COLUMN public.climate.solar_sunset_min IS
+'Firmware-v2 sunset time, minutes after local midnight (America/Denver).';
+COMMENT ON COLUMN public.climate.house_temp_target_f IS
+'Firmware-v2 on-chip house thermal band target (°F) at the current solar phase.';
+COMMENT ON COLUMN public.climate.house_temp_delta_f IS
+'Firmware-v2 on-chip house thermal band half-width (°F): band = target -/+ delta.';
+COMMENT ON COLUMN public.climate.house_vpd_target IS
+'Firmware-v2 on-chip house VPD band target (kPa) at the current solar phase.';
+COMMENT ON COLUMN public.climate.house_vpd_delta IS
+'Firmware-v2 on-chip house VPD band half-width (kPa): band = target -/+ delta.';
+COMMENT ON COLUMN public.climate.vpd_target_center IS
+'Firmware-v2 on-chip center-zone VPD target (kPa) at the current solar phase.';
+COMMENT ON COLUMN public.climate.vpd_target_south IS
+'Firmware-v2 on-chip south-zone VPD target (kPa) at the current solar phase.';
+COMMENT ON COLUMN public.climate.vpd_target_west IS
+'Firmware-v2 on-chip west-zone VPD target (kPa) at the current solar phase.';
+COMMENT ON COLUMN public.climate.vpd_target_east IS
+'Firmware-v2 on-chip east-zone VPD target (kPa) at the current solar phase.';
+COMMENT ON COLUMN public.climate.vpd_delta_center IS
+'Firmware-v2 on-chip center-zone VPD band half-width (kPa).';
+COMMENT ON COLUMN public.climate.vpd_delta_south IS
+'Firmware-v2 on-chip south-zone VPD band half-width (kPa).';
+COMMENT ON COLUMN public.climate.vpd_delta_west IS
+'Firmware-v2 on-chip west-zone VPD band half-width (kPa).';
+COMMENT ON COLUMN public.climate.vpd_delta_east IS
+'Firmware-v2 on-chip east-zone VPD band half-width (kPa).';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 166.2  diagnostics: 2 firmware-v2 text telemetry columns (nullable)
+-- ─────────────────────────────────────────────────────────────────────
+ALTER TABLE public.diagnostics ADD COLUMN IF NOT EXISTS zone_wet_granted text;
+ALTER TABLE public.diagnostics ADD COLUMN IF NOT EXISTS band_source      text;
+
+COMMENT ON COLUMN public.diagnostics.zone_wet_granted IS
+'Firmware-v2 evidence surface: which zone the priority arbiter granted wetting '
+'to this cycle (or none).';
+COMMENT ON COLUMN public.diagnostics.band_source IS
+'Firmware-v2 evidence surface: source of the served band (on-chip solar curve '
+'vs other).';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 166.3  sensor_registry: 18 rows (16 numeric climate + 2 text diagnostics).
+--   sensor_id   = '<prefix>.<source_column>' ('climate.' / 'diag.' per the live
+--                 convention); the natural key for ON CONFLICT.
+--   entity_id   = the ESPHome object_id (sanitized friendly NAME).
+--   zone        = NULL for house/solar; center/south/west/east for zone bands.
+--   expected_interval_s = 60 for the every-60s numeric sensors; 604800 for the
+--                 publish-on-change text sensors (matches the system_state text
+--                 convention so the staleness monitor does not false-alarm).
+-- ─────────────────────────────────────────────────────────────────────
+INSERT INTO public.sensor_registry
+    (sensor_id, entity_id, type, zone, source_table, source_column, unit, expected_interval_s, active, notes)
+VALUES
+    ('climate.solar_phase',        'solar_phase',               'derived',     NULL,     'climate', 'solar_phase',        NULL,  60, true, 'Firmware-v2 #327 on-chip solar phase [0,4)'),
+    ('climate.solar_sunrise_min',  'solar_sunrise__min_local_', 'derived',     NULL,     'climate', 'solar_sunrise_min',  'min', 60, true, 'Firmware-v2 #327 on-chip sunrise (min local)'),
+    ('climate.solar_noon_min',     'solar_noon__min_local_',    'derived',     NULL,     'climate', 'solar_noon_min',     'min', 60, true, 'Firmware-v2 #327 on-chip solar noon (min local)'),
+    ('climate.solar_sunset_min',   'solar_sunset__min_local_',  'derived',     NULL,     'climate', 'solar_sunset_min',   'min', 60, true, 'Firmware-v2 #327 on-chip sunset (min local)'),
+    ('climate.house_temp_target_f','house_temp_target_f',       'temperature', NULL,     'climate', 'house_temp_target_f','°F',  60, true, 'Firmware-v2 #327 on-chip house temp band target'),
+    ('climate.house_temp_delta_f', 'house_temp_delta_f',        'temperature', NULL,     'climate', 'house_temp_delta_f', '°F',  60, true, 'Firmware-v2 #327 on-chip house temp band half-width'),
+    ('climate.house_vpd_target',   'house_vpd_target_kpa',      'vpd',         NULL,     'climate', 'house_vpd_target',   'kPa', 60, true, 'Firmware-v2 #327 on-chip house VPD band target'),
+    ('climate.house_vpd_delta',    'house_vpd_delta_kpa',       'vpd',         NULL,     'climate', 'house_vpd_delta',    'kPa', 60, true, 'Firmware-v2 #327 on-chip house VPD band half-width'),
+    ('climate.vpd_target_center',  'zone_vpd_target_center',    'vpd',         'center', 'climate', 'vpd_target_center',  'kPa', 60, true, 'Firmware-v2 #327 on-chip center-zone VPD target'),
+    ('climate.vpd_target_south',   'zone_vpd_target_south',     'vpd',         'south',  'climate', 'vpd_target_south',   'kPa', 60, true, 'Firmware-v2 #327 on-chip south-zone VPD target'),
+    ('climate.vpd_target_west',    'zone_vpd_target_west',      'vpd',         'west',   'climate', 'vpd_target_west',    'kPa', 60, true, 'Firmware-v2 #327 on-chip west-zone VPD target'),
+    ('climate.vpd_target_east',    'zone_vpd_target_east',      'vpd',         'east',   'climate', 'vpd_target_east',    'kPa', 60, true, 'Firmware-v2 #327 on-chip east-zone VPD target'),
+    ('climate.vpd_delta_center',   'zone_vpd_delta_center',     'vpd',         'center', 'climate', 'vpd_delta_center',   'kPa', 60, true, 'Firmware-v2 #327 on-chip center-zone VPD band half-width'),
+    ('climate.vpd_delta_south',    'zone_vpd_delta_south',      'vpd',         'south',  'climate', 'vpd_delta_south',    'kPa', 60, true, 'Firmware-v2 #327 on-chip south-zone VPD band half-width'),
+    ('climate.vpd_delta_west',     'zone_vpd_delta_west',       'vpd',         'west',   'climate', 'vpd_delta_west',     'kPa', 60, true, 'Firmware-v2 #327 on-chip west-zone VPD band half-width'),
+    ('climate.vpd_delta_east',     'zone_vpd_delta_east',       'vpd',         'east',   'climate', 'vpd_delta_east',     'kPa', 60, true, 'Firmware-v2 #327 on-chip east-zone VPD band half-width'),
+    ('diag.zone_wet_granted',      'zone_wet_granted',          'diagnostic',  NULL,     'diagnostics', 'zone_wet_granted', 'text', 604800, true, 'Firmware-v2 #327 evidence: zone granted wetting'),
+    ('diag.band_source',           'band_source',               'diagnostic',  NULL,     'diagnostics', 'band_source',      'text', 604800, true, 'Firmware-v2 #327 evidence: served band source')
+ON CONFLICT (sensor_id) DO NOTHING;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 166.4  Verification: 16 climate cols + 2 diagnostics cols + 18 registry rows.
+-- ─────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+    n_climate int;
+    n_diag    int;
+    n_reg     int;
+BEGIN
+    SELECT count(*) INTO n_climate
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'climate'
+       AND column_name IN
+           ('solar_phase','solar_sunrise_min','solar_noon_min','solar_sunset_min',
+            'house_temp_target_f','house_temp_delta_f','house_vpd_target','house_vpd_delta',
+            'vpd_target_center','vpd_target_south','vpd_target_west','vpd_target_east',
+            'vpd_delta_center','vpd_delta_south','vpd_delta_west','vpd_delta_east');
+    IF n_climate <> 16 THEN
+        RAISE EXCEPTION 'migration 166: climate firmware-v2 columns incomplete (found %/16)', n_climate;
+    END IF;
+
+    SELECT count(*) INTO n_diag
+      FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'diagnostics'
+       AND column_name IN ('zone_wet_granted','band_source')
+       AND data_type = 'text';
+    IF n_diag <> 2 THEN
+        RAISE EXCEPTION 'migration 166: diagnostics firmware-v2 text columns incomplete (found %/2)', n_diag;
+    END IF;
+
+    SELECT count(*) INTO n_reg
+      FROM public.sensor_registry
+     WHERE sensor_id IN
+           ('climate.solar_phase','climate.solar_sunrise_min','climate.solar_noon_min',
+            'climate.solar_sunset_min','climate.house_temp_target_f','climate.house_temp_delta_f',
+            'climate.house_vpd_target','climate.house_vpd_delta','climate.vpd_target_center',
+            'climate.vpd_target_south','climate.vpd_target_west','climate.vpd_target_east',
+            'climate.vpd_delta_center','climate.vpd_delta_south','climate.vpd_delta_west',
+            'climate.vpd_delta_east','diag.zone_wet_granted','diag.band_source');
+    IF n_reg <> 18 THEN
+        RAISE EXCEPTION 'migration 166: sensor_registry firmware-v2 rows incomplete (found %/18)', n_reg;
+    END IF;
+
+    RAISE NOTICE 'migration 166 OK: climate(16 numeric) + diagnostics(zone_wet_granted, band_source) columns present; sensor_registry has 18 firmware-v2 rows.';
+END $$;

--- a/db/migrations/167-band-curve-matview-cache.sql
+++ b/db/migrations/167-band-curve-matview-cache.sql
@@ -1,0 +1,64 @@
+-- 167-band-curve-matview-cache.sql
+-- ============================================================================
+-- Cache the deterministic solar band + per-zone VPD target curves in a
+-- materialized view so the Grafana compliance panels read pre-computed rows
+-- instead of calling fn_crop_band_value / fn_zone_vpd_targets live per render
+-- (each call runs a 30-iteration sunrise/sunset bisection; the 144h panel
+-- queries were ~1-2s). The curves are pure-deterministic (functions of solar
+-- phase + the crop_band_anchors), so a periodic refresh is exact.
+--
+-- mv_band_curve covers a WIDE window (now-4d .. now+4d) at 15-min resolution so
+-- it serves the dashboards' default now-72h..now+72h view plus zoom headroom.
+-- A k8s CronJob (deploy/k8s/components/grafana/band-curve-refresh-cronjob.yaml)
+-- runs REFRESH MATERIALIZED VIEW CONCURRENTLY every 10 min — independent of the
+-- ingestor (whose mv_zone_band_grade refresh is unreliable on prod).
+--
+-- v_band_curve is the stable read surface the panels query (time-filtered).
+--
+-- SAFETY: non-self-transactional (CREATE MATERIALIZED VIEW / VIEW / INDEX, no
+-- COMMIT). The CREATE MATERIALIZED VIEW ... WITH DATA populates once inline.
+-- Idempotent via DROP ... IF EXISTS guards. Rollback-validate under an outer
+-- BEGIN; ... ROLLBACK;.
+-- ============================================================================
+
+DROP MATERIALIZED VIEW IF EXISTS mv_band_curve CASCADE;
+
+CREATE MATERIALIZED VIEW mv_band_curve AS
+SELECT
+    g.ts AS ts,
+    'vallery'::text AS greenhouse_id,
+    fn_crop_band_value('house', 'temp_low',    g.ts) AS temp_low,
+    fn_crop_band_value('house', 'temp_target', g.ts) AS temp_target,
+    fn_crop_band_value('house', 'temp_high',   g.ts) AS temp_high,
+    fn_crop_band_value('house', 'vpd_low',     g.ts) AS vpd_low,
+    fn_crop_band_value('house', 'vpd_target',  g.ts) AS vpd_target,
+    fn_crop_band_value('house', 'vpd_high',    g.ts) AS vpd_high,
+    z.vpd_target_center,
+    z.vpd_target_south,
+    z.vpd_target_west,
+    z.vpd_target_east,
+    fn_solar_phase(g.ts) AS solar_phase
+FROM generate_series(
+        date_trunc('hour', now()) - interval '4 days',
+        date_trunc('hour', now()) + interval '4 days',
+        interval '15 minutes') g(ts)
+CROSS JOIN LATERAL fn_zone_vpd_targets(g.ts) AS z
+WITH DATA;
+
+-- UNIQUE index required for REFRESH ... CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS mv_band_curve_ts_uidx ON mv_band_curve (ts, greenhouse_id);
+
+-- Stable read surface for the panels.
+CREATE OR REPLACE VIEW v_band_curve AS SELECT * FROM mv_band_curve;
+
+DO $$
+DECLARE
+    n integer; peak_hr integer;
+BEGIN
+    SELECT count(*) INTO n FROM mv_band_curve;
+    SELECT extract(hour FROM (ts AT TIME ZONE 'America/Denver'))::int INTO peak_hr
+    FROM mv_band_curve
+    WHERE ts BETWEEN now() - interval '12 hours' AND now() + interval '12 hours'
+    ORDER BY temp_high DESC NULLS LAST LIMIT 1;
+    RAISE NOTICE 'migration 167 OK: mv_band_curve has % rows; temp_high peaks at local hour % (expect ~13 solar noon).', n, peak_hr;
+END $$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8494,7 +8494,9 @@ CREATE TABLE public.diagnostics (
     effective_heat_target_f double precision,
     effective_cool_stage2_delta_f double precision,
     effective_vpd_hysteresis_kpa double precision,
-    effective_dehum_aggressive_kpa double precision
+    effective_dehum_aggressive_kpa double precision,
+    zone_wet_granted text,
+    band_source text
 );
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -5125,7 +5125,23 @@ CREATE TABLE public.climate (
     intake_rh double precision,
     intake_vpd double precision,
     outdoor_illuminance double precision,
-    greenhouse_id text DEFAULT 'vallery'::text
+    greenhouse_id text DEFAULT 'vallery'::text,
+    solar_phase double precision,
+    solar_sunrise_min integer,
+    solar_noon_min integer,
+    solar_sunset_min integer,
+    house_temp_target_f double precision,
+    house_temp_delta_f double precision,
+    house_vpd_target double precision,
+    house_vpd_delta double precision,
+    vpd_target_center double precision,
+    vpd_target_south double precision,
+    vpd_target_west double precision,
+    vpd_target_east double precision,
+    vpd_delta_center double precision,
+    vpd_delta_south double precision,
+    vpd_delta_west double precision,
+    vpd_delta_east double precision
 );
 
 

--- a/deploy/k8s/components/grafana/band-curve-refresh-cronjob.yaml
+++ b/deploy/k8s/components/grafana/band-curve-refresh-cronjob.yaml
@@ -1,0 +1,83 @@
+# Refreshes mv_band_curve (migration 167) every 10 min so the graphs.verdify.ai
+# compliance panels read the pre-computed deterministic solar band / per-zone
+# VPD target curves instead of calling fn_crop_band_value live (~1-2s → ~0.6ms).
+# Independent of the ingestor (whose mv_zone_band_grade refresh is unreliable).
+# CONCURRENTLY keeps the matview readable during refresh (needs the unique index
+# created by migration 167).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: verdify-band-curve-refresh
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: grafana
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: verdify
+            app.kubernetes.io/component: grafana
+        spec:
+          restartPolicy: Never
+          # Co-locate with the DB pod so the refresh connection never crosses
+          # the Flannel overlay mesh (cross-node pod traffic is intermittently
+          # dropped on this cluster) — same-node pod-to-pod is reliable.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: db
+                  topologyKey: kubernetes.io/hostname
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: refresh
+              image: timescale/timescaledb:2.25.2-pg16
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              command:
+                - /bin/sh
+                - -c
+                - >-
+                  psql -v ON_ERROR_STOP=1 -c
+                  "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_band_curve;"
+                  && echo "mv_band_curve refreshed $(date -u +%FT%TZ)"
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    configMapKeyRef: { key: DB_HOST, name: verdify-config }
+                - name: PGPORT
+                  valueFrom:
+                    configMapKeyRef: { key: DB_PORT, name: verdify-config }
+                - name: PGDATABASE
+                  valueFrom:
+                    configMapKeyRef: { key: DB_NAME, name: verdify-config }
+                - name: PGUSER
+                  valueFrom:
+                    configMapKeyRef: { key: DB_USER, name: verdify-config }
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef: { key: POSTGRES_PASSWORD, name: verdify-app-secrets }
+              resources:
+                requests: { cpu: 25m, memory: 64Mi }
+                limits: { cpu: 250m, memory: 128Mi }

--- a/deploy/k8s/components/grafana/generated/dashboards-cm-0.yaml
+++ b/deploy/k8s/components/grafana/generated/dashboards-cm-0.yaml
@@ -3,14 +3,12 @@ kind: ConfigMap
 metadata:
   name: verdify-grafana-dashboards-0
   annotations:
-    # Big CM: the client-side-apply last-applied annotation exceeds the 262144
-    # byte metadata limit, so ArgoCD must server-side-apply this resource.
     argocd.argoproj.io/sync-options: ServerSideApply=true
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: grafana
 data:
-  site-climate-cooling.json: |-
+  site-climate-cooling.json: |
     {
       "uid": "site-climate-cooling",
       "title": "Site: Climate \u2014 Cooling",
@@ -2447,7 +2445,7 @@ data:
       "version": 2,
       "style": "light"
     }
-  site-climate-heating.json: |-
+  site-climate-heating.json: |
     {
       "uid": "site-climate-heating",
       "title": "Site: Climate \u2014 Heating",
@@ -4159,7 +4157,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-climate-humidity.json: |-
+  site-climate-humidity.json: |
     {
       "uid": "site-climate-humidity",
       "title": "Site: Climate \u2014 Humidity",
@@ -5516,7 +5514,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-evidence-economics.json: |-
+  site-evidence-economics.json: |
     {
       "uid": "site-evidence-economics",
       "title": "Site: Evidence \u2014 Economics",
@@ -7464,7 +7462,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-evidence-planning-quality.json: |-
+  site-evidence-planning-quality.json: |
     {
       "annotations": {
         "list": []
@@ -10518,7 +10516,7 @@ data:
       "weekStart": "",
       "style": "light"
     }
-  site-greenhouse-crops.json: |-
+  site-greenhouse-crops.json: |
     {
       "uid": "site-greenhouse-crops",
       "title": "Site: Greenhouse \u2014 Crops",
@@ -12156,7 +12154,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-greenhouse-zones.json: |-
+  site-greenhouse-zones.json: |
     {
       "uid": "site-greenhouse-zones",
       "title": "Site: Greenhouse \u2014 Zones",
@@ -13872,7 +13870,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-home.json: |-
+  site-home.json: |
     {
       "uid": "site-home",
       "title": "Site: Home",
@@ -15133,7 +15131,9 @@ data:
                 },
                 "thresholdsStyle": {
                   "mode": "off"
-                }
+                },
+                "axisSoftMax": 104,
+                "axisSoftMin": 45
               },
               "decimals": 1,
               "mappings": [],
@@ -15341,6 +15341,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15388,6 +15392,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15423,6 +15431,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15470,6 +15482,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15505,6 +15521,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15552,6 +15572,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15587,6 +15611,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15634,6 +15662,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15669,6 +15701,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15716,6 +15752,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -15885,6 +15925,41 @@ data:
                     "value": "none"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF9830",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
               }
             ]
           },
@@ -15938,7 +16013,7 @@ data:
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT ts AS time,\n    projected_temp_low::float AS \"Target Band Base\",\n    projected_temp_high::float AS \"Target Band\"\nFROM fn_band_timeline($__timeFrom(), $__timeTo(), interval '30 minutes', 'vallery')\nORDER BY ts",
+              "rawSql": "SELECT ts AS time,\n    temp_low AS \"Target Band Base\",\n    temp_high AS \"Target Band\",\n    temp_target AS \"Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
               "refId": "C",
               "sql": {
                 "columns": [
@@ -16050,7 +16125,7 @@ data:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('heat2'::text, 'Heat 2 (Gas)'::text, 'Heat 2 (Gas) Base'::text, 54.5::double precision, 56.0::double precision),\n    ('heat1'::text, 'Heat 1 (Electric)'::text, 'Heat 1 (Electric) Base'::text, 56.5::double precision, 58.0::double precision),\n    ('fan1'::text, 'Fan 1'::text, 'Fan 1 Base'::text, 80.5::double precision, 82.0::double precision),\n    ('fan2'::text, 'Fan 2'::text, 'Fan 2 Base'::text, 82.5::double precision, 84.0::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 84.5::double precision, 86.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('heat2', 'heat1', 'fan1', 'fan2', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+              "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('heat2'::text, 'Heat 2 (Gas)'::text, 'Heat 2 (Gas) Base'::text, 95.0::double precision, 96.0::double precision),\n    ('heat1'::text, 'Heat 1 (Electric)'::text, 'Heat 1 (Electric) Base'::text, 96.5::double precision, 97.5::double precision),\n    ('fan1'::text, 'Fan 1'::text, 'Fan 1 Base'::text, 98.0::double precision, 99.0::double precision),\n    ('fan2'::text, 'Fan 2'::text, 'Fan 2 Base'::text, 99.5::double precision, 100.5::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 101.0::double precision, 102.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('heat2', 'heat1', 'fan1', 'fan2', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
               "refId": "E"
             }
           ],
@@ -16094,7 +16169,9 @@ data:
                 },
                 "thresholdsStyle": {
                   "mode": "off"
-                }
+                },
+                "axisSoftMax": 4.2,
+                "axisSoftMin": 0.0
               },
               "decimals": 2,
               "mappings": [],
@@ -16246,6 +16323,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16293,6 +16374,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16328,6 +16413,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16375,6 +16464,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16410,6 +16503,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16457,6 +16554,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16492,6 +16593,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16539,6 +16644,10 @@ data:
                       "tooltip": true,
                       "viz": false
                     }
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
                   }
                 ]
               },
@@ -16764,6 +16873,41 @@ data:
                     "value": "none"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF9830",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
               }
             ]
           },
@@ -16811,7 +16955,7 @@ data:
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT ts AS time,\n    projected_vpd_low::float AS \"Target Band Base\",\n    projected_vpd_high::float AS \"Target Band\"\nFROM fn_band_timeline($__timeFrom(), $__timeTo(), interval '30 minutes', 'vallery')\nORDER BY ts",
+              "rawSql": "SELECT ts AS time,\n    vpd_low AS \"Target Band Base\",\n    vpd_high AS \"Target Band\",\n    vpd_target AS \"Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
               "refId": "C",
               "sql": {
                 "columns": [
@@ -16923,7 +17067,7 @@ data:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('mister_south'::text, 'Mister South'::text, 'Mister South Base'::text, 1.75::double precision, 1.8::double precision),\n    ('mister_west'::text, 'Mister West'::text, 'Mister West Base'::text, 1.85::double precision, 1.9::double precision),\n    ('mister_center'::text, 'Mister Center'::text, 'Mister Center Base'::text, 1.95::double precision, 2.0::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 2.05::double precision, 2.1::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('mister_south', 'mister_west', 'mister_center', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+              "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('mister_south'::text, 'Mister South'::text, 'Mister South Base'::text, 3.0::double precision, 3.2::double precision),\n    ('mister_west'::text, 'Mister West'::text, 'Mister West Base'::text, 3.3::double precision, 3.5::double precision),\n    ('mister_center'::text, 'Mister Center'::text, 'Mister Center Base'::text, 3.6::double precision, 3.8::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 3.9::double precision, 4.1::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('mister_south', 'mister_west', 'mister_center', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
               "refId": "E"
             }
           ],
@@ -17913,7 +18057,7 @@ data:
             "type": "grafana-postgresql-datasource",
             "uid": "verdify-tsdb"
           },
-          "description": "Observed and forecast solar lux, the grow-light threshold band, and confirmed main grow-light state.",
+          "description": "Two independent grow-light circuits (overhead/orchid + hydro grow). Per-circuit relay-state lanes (dots-fixed), per-circuit lux switch-threshold bands, and observed/forecast solar lux.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -17983,188 +18127,12 @@ data:
                     "value": 100
                   },
                   {
-                    "id": "unit",
-                    "value": "lux"
-                  },
-                  {
                     "id": "custom.gradientMode",
                     "value": "opacity"
                   },
                   {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Grow Light Threshold Base"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "#73BF69",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.lineWidth",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.gradientMode",
-                    "value": "none"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": false
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Grow Light Threshold"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "#73BF69",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.lineWidth",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.fillBelowTo",
-                    "value": "Grow Light Threshold Base"
-                  },
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 22
-                  },
-                  {
-                    "id": "custom.gradientMode",
-                    "value": "none"
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": true,
-                      "viz": false
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Grow Light On Base"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "#9CCC65",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.drawStyle",
-                    "value": "line"
-                  },
-                  {
-                    "id": "custom.lineInterpolation",
-                    "value": "stepAfter"
-                  },
-                  {
-                    "id": "custom.spanNulls",
-                    "value": false
-                  },
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.lineWidth",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": true,
-                      "tooltip": true,
-                      "viz": false
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Grow Light On"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "#5794F2",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.drawStyle",
-                    "value": "line"
-                  },
-                  {
-                    "id": "custom.lineInterpolation",
-                    "value": "stepAfter"
-                  },
-                  {
-                    "id": "custom.spanNulls",
-                    "value": false
-                  },
-                  {
-                    "id": "custom.fillBelowTo",
-                    "value": "Grow Light On Base"
-                  },
-                  {
-                    "id": "custom.fillOpacity",
-                    "value": 100
-                  },
-                  {
-                    "id": "custom.lineWidth",
-                    "value": 0
-                  },
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": true,
-                      "viz": false
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "Grow Light On"
+                    "id": "unit",
+                    "value": "lux"
                   }
                 ]
               },
@@ -18194,16 +18162,370 @@ data:
                     "value": "opacity"
                   },
                   {
-                    "id": "custom.hideFrom",
+                    "id": "unit",
+                    "value": "lux"
+                  },
+                  {
+                    "id": "custom.lineStyle",
                     "value": {
-                      "legend": true,
-                      "tooltip": false,
-                      "viz": false
+                      "fill": "dash",
+                      "dash": [
+                        10,
+                        5
+                      ]
                     }
                   },
                   {
-                    "id": "unit",
-                    "value": "lux"
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Overhead Threshold Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFA600",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Overhead Threshold"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFA600",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Overhead Threshold Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Grow Threshold Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Grow Threshold"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Grow Threshold Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Overhead Light Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFA600",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Overhead Light"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFA600",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Overhead Light Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Grow Light Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Grow Light"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Grow Light Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
                   }
                 ]
               }
@@ -18237,7 +18559,7 @@ data:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "WITH raw_bounds AS (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT\n    GREATEST(from_ts, to_ts - interval '7 days') AS from_ts,\n    to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts,\n    interval '10 minutes' AS step\n  FROM raw_bounds\n),\ntracked_params AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('gl_lux_threshold'::text),\n    ('gl_lux_hysteresis'::text),\n    ('gl_main_lux_threshold'::text),\n    ('gl_main_lux_hysteresis'::text)\n  ) AS p(parameter)\n),\nlatest_snapshot AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    ss.value::double precision AS value,\n    ss.ts,\n    1 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, ts\n    FROM setpoint_snapshot ss\n    WHERE ss.greenhouse_id = 'vallery'\n      AND ss.parameter = tp.parameter\n    ORDER BY ss.ts DESC\n    LIMIT 1\n  ) ss ON true\n  WHERE ss.ts IS NOT NULL\n),\nlatest_confirmed_changes AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    sc.value::double precision AS value,\n    COALESCE(sc.confirmed_at, sc.ts) AS ts,\n    2 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, confirmed_at, ts\n    FROM setpoint_changes sc\n    WHERE sc.greenhouse_id = 'vallery'\n      AND sc.parameter = tp.parameter\n      AND COALESCE(sc.source, '') <> 'esp32'\n      AND (\n        sc.confirmed_at IS NOT NULL\n        OR COALESCE(sc.delivery_status, '') = 'confirmed'\n      )\n      AND COALESCE(sc.delivery_status, '') NOT IN ('pending', 'superseded', 'expired', 'deferred_heap_pressure')\n    ORDER BY COALESCE(sc.confirmed_at, sc.ts) DESC\n    LIMIT 1\n  ) sc ON true\n  WHERE sc.ts IS NOT NULL\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (parameter)\n    parameter,\n    value\n  FROM (\n    SELECT * FROM latest_snapshot\n    UNION ALL\n    SELECT * FROM latest_confirmed_changes\n  ) values_union\n  ORDER BY parameter, source_rank, ts DESC\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_threshold'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_threshold'), 40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_hysteresis'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_hysteresis'), 8000.0))) AS main_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off\n  FROM policy\n),\nthresholds AS (\n  SELECT x.time, s.metric, s.value\n  FROM bounds bd\n  CROSS JOIN policy_wide p\n  CROSS JOIN LATERAL (VALUES (bd.from_ts), (bd.to_ts)) AS x(time)\n  CROSS JOIN LATERAL (VALUES\n    ('Grow Light Threshold Base'::text, p.main_on),\n    ('Grow Light Threshold'::text, p.main_off)\n  ) AS s(metric, value)\n),\nsolar_actual AS MATERIALIZED (\n  SELECT\n    time_bucket((SELECT step FROM bounds), c.ts) AS time,\n    'Solar'::text AS metric,\n    avg(COALESCE(c.outdoor_lux, c.lux))::double precision AS value\n  FROM climate c\n  WHERE c.ts >= (SELECT from_ts FROM bounds)\n    AND c.ts <= (SELECT state_to_ts FROM bounds)\n    AND COALESCE(c.outdoor_lux, c.lux) IS NOT NULL\n  GROUP BY 1\n),\nsolar_forecast_seed AS MATERIALIZED (\n  SELECT time, 'Solar Forecast'::text AS metric, value\n  FROM solar_actual\n  WHERE (SELECT to_ts FROM bounds) > (SELECT state_to_ts FROM bounds)\n  ORDER BY time DESC\n  LIMIT 1\n),\nsolar_forecast AS MATERIALIZED (\n  SELECT DISTINCT ON (time_bucket((SELECT step FROM bounds), wf.ts))\n    time_bucket((SELECT step FROM bounds), wf.ts) AS time,\n    'Solar Forecast'::text AS metric,\n    (wf.solar_w_m2 * 120.0)::double precision AS value\n  FROM weather_forecast wf\n  WHERE wf.ts > (SELECT state_to_ts FROM bounds)\n    AND wf.ts >= (SELECT from_ts FROM bounds)\n    AND wf.ts <= (SELECT to_ts FROM bounds)\n    AND wf.solar_w_m2 IS NOT NULL\n  ORDER BY time_bucket((SELECT step FROM bounds), wf.ts), wf.fetched_at DESC\n)\nSELECT time, metric, value\nFROM (\n  SELECT time, metric, value FROM solar_actual\n  UNION ALL\n  SELECT time, metric, value FROM solar_forecast_seed\n  UNION ALL\n  SELECT time, metric, value FROM solar_forecast\n  UNION ALL\n  SELECT time, metric, value FROM thresholds\n) series\nORDER BY time,\n  CASE metric WHEN 'Solar' THEN 0 WHEN 'Solar Forecast' THEN 1 WHEN 'Grow Light Threshold Base' THEN 2 WHEN 'Grow Light Threshold' THEN 3 ELSE 4 END,\n  metric",
+              "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT GREATEST(from_ts, to_ts - interval '7 days') AS from_ts, to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts, interval '10 minutes' AS step\n  FROM raw_bounds\n),\ntracked_params AS MATERIALIZED (\n  SELECT * FROM (VALUES ('gl_main_lux_threshold'),('gl_main_lux_hysteresis'),('gl_grow_lux_threshold'),('gl_grow_lux_hysteresis'),('gl_lux_threshold'),('gl_lux_hysteresis')) AS p(parameter)\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (tp.parameter) tp.parameter, ss.value::double precision AS value\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (SELECT value, ts FROM setpoint_snapshot ss WHERE ss.greenhouse_id='vallery' AND ss.parameter=tp.parameter ORDER BY ss.ts DESC LIMIT 1) ss ON true\n  WHERE ss.value IS NOT NULL\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_main_lux_threshold'),(SELECT value FROM latest_values WHERE parameter='gl_lux_threshold'),40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_main_lux_hysteresis'),(SELECT value FROM latest_values WHERE parameter='gl_lux_hysteresis'),8000.0))) AS main_hyst,\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_grow_lux_threshold'),40000.0))) AS grow_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_grow_lux_hysteresis'),8000.0))) AS grow_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off, grow_on, grow_on + grow_hyst AS grow_off FROM policy\n),\nthresholds AS (\n  SELECT x.time, s.metric, s.value\n  FROM bounds bd CROSS JOIN policy_wide p\n  CROSS JOIN LATERAL (VALUES (bd.from_ts),(bd.to_ts)) AS x(time)\n  CROSS JOIN LATERAL (VALUES\n    ('Overhead Threshold Base'::text, p.main_on),\n    ('Overhead Threshold'::text,      p.main_off),\n    ('Grow Threshold Base'::text,     p.grow_on),\n    ('Grow Threshold'::text,          p.grow_off)\n  ) AS s(metric, value)\n),\nsolar_actual AS MATERIALIZED (\n  SELECT time_bucket((SELECT step FROM bounds), c.ts) AS time, 'Solar'::text AS metric,\n    avg(COALESCE(c.outdoor_lux, c.lux))::double precision AS value\n  FROM climate c\n  WHERE c.ts >= (SELECT from_ts FROM bounds) AND c.ts <= (SELECT state_to_ts FROM bounds)\n    AND COALESCE(c.outdoor_lux, c.lux) IS NOT NULL\n  GROUP BY 1\n),\nsolar_forecast_seed AS MATERIALIZED (\n  SELECT time, 'Solar Forecast'::text AS metric, value FROM solar_actual\n  WHERE (SELECT to_ts FROM bounds) > (SELECT state_to_ts FROM bounds)\n  ORDER BY time DESC LIMIT 1\n),\nsolar_forecast AS MATERIALIZED (\n  SELECT DISTINCT ON (time_bucket((SELECT step FROM bounds), wf.ts))\n    time_bucket((SELECT step FROM bounds), wf.ts) AS time, 'Solar Forecast'::text AS metric,\n    (wf.solar_w_m2 * 120.0)::double precision AS value\n  FROM weather_forecast wf\n  WHERE wf.ts > (SELECT state_to_ts FROM bounds) AND wf.ts >= (SELECT from_ts FROM bounds)\n    AND wf.ts <= (SELECT to_ts FROM bounds) AND wf.solar_w_m2 IS NOT NULL\n  ORDER BY time_bucket((SELECT step FROM bounds), wf.ts), wf.fetched_at DESC\n)\nSELECT time, metric, value\nFROM (\n  SELECT time, metric, value FROM solar_actual\n  UNION ALL SELECT time, metric, value FROM solar_forecast_seed\n  UNION ALL SELECT time, metric, value FROM solar_forecast\n  UNION ALL SELECT time, metric, value FROM thresholds\n) series\nORDER BY time,\n  CASE metric WHEN 'Solar' THEN 0 WHEN 'Solar Forecast' THEN 1\n    WHEN 'Overhead Threshold Base' THEN 2 WHEN 'Overhead Threshold' THEN 3\n    WHEN 'Grow Threshold Base' THEN 4 WHEN 'Grow Threshold' THEN 5 ELSE 6 END, metric",
               "refId": "A"
             },
             {
@@ -18248,11 +18570,1588 @@ data:
               "editorMode": "code",
               "format": "time_series",
               "rawQuery": true,
-              "rawSql": "WITH raw_bounds AS (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT\n    GREATEST(from_ts, to_ts - interval '7 days') AS from_ts,\n    LEAST(to_ts, now()) AS to_ts,\n    interval '10 minutes' AS step,\n    date_trunc('day', GREATEST(from_ts, to_ts - interval '7 days') AT TIME ZONE 'America/Denver') AT TIME ZONE 'America/Denver' AS seed_start_ts\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\ntracked_params AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('gl_lux_threshold'::text),\n    ('gl_lux_hysteresis'::text),\n    ('gl_main_lux_threshold'::text),\n    ('gl_main_lux_hysteresis'::text)\n  ) AS p(parameter)\n),\nlatest_snapshot AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    ss.value::double precision AS value,\n    ss.ts,\n    1 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, ts\n    FROM setpoint_snapshot ss\n    WHERE ss.greenhouse_id = 'vallery'\n      AND ss.parameter = tp.parameter\n    ORDER BY ss.ts DESC\n    LIMIT 1\n  ) ss ON true\n  WHERE ss.ts IS NOT NULL\n),\nlatest_confirmed_changes AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    sc.value::double precision AS value,\n    COALESCE(sc.confirmed_at, sc.ts) AS ts,\n    2 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, confirmed_at, ts\n    FROM setpoint_changes sc\n    WHERE sc.greenhouse_id = 'vallery'\n      AND sc.parameter = tp.parameter\n      AND COALESCE(sc.source, '') <> 'esp32'\n      AND (\n        sc.confirmed_at IS NOT NULL\n        OR COALESCE(sc.delivery_status, '') = 'confirmed'\n      )\n      AND COALESCE(sc.delivery_status, '') NOT IN ('pending', 'superseded', 'expired', 'deferred_heap_pressure')\n    ORDER BY COALESCE(sc.confirmed_at, sc.ts) DESC\n    LIMIT 1\n  ) sc ON true\n  WHERE sc.ts IS NOT NULL\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (parameter)\n    parameter,\n    value\n  FROM (\n    SELECT * FROM latest_snapshot\n    UNION ALL\n    SELECT * FROM latest_confirmed_changes\n  ) values_union\n  ORDER BY parameter, source_rank, ts DESC\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_threshold'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_threshold'), 40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_hysteresis'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_hysteresis'), 8000.0))) AS main_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off\n  FROM policy\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = 'grow_light_main'\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment = 'grow_light_main'\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, state FROM state_seed\n    UNION ALL\n    SELECT time, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    'Grow Light On'::text AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN p.main_off ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN policy_wide p\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, 'Grow Light On Base'::text AS metric, p.main_on AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN policy_wide p\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+              "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT GREATEST(from_ts, to_ts - interval '7 days') AS from_ts, to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts,\n    date_trunc('hour', GREATEST(from_ts, to_ts - interval '7 days')) AS seed_start_ts,\n    interval '10 minutes' AS step\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), LEAST(b.to_ts, now()), b.step) AS time FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT * FROM (VALUES\n    ('grow_light_main'::text, 'Overhead Light'::text, 'Overhead Light Base'::text, 18000.0::double precision, 24000.0::double precision),\n    ('grow_light_grow'::text, 'Grow Light'::text,     'Grow Light Base'::text,     8000.0::double precision,  14000.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (SELECT e.state FROM equipment_state e WHERE e.greenhouse_id='vallery' AND e.equipment=m.equipment AND e.ts <= bd.seed_start_ts ORDER BY e.ts DESC LIMIT 1) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id='vallery' AND e.equipment IN ('grow_light_main','grow_light_grow') AND e.ts >= bd.seed_start_ts AND e.ts <= bd.state_to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT e.time, e.equipment, e.state, lead(e.time,1,(SELECT state_to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (SELECT time,equipment,state FROM state_seed UNION ALL SELECT time,equipment,state FROM state_events) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT greatest(st.time, bd.seed_start_ts) AS start_time, least(st.next_time, bd.state_to_ts) AS end_time, st.equipment\n  FROM state_timeline st CROSS JOIN bounds bd WHERE st.state AND st.time < bd.state_to_ts AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT b.time, m.top_metric AS metric,\n    CASE WHEN EXISTS (SELECT 1 FROM state_segments s WHERE s.equipment=m.equipment AND s.start_time < b.time + bd.step AND s.end_time > b.time)\n      THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b CROSS JOIN bounds bd CROSS JOIN lane_metrics m WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low FROM buckets b CROSS JOIN bounds bd CROSS JOIN lane_metrics m WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
               "refId": "B"
             }
           ],
-          "title": "Lighting: Lux, Thresholds & Switch State",
+          "title": "Lighting: Overhead vs Grow Circuit \u2014 Lux, Thresholds & Switch State",
+          "type": "timeseries",
+          "transparent": true
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "description": "Per-zone air temperatures (labeled by crop) against the shared on-chip house temperature band (green envelope = low..high) and the house target center line. Band renders 24h forward; zone lines are past-only.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "\u00b0F",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                },
+                "axisSoftMin": 55,
+                "axisSoftMax": 95
+              },
+              "decimals": 1,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "fahrenheit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "House Band Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "House Band"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "House Band Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 18
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "none"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "House Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF9830",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "North"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B877D9",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "South (Cannabis)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "West (Lime)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "East (Pepper)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Center (Vanda)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 102,
+            "w": 24,
+            "h": 12
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n    temp_low AS \"House Band Base\",\n    temp_high AS \"House Band\",\n    temp_target AS \"House Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(temp_north) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"North\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_north IS NOT NULL ORDER BY ts",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(temp_south) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"South (Cannabis)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_south IS NOT NULL ORDER BY ts",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(temp_west) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"West (Lime)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_west IS NOT NULL ORDER BY ts",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(temp_east) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"East (Pepper)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_east IS NOT NULL ORDER BY ts",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(temp_avg) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"Center (Vanda)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_avg IS NOT NULL ORDER BY ts",
+              "refId": "F"
+            }
+          ],
+          "title": "Zone Temperature vs House Band",
+          "type": "timeseries",
+          "transparent": true
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "description": "Per-zone vapour-pressure deficit (solid, by crop) each against ITS OWN target curve (dashed, matched color) from fn_zone_vpd_targets: South=Cannabis (driest), West=Lime, East=Pepper, Center=Vanda (lowest). Targets render 24h forward.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "kPa",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                },
+                "axisSoftMin": 0,
+                "axisSoftMax": 2
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "North"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B877D9",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "South (Cannabis)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "West (Lime)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "East (Pepper)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "South Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#56A64B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "dash",
+                      "dash": [
+                        8,
+                        4
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "West Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "dash",
+                      "dash": [
+                        8,
+                        4
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "East Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "dash",
+                      "dash": [
+                        8,
+                        4
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Center Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "dash",
+                      "dash": [
+                        8,
+                        4
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 114,
+            "w": 24,
+            "h": 12
+          },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n    vpd_target_south AS \"South Target\",\n    vpd_target_west AS \"West Target\",\n    vpd_target_east AS \"East Target\",\n    vpd_target_center AS \"Center Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(vpd_north) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"North\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_north IS NOT NULL ORDER BY ts",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(vpd_south) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"South (Cannabis)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_south IS NOT NULL ORDER BY ts",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(vpd_west) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"West (Lime)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_west IS NOT NULL ORDER BY ts",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT ts AS time,\n  avg(vpd_east) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"East (Pepper)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_east IS NOT NULL ORDER BY ts",
+              "refId": "E"
+            }
+          ],
+          "title": "Zone VPD vs Per-Zone Targets",
+          "type": "timeseries",
+          "transparent": true
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "description": "Firmware arbitration view: normalized temp & VPD deltas (0 = on target, \u00b11 = band edge \u2014 the dimensionless temp-vs-VPD 'equality statement', bigger |\u0394| wins). Faint green = in-band (|\u0394|<1). FSM state family lane at top (Heat/Cool-Vent/Mist-Fog/Idle from system_state). Actuals stop at now; the in-band reference renders \u00b172h forward.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "normalized \u0394 (band-half-widths)",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                },
+                "axisSoftMin": -3,
+                "axisSoftMax": 3
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none",
+              "min": -3,
+              "max": 3.2
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "In-Band Low"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "In-Band High"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#73BF69",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "In-Band Low"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 12
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "On Target"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#8C8C8C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "fill": "dash",
+                      "dash": [
+                        4,
+                        4
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Norm Temp \u0394"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "thresholds"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "#F2495C",
+                          "value": null
+                        },
+                        {
+                          "color": "#FF9830",
+                          "value": -1.5
+                        },
+                        {
+                          "color": "#73BF69",
+                          "value": -1.0
+                        },
+                        {
+                          "color": "#FF9830",
+                          "value": 1.0
+                        },
+                        {
+                          "color": "#F2495C",
+                          "value": 1.5
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.thresholdsStyle",
+                    "value": {
+                      "mode": "off"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Norm VPD \u0394"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "smooth"
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Heat Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Heat"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "State Heat Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Cool/Vent Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Cool/Vent"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "State Cool/Vent Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Mist/Fog Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#4FC3F7",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Mist/Fog"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#4FC3F7",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "State Mist/Fog Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Idle Base"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#8C8C8C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "State Idle"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#8C8C8C",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.drawStyle",
+                    "value": "line"
+                  },
+                  {
+                    "id": "custom.lineInterpolation",
+                    "value": "stepAfter"
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "State Idle Base"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.spanNulls",
+                    "value": false
+                  },
+                  {
+                    "id": "custom.showPoints",
+                    "value": "never"
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": true,
+                      "viz": false
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 126,
+            "w": 24,
+            "h": 12
+          },
+          "id": 42,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT b.ts AS time,\n  GREATEST(-2.5, LEAST(2.5, (c.temp_avg - b.temp_target)/GREATEST(0.5,(b.temp_high-b.temp_low)/2)))::float AS \"Norm Temp \u0394\",\n  GREATEST(-2.5, LEAST(2.5, (c.vpd_avg - b.vpd_target)/GREATEST(0.05,(b.vpd_high-b.vpd_low)/2)))::float AS \"Norm VPD \u0394\"\nFROM v_band_curve b\nJOIN LATERAL (\n  SELECT avg(temp_avg) AS temp_avg, avg(vpd_avg) AS vpd_avg FROM climate\n  WHERE ts >= b.ts AND ts < b.ts + interval '15 minutes' AND temp_avg IS NOT NULL AND vpd_avg IS NOT NULL\n) c ON c.temp_avg IS NOT NULL\nWHERE $__timeFilter(b.ts) AND b.ts <= now()\nORDER BY b.ts",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT g.ts AS time,\n  (-1.0)::float AS \"In-Band Low\",\n  ( 1.0)::float AS \"In-Band High\",\n  ( 0.0)::float AS \"On Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "verdify-tsdb"
+              },
+              "editorMode": "code",
+              "format": "time_series",
+              "rawQuery": true,
+              "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT from_ts, to_ts, LEAST(to_ts, now()) AS state_to_ts,\n    date_trunc('hour', from_ts) AS seed_start_ts, interval '10 minutes' AS step\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), LEAST(b.to_ts, now()), b.step) AS time FROM bounds b\n),\nfamilies AS MATERIALIZED (\n  SELECT * FROM (VALUES\n    ('Heat'::text,     'State Heat'::text,     'State Heat Base'::text),\n    ('Cool/Vent'::text,'State Cool/Vent'::text,'State Cool/Vent Base'::text),\n    ('Mist/Fog'::text, 'State Mist/Fog'::text, 'State Mist/Fog Base'::text),\n    ('Idle'::text,     'State Idle'::text,     'State Idle Base'::text)\n  ) AS f(family, top_metric, base_metric)\n),\nstate_events AS MATERIALIZED (\n  SELECT ss.ts AS time,\n    CASE\n      WHEN ss.value ILIKE '%HEAT%' THEN 'Heat'\n      WHEN ss.value ILIKE '%COOL%' OR ss.value ILIKE '%VENT%' OR ss.value ILIKE '%THERMAL%' OR ss.value ILIKE '%SAFETY%' THEN 'Cool/Vent'\n      WHEN ss.value ILIKE '%MIST%' OR ss.value ILIKE '%FOG%' OR ss.value ILIKE '%HUMID%' THEN 'Mist/Fog'\n      ELSE 'Idle'\n    END AS family\n  FROM system_state ss, bounds bd\n  WHERE ss.entity='greenhouse_state' AND ss.greenhouse_id='vallery'\n    AND ss.ts >= bd.seed_start_ts AND ss.ts <= bd.state_to_ts\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time,\n    COALESCE((\n      SELECT CASE\n        WHEN s.value ILIKE '%HEAT%' THEN 'Heat'\n        WHEN s.value ILIKE '%COOL%' OR s.value ILIKE '%VENT%' OR s.value ILIKE '%THERMAL%' OR s.value ILIKE '%SAFETY%' THEN 'Cool/Vent'\n        WHEN s.value ILIKE '%MIST%' OR s.value ILIKE '%FOG%' OR s.value ILIKE '%HUMID%' THEN 'Mist/Fog'\n        ELSE 'Idle' END\n      FROM system_state s WHERE s.entity='greenhouse_state' AND s.greenhouse_id='vallery' AND s.ts <= bd.seed_start_ts\n      ORDER BY s.ts DESC LIMIT 1), 'Idle') AS family\n  FROM bounds bd\n),\ntimeline AS MATERIALIZED (\n  SELECT e.time, e.family,\n    lead(e.time,1,(SELECT state_to_ts FROM bounds)) OVER (ORDER BY e.time) AS next_time\n  FROM (SELECT time, family FROM state_seed UNION ALL SELECT time, family FROM state_events) e\n),\nlanes AS (\n  SELECT b.time, f.top_metric AS metric,\n    CASE WHEN EXISTS (SELECT 1 FROM timeline t WHERE t.family=f.family AND t.time < b.time + bd.step AND t.next_time > b.time)\n      THEN 3.0 ELSE 2.8 END AS value\n  FROM buckets b CROSS JOIN bounds bd CROSS JOIN families f WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n  UNION ALL\n  SELECT b.time, f.base_metric, 2.8 FROM buckets b CROSS JOIN bounds bd CROSS JOIN families f WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+              "refId": "B"
+            }
+          ],
+          "title": "Climate Delta & State Machine (normalized)",
           "type": "timeseries",
           "transparent": true
         }
@@ -18437,7 +20336,7 @@ data:
       },
       "style": "light"
     }
-  site-intelligence-data.json: |-
+  site-intelligence-data.json: |
     {
       "uid": "site-intelligence-data",
       "title": "Site: Intelligence \u2014 Data",
@@ -19021,7 +20920,7 @@ data:
       "timezone": "America/Denver",
       "style": "light"
     }
-  site-irrigation.json: |-
+  site-irrigation.json: |
     {
       "uid": "site-irrigation",
       "title": "Site: Irrigation",

--- a/deploy/k8s/components/grafana/kustomization.yaml
+++ b/deploy/k8s/components/grafana/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
   - generated/dashboards-cm-0.yaml
   - generated/dashboards-cm-1.yaml
   - generated/dashboards-cm-2.yaml
+  - band-curve-refresh-cronjob.yaml

--- a/grafana/dashboards/site-home.json
+++ b/grafana/dashboards/site-home.json
@@ -4184,7 +4184,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "verdify-tsdb"
       },
-      "description": "Observed and forecast solar lux, the grow-light threshold band, and confirmed main grow-light state.",
+      "description": "Two independent grow-light circuits (overhead/orchid + hydro grow). Per-circuit relay-state lanes (dots-fixed), per-circuit lux switch-threshold bands, and observed/forecast solar lux.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4254,188 +4254,12 @@
                 "value": 100
               },
               {
-                "id": "unit",
-                "value": "lux"
-              },
-              {
                 "id": "custom.gradientMode",
                 "value": "opacity"
               },
               {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Grow Light Threshold Base"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#73BF69",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 0
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.gradientMode",
-                "value": "none"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Grow Light Threshold"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#73BF69",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 0
-              },
-              {
-                "id": "custom.fillBelowTo",
-                "value": "Grow Light Threshold Base"
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 22
-              },
-              {
-                "id": "custom.gradientMode",
-                "value": "none"
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": true,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Grow Light On Base"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#9CCC65",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.drawStyle",
-                "value": "line"
-              },
-              {
-                "id": "custom.lineInterpolation",
-                "value": "stepAfter"
-              },
-              {
-                "id": "custom.spanNulls",
-                "value": false
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 0
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": true,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Grow Light On"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#5794F2",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.drawStyle",
-                "value": "line"
-              },
-              {
-                "id": "custom.lineInterpolation",
-                "value": "stepAfter"
-              },
-              {
-                "id": "custom.spanNulls",
-                "value": false
-              },
-              {
-                "id": "custom.fillBelowTo",
-                "value": "Grow Light On Base"
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 100
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 0
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": true,
-                  "viz": false
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Grow Light On"
+                "id": "unit",
+                "value": "lux"
               }
             ]
           },
@@ -4465,16 +4289,370 @@
                 "value": "opacity"
               },
               {
-                "id": "custom.hideFrom",
+                "id": "unit",
+                "value": "lux"
+              },
+              {
+                "id": "custom.lineStyle",
                 "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    5
+                  ]
                 }
               },
               {
-                "id": "unit",
-                "value": "lux"
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Overhead Threshold Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFA600",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Overhead Threshold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFA600",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "Overhead Threshold Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Grow Threshold Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Grow Threshold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "Grow Threshold Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Overhead Light Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFA600",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Overhead Light"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFA600",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "Overhead Light Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Grow Light Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Grow Light"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "Grow Light Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
               }
             ]
           }
@@ -4508,7 +4686,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH raw_bounds AS (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT\n    GREATEST(from_ts, to_ts - interval '7 days') AS from_ts,\n    to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts,\n    interval '10 minutes' AS step\n  FROM raw_bounds\n),\ntracked_params AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('gl_lux_threshold'::text),\n    ('gl_lux_hysteresis'::text),\n    ('gl_main_lux_threshold'::text),\n    ('gl_main_lux_hysteresis'::text)\n  ) AS p(parameter)\n),\nlatest_snapshot AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    ss.value::double precision AS value,\n    ss.ts,\n    1 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, ts\n    FROM setpoint_snapshot ss\n    WHERE ss.greenhouse_id = 'vallery'\n      AND ss.parameter = tp.parameter\n    ORDER BY ss.ts DESC\n    LIMIT 1\n  ) ss ON true\n  WHERE ss.ts IS NOT NULL\n),\nlatest_confirmed_changes AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    sc.value::double precision AS value,\n    COALESCE(sc.confirmed_at, sc.ts) AS ts,\n    2 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, confirmed_at, ts\n    FROM setpoint_changes sc\n    WHERE sc.greenhouse_id = 'vallery'\n      AND sc.parameter = tp.parameter\n      AND COALESCE(sc.source, '') <> 'esp32'\n      AND (\n        sc.confirmed_at IS NOT NULL\n        OR COALESCE(sc.delivery_status, '') = 'confirmed'\n      )\n      AND COALESCE(sc.delivery_status, '') NOT IN ('pending', 'superseded', 'expired', 'deferred_heap_pressure')\n    ORDER BY COALESCE(sc.confirmed_at, sc.ts) DESC\n    LIMIT 1\n  ) sc ON true\n  WHERE sc.ts IS NOT NULL\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (parameter)\n    parameter,\n    value\n  FROM (\n    SELECT * FROM latest_snapshot\n    UNION ALL\n    SELECT * FROM latest_confirmed_changes\n  ) values_union\n  ORDER BY parameter, source_rank, ts DESC\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_threshold'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_threshold'), 40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_hysteresis'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_hysteresis'), 8000.0))) AS main_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off\n  FROM policy\n),\nthresholds AS (\n  SELECT x.time, s.metric, s.value\n  FROM bounds bd\n  CROSS JOIN policy_wide p\n  CROSS JOIN LATERAL (VALUES (bd.from_ts), (bd.to_ts)) AS x(time)\n  CROSS JOIN LATERAL (VALUES\n    ('Grow Light Threshold Base'::text, p.main_on),\n    ('Grow Light Threshold'::text, p.main_off)\n  ) AS s(metric, value)\n),\nsolar_actual AS MATERIALIZED (\n  SELECT\n    time_bucket((SELECT step FROM bounds), c.ts) AS time,\n    'Solar'::text AS metric,\n    avg(COALESCE(c.outdoor_lux, c.lux))::double precision AS value\n  FROM climate c\n  WHERE c.ts >= (SELECT from_ts FROM bounds)\n    AND c.ts <= (SELECT state_to_ts FROM bounds)\n    AND COALESCE(c.outdoor_lux, c.lux) IS NOT NULL\n  GROUP BY 1\n),\nsolar_forecast_seed AS MATERIALIZED (\n  SELECT time, 'Solar Forecast'::text AS metric, value\n  FROM solar_actual\n  WHERE (SELECT to_ts FROM bounds) > (SELECT state_to_ts FROM bounds)\n  ORDER BY time DESC\n  LIMIT 1\n),\nsolar_forecast AS MATERIALIZED (\n  SELECT DISTINCT ON (time_bucket((SELECT step FROM bounds), wf.ts))\n    time_bucket((SELECT step FROM bounds), wf.ts) AS time,\n    'Solar Forecast'::text AS metric,\n    (wf.solar_w_m2 * 120.0)::double precision AS value\n  FROM weather_forecast wf\n  WHERE wf.ts > (SELECT state_to_ts FROM bounds)\n    AND wf.ts >= (SELECT from_ts FROM bounds)\n    AND wf.ts <= (SELECT to_ts FROM bounds)\n    AND wf.solar_w_m2 IS NOT NULL\n  ORDER BY time_bucket((SELECT step FROM bounds), wf.ts), wf.fetched_at DESC\n)\nSELECT time, metric, value\nFROM (\n  SELECT time, metric, value FROM solar_actual\n  UNION ALL\n  SELECT time, metric, value FROM solar_forecast_seed\n  UNION ALL\n  SELECT time, metric, value FROM solar_forecast\n  UNION ALL\n  SELECT time, metric, value FROM thresholds\n) series\nORDER BY time,\n  CASE metric WHEN 'Solar' THEN 0 WHEN 'Solar Forecast' THEN 1 WHEN 'Grow Light Threshold Base' THEN 2 WHEN 'Grow Light Threshold' THEN 3 ELSE 4 END,\n  metric",
+          "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT GREATEST(from_ts, to_ts - interval '7 days') AS from_ts, to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts, interval '10 minutes' AS step\n  FROM raw_bounds\n),\ntracked_params AS MATERIALIZED (\n  SELECT * FROM (VALUES ('gl_main_lux_threshold'),('gl_main_lux_hysteresis'),('gl_grow_lux_threshold'),('gl_grow_lux_hysteresis'),('gl_lux_threshold'),('gl_lux_hysteresis')) AS p(parameter)\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (tp.parameter) tp.parameter, ss.value::double precision AS value\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (SELECT value, ts FROM setpoint_snapshot ss WHERE ss.greenhouse_id='vallery' AND ss.parameter=tp.parameter ORDER BY ss.ts DESC LIMIT 1) ss ON true\n  WHERE ss.value IS NOT NULL\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_main_lux_threshold'),(SELECT value FROM latest_values WHERE parameter='gl_lux_threshold'),40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_main_lux_hysteresis'),(SELECT value FROM latest_values WHERE parameter='gl_lux_hysteresis'),8000.0))) AS main_hyst,\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_grow_lux_threshold'),40000.0))) AS grow_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter='gl_grow_lux_hysteresis'),8000.0))) AS grow_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off, grow_on, grow_on + grow_hyst AS grow_off FROM policy\n),\nthresholds AS (\n  SELECT x.time, s.metric, s.value\n  FROM bounds bd CROSS JOIN policy_wide p\n  CROSS JOIN LATERAL (VALUES (bd.from_ts),(bd.to_ts)) AS x(time)\n  CROSS JOIN LATERAL (VALUES\n    ('Overhead Threshold Base'::text, p.main_on),\n    ('Overhead Threshold'::text,      p.main_off),\n    ('Grow Threshold Base'::text,     p.grow_on),\n    ('Grow Threshold'::text,          p.grow_off)\n  ) AS s(metric, value)\n),\nsolar_actual AS MATERIALIZED (\n  SELECT time_bucket((SELECT step FROM bounds), c.ts) AS time, 'Solar'::text AS metric,\n    avg(COALESCE(c.outdoor_lux, c.lux))::double precision AS value\n  FROM climate c\n  WHERE c.ts >= (SELECT from_ts FROM bounds) AND c.ts <= (SELECT state_to_ts FROM bounds)\n    AND COALESCE(c.outdoor_lux, c.lux) IS NOT NULL\n  GROUP BY 1\n),\nsolar_forecast_seed AS MATERIALIZED (\n  SELECT time, 'Solar Forecast'::text AS metric, value FROM solar_actual\n  WHERE (SELECT to_ts FROM bounds) > (SELECT state_to_ts FROM bounds)\n  ORDER BY time DESC LIMIT 1\n),\nsolar_forecast AS MATERIALIZED (\n  SELECT DISTINCT ON (time_bucket((SELECT step FROM bounds), wf.ts))\n    time_bucket((SELECT step FROM bounds), wf.ts) AS time, 'Solar Forecast'::text AS metric,\n    (wf.solar_w_m2 * 120.0)::double precision AS value\n  FROM weather_forecast wf\n  WHERE wf.ts > (SELECT state_to_ts FROM bounds) AND wf.ts >= (SELECT from_ts FROM bounds)\n    AND wf.ts <= (SELECT to_ts FROM bounds) AND wf.solar_w_m2 IS NOT NULL\n  ORDER BY time_bucket((SELECT step FROM bounds), wf.ts), wf.fetched_at DESC\n)\nSELECT time, metric, value\nFROM (\n  SELECT time, metric, value FROM solar_actual\n  UNION ALL SELECT time, metric, value FROM solar_forecast_seed\n  UNION ALL SELECT time, metric, value FROM solar_forecast\n  UNION ALL SELECT time, metric, value FROM thresholds\n) series\nORDER BY time,\n  CASE metric WHEN 'Solar' THEN 0 WHEN 'Solar Forecast' THEN 1\n    WHEN 'Overhead Threshold Base' THEN 2 WHEN 'Overhead Threshold' THEN 3\n    WHEN 'Grow Threshold Base' THEN 4 WHEN 'Grow Threshold' THEN 5 ELSE 6 END, metric",
           "refId": "A"
         },
         {
@@ -4519,11 +4697,1588 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH raw_bounds AS (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT\n    GREATEST(from_ts, to_ts - interval '7 days') AS from_ts,\n    LEAST(to_ts, now()) AS to_ts,\n    interval '10 minutes' AS step,\n    date_trunc('day', GREATEST(from_ts, to_ts - interval '7 days') AT TIME ZONE 'America/Denver') AT TIME ZONE 'America/Denver' AS seed_start_ts\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\ntracked_params AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('gl_lux_threshold'::text),\n    ('gl_lux_hysteresis'::text),\n    ('gl_main_lux_threshold'::text),\n    ('gl_main_lux_hysteresis'::text)\n  ) AS p(parameter)\n),\nlatest_snapshot AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    ss.value::double precision AS value,\n    ss.ts,\n    1 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, ts\n    FROM setpoint_snapshot ss\n    WHERE ss.greenhouse_id = 'vallery'\n      AND ss.parameter = tp.parameter\n    ORDER BY ss.ts DESC\n    LIMIT 1\n  ) ss ON true\n  WHERE ss.ts IS NOT NULL\n),\nlatest_confirmed_changes AS MATERIALIZED (\n  SELECT\n    tp.parameter,\n    sc.value::double precision AS value,\n    COALESCE(sc.confirmed_at, sc.ts) AS ts,\n    2 AS source_rank\n  FROM tracked_params tp\n  LEFT JOIN LATERAL (\n    SELECT value, confirmed_at, ts\n    FROM setpoint_changes sc\n    WHERE sc.greenhouse_id = 'vallery'\n      AND sc.parameter = tp.parameter\n      AND COALESCE(sc.source, '') <> 'esp32'\n      AND (\n        sc.confirmed_at IS NOT NULL\n        OR COALESCE(sc.delivery_status, '') = 'confirmed'\n      )\n      AND COALESCE(sc.delivery_status, '') NOT IN ('pending', 'superseded', 'expired', 'deferred_heap_pressure')\n    ORDER BY COALESCE(sc.confirmed_at, sc.ts) DESC\n    LIMIT 1\n  ) sc ON true\n  WHERE sc.ts IS NOT NULL\n),\nlatest_values AS MATERIALIZED (\n  SELECT DISTINCT ON (parameter)\n    parameter,\n    value\n  FROM (\n    SELECT * FROM latest_snapshot\n    UNION ALL\n    SELECT * FROM latest_confirmed_changes\n  ) values_union\n  ORDER BY parameter, source_rank, ts DESC\n),\npolicy AS MATERIALIZED (\n  SELECT\n    greatest(100.0, least(100000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_threshold'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_threshold'), 40000.0))) AS main_on,\n    greatest(0.0, least(25000.0, COALESCE((SELECT value FROM latest_values WHERE parameter = 'gl_main_lux_hysteresis'), (SELECT value FROM latest_values WHERE parameter = 'gl_lux_hysteresis'), 8000.0))) AS main_hyst\n),\npolicy_wide AS MATERIALIZED (\n  SELECT main_on, main_on + main_hyst AS main_off\n  FROM policy\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = 'grow_light_main'\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment = 'grow_light_main'\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, state FROM state_seed\n    UNION ALL\n    SELECT time, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    'Grow Light On'::text AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN p.main_off ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN policy_wide p\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, 'Grow Light On Base'::text AS metric, p.main_on AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN policy_wide p\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+          "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT GREATEST(from_ts, to_ts - interval '7 days') AS from_ts, to_ts AS to_ts,\n    LEAST(to_ts, now()) AS state_to_ts,\n    date_trunc('hour', GREATEST(from_ts, to_ts - interval '7 days')) AS seed_start_ts,\n    interval '10 minutes' AS step\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), LEAST(b.to_ts, now()), b.step) AS time FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT * FROM (VALUES\n    ('grow_light_main'::text, 'Overhead Light'::text, 'Overhead Light Base'::text, 18000.0::double precision, 24000.0::double precision),\n    ('grow_light_grow'::text, 'Grow Light'::text,     'Grow Light Base'::text,     8000.0::double precision,  14000.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (SELECT e.state FROM equipment_state e WHERE e.greenhouse_id='vallery' AND e.equipment=m.equipment AND e.ts <= bd.seed_start_ts ORDER BY e.ts DESC LIMIT 1) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id='vallery' AND e.equipment IN ('grow_light_main','grow_light_grow') AND e.ts >= bd.seed_start_ts AND e.ts <= bd.state_to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT e.time, e.equipment, e.state, lead(e.time,1,(SELECT state_to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (SELECT time,equipment,state FROM state_seed UNION ALL SELECT time,equipment,state FROM state_events) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT greatest(st.time, bd.seed_start_ts) AS start_time, least(st.next_time, bd.state_to_ts) AS end_time, st.equipment\n  FROM state_timeline st CROSS JOIN bounds bd WHERE st.state AND st.time < bd.state_to_ts AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT b.time, m.top_metric AS metric,\n    CASE WHEN EXISTS (SELECT 1 FROM state_segments s WHERE s.equipment=m.equipment AND s.start_time < b.time + bd.step AND s.end_time > b.time)\n      THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b CROSS JOIN bounds bd CROSS JOIN lane_metrics m WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low FROM buckets b CROSS JOIN bounds bd CROSS JOIN lane_metrics m WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
           "refId": "B"
         }
       ],
-      "title": "Lighting: Lux, Thresholds & Switch State",
+      "title": "Lighting: Overhead vs Grow Circuit \u2014 Lux, Thresholds & Switch State",
+      "type": "timeseries",
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "Per-zone air temperatures (labeled by crop) against the shared on-chip house temperature band (green envelope = low..high) and the house target center line. Band renders 24h forward; zone lines are past-only.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "\u00b0F",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "axisSoftMin": 55,
+            "axisSoftMax": 95
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "fahrenheit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "House Band Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "House Band"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "House Band Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 18
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "House Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "North"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#B877D9",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "South (Cannabis)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "West (Lime)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "East (Pepper)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Center (Vanda)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 102,
+        "w": 24,
+        "h": 12
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT g.ts AS time,\n  fn_crop_band_value('house','temp_low',  g.ts)::float AS \"House Band Base\",\n  fn_crop_band_value('house','temp_high', g.ts)::float AS \"House Band\",\n  fn_crop_band_value('house','temp_target', g.ts)::float AS \"House Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(temp_north) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"North\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_north IS NOT NULL ORDER BY ts",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(temp_south) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"South (Cannabis)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_south IS NOT NULL ORDER BY ts",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(temp_west) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"West (Lime)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_west IS NOT NULL ORDER BY ts",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(temp_east) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"East (Pepper)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_east IS NOT NULL ORDER BY ts",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(temp_avg) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"Center (Vanda)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND temp_avg IS NOT NULL ORDER BY ts",
+          "refId": "F"
+        }
+      ],
+      "title": "Zone Temperature vs House Band",
+      "type": "timeseries",
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "Per-zone vapour-pressure deficit (solid, by crop) each against ITS OWN target curve (dashed, matched color) from fn_zone_vpd_targets: South=Cannabis (driest), West=Lime, East=Pepper, Center=Vanda (lowest). Targets render 24h forward.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "kPa",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "axisSoftMin": 0,
+            "axisSoftMax": 2
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "North"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#B877D9",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "South (Cannabis)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "West (Lime)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "East (Pepper)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "South Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    8,
+                    4
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "West Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    8,
+                    4
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "East Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    8,
+                    4
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Center Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    8,
+                    4
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 114,
+        "w": 24,
+        "h": 12
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT g.ts AS time,\n  z.vpd_target_south  AS \"South Target\",\n  z.vpd_target_west   AS \"West Target\",\n  z.vpd_target_east   AS \"East Target\",\n  z.vpd_target_center AS \"Center Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nCROSS JOIN LATERAL fn_zone_vpd_targets(g.ts) z\nORDER BY g.ts",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(vpd_north) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"North\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_north IS NOT NULL ORDER BY ts",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(vpd_south) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"South (Cannabis)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_south IS NOT NULL ORDER BY ts",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(vpd_west) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"West (Lime)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_west IS NOT NULL ORDER BY ts",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  avg(vpd_east) OVER (ORDER BY ts ROWS BETWEEN 14 PRECEDING AND CURRENT ROW) AS \"East (Pepper)\"\nFROM climate WHERE $__timeFilter(ts) AND ts <= now() AND vpd_east IS NOT NULL ORDER BY ts",
+          "refId": "E"
+        }
+      ],
+      "title": "Zone VPD vs Per-Zone Targets",
+      "type": "timeseries",
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "verdify-tsdb"
+      },
+      "description": "Firmware arbitration view: normalized temp & VPD deltas (0 = on target, \u00b11 = band edge \u2014 the dimensionless temp-vs-VPD 'equality statement', bigger |\u0394| wins). Faint green = in-band (|\u0394|<1). FSM state family lane at top (Heat/Cool-Vent/Mist-Fog/Idle from system_state). Actuals stop at now; the in-band reference renders \u00b172h forward.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "normalized \u0394 (band-half-widths)",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "axisSoftMin": -3,
+            "axisSoftMax": 3
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "min": -3,
+          "max": 3.2
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "In-Band Low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "In-Band High"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "In-Band Low"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 12
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "On Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8C8C8C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    4,
+                    4
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Norm Temp \u0394"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#F2495C",
+                      "value": null
+                    },
+                    {
+                      "color": "#FF9830",
+                      "value": -1.5
+                    },
+                    {
+                      "color": "#73BF69",
+                      "value": -1.0
+                    },
+                    {
+                      "color": "#FF9830",
+                      "value": 1.0
+                    },
+                    {
+                      "color": "#F2495C",
+                      "value": 1.5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "off"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Norm VPD \u0394"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Heat Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Heat"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "State Heat Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Cool/Vent Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Cool/Vent"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "State Cool/Vent Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Mist/Fog Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4FC3F7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Mist/Fog"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4FC3F7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "State Mist/Fog Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Idle Base"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8C8C8C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8C8C8C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "stepAfter"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillBelowTo",
+                "value": "State Idle Base"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 100
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": false
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 126,
+        "w": 24,
+        "h": 12
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ts AS time,\n  GREATEST(-2.5, LEAST(2.5, (temp_avg - fn_crop_band_value('house','temp_target',ts))\n    / GREATEST(0.5,(fn_crop_band_value('house','temp_high',ts)-fn_crop_band_value('house','temp_low',ts))/2)))::float AS \"Norm Temp \u0394\",\n  GREATEST(-2.5, LEAST(2.5, (vpd_avg - fn_crop_band_value('house','vpd_target',ts))\n    / GREATEST(0.05,(fn_crop_band_value('house','vpd_high',ts)-fn_crop_band_value('house','vpd_low',ts))/2)))::float AS \"Norm VPD \u0394\"\nFROM climate\nWHERE $__timeFilter(ts) AND ts <= now() AND temp_avg IS NOT NULL AND vpd_avg IS NOT NULL\nORDER BY ts",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT g.ts AS time,\n  (-1.0)::float AS \"In-Band Low\",\n  ( 1.0)::float AS \"In-Band High\",\n  ( 0.0)::float AS \"On Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "verdify-tsdb"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "WITH raw_bounds AS (\n  SELECT $__timeFrom()::timestamptz AS from_ts, $__timeTo()::timestamptz AS to_ts\n),\nbounds AS MATERIALIZED (\n  SELECT from_ts, to_ts, LEAST(to_ts, now()) AS state_to_ts,\n    date_trunc('hour', from_ts) AS seed_start_ts, interval '10 minutes' AS step\n  FROM raw_bounds\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), LEAST(b.to_ts, now()), b.step) AS time FROM bounds b\n),\nfamilies AS MATERIALIZED (\n  SELECT * FROM (VALUES\n    ('Heat'::text,     'State Heat'::text,     'State Heat Base'::text),\n    ('Cool/Vent'::text,'State Cool/Vent'::text,'State Cool/Vent Base'::text),\n    ('Mist/Fog'::text, 'State Mist/Fog'::text, 'State Mist/Fog Base'::text),\n    ('Idle'::text,     'State Idle'::text,     'State Idle Base'::text)\n  ) AS f(family, top_metric, base_metric)\n),\nstate_events AS MATERIALIZED (\n  SELECT ss.ts AS time,\n    CASE\n      WHEN ss.value ILIKE '%HEAT%' THEN 'Heat'\n      WHEN ss.value ILIKE '%COOL%' OR ss.value ILIKE '%VENT%' OR ss.value ILIKE '%THERMAL%' OR ss.value ILIKE '%SAFETY%' THEN 'Cool/Vent'\n      WHEN ss.value ILIKE '%MIST%' OR ss.value ILIKE '%FOG%' OR ss.value ILIKE '%HUMID%' THEN 'Mist/Fog'\n      ELSE 'Idle'\n    END AS family\n  FROM system_state ss, bounds bd\n  WHERE ss.entity='greenhouse_state' AND ss.greenhouse_id='vallery'\n    AND ss.ts >= bd.seed_start_ts AND ss.ts <= bd.state_to_ts\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time,\n    COALESCE((\n      SELECT CASE\n        WHEN s.value ILIKE '%HEAT%' THEN 'Heat'\n        WHEN s.value ILIKE '%COOL%' OR s.value ILIKE '%VENT%' OR s.value ILIKE '%THERMAL%' OR s.value ILIKE '%SAFETY%' THEN 'Cool/Vent'\n        WHEN s.value ILIKE '%MIST%' OR s.value ILIKE '%FOG%' OR s.value ILIKE '%HUMID%' THEN 'Mist/Fog'\n        ELSE 'Idle' END\n      FROM system_state s WHERE s.entity='greenhouse_state' AND s.greenhouse_id='vallery' AND s.ts <= bd.seed_start_ts\n      ORDER BY s.ts DESC LIMIT 1), 'Idle') AS family\n  FROM bounds bd\n),\ntimeline AS MATERIALIZED (\n  SELECT e.time, e.family,\n    lead(e.time,1,(SELECT state_to_ts FROM bounds)) OVER (ORDER BY e.time) AS next_time\n  FROM (SELECT time, family FROM state_seed UNION ALL SELECT time, family FROM state_events) e\n),\nlanes AS (\n  SELECT b.time, f.top_metric AS metric,\n    CASE WHEN EXISTS (SELECT 1 FROM timeline t WHERE t.family=f.family AND t.time < b.time + bd.step AND t.next_time > b.time)\n      THEN 3.0 ELSE 2.8 END AS value\n  FROM buckets b CROSS JOIN bounds bd CROSS JOIN families f WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n  UNION ALL\n  SELECT b.time, f.base_metric, 2.8 FROM buckets b CROSS JOIN bounds bd CROSS JOIN families f WHERE b.time >= bd.from_ts AND b.time <= bd.state_to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+          "refId": "B"
+        }
+      ],
+      "title": "Climate Delta & State Machine (normalized)",
       "type": "timeseries",
       "transparent": true
     }

--- a/grafana/dashboards/site-home.json
+++ b/grafana/dashboards/site-home.json
@@ -1258,7 +1258,9 @@
             },
             "thresholdsStyle": {
               "mode": "off"
-            }
+            },
+            "axisSoftMax": 104,
+            "axisSoftMin": 45
           },
           "decimals": 1,
           "mappings": [],
@@ -1466,6 +1468,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1513,6 +1519,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1548,6 +1558,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1595,6 +1609,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1630,6 +1648,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1677,6 +1699,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1712,6 +1738,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1759,6 +1789,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1794,6 +1828,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -1841,6 +1879,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2010,6 +2052,41 @@
                 "value": "none"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
           }
         ]
       },
@@ -2063,7 +2140,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT ts AS time,\n    projected_temp_low::float AS \"Target Band Base\",\n    projected_temp_high::float AS \"Target Band\"\nFROM fn_band_timeline($__timeFrom(), $__timeTo(), interval '30 minutes', 'vallery')\nORDER BY ts",
+          "rawSql": "SELECT g.ts AS time,\n    fn_crop_band_value('house','temp_low',  g.ts)::float AS \"Target Band Base\",\n    fn_crop_band_value('house','temp_high', g.ts)::float AS \"Target Band\",\n    fn_crop_band_value('house','temp_target', g.ts)::float AS \"Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
           "refId": "C",
           "sql": {
             "columns": [
@@ -2175,7 +2252,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('heat2'::text, 'Heat 2 (Gas)'::text, 'Heat 2 (Gas) Base'::text, 54.5::double precision, 56.0::double precision),\n    ('heat1'::text, 'Heat 1 (Electric)'::text, 'Heat 1 (Electric) Base'::text, 56.5::double precision, 58.0::double precision),\n    ('fan1'::text, 'Fan 1'::text, 'Fan 1 Base'::text, 80.5::double precision, 82.0::double precision),\n    ('fan2'::text, 'Fan 2'::text, 'Fan 2 Base'::text, 82.5::double precision, 84.0::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 84.5::double precision, 86.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('heat2', 'heat1', 'fan1', 'fan2', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+          "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('heat2'::text, 'Heat 2 (Gas)'::text, 'Heat 2 (Gas) Base'::text, 95.0::double precision, 96.0::double precision),\n    ('heat1'::text, 'Heat 1 (Electric)'::text, 'Heat 1 (Electric) Base'::text, 96.5::double precision, 97.5::double precision),\n    ('fan1'::text, 'Fan 1'::text, 'Fan 1 Base'::text, 98.0::double precision, 99.0::double precision),\n    ('fan2'::text, 'Fan 2'::text, 'Fan 2 Base'::text, 99.5::double precision, 100.5::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 101.0::double precision, 102.0::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('heat2', 'heat1', 'fan1', 'fan2', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
           "refId": "E"
         }
       ],
@@ -2219,7 +2296,9 @@
             },
             "thresholdsStyle": {
               "mode": "off"
-            }
+            },
+            "axisSoftMax": 4.2,
+            "axisSoftMin": 0.0
           },
           "decimals": 2,
           "mappings": [],
@@ -2371,6 +2450,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2418,6 +2501,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2453,6 +2540,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2500,6 +2591,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2535,6 +2630,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2582,6 +2681,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2617,6 +2720,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2664,6 +2771,10 @@
                   "tooltip": true,
                   "viz": false
                 }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
               }
             ]
           },
@@ -2889,6 +3000,41 @@
                 "value": "none"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Target"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineInterpolation",
+                "value": "smooth"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              }
+            ]
           }
         ]
       },
@@ -2936,7 +3082,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT ts AS time,\n    projected_vpd_low::float AS \"Target Band Base\",\n    projected_vpd_high::float AS \"Target Band\"\nFROM fn_band_timeline($__timeFrom(), $__timeTo(), interval '30 minutes', 'vallery')\nORDER BY ts",
+          "rawSql": "SELECT g.ts AS time,\n    fn_crop_band_value('house','vpd_low',   g.ts)::float AS \"Target Band Base\",\n    fn_crop_band_value('house','vpd_high',  g.ts)::float AS \"Target Band\",\n    fn_crop_band_value('house','vpd_target', g.ts)::float AS \"Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
           "refId": "C",
           "sql": {
             "columns": [
@@ -3048,7 +3194,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('mister_south'::text, 'Mister South'::text, 'Mister South Base'::text, 1.75::double precision, 1.8::double precision),\n    ('mister_west'::text, 'Mister West'::text, 'Mister West Base'::text, 1.85::double precision, 1.9::double precision),\n    ('mister_center'::text, 'Mister Center'::text, 'Mister Center Base'::text, 1.95::double precision, 2.0::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 2.05::double precision, 2.1::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('mister_south', 'mister_west', 'mister_center', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE NULL::double precision END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
+          "rawSql": "WITH bounds AS MATERIALIZED (\n  SELECT\n    $__timeFrom()::timestamptz AS from_ts,\n    LEAST($__timeTo()::timestamptz, now()) AS to_ts,\n    interval '5 minutes' AS step,\n    date_trunc('hour', $__timeFrom()::timestamptz) AS seed_start_ts\n),\nbuckets AS MATERIALIZED (\n  SELECT generate_series(time_bucket(b.step, b.seed_start_ts), b.to_ts, b.step) AS time\n  FROM bounds b\n),\nlane_metrics AS MATERIALIZED (\n  SELECT *\n  FROM (VALUES\n    ('mister_south'::text, 'Mister South'::text, 'Mister South Base'::text, 3.0::double precision, 3.2::double precision),\n    ('mister_west'::text, 'Mister West'::text, 'Mister West Base'::text, 3.3::double precision, 3.5::double precision),\n    ('mister_center'::text, 'Mister Center'::text, 'Mister Center Base'::text, 3.6::double precision, 3.8::double precision),\n    ('fog'::text, 'Fog'::text, 'Fog Base'::text, 3.9::double precision, 4.1::double precision)\n  ) AS m(equipment, top_metric, base_metric, lane_low, lane_high)\n),\nstate_seed AS MATERIALIZED (\n  SELECT bd.seed_start_ts AS time, m.equipment, COALESCE(seed.state, false) AS state\n  FROM bounds bd\n  CROSS JOIN lane_metrics m\n  LEFT JOIN LATERAL (\n    SELECT e.state\n    FROM equipment_state e\n    WHERE e.greenhouse_id = 'vallery'\n      AND e.equipment = m.equipment\n      AND e.ts <= bd.seed_start_ts\n    ORDER BY e.ts DESC\n    LIMIT 1\n  ) seed ON true\n),\nstate_events AS MATERIALIZED (\n  SELECT e.ts AS time, e.equipment, e.state\n  FROM equipment_state e, bounds bd\n  WHERE e.greenhouse_id = 'vallery'\n    AND e.equipment IN ('mister_south', 'mister_west', 'mister_center', 'fog')\n    AND e.ts >= bd.seed_start_ts\n    AND e.ts <= bd.to_ts\n),\nstate_timeline AS MATERIALIZED (\n  SELECT\n    e.time,\n    e.equipment,\n    e.state,\n    lead(e.time, 1, (SELECT to_ts FROM bounds)) OVER (PARTITION BY e.equipment ORDER BY e.time) AS next_time\n  FROM (\n    SELECT time, equipment, state FROM state_seed\n    UNION ALL\n    SELECT time, equipment, state FROM state_events\n  ) e\n),\nstate_segments AS MATERIALIZED (\n  SELECT\n    greatest(st.time, bd.seed_start_ts) AS start_time,\n    least(st.next_time, bd.to_ts) AS end_time,\n    st.equipment\n  FROM state_timeline st\n  CROSS JOIN bounds bd\n  WHERE st.state\n    AND st.time < bd.to_ts\n    AND st.next_time > bd.seed_start_ts\n),\nlanes AS (\n  SELECT\n    b.time,\n    m.top_metric AS metric,\n    CASE WHEN EXISTS (\n      SELECT 1\n      FROM state_segments s\n      WHERE s.equipment = m.equipment\n        AND s.start_time < b.time + bd.step\n        AND s.end_time > b.time\n    ) THEN m.lane_high ELSE m.lane_low END AS value\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n  UNION ALL\n  SELECT b.time, m.base_metric, m.lane_low\n  FROM buckets b\n  CROSS JOIN bounds bd\n  CROSS JOIN lane_metrics m\n  WHERE b.time >= bd.from_ts\n    AND b.time <= bd.to_ts\n)\nSELECT time, metric, value FROM lanes ORDER BY time, metric",
           "refId": "E"
         }
       ],

--- a/grafana/dashboards/site-home.json
+++ b/grafana/dashboards/site-home.json
@@ -2140,7 +2140,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT g.ts AS time,\n    fn_crop_band_value('house','temp_low',  g.ts)::float AS \"Target Band Base\",\n    fn_crop_band_value('house','temp_high', g.ts)::float AS \"Target Band\",\n    fn_crop_band_value('house','temp_target', g.ts)::float AS \"Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+          "rawSql": "SELECT ts AS time,\n    temp_low AS \"Target Band Base\",\n    temp_high AS \"Target Band\",\n    temp_target AS \"Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
           "refId": "C",
           "sql": {
             "columns": [
@@ -3082,7 +3082,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT g.ts AS time,\n    fn_crop_band_value('house','vpd_low',   g.ts)::float AS \"Target Band Base\",\n    fn_crop_band_value('house','vpd_high',  g.ts)::float AS \"Target Band\",\n    fn_crop_band_value('house','vpd_target', g.ts)::float AS \"Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+          "rawSql": "SELECT ts AS time,\n    vpd_low AS \"Target Band Base\",\n    vpd_high AS \"Target Band\",\n    vpd_target AS \"Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
           "refId": "C",
           "sql": {
             "columns": [
@@ -5081,7 +5081,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT g.ts AS time,\n  fn_crop_band_value('house','temp_low',  g.ts)::float AS \"House Band Base\",\n  fn_crop_band_value('house','temp_high', g.ts)::float AS \"House Band\",\n  fn_crop_band_value('house','temp_target', g.ts)::float AS \"House Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nORDER BY g.ts",
+          "rawSql": "SELECT ts AS time,\n    temp_low AS \"House Band Base\",\n    temp_high AS \"House Band\",\n    temp_target AS \"House Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
           "refId": "A"
         },
         {
@@ -5548,7 +5548,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT g.ts AS time,\n  z.vpd_target_south  AS \"South Target\",\n  z.vpd_target_west   AS \"West Target\",\n  z.vpd_target_east   AS \"East Target\",\n  z.vpd_target_center AS \"Center Target\"\nFROM generate_series($__timeFrom()::timestamptz, $__timeTo()::timestamptz, interval '15 minutes') g(ts)\nCROSS JOIN LATERAL fn_zone_vpd_targets(g.ts) z\nORDER BY g.ts",
+          "rawSql": "SELECT ts AS time,\n    vpd_target_south AS \"South Target\",\n    vpd_target_west AS \"West Target\",\n    vpd_target_east AS \"East Target\",\n    vpd_target_center AS \"Center Target\"\nFROM v_band_curve WHERE $__timeFilter(ts) ORDER BY ts",
           "refId": "A"
         },
         {
@@ -6252,7 +6252,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT ts AS time,\n  GREATEST(-2.5, LEAST(2.5, (temp_avg - fn_crop_band_value('house','temp_target',ts))\n    / GREATEST(0.5,(fn_crop_band_value('house','temp_high',ts)-fn_crop_band_value('house','temp_low',ts))/2)))::float AS \"Norm Temp \u0394\",\n  GREATEST(-2.5, LEAST(2.5, (vpd_avg - fn_crop_band_value('house','vpd_target',ts))\n    / GREATEST(0.05,(fn_crop_band_value('house','vpd_high',ts)-fn_crop_band_value('house','vpd_low',ts))/2)))::float AS \"Norm VPD \u0394\"\nFROM climate\nWHERE $__timeFilter(ts) AND ts <= now() AND temp_avg IS NOT NULL AND vpd_avg IS NOT NULL\nORDER BY ts",
+          "rawSql": "SELECT b.ts AS time,\n  GREATEST(-2.5, LEAST(2.5, (c.temp_avg - b.temp_target)/GREATEST(0.5,(b.temp_high-b.temp_low)/2)))::float AS \"Norm Temp \u0394\",\n  GREATEST(-2.5, LEAST(2.5, (c.vpd_avg - b.vpd_target)/GREATEST(0.05,(b.vpd_high-b.vpd_low)/2)))::float AS \"Norm VPD \u0394\"\nFROM v_band_curve b\nJOIN LATERAL (\n  SELECT avg(temp_avg) AS temp_avg, avg(vpd_avg) AS vpd_avg FROM climate\n  WHERE ts >= b.ts AND ts < b.ts + interval '15 minutes' AND temp_avg IS NOT NULL AND vpd_avg IS NOT NULL\n) c ON c.temp_avg IS NOT NULL\nWHERE $__timeFilter(b.ts) AND b.ts <= now()\nORDER BY b.ts",
           "refId": "A"
         },
         {

--- a/ingestor/entity_map.py
+++ b/ingestor/entity_map.py
@@ -103,6 +103,28 @@ CLIMATE_MAP: dict[str, str] = {
     "tempest_precipitation_rate": "precip_in",  # NOTE: arrives as mm/min, DB expects in
     "tempest_lightning_count": "lightning_count",
     "tempest_lightning_distance": "lightning_avg_dist_mi",  # NOTE: arrives as km, DB expects mi
+    # Firmware-v2 (#327) on-chip telemetry evidence surface (numeric). The chip
+    # publishes these as template sensors (hardware.yaml ids gh_solar_*,
+    # gh_house_*, gh_zone_vpd_*); keys here are the ESPHome object_ids derived
+    # from the friendly NAME via sanitize (lowercase, non-[a-z0-9]→'_', no
+    # collapse) — e.g. id gh_solar_sunrise_min / name "Solar Sunrise (min local)"
+    # → object_id "solar_sunrise__min_local_". Columns added in migration 166.
+    "solar_phase": "solar_phase",
+    "solar_sunrise__min_local_": "solar_sunrise_min",
+    "solar_noon__min_local_": "solar_noon_min",
+    "solar_sunset__min_local_": "solar_sunset_min",
+    "house_temp_target_f": "house_temp_target_f",
+    "house_temp_delta_f": "house_temp_delta_f",
+    "house_vpd_target_kpa": "house_vpd_target",
+    "house_vpd_delta_kpa": "house_vpd_delta",
+    "zone_vpd_target_center": "vpd_target_center",
+    "zone_vpd_target_south": "vpd_target_south",
+    "zone_vpd_target_west": "vpd_target_west",
+    "zone_vpd_target_east": "vpd_target_east",
+    "zone_vpd_delta_center": "vpd_delta_center",
+    "zone_vpd_delta_south": "vpd_delta_south",
+    "zone_vpd_delta_west": "vpd_delta_west",
+    "zone_vpd_delta_east": "vpd_delta_east",
 }
 
 # Optional ESPHome feedback aliases for center root-zone/runoff instrumentation.
@@ -458,6 +480,12 @@ DIAGNOSTIC_MAP: dict[str, str] = {
     "sntp_valid": "sntp_valid",
     "sntp_miss_count": "sntp_miss_count",
     "last_sntp_sync_age_s": "last_sntp_sync_age_s",
+    # Firmware-v2 (#327) on-chip text evidence surface. Chip ids
+    # gh_zone_wet_granted / gh_band_source; keys are the sanitized friendly
+    # NAMEs ("Zone Wet Granted" → "zone_wet_granted", "Band Source" →
+    # "band_source"). Columns added in migration 166.
+    "zone_wet_granted": "zone_wet_granted",  # TextSensorInfo
+    "band_source": "band_source",  # TextSensorInfo
 }
 
 # ──────────────────────────────────────────────────────────────

--- a/ingestor/tasks/ha.py
+++ b/ingestor/tasks/ha.py
@@ -114,6 +114,14 @@ async def matview_refresh(pool: asyncpg.Pool) -> None:
         await conn.execute("SELECT refresh_relay_stuck(0, '{}'::jsonb)")
         await conn.execute("SELECT refresh_climate_merged(0, '{}'::jsonb)")
         await conn.execute("SELECT refresh_greenhouse_state(0, '{}'::jsonb)")
+        # mv_band_curve (migration 167) caches the deterministic solar band +
+        # per-zone VPD target curves for the graphs.verdify.ai compliance panels
+        # (slides now±4d). Guard on existence so this is a no-op before the
+        # migration lands. CONCURRENTLY needs the matview's unique index.
+        try:
+            await conn.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY mv_band_curve")
+        except asyncpg.exceptions.UndefinedTableError:
+            pass
     log.debug("Materialized views refreshed")
 
 

--- a/scripts/gen-grafana-dashboard-cms.py
+++ b/scripts/gen-grafana-dashboard-cms.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regenerate the Grafana dashboard ConfigMaps from grafana/dashboards/*.json.
+
+The live graphs.verdify.ai Grafana provisions its dashboards from
+deploy/k8s/components/grafana/generated/dashboards-cm-{0,1,2}.yaml — each holds
+a subset of the site-*.json dashboards as ConfigMap data keys (split to stay
+under the 1 MiB ConfigMap limit). This script refreshes every existing .json
+data key from its source file under grafana/dashboards/, preserving the
+existing CM→dashboard assignment (so a JSON edit re-renders without re-sharding).
+
+Idempotent: run after editing any grafana/dashboards/*.json, then commit the CMs.
+Validates each source is parseable JSON and warns if a CM nears the 1 MiB limit.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "grafana" / "dashboards"
+GEN = REPO / "deploy" / "k8s" / "components" / "grafana" / "generated"
+CM_LIMIT = 1024 * 1024
+
+
+class LiteralStr(str):
+    pass
+
+
+def _literal_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+yaml.add_representer(LiteralStr, _literal_representer)
+
+
+def main() -> int:
+    cms = sorted(GEN.glob("dashboards-cm-*.yaml"))
+    if not cms:
+        print("no dashboards-cm-*.yaml found", file=sys.stderr)
+        return 1
+    changed = 0
+    for cm_path in cms:
+        doc = yaml.safe_load(cm_path.read_text())
+        data = doc.get("data") or {}
+        new_data: dict[str, str] = {}
+        for key in data:
+            if key.endswith(".json"):
+                src = SRC / key
+                if not src.exists():
+                    print(f"WARN: {cm_path.name} key {key} has no source {src} — keeping existing")
+                    new_data[key] = data[key]
+                    continue
+                raw = src.read_text()
+                json.loads(raw)  # parse-validate
+                new_data[key] = LiteralStr(raw if raw.endswith("\n") else raw + "\n")
+            else:
+                new_data[key] = LiteralStr(data[key]) if isinstance(data[key], str) and "\n" in data[key] else data[key]
+        doc["data"] = new_data
+        out = yaml.dump(doc, sort_keys=False, width=10**9, allow_unicode=True)
+        size = len(out.encode())
+        if size > CM_LIMIT:
+            print(f"ERROR: {cm_path.name} is {size} bytes (> 1 MiB limit) — re-shard", file=sys.stderr)
+            return 2
+        if size > CM_LIMIT * 0.9:
+            print(f"WARN: {cm_path.name} is {size} bytes (>90% of 1 MiB)")
+        if out != cm_path.read_text():
+            cm_path.write_text(out)
+            changed += 1
+            print(f"regenerated {cm_path.name} ({size} bytes, {sum(1 for k in new_data if k.endswith('.json'))} dashboards)")
+    print(f"done: {changed} ConfigMap(s) updated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen-grafana-dashboard-cms.py
+++ b/scripts/gen-grafana-dashboard-cms.py
@@ -11,6 +11,7 @@ existing CM→dashboard assignment (so a JSON edit re-renders without re-shardin
 Idempotent: run after editing any grafana/dashboards/*.json, then commit the CMs.
 Validates each source is parseable JSON and warns if a CM nears the 1 MiB limit.
 """
+
 from __future__ import annotations
 
 import json
@@ -69,7 +70,9 @@ def main() -> int:
         if out != cm_path.read_text():
             cm_path.write_text(out)
             changed += 1
-            print(f"regenerated {cm_path.name} ({size} bytes, {sum(1 for k in new_data if k.endswith('.json'))} dashboards)")
+            print(
+                f"regenerated {cm_path.name} ({size} bytes, {sum(1 for k in new_data if k.endswith('.json'))} dashboards)"
+            )
     print(f"done: {changed} ConfigMap(s) updated")
     return 0
 

--- a/verdify_schemas/telemetry.py
+++ b/verdify_schemas/telemetry.py
@@ -161,6 +161,25 @@ class ClimateRow(BaseModel):
     intake_rh: float | None = Field(default=None, ge=0, le=100)
     intake_vpd: float | None = Field(default=None, ge=0, le=20)
 
+    # firmware-v2 on-chip telemetry (#327) — solar ephemeris + house targets +
+    # per-zone VPD targets/deltas the ESP32 computes on-chip and publishes.
+    solar_phase: float | None = None
+    solar_sunrise_min: int | None = None
+    solar_noon_min: int | None = None
+    solar_sunset_min: int | None = None
+    house_temp_target_f: float | None = None
+    house_temp_delta_f: float | None = None
+    house_vpd_target: float | None = None
+    house_vpd_delta: float | None = None
+    vpd_target_center: float | None = None
+    vpd_target_south: float | None = None
+    vpd_target_west: float | None = None
+    vpd_target_east: float | None = None
+    vpd_delta_center: float | None = None
+    vpd_delta_south: float | None = None
+    vpd_delta_west: float | None = None
+    vpd_delta_east: float | None = None
+
 
 class Diagnostics(BaseModel):
     """diagnostics hypertable row — ESP32 health heartbeat every 60 s."""
@@ -344,24 +363,6 @@ class ClimateActionLogRow(BaseModel):
     sensor_status: dict = Field(default_factory=dict)
     candidate_summary: str | None = None
     source_system_state: dict = Field(default_factory=dict)
-    # firmware-v2 on-chip telemetry (#327) — solar ephemeris + house targets +
-    # per-zone VPD targets/deltas the ESP32 computes on-chip and publishes.
-    solar_phase: float | None = None
-    solar_sunrise_min: int | None = None
-    solar_noon_min: int | None = None
-    solar_sunset_min: int | None = None
-    house_temp_target_f: float | None = None
-    house_temp_delta_f: float | None = None
-    house_vpd_target: float | None = None
-    house_vpd_delta: float | None = None
-    vpd_target_center: float | None = None
-    vpd_target_south: float | None = None
-    vpd_target_west: float | None = None
-    vpd_target_east: float | None = None
-    vpd_delta_center: float | None = None
-    vpd_delta_south: float | None = None
-    vpd_delta_west: float | None = None
-    vpd_delta_east: float | None = None
 
 
 class OverrideEvent(BaseModel):

--- a/verdify_schemas/telemetry.py
+++ b/verdify_schemas/telemetry.py
@@ -344,6 +344,24 @@ class ClimateActionLogRow(BaseModel):
     sensor_status: dict = Field(default_factory=dict)
     candidate_summary: str | None = None
     source_system_state: dict = Field(default_factory=dict)
+    # firmware-v2 on-chip telemetry (#327) — solar ephemeris + house targets +
+    # per-zone VPD targets/deltas the ESP32 computes on-chip and publishes.
+    solar_phase: float | None = None
+    solar_sunrise_min: int | None = None
+    solar_noon_min: int | None = None
+    solar_sunset_min: int | None = None
+    house_temp_target_f: float | None = None
+    house_temp_delta_f: float | None = None
+    house_vpd_target: float | None = None
+    house_vpd_delta: float | None = None
+    vpd_target_center: float | None = None
+    vpd_target_south: float | None = None
+    vpd_target_west: float | None = None
+    vpd_target_east: float | None = None
+    vpd_delta_center: float | None = None
+    vpd_delta_south: float | None = None
+    vpd_delta_west: float | None = None
+    vpd_delta_east: float | None = None
 
 
 class OverrideEvent(BaseModel):


### PR DESCRIPTION
Fixes the three broken site-home compliance panels and aligns them end-to-end with the firmware-v2 on-chip solar bands, plus new zone + delta companions and a query cache. Driven by owner review of panels 30/31/36 on graphs.verdify.ai.

## Root cause of the band offset (the headline)
`fn_diurnal_interp` baked in `peak := solar_noon + 2.0` (a hardcoded "thermal lag") — so the rendered band peaked at 15:00 while solar noon (and the firmware on-chip band, and the solar actuals) peak at 13:00. **db(165)** re-points `fn_center_band_setpoints` onto `fn_crop_band_value('house',…)`, the exact mirror of `greenhouse_solar.h` — band now peaks at solar noon for every consumer, history + forward-72h. No signature change; the firmware already runs solar-noon-anchored on-chip and ignores the pushed band, so no control change.

## Panel fixes (owner feedback, item by item)
- **Relay state dots** → the lane "top" series emitted `NULL` when off, so brief relay blips rendered as orphan point markers. Now emits `lane_low` (continuous) + `showPoints:never` → clean filled bars, no dots. (panels 30/31/36)
- **Relay lanes overlaying data** → moved to fixed Y above the data (temp >95°F, VPD >3.0 kPa) so they never collide with real readings as it gets hotter.
- **VPD "dynamic" relay Y** → the lanes were fixed all along; the VPD line crossing them read as motion. Moved above the data range → unambiguously fixed.
- **"Weirdly shaped" VPD band** → was the old `fn_house_vpd_control_band` widening around zone targets. Repointed to the deterministic `fn_crop_band_value` house VPD curve → smooth diurnal band peaking at solar noon.
- **Target band shading** → now a min/max envelope with the **setpoint as a center line** (`*_target`), per request.
- **Solar alignment** → band peak now sits under the solar actual/forecast peak (verified visually, history + forecast).
- **Lighting (36)** → two independent circuits: **Overhead** (`grow_light_main`, amber) + **Grow** (`grow_light_grow`, green) in distinct non-overlapping lanes, no dots, per-circuit thresholds.

## New panels
- **40 Zone Temperature vs House Band** — per-zone temp lines (crop-labeled: Vanda/Cannabis/Lime/Pepper/North) over the shared house band + target (temp is one air mass). Shows which zone runs hot/cold.
- **41 Zone VPD vs Per-Zone Targets** — each zone's VPD against its **own** solar target (`fn_zone_vpd_targets`): Pepper highest, Vanda lowest.
- **42 Climate Delta & State Machine (normalized)** — temp/VPD deltas in **band-half-width units** (the firmware's actual arbitration metric — bigger normalized miss wins), with the ±1 in-band zone, zero line, and the FSM state lane, over 72h past + 72h forecast. Reads "how far off-target, and what the controller did about it."

## Telemetry wiring (#327)
The chip publishes `gh_solar_*`, `gh_house_*`, `gh_zone_vpd_*`, `gh_zone_wet_granted`, `gh_band_source` but they weren't stored. **db(166)** adds 16 climate columns + 2 diagnostics columns + 18 sensor_registry rows; `entity_map.py` routes them (keyed by sanitized ESPHome name); `ClimateRow` gains the fields (CI drift guard). These flow once the new ingestor deploys and serve as firmware↔DB validation overlays (panels render off the deterministic DB functions today, which match the firmware by construction).

## Caching / performance
**db(167)** `mv_band_curve` materializes the deterministic band + zone-target curves (now±4d, 15-min). Panel band queries **~956ms→0.6ms**; the delta panel's normalized query **17s→1.1s** (it was timing out → blank). Refreshed by the ingestor `matview_refresh` task (also fixes that task's missing band refresh) + a DB-node-co-located CronJob backup. `scripts/gen-grafana-dashboard-cms.py` is the previously-missing CM generator.

## Validation
All 6 panels render at the full 72h±72h range (screenshots reviewed); band peaks at solar noon; no dots; lanes above data; zone lines + per-zone targets visible; delta panel shows the in-band zone + FSM lane. Migrations 165/166/167 applied to prod + dev-validated, all rollback-safe. The live graphs.verdify.ai already reflects these (CM hot-updated during iteration).

## Service restarts post-merge
`verdify-ingestor` (entity_map.py + matview_refresh task changed).

Follow-ups: the gh_* telemetry validation overlays activate once the new ingestor reaches prod (prod-promote, #320); #326 retire 5 consolidated params.