### PR TITLE
lab-publisher: content-hash delta uploads to S3 (stop re-pushing the whole tree every 10 min)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -214,7 +214,7 @@ jobs:
             # workflow: Quartz toolchain, generated-content scripts, schemas,
             # firmware tunable source docs, and the k3s publisher wrapper.
             case "$f" in
-              site/*|scripts/Dockerfile.lab-publisher|scripts/lab-publish-k3s.sh|scripts/lab-publisher-docker-shim.sh)
+              site/*|scripts/Dockerfile.lab-publisher|scripts/lab-publish-k3s.sh|scripts/lab-publisher-docker-shim.sh|scripts/s3-delta-sync.py)
                 lab_publisher_impact=true
                 ;;
               scripts/publish-site-content.sh|scripts/rebuild-site.sh|scripts/generate-*.py|scripts/render-*.py)

--- a/docs/site-publishing-pipeline.md
+++ b/docs/site-publishing-pipeline.md
@@ -10,9 +10,10 @@ storage. The bucket is provided by Secret `verdify-lab-publisher-s3`; the
 default prefix is `lab`.
 
 ```text
-s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/content/  # Markdown + static source tree
-s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/public/   # generated Quartz public tree
-s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/state/    # publish/build logs and context
+s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/content/    # Markdown + static source tree
+s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/public/     # generated Quartz public tree
+s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/state/      # publish/build logs and context
+s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/manifests/  # per-tree content-hash manifests (delta-sync bookkeeping)
 ```
 
 The in-cluster publisher syncs content to the `verdify-lab-site-cache` PVC at
@@ -68,7 +69,7 @@ Curated website content
   -> scripts/rebuild-site.sh
   -> npx quartz build --output /work/builds/public.*
   -> rsync staged output into /work/public
-  -> sync /work/content, /work/public, /work/state back to S3
+  -> delta-sync /work/content, /work/public, /work/state back to S3 (content-hash gated)
   -> verdify-lab nginx reads /work/public through the lab cache PVC
   -> Traefik / Cloudflare / lab.verdify.ai
 ```
@@ -94,6 +95,37 @@ the staged output into the live public directory:
 The sync uses delayed deletes, so existing pages stay available while new files
 copy into place. The `verdify-lab` nginx container serves the PVC read-only and
 does not need S3 credentials.
+
+## Delta Uploads to S3 (content-hash, change-gated)
+
+The S3 `public/` tree is a **durable mirror only** — nginx serves the PVC, and
+the publisher only ever downloads `content/` (never `public/`) to hydrate a cold
+PVC. That mirror used to be written with `aws s3 sync … --delete`, which decides
+what to upload by comparing **size + mtime**. Because the Quartz rebuild
+regenerates the whole `public/` tree every run, every file got a fresh mtime and
+the full ~400 MiB site re-uploaded to the (HDD-backed) endpoint every 10 minutes
+even when the rendered bytes were identical — pure write pressure on a saturated
+endpoint.
+
+`lab-publish-k3s` now uploads through `scripts/s3-delta-sync.py`, which drives
+uploads off a per-file **SHA-256 manifest** instead of mtime:
+
+- Walks the local tree → `{relpath: sha256}` and compares against the manifest of
+  what was last uploaded (PVC cache `/work/manifests/<tree>.json`, else the S3
+  copy under the `manifests/` prefix, else cold).
+- **Change gate:** if nothing differs, it uploads **zero** objects (the common
+  every-10-minutes no-op case).
+- Otherwise it uploads **only** the changed/new files (one
+  `aws s3 cp --recursive` over a hardlink staging tree of just those files) and,
+  with `--delete`, prunes keys whose local file vanished.
+- Persists the new manifest to the PVC and S3 so the next run is a true delta. A
+  rescheduled (wiped) PVC falls back to the S3 manifest, so it still deltas
+  instead of re-uploading the whole tree.
+
+The manifests live under their own `manifests/` prefix (outside
+content/public/state) so they never feed back into the walk. Steady-state runs
+now move only the handful of HTML pages whose content actually changed (e.g. a
+regenerated `generated at` timestamp) instead of the entire tree.
 
 ## Change Detection
 

--- a/scripts/lab-publish-k3s.sh
+++ b/scripts/lab-publish-k3s.sh
@@ -2,11 +2,17 @@
 # lab-publish-k3s.sh - in-cluster lab.verdify.ai publisher.
 #
 # S3/object storage is the durable store:
-#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/content/  Markdown + static source tree
-#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/public/   built Quartz output
-#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/state/    publish/build logs and context
+#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/content/    Markdown + static source tree
+#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/public/     built Quartz output
+#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/state/      publish/build logs and context
+#   s3://$LAB_S3_BUCKET/$LAB_S3_PREFIX/manifests/  per-tree content-hash manifests
 #
 # The RWX PVC mounted at /work is only the local build/serve cache.
+#
+# Uploads go through scripts/s3-delta-sync.py: a per-file SHA-256 manifest gates
+# the upload so an unchanged tree pushes nothing, and a changed tree pushes only
+# the files whose content actually changed (NOT the whole ~400 MiB tree every run
+# just because Quartz refreshed every mtime). See docs/site-publishing-pipeline.md.
 set -euo pipefail
 
 : "${LAB_S3_BUCKET:?set LAB_S3_BUCKET in the verdify-lab-publisher-s3 Secret}"
@@ -28,6 +34,9 @@ LAB_S3_PREFIX="${LAB_S3_PREFIX%/}"
 CONTENT_URI="${LAB_S3_CONTENT_URI:-s3://${LAB_S3_BUCKET}/${LAB_S3_PREFIX}/content}"
 PUBLIC_URI="${LAB_S3_PUBLIC_URI:-s3://${LAB_S3_BUCKET}/${LAB_S3_PREFIX}/public}"
 STATE_URI="${LAB_S3_STATE_URI:-s3://${LAB_S3_BUCKET}/${LAB_S3_PREFIX}/state}"
+# Per-tree content-hash manifests live OUTSIDE content/public/state so they never
+# feed back into the delta walk; see scripts/s3-delta-sync.py.
+MANIFEST_URI="${LAB_S3_MANIFEST_URI:-s3://${LAB_S3_BUCKET}/${LAB_S3_PREFIX}/manifests}"
 ENDPOINT_URL="${LAB_S3_ENDPOINT_URL:-${AWS_ENDPOINT_URL:-}}"
 
 WORK_ROOT="${LAB_WORK_ROOT:-/work}"
@@ -36,6 +45,7 @@ PUBLIC_DIR="${WORK_ROOT}/public"
 STATE_DIR="${WORK_ROOT}/state"
 BUILD_ROOT="${WORK_ROOT}/builds"
 LOCK_DIR="${WORK_ROOT}/locks"
+MANIFEST_DIR="${WORK_ROOT}/manifests"
 SITE_RUNTIME="${LAB_SITE_RUNTIME:-/opt/verdify-site}"
 
 DATE_ARG="${1:-${LAB_PUBLISH_DATE:-$(date +%Y-%m-%d)}}"
@@ -49,7 +59,22 @@ aws_s3() {
   fi
 }
 
-mkdir -p "$CONTENT_DIR" "$PUBLIC_DIR" "$STATE_DIR" "$BUILD_ROOT" "$LOCK_DIR"
+# delta_sync LABEL LOCAL_DIR REMOTE_URI — content-hash, change-gated upload.
+# Uploads only files whose SHA-256 changed and skips entirely when nothing
+# changed, so the every-10-min rebuild no longer re-pushes the whole tree to the
+# (HDD-backed) endpoint just because Quartz refreshed every mtime.
+delta_sync() {
+  "$PYTHON" "${VERDIFY_SCRIPT_ROOT}/s3-delta-sync.py" \
+    --label "$1" \
+    --local "$2" \
+    --remote "$3" \
+    --manifest "${MANIFEST_URI}/$1.json" \
+    --local-manifest "${MANIFEST_DIR}/$1.json" \
+    --endpoint "$ENDPOINT_URL" \
+    --delete
+}
+
+mkdir -p "$CONTENT_DIR" "$PUBLIC_DIR" "$STATE_DIR" "$BUILD_ROOT" "$LOCK_DIR" "$MANIFEST_DIR"
 
 CONTENT_LIST="${STATE_DIR}/s3-content-list.tmp"
 if aws_s3 ls "${CONTENT_URI}/" >"$CONTENT_LIST" 2>/dev/null && [[ -s "$CONTENT_LIST" ]]; then
@@ -110,11 +135,9 @@ export VERDIFY_DAILY_PLAN_DB_CMD="${VERDIFY_DAILY_PLAN_DB_CMD:-psql -U ${PGUSER}
 echo "Starting k3s lab publish: date=${DATE_ARG} reason=${REASON}"
 /app/scripts/publish-site-content.sh --date "$DATE_ARG" --reason "$REASON"
 
-echo "Uploading generated content to ${CONTENT_URI}/"
-aws_s3 sync "${CONTENT_DIR}/" "${CONTENT_URI}/" --delete
-echo "Uploading built public site to ${PUBLIC_URI}/"
-aws_s3 sync "${PUBLIC_DIR}/" "${PUBLIC_URI}/" --delete
-echo "Uploading publish state to ${STATE_URI}/"
-aws_s3 sync "${STATE_DIR}/" "${STATE_URI}/" --delete
+echo "Publishing content-hash deltas to object storage (skips unchanged trees)"
+delta_sync content "$CONTENT_DIR" "$CONTENT_URI"
+delta_sync public "$PUBLIC_DIR" "$PUBLIC_URI"
+delta_sync state "$STATE_DIR" "$STATE_URI"
 
 echo "k3s lab publish complete: date=${DATE_ARG} reason=${REASON}"

--- a/scripts/s3-delta-sync.py
+++ b/scripts/s3-delta-sync.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""s3-delta-sync.py — content-hash, change-gated delta uploader for the lab publisher.
+
+WHY THIS EXISTS
+---------------
+`aws s3 sync` decides what to upload by comparing **size + mtime**. The Quartz
+rebuild in `publish-site-content.sh` regenerates the *entire* `public/` tree on
+every run, so every file gets a fresh mtime and `aws s3 sync` re-uploads the
+whole ~400 MiB site to the HDD-backed S3 endpoint every 10 minutes — even when
+the rendered bytes are identical. On a saturated endpoint that is pure waste.
+
+WHAT THIS DOES
+--------------
+Drives uploads off a per-file SHA-256 manifest instead of mtime:
+
+  1. walk LOCAL                       -> {relpath: sha256}
+  2. load the manifest of what was last uploaded (PVC cache, else S3, else cold)
+  3. CHANGE GATE: if nothing differs, upload zero objects and exit
+  4. otherwise upload ONLY the changed/new files (one `aws s3 cp --recursive`
+     over a hardlink staging tree containing just those files)
+  5. with --delete, remove keys whose local file vanished
+  6. persist the new manifest (PVC cache + S3) so the next run is a true delta
+
+The manifest lives OUTSIDE the synced trees (its own `manifests/` prefix), so it
+never feeds back into the walk. nginx serves the PVC directly; the S3 copy of
+`public/` is a durable mirror only, so delta/skip behaviour is invisible to the
+live site.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+MANIFEST_VERSION = 1
+_READ_CHUNK = 1024 * 1024
+
+
+def log(label: str, msg: str) -> None:
+    print(f"[s3-delta-sync:{label}] {msg}", flush=True)
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(_READ_CHUNK), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def build_manifest(local: str) -> dict[str, str]:
+    """Map each regular file under ``local`` to its content hash (relpath keys)."""
+    manifest: dict[str, str] = {}
+    # followlinks=False: never descend symlinked dirs (avoid loops / escaping the tree).
+    for root, _dirs, files in os.walk(local, followlinks=False):
+        for name in files:
+            full = os.path.join(root, name)
+            if not os.path.isfile(full):  # skip sockets, broken symlinks, etc.
+                continue
+            manifest[os.path.relpath(full, local)] = sha256_file(full)
+    return manifest
+
+
+def aws_argv(endpoint: str | None, *args: str) -> list[str]:
+    argv = ["aws"]
+    if endpoint:
+        argv += ["--endpoint-url", endpoint]
+    argv += list(args)
+    return argv
+
+
+def run_aws(endpoint: str | None, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 — fixed argv, no shell
+        aws_argv(endpoint, *args),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def load_prev_manifest(local_manifest: str, manifest_uri: str, endpoint: str | None, label: str) -> dict[str, str]:
+    """Prefer the PVC cache; fall back to S3 so a rescheduled (wiped) PVC still deltas."""
+    if os.path.isfile(local_manifest):
+        try:
+            with open(local_manifest, encoding="utf-8") as fh:
+                return dict(json.load(fh).get("files", {}))
+        except (OSError, ValueError) as exc:
+            log(label, f"local manifest unreadable ({exc}); falling back to S3")
+    try:
+        proc = run_aws(endpoint, "s3", "cp", manifest_uri, "-")
+        return dict(json.loads(proc.stdout).get("files", {}))
+    except subprocess.CalledProcessError:
+        log(label, "no prior manifest in S3 — treating as cold start (full upload)")
+    except ValueError as exc:
+        log(label, f"S3 manifest unparseable ({exc}); treating as cold start")
+    return {}
+
+
+def stage_changed(local: str, changed: list[str], parent: str) -> str:
+    """Hardlink (copy on cross-device) the changed files into a temp tree mirroring relpaths."""
+    staging = tempfile.mkdtemp(prefix=".s3delta-", dir=parent)
+    for rel in changed:
+        src = os.path.join(local, rel)
+        dst = os.path.join(staging, rel)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        try:
+            os.link(src, dst)
+        except OSError:
+            shutil.copy2(src, dst)
+    return staging
+
+
+def write_manifest(local_manifest: str, manifest_uri: str, endpoint: str | None, files: dict[str, str]) -> None:
+    os.makedirs(os.path.dirname(local_manifest) or ".", exist_ok=True)
+    payload = json.dumps({"version": MANIFEST_VERSION, "files": files}, sort_keys=True)
+    with open(local_manifest, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+    run_aws(endpoint, "s3", "cp", local_manifest, manifest_uri, "--only-show-errors")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--local", required=True, help="local directory to mirror")
+    p.add_argument("--remote", required=True, help="destination s3://bucket/prefix (no trailing slash needed)")
+    p.add_argument("--manifest", required=True, help="s3:// URI of the per-tree manifest (outside the synced tree)")
+    p.add_argument("--local-manifest", required=True, help="PVC path for the manifest cache")
+    p.add_argument("--endpoint", default="", help="S3 endpoint URL (empty = AWS default resolution)")
+    p.add_argument("--label", default="tree", help="log label for this tree (content/public/state)")
+    p.add_argument("--delete", action="store_true", help="remove remote keys whose local file vanished")
+    p.add_argument("--dry-run", action="store_true", help="report the delta without touching S3")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    label = args.label
+    endpoint = args.endpoint or None
+    remote = args.remote.rstrip("/")
+
+    if not os.path.isdir(args.local):
+        log(label, f"local dir missing: {args.local}")
+        return 2
+
+    new_files = build_manifest(args.local)
+    prev_files = load_prev_manifest(args.local_manifest, args.manifest, endpoint, label)
+
+    changed = sorted(rel for rel, h in new_files.items() if prev_files.get(rel) != h)
+    deleted = sorted(rel for rel in prev_files if rel not in new_files) if args.delete else []
+
+    total_mb = sum(os.path.getsize(os.path.join(args.local, r)) for r in changed) / (1024 * 1024)
+    log(
+        label,
+        f"{len(new_files)} files; {len(changed)} changed/new (~{total_mb:.1f} MiB), {len(deleted)} to delete",
+    )
+
+    if not changed and not deleted:
+        log(label, "no content changes — skipping upload (change gate)")
+        return 0
+
+    if args.dry_run:
+        for rel in changed[:20]:
+            log(label, f"  would upload {rel}")
+        for rel in deleted[:20]:
+            log(label, f"  would delete {rel}")
+        if len(changed) + len(deleted) > 40:
+            log(label, "  … (list truncated)")
+        return 0
+
+    staging = ""
+    try:
+        if changed:
+            staging = stage_changed(args.local, changed, os.path.dirname(os.path.abspath(args.local)))
+            log(label, f"uploading {len(changed)} object(s) to {remote}/")
+            run_aws(endpoint, "s3", "cp", staging, remote, "--recursive", "--only-show-errors")
+        for rel in deleted:
+            run_aws(endpoint, "s3", "rm", f"{remote}/{rel}", "--only-show-errors")
+        if deleted:
+            log(label, f"pruned {len(deleted)} stale object(s) from {remote}/")
+        write_manifest(args.local_manifest, args.manifest, endpoint, new_files)
+    finally:
+        if staging and os.path.isdir(staging):
+            shutil.rmtree(staging, ignore_errors=True)
+
+    log(label, "delta upload complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The `verdify-lab-publisher` CronJob runs **every 10 minutes** and mirrors its
`content/`, `public/`, and `state/` trees to the **HDD-backed S3 endpoint**
(`s3-hdd.vallery.net`) with `aws s3 sync --delete`. `aws s3 sync` decides what to
upload by comparing **size + mtime** — but the Quartz rebuild in
`publish-site-content.sh` regenerates the *entire* ~400 MiB `public/` tree on
every run, so every file gets a fresh mtime and the **whole site re-uploads every
10 minutes even when the rendered bytes are identical**. That was flagged as the
top active client pressure on a saturated endpoint.

## Fix — push deltas, only on change

Route uploads through a new `scripts/s3-delta-sync.py` that drives uploads off a
per-file **SHA-256 manifest** instead of mtime:

- **Change gate** — if nothing differs, upload **zero** objects (the dominant
  every-10-minutes no-op case).
- **Delta only** — a changed tree uploads **only** the files whose content hash
  changed (one `aws s3 cp --recursive` over a hardlink staging tree of just those
  files) and, with `--delete`, prunes keys whose local file vanished.
- **Durable bookkeeping** — the manifest is persisted to the PVC cache and S3
  (`manifests/` prefix, outside the synced trees). A rescheduled/wiped PVC falls
  back to the S3 manifest, so it still deltas instead of re-uploading everything.

Steady-state runs now move only the handful of HTML pages whose content actually
changed (e.g. a regenerated `generated at` timestamp) instead of the full tree;
truly-unchanged runs move nothing.

### Why this is safe for the live site
nginx serves the PVC directly, and the publisher only ever **downloads**
`content/` (never `public/`) to hydrate a cold PVC. The S3 `public/` tree is a
**durable mirror only**, so delta/skip behaviour is invisible to `lab.verdify.ai`.

## Verification (offline, stub `aws`)
- cold start → full upload + manifest write
- no change → change gate, **0 aws calls**
- changed + added + deleted → only deltas uploaded, stale key pruned
- `--dry-run` → report only, no mutations
- PVC-wipe (local cache gone) → S3 manifest fallback → still deltas (no full re-upload)
- `ruff check` + `ruff format --check` clean; `bash -n` + `git diff --check` clean

## Deploy note (not in this PR)
Takes effect once the `verdify-lab-publisher-k3s` image rebuilds on merge (CI
path filter updated to include the new script), the overlay digest is repinned,
and the gated ArgoCD sync runs. No device path; web tier only.

### Optional follow-up
With the change gate, an unchanged run now costs ~1 S3 `ls` (the content
download check) and no uploads, so the every-10-min schedule is no longer a
bandwidth concern. The cadence could still be relaxed (e.g. `*/30`) if desired,
but it's not required to fix the utilization issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)