### PR TITLE
k8s(ingestor): liveness probe + soft anti-affinity off node6 (L1 Phase 2)

### DIFF
--- a/COORDINATION_REQUESTS.md
+++ b/COORDINATION_REQUESTS.md
@@ -17,6 +17,7 @@ action and create/update a GitHub issue when the request blocks delivery.
 | L7 Lighting/Occupancy (#349) | Jason / integration owners | Choose/confirm the occupancy event path to firmware: MQTT, Home Assistant API, direct Frigate, or Kubernetes-local bridge. | Yes for L7 implementation | Before occupancy firmware/service changes | Contract review; no credential values |
 | L9 Lab Notebook (#351) | Secret-delivery owner | Verify S3 lab publisher Secret presence by name/key only and document which repo/system owns content/public/state prefixes. | Yes before L9 publish-path closure | Before lab publishing audit closure | Secret metadata/status only |
 | L1/L5 | Secret-delivery owner | Verify prod Secret presence by name/key in `verdify-prod` without exposing values. | Yes before live readiness claims | Before secret audit closure | Secret metadata/status only |
+| L1 Architecture Audit (#343) | `monitoring-stack` | Add (or confirm the split-brain alarm #241 already covers) an OUT-OF-BAND alert on `sum(verdify_esp32_writer_estab) == 0` (writer absent) and on `time() - max(climate.ts)` (telemetry stall), Slack-routed independently of the ingestor. The audit's P0: the in-repo staleness monitor runs INSIDE the writer, so a dead writer self-silences. This repo ships no PrometheusRules; the rule belongs in monitoring-stack. | Yes — P0 reliability gap | Before G2 observability closure | Add/confirm a PrometheusRule + Alertmanager route; share the rule name/expr |
 
 ## Resolved / No Current Blocker
 

--- a/deploy/k8s/overlays/prod/ingestor-resilience.patch.yaml
+++ b/deploy/k8s/overlays/prod/ingestor-resilience.patch.yaml
@@ -1,0 +1,50 @@
+# INGESTOR RESILIENCE (L1 Phase 2) — liveness probe + soft node anti-affinity.
+#
+# Strategic-merge onto the single-writer verdify-ingestor Deployment. Applying
+# this RESTARTS the sole ESP32 writer (Recreate tears the old pod down first —
+# no double-writer) and is therefore a laptop-root/Jason GATED action at the
+# device-write window, NOT autonomous. Landed here ready-to-sync.
+#
+# 1. LIVENESS (audit §8 P1.5): the single writer has had NO probe, so a wedged
+#    event loop (stalled setpoint_listener / hung task loop) never self-heals.
+#    This wires ingestor-healthz.py (climate-freshness) but TOLERATES exit 2
+#    (DB unreachable) — so a DB outage NEVER restarts the writer. It restarts
+#    ONLY on exit 1 (climate stale despite a REACHABLE DB = genuinely wedged).
+#    During a DB outage the loop keeps reconnecting and spooling telemetry to
+#    /srv/verdify/state/spool/climate.jsonl, so a restart there would only widen
+#    the write gap — hence the exit-2 tolerance. Generous thresholds: ~120 s
+#    warmup, then 5 × 30 s of reachable-but-stale before a restart.
+#
+# 2. SOFT nodeAffinity AWAY from the storage-flaky node6 (audit D3: node6
+#    iSCSI/NFS FailedMount churned the writer twice in ~50 min and timed out the
+#    lab-publisher). PREFERRED, not required: the writer must stay on a
+#    device-VLAN-reachable node, and the real fix is storage-infra repairing
+#    node6 (coordination request filed). This is a stopgap scheduling nudge.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-ingestor
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["vm-k3s-node6"]
+      containers:
+        - name: ingestor
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'python ingestor-healthz.py; rc=$?; [ "$rc" = 0 ] || [ "$rc" = 2 ]'
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -144,6 +144,10 @@ patches:
   # #130 ingestor state volume: durable RWO PVC at /srv/verdify/state for
   # dispatcher/MCP bookkeeping and DB-outage telemetry spooling.
   - path: ingestor-state-volume.yaml
+  # L1 Phase 2 resilience: liveness probe (DB-outage-tolerant — restarts only a
+  # wedged writer, never during a DB outage) + soft anti-affinity off the
+  # storage-flaky node6. Applying RESTARTS the single ESP32 writer (gated).
+  - path: ingestor-resilience.patch.yaml
   # HA Sprint ha-1 / Lane A (#226/#227/#229): add verdify-serving priorityClass +
   # a CPU LIMIT (burst containment, NOT a tight throttle) + tuned mem to the
   # STATELESS surfaces (www/lab/api/mcp/planner/grafana). Strategic-merge by

--- a/docs/reviews/lane1-architecture-audit-2026-06-16.md
+++ b/docs/reviews/lane1-architecture-audit-2026-06-16.md
@@ -426,9 +426,9 @@ A draft **release checklist** for firmware + services + dashboards + docs is in
 |---|---|---|---|---|
 | ESP32 disconnects | keepalive/on_stop clears client; pushes no-op; firmware runs on-chip | ≤60 s (keepalive) | auto-reconnect | ≤60 s silent TCP death window |
 | ESP32 reconnects | re-enumerates, force-push reconciles drift, immediate dispatch, logs `data_gaps` | yes | auto | gap telemetry not reconstructed here (HA job's job) |
-| DB unreadable | writes try/except + continue; telemetry buffered in-memory (lost on restart); ESP32 keeps running on-chip | partial (the monitor needs the DB) | DB self-heal / watchdog | **no bounded buffer/WAL → permanent telemetry loss for the window**; `setpoint_listener` conn has **no reconnect** |
+| DB unreadable | writes try/except + continue; telemetry **spooled to disk** (`/srv/verdify/state/spool/climate.jsonl` on the state PVC) and replayed on recovery; ESP32 keeps running on-chip | partial (the monitor needs the DB) | DB self-heal / watchdog | the climate spool IS the bounded buffer (corrects the earlier "no buffer" claim); `setpoint_listener` conn still has **no reconnect** |
 | Push partial/failed | `push_to_esp32` breaks on first exception, returns short count; dispatcher retries 3× then 1 warning alert | `esp32_push_failed` + `setpoint_unconfirmed` 5/15 min | auto next cycle | later params unpushed until next 300 s cycle |
-| Ingestor pod rescheduled (Recreate) | mandatory zero-writer window; **RWO Longhorn PVC detach/reattach race amplifies to minutes** (observed FailedMount on node6) | `sensor_offline` 2× interval | auto, slow | **no liveness probe → wedged pod never restarted**; STATE_DIR is non-critical regenerable cache |
+| Ingestor pod rescheduled (Recreate) | mandatory zero-writer window; **RWO Longhorn PVC detach/reattach race amplifies to minutes** (observed FailedMount on node6) | `sensor_offline` 2× interval | auto, slow | liveness probe + soft anti-affinity-off-node6 landed (L1 Phase 2, ready-to-sync). NOTE: STATE_DIR is NOT disposable — it holds the climate spool — so emptyDir is not an option; the real node6 fix is storage-infra |
 | MQTT down | reconnect loop | log only | auto | no dedicated alert |
 | Open-Meteo down | timeout → None → no-op | `sensor_offline`(forecast) ≤300 s | auto hourly | degrades planner only |
 
@@ -484,9 +484,11 @@ the monitor that detects a dead writer runs *in* the writer. The only out-of-ban
    of the ingestor.
 
 **P1**
-3. **Ingestor on node6 + RWO Longhorn PVC = recurring multi-minute write-gaps.** → pin ingestor off
-   node6 (affinity) and replace the RWO state PVC with `emptyDir` (STATE_DIR is regenerable cache)
-   to kill the detach/reattach race. (k8s manifest; the sync is the Jason device-write gate)
+3. **Ingestor on node6 + RWO Longhorn PVC = recurring multi-minute write-gaps.** → **landed (L1 Phase 2):**
+   a soft nodeAffinity off node6 + a DB-outage-tolerant liveness probe (`ingestor-resilience.patch.yaml`,
+   ready-to-sync). **Correction:** do NOT `emptyDir` the state PVC — `/srv/verdify/state/spool/climate.jsonl`
+   is the DB-outage replay buffer (operational data), so the PVC stays. The durable node6 storage fix is
+   a `storage-infra` item (coordination request filed). (Applying the patch restarts the writer — Jason gate.)
 4. **Writer-lease fence inert** (`VERDIFY_WRITER_LEASE_ENABLED=0`); firmware `max_connections:20`
    means two pods *could* both connect. → arm `#240` (also buys SIGTERM fast-release). (Jason-gated)
 5. **No liveness/readiness probe on the single writer** — `ingestor-healthz.py` exists but is wired
@@ -517,9 +519,12 @@ the monitor that detects a dead writer runs *in* the writer. The only out-of-ban
 add the corpus-freshness gate, remove the soft-skip, run the broad test suite in CI, add the
 registry↔firmware↔anchors guards (D7), strengthen the two weak guards, seal the OTA password.
 
-**Phase 2 — reliability (mix; cluster syncs are Jason-gated)** — pin ingestor off node6 +
-`emptyDir` state, out-of-band writer-absent alert, liveness probe, arm the writer lease (#240),
-DB PITR via CNPG re-arm or WAL archiving + restore drill.
+**Phase 2 — reliability (mix; cluster syncs are Jason-gated)** — DONE/landed ready-to-sync: soft
+anti-affinity off node6 + DB-outage-tolerant liveness probe (keep the state PVC — it holds the
+climate spool, NOT emptyDir). Filed as coordination requests: out-of-band writer-absent +
+telemetry-stall alert (`monitoring-stack`), durable node6 storage fix (`storage-infra`). Gated
+(already STAGED / dependency): arm the writer lease (#240, `overlays/prod/STAGED-ha3-*`), DB PITR
+via CNPG re-arm or WAL archiving + restore drill (`storage-infra`/Jason).
 
 **Phase 3 — single-source-of-truth (larger, confirm scope)** — generate firmware `globals.yaml`
 band defaults + registry `_FW2_*` from the `crop_band_anchors` seed; repoint compliance dashboards


### PR DESCRIPTION
**Lane 1 (#343) Phase 2** — reliability hardening for the **sole ESP32 writer** (audit §8). Strategic-merge prod patch; applying it RESTARTS the single writer (Recreate) so the `argocd app sync` is a **Jason-gated** step — the manifest lands ready-to-sync.

### Changes
- **Liveness probe** — the writer had **none**, so a wedged event loop never self-healed. Wires `ingestor-healthz.py` but **tolerates exit 2 (DB unreachable)**: it restarts ONLY on exit 1 (climate stale despite a *reachable* DB = genuinely wedged). A DB outage therefore never restarts the writer — the loop keeps reconnecting and spooling to `climate.jsonl`. Thresholds: 120 s warmup, 5×30 s.
- **Soft `nodeAffinity` off node6** (audit D3 — node6 iSCSI/NFS FailedMount churned the writer twice in ~50 min). Preferred, not required (must stay device-VLAN-reachable); durable fix is storage-infra.

### Corrections folded in
The state PVC is **not** disposable — `/srv/verdify/state/spool/climate.jsonl` is the DB-outage replay buffer, so **emptyDir is out** and the audit's "no bounded buffer/WAL" finding is withdrawn (the spool IS it).

### Filed as coordination requests (not in this repo's ownership)
- `monitoring-stack`: out-of-band **writer-absent** (`sum(verdify_esp32_writer_estab)==0`) + telemetry-stall alert (the audit's P0 — the in-repo monitor runs *inside* the writer).
- `storage-infra`: durable node6 storage fix.

Gated remainder (unchanged): writer-lease **#240** (already STAGED in `overlays/prod/STAGED-ha3-*`), DB PITR.

`kubectl kustomize overlays/prod` renders clean; **replicas:1 + Recreate intact**, state volume still PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)