### PR TITLE
firmware(#299): mister re-fire dwell fence (planner-tunable min_off) — cut the dominant relay chatter

### DIFF
--- a/firmware/greenhouse/controls.yaml
+++ b/firmware/greenhouse/controls.yaml
@@ -153,6 +153,11 @@ interval:
                   id(runtime_mister_south_ms)  = 0;
                   id(runtime_mister_west_ms)   = 0;
                   id(runtime_mister_center_ms) = 0;
+                  // Clear the dwell-fence last-off stamps so a day rollover
+                  // never leaves a stale stamp that wrongly fences a zone.
+                  id(last_off_south_ms)  = 0;
+                  id(last_off_west_ms)   = 0;
+                  id(last_off_center_ms) = 0;
                   id(mister_water_today) = 0.0f;
                   // B5: reset DLI accumulator at midnight
                   id(dli_accumulator) = 0.0f;
@@ -1261,6 +1266,23 @@ interval:
               auto pulse_on_ms_for  = [&](int zone) -> uint32_t { return zone == 3 ? CENTER_PULSE_ON_MS  : PULSE_ON_MS;  };
               auto pulse_gap_ms_for = [&](int zone) -> uint32_t { return zone == 3 ? CENTER_PULSE_GAP_MS : PULSE_GAP_MS; };
 
+              // Mister re-fire dwell fence: a zone may not re-energize within
+              // mister_min_off_s of its own last off. The misters bypass the
+              // RelayMeta R[] min-on/off machinery (they're a multi-zone pulse
+              // FSM), so this is their per-zone equivalent. Suppression only
+              // DELAYS a re-fire (never forces a relay on / never over-waters),
+              // so the failure mode is benign. Returns true if energizing is
+              // allowed now.
+              const uint32_t MISTER_MIN_OFF_MS = (uint32_t)id(mister_min_off_s) * 1000UL;
+              auto mister_zone_last_off = [&](int z) -> uint32_t {
+                return z == 1 ? id(last_off_south_ms)
+                     : z == 2 ? id(last_off_west_ms)
+                     : id(last_off_center_ms);
+              };
+              auto mister_zone_can_on = [&](int z) -> bool {
+                return z <= 0 || (now_ms - mister_zone_last_off(z)) >= MISTER_MIN_OFF_MS;
+              };
+
               // IRR-2: raise the hysteresis floor from the legacy 0.05 to the
               // operator-tunable mister_hysteresis_kpa (default 0.10) so the
               // mister state machine cannot chatter inside a tight band. Still
@@ -1327,7 +1349,25 @@ interval:
                 if(zone == 1 && !south_wet_allowed) zone = first_allowed_mister_zone();
                 if(zone == 2 && !west_wet_allowed) zone = first_allowed_mister_zone();
                 if(zone == 3 && !center_wet_allowed) zone = first_allowed_mister_zone();
-                if(zone == 0) return;
+                if(zone == 0) { id(mister_pulse_zone) = 0; return; }
+                // Mister re-fire dwell fence (mister_min_off_s): if the chosen
+                // zone is still inside its min-off hold, try the other eligible
+                // zone; if none is ready, hold this cycle (all misters stay off,
+                // mister_pulse_zone=0). The caller arms mister_pulse_timer_ms =
+                // pulse_on_ms_for(0) = PULSE_ON_MS, so the FSM re-evaluates ~one
+                // gap later — by which point min_off has elapsed and it fires.
+                // Suppression only DELAYS a re-fire; it never forces a relay on
+                // and never extends a normal pulse, so the failure mode is benign.
+                if(!mister_zone_can_on(zone)) {
+                  int alt = first_allowed_mister_zone();
+                  if(alt > 0 && alt != zone && mister_zone_can_on(alt)) {
+                    zone = alt;
+                  } else {
+                    ESP_LOGI("mister","DWELL-HOLD zone=%d (min_off %us)", zone, (unsigned)id(mister_min_off_s));
+                    id(mister_pulse_zone) = 0;
+                    return;
+                  }
+                }
                 // sprint-2: last-fire ms for fairness watchdog.
                 // sprint-7: per-zone cycle counters at the rising edge
                 //          (turn_on_zone is always preceded by all-off,
@@ -1342,6 +1382,14 @@ interval:
               };
 
               auto turn_off_all_misters = [&]() {
+                // Stamp the just-energized zone's last-off BEFORE clearing
+                // mister_pulse_zone so the dwell fence can suppress a too-fast
+                // re-fire of that zone. All off-paths (pulse expiry, de-escalate,
+                // blocked, safety) funnel through here, so the stamp is complete.
+                const int off_z = id(mister_pulse_zone);
+                if(off_z == 1)      id(last_off_south_ms)  = now_ms;
+                else if(off_z == 2) id(last_off_west_ms)   = now_ms;
+                else if(off_z == 3) id(last_off_center_ms) = now_ms;
                 id(south_wall_mister).turn_off();
                 id(south_wall_mister_fertilized).turn_off();
                 id(west_wall_mister).turn_off();

--- a/firmware/greenhouse/globals.yaml
+++ b/firmware/greenhouse/globals.yaml
@@ -1336,6 +1336,22 @@ globals:
     restore_value: no
     initial_value: '0'
 
+  # Per-zone last turn-OFF stamp (ms). Powers the mister re-fire dwell fence
+  # (mister_min_off_s): a zone may not re-energize within mister_min_off_s of
+  # its own last off, collapsing sub-gap chatter without touching zone choice.
+  - id: last_off_south_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+  - id: last_off_west_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+  - id: last_off_center_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+
   # Daily counter of fairness-watchdog overrides (reset at midnight).
   - id: cnt_mister_fairness_overrides_today
     type: int
@@ -1568,6 +1584,17 @@ globals:
     initial_value: '60'
 
   - id: mister_pulse_gap_s
+    type: int
+    restore_value: no
+    initial_value: '45'
+
+  # Mister re-fire dwell floor (s). A zone may not re-energize within this of
+  # its own last turn-off — suppresses the sub-gap on/off chatter the misters
+  # (uniquely among relays) had no min-on/off protection against. Default 45s
+  # == the designed pulse gap, so it only fences re-fires FASTER than the
+  # intended cadence (never extends a normal pulse / never over-waters).
+  # Planner-tunable for cycling reduction; firmware-clamped to a sane minimum.
+  - id: mister_min_off_s
     type: int
     restore_value: no
     initial_value: '45'

--- a/firmware/greenhouse/sensors.yaml
+++ b/firmware/greenhouse/sensors.yaml
@@ -2229,6 +2229,18 @@ sensor:
       return (float)id(mister_pulse_gap_s);
 
   - platform: template
+    id: cfg_mister_min_off_s
+    name: "Cfg • Mister Min Off (s)"
+    unit_of_measurement: "s"
+    state_class: measurement
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    update_interval: 30s
+    lambda: |-
+      if (!id(cfg_first_pull_ok)) return NAN;
+      return (float)id(mister_min_off_s);
+
+  - platform: template
     id: cfg_mister_water_budget_gal
     name: "Cfg • Mister Water Budget (gal)"
     unit_of_measurement: "gal"

--- a/firmware/greenhouse/tunables.yaml
+++ b/firmware/greenhouse/tunables.yaml
@@ -551,6 +551,18 @@ number:
           id(num_mister_pulse_gap).publish_state(x);
 
   - platform: template
+    id: num_mister_min_off
+    name: "Mister Min Off (s)"
+    min_value: 30
+    max_value: 120
+    step: 5
+    lambda: "return id(mister_min_off_s);"
+    set_action:
+      - lambda: |
+          id(mister_min_off_s) = (int)x;
+          id(num_mister_min_off).publish_state(x);
+
+  - platform: template
     id: num_mister_vpd_weight
     name: "Mister VPD Weight"
     min_value: 0.5

--- a/ingestor/iris_planner.py
+++ b/ingestor/iris_planner.py
@@ -384,6 +384,13 @@ dispatcher-owned range.
   25-35s near the edge, and 45-60s after VPD-low overshoot or condensation
   risk. Keep `mister_pulse_on_s` around 60s unless cycles visibly fail to move
   VPD.
+- `mister_min_off_s` s, [30-120], def 45 — re-fire dwell floor: a mister zone
+  cannot re-energize within this of its own last off, so it collapses sub-gap
+  on/off chatter (the misters lack the relay min-on/off protection the climate
+  relays have). Default 45s == the designed pulse gap (only fences chatter,
+  never normal misting). Raise toward 60-90s to cut mister cycling/wear when
+  the transition log shows a zone re-firing faster than the climate needs; it
+  never reduces intended misting above the gap. Confirmed by `cfg_mister_min_off_s`.
 - Escalate with fog when misters are pulsing but VPD is still above band. Fog is
   the heavy 7x wet-assist path: use `fog_escalation_kpa` 0.15-0.20 for hot/dry
   venting with healthy dew margin, 0.25-0.30 for mild dry stress, and 0.35-0.50

--- a/verdify_schemas/tunable_registry.py
+++ b/verdify_schemas/tunable_registry.py
@@ -645,6 +645,24 @@ REGISTRY: dict[str, TunableDef] = {
         tier=1,
         notes="Pulse-rotation OFF (evap dwell) between zones.",
     ),
+    "mister_min_off_s": TunableDef(
+        name="mister_min_off_s",
+        kind="numeric",
+        min=30,
+        max=120,
+        default=45,
+        fw_clamp_lo=30,
+        fw_clamp_hi=120,
+        esp_object_id="mister_min_off__s_",
+        cfg_readback_object_id="cfg___mister_min_off__s_",
+        push_owner="planner",
+        planner_pushable=True,
+        tier=2,
+        notes="Mister re-fire dwell floor: a zone may not re-energize within "
+        "this of its own last off. Default 45s == the designed pulse gap, so it "
+        "only fences sub-gap chatter (never extends a pulse / over-waters). "
+        "Raise to cut mister cycling/wear when re-fires are faster than needed.",
+    ),
     "mister_vpd_weight": TunableDef(
         name="mister_vpd_weight",
         kind="numeric",


### PR DESCRIPTION
REPLAY_DIFF_THRESHOLD_PCT: 0

## What
The three misters are the **only physical relays with no min-on/off protection** — they bypass `RelayMeta R[]` for a multi-zone rotating pulse FSM. Root cause of the dominant chatter: mister_center **202 sub-60s / 79 sub-30s / 191 refire<90s** per 7d, vs vent/fan/heat at **0-1 sub-60s**. Adds a per-zone re-fire dwell fence (`mister_min_off_s`): a zone may not re-energize within min_off of its own last off.

## How (benign by construction)
`turn_on_zone()` tries an alternate eligible zone when the chosen one is fenced, else holds the cycle (all misters off, `mister_pulse_zone=0`); the caller arms `pulse_on_ms_for(0)=PULSE_ON_MS`, so the FSM re-evaluates ~one gap later and fires once min_off elapses. **Suppression only ever DELAYS a re-fire — never forces a relay on, never extends a pulse, never over-waters.** Default 45s == the designed pulse gap, so it fences only sub-gap chatter, not intended misting. Planner-tunable (registry + `cfg_mister_min_off_s` readback + Iris prompt, sane min 30s).

## Validation (firmware freeze artifacts)
- `firmware-replay OLD=origin/main NEW=HEAD` — **0 divergent rows** (mister FSM is not in the replay harness AND `greenhouse_logic.h` is untouched, so mode/relay decisions are byte-identical).
- `firmware-invariants` — **16/16 pass**, 193,525 rows.
- `make test-firmware` — pass.
- esphome compile — **SUCCESS** (Flash 59%, RAM 33%).
- registry/drift/prompt-coverage/ruff — pass.

Validation caveat (honest): the mister FSM lives in `controls.yaml`, so it is exercised by esphome-compile + the 48h on-device bake, **not** by replay/unit tests (replay covers `greenhouse_logic.h` only). The benign failure mode + the 48h bake are the safety net.

## Deploy
Source PR. The `cfg_mister_min_off_s` readback + registry route ride the mcp/ingestor containers; the firmware itself is a **gated OTA** (preflight: 0 critical alerts ✓, 3-day bake since #295 ✓, first OTA this Denver-week ✓, single-writer interlock at flash time).

## Post-merge restart
Bounce **verdify-mcp** (new `mister_min_off_s` planner-pushable surface) and **verdify-ingestor** (registry route + `cfg_mister_min_off_s` + prompt) so the schema change takes effect.