### PR TITLE
gitops(prod-promote): bump prod digests for mister-dwell registry (mcp/ingestor) + planner playbook

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -181,13 +181,13 @@ patches:
 # GHCR digests in-repo.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:380c8ae717e9cc5761c3c599959eb0161741c2adc72b9f0b2628fd4799a8bc2b
+    digest: sha256:8b7b34f6adcd33353e0f34d06c85cfd821e00e7ec5beff02b3b49aae46768015
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
-    digest: sha256:6b084eb7c28f0ec3ceed2b999a710a832644c9dfbf9ea5f615638d4c045650a4
+    digest: sha256:23f1076ad4d3428d0b151c8ef09be062daff3e01bab881ab70984573694fce76
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
-    digest: sha256:836e08248ceaf8a8556df6ab6d297e709ae0c9400d9ea545b00c3831533ee2a2
+    digest: sha256:f4bb0bdf65c5fcaf920df2347b8c1784f722f3f2dc73d2bd6a66866d1f3d9a1a
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
-    digest: sha256:aca5138e6a525b9214becb6b685f30a8b9f167f8a60197a593ba892b74ad7741
+    digest: sha256:3f822d9ed7cd108761881d399a0eb177a012c914e97afc196427cb495bff5970
   # verdify-planner (#117): real published GHCR digest, resolved read-only via
   # `gh api orgs/VerdifyConsultancy/packages/container/verdify-planner/versions`
   # (the `branch-live-platform-main` build of planner_graph/). The planner image is
@@ -195,7 +195,7 @@ images:
   # from each overlay's verdify-config + sealed secret). prod is human-gated and
   # its digest is advanced only by a reviewed prod-promote PR.
   - name: ghcr.io/verdifyconsultancy/verdify-planner
-    digest: sha256:ce1d8271e344b8e9cb3af2f8dde933116db56cc5159dbb8e0da710526bc20b0d
+    digest: sha256:41d057d7b7c1f369b9c72f847417333a43ffdcbac956e1d49f9c9e9b1abdc2c7
   # verdify-setpoint-server (#118): real GHCR digest of the grow-light writer +
   # setpoint-diagnostics image built from scripts/Dockerfile.setpoint-server. The
   # `branch-live-platform-main` build is published + repo-linked to


### PR DESCRIPTION
Prod digest promotion (opened manually — #320: Actions can't create PRs).

Promotes the `:branch-main` GHCR digests into `overlays/prod` so the prod cluster picks up:
- **verdify-mcp** — new `mister_min_off_s` planner-pushable surface + climate-relay dwell knobs (PR #403/#404).
- **verdify-ingestor** — registry route + `cfg_mister_min_off_s` ingestion + the restored planner playbook (path fix + in-image copy).
- api/migrate/planner digests advance with main.

Digests-only change to `overlays/prod/kustomization.yaml` (promote-diff-guard enforces). After merge: `argocd app sync verdify-prod-dark`, then bounce verdify-mcp + verdify-ingestor.

This completes the e2e: the planner will then be able to tune `mister_min_off` live (cfg readback confirms on the device, which is already running the dwell at the 45s firmware default).