### PR TITLE
fix(prod): ingestor state volume emptyDir in git == live (#382) — get ArgoCD synced

### DIFF
--- a/deploy/k8s/overlays/prod/ingestor-state-volume.yaml
+++ b/deploy/k8s/overlays/prod/ingestor-state-volume.yaml
@@ -34,6 +34,20 @@ spec:
             - name: state
               mountPath: /srv/verdify/state
       volumes:
+        # ⚠️ TEMPORARY (#382, 2026-06-20): emptyDir, NOT the iSCSI PVC below. The
+        # Synology iSCSI target-cap is exhausted and verdify-ingestor-state won't
+        # remount on restart (writer was down ~10min). The LIVE writer runs emptyDir,
+        # so this keeps git==live and a sync won't re-wedge the writer. The
+        # dispatcher re-seeds /srv/verdify/state on boot (146 cfg readbacks + band
+        # setpoints), so losing the prior spool is bounded. The separate broken
+        # TEMP-ingestor-state-emptydir.patch.yaml `$patch: replace` never overrode
+        # this PVC in the render (it left git=PVC vs live=emptyDir → ArgoCD
+        # OutOfSync); defining emptyDir here directly is the reliable fix.
+        # REVERT to the persistentVolumeClaim below (and drop this block) once the
+        # iSCSI cap is fixed.
         - name: state
-          persistentVolumeClaim:
-            claimName: verdify-ingestor-state
+          emptyDir: {}
+        # PVC (restore when #382/iSCSI is fixed):
+        # - name: state
+        #   persistentVolumeClaim:
+        #     claimName: verdify-ingestor-state

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -115,12 +115,12 @@ patches:
   - path: db-storageclass-iscsi.yaml
   # DEVICE-WRITE INTERLOCK (#79): VERDIFY_DEVICE_WRITE_ENABLED=1 — prod only.
   - path: device-write-configmap.yaml
-  # ⚠️ TEMPORARY (2026-06-20): ingestor state on emptyDir, not the iSCSI PVC — the
-  # Synology iSCSI target-cap is exhausted and the PVC won't remount on restart
-  # (writer was down ~10min). Keeps git==live so a sync won't re-wedge the writer.
-  # REVERT (remove this line + TEMP-ingestor-state-emptydir.patch.yaml) once the
-  # iSCSI cap is fixed. See the storage-wedge tracking issue.
-  - path: TEMP-ingestor-state-emptydir.patch.yaml
+  # ⚠️ TEMPORARY (#382, 2026-06-20): the ingestor `state` volume is emptyDir, not the
+  # iSCSI PVC — defined DIRECTLY in ingestor-state-volume.yaml. (The old
+  # TEMP-ingestor-state-emptydir.patch.yaml `$patch: replace` here never overrode the
+  # PVC in the render, leaving git=PVC vs live=emptyDir → ArgoCD OutOfSync; the
+  # emptyDir now lives in ingestor-state-volume.yaml so git==live.) REVERT that file
+  # to the PVC once the iSCSI cap is fixed. See the storage-wedge tracking issue.
   # HA-3.1 FAST FAILOVER (#239, Jason-approved 2026-06-20): pin the ingestor to
   # priorityClassName verdify-device-writer + 20s NoExecute tolerations + a cpu
   # request (no cpu LIMIT) + terminationGracePeriodSeconds:15, so the sole writer


### PR DESCRIPTION
**Gets `verdify-prod-dark` to Synced.** The ingestor was permanently OutOfSync because the prod overlay rendered the iSCSI `persistentVolumeClaim` while the live writer runs **emptyDir** (the #382 target-cap TEMP patch). The separate `TEMP-ingestor-state-emptydir.patch.yaml` used a strategic-merge `$patch: replace` that **never** overrode the PVC in the render — so git=PVC vs live=emptyDir, and `argocd app sync` failed trying to re-attach the wedged iSCSI PVC.

## Fix
Define `state` as emptyDir **directly** in `ingestor-state-volume.yaml` (single source), keep the `/srv/verdify/state` mount, drop the broken TEMP patch from the kustomization. Render now == live → a refresh goes Synced **with no writer restart** (the volume already matches). PVC preserved in a comment + the `ingestor-state-pvc.yaml` resource for the #382 revert.

Render-verified: prod overlay → `state=emptyDir`, mount `/srv/verdify/state`. `argocd diff` confirmed the volume is the only real drift (rest is normalized annotation noise).