### PR TITLE
prod-promote: 0.25 pinch baseline (ingestor/mcp registry + planner prompt)

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -169,13 +169,13 @@ patches:
 # GHCR digests in-repo.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:95111ef843c225a6261c1791582198c3b91d1fbb9eb766c96b426187ba8c25d0
+    digest: sha256:380c8ae717e9cc5761c3c599959eb0161741c2adc72b9f0b2628fd4799a8bc2b
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
-    digest: sha256:14c608bb932c06fde30fdccec1019f3b6dbc0e6183d6cce24d34241f64f5e524
+    digest: sha256:6b084eb7c28f0ec3ceed2b999a710a832644c9dfbf9ea5f615638d4c045650a4
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
-    digest: sha256:22184ccae85d4c107d6011ff0324a3750b56cf2e74ea2add43a5eded42856b5a
+    digest: sha256:836e08248ceaf8a8556df6ab6d297e709ae0c9400d9ea545b00c3831533ee2a2
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
-    digest: sha256:900fed0dea328274c1675b35c1deadebdeba2d6cb40be3bd8d764717ff0a7f57
+    digest: sha256:aca5138e6a525b9214becb6b685f30a8b9f167f8a60197a593ba892b74ad7741
   # verdify-planner (#117): real published GHCR digest, resolved read-only via
   # `gh api orgs/VerdifyConsultancy/packages/container/verdify-planner/versions`
   # (the `branch-live-platform-main` build of planner_graph/). The planner image is


### PR DESCRIPTION
Digests-only promotion of the floating-baseline commit (2d5e245): band_track_fraction registry default 0.50→0.25 + planner prompt relax. Promotes the new ingestor/mcp `:branch-main` digests so the running planner uses the 0.25 baseline (no re-ramp to 0.50). Device already at 0.25 (operator push). ADR-0004. Auto-opened by operator (Actions PR-create org-blocked). After guard+merge: gated argocd sync verdify-prod-dark.