### PR TITLE
planning: S8 vanda-night-dehum — sprint transaction (plan approval gate HR-01)

### DIFF
--- a/.agent-workflow/sprints/s8-vanda-night-dehum/gates/g-377-pinch-repin.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/gates/g-377-pinch-repin.yaml
@@ -1,0 +1,34 @@
+---
+schema_ref: human-gate.schema.yaml
+kind: HumanGate
+schema_version: '1.0'
+gate_id: g-377-pinch-repin
+sprint_id: s8-vanda-night-dehum
+lane_id: null
+type: decision
+status: open
+question: >-
+  The next OTA silently resets band_track_fraction 0.25 -> 0.0 (restore_value:
+  no; HEAD initial_value 0.0; planner registry now emits only 0), which is the
+  #377 float flip riding along invisibly (corpus-fed replay cannot show it).
+  Post-OTA, which pinch state runs during the #410 bake: (a) re-pin 0.25 for an
+  apples-to-apples bake and run the float trial separately later, or (b) accept
+  the float (0.0) and evaluate the joint change, effectively executing #377?
+  Night control-surface deltas at float: dehum entry 0.68 -> 0.64 kPa; cooling
+  edge from pinched-high (~65F, currently causing ~14% overnight VENT_COOL) to
+  the raw band high.
+owner: jason
+evidence_required:
+  - '2026-07-03 comment on #377 (reset mechanics + deltas)'
+  - '#410 design-review comment, deploy-confound 1'
+allowed_decisions:
+  - 'repin-0.25-post-ota: operator re-pushes 0.25 immediately after the OTA; #377 float trial scheduled separately'
+  - 'float-joint-bake: leave 0.0, bake the joint change, record it as the #377 trial'
+decision: null
+rationale: null
+opened_at: '2026-07-03T20:05:00Z'
+resolved_at: null
+resume_state: >-
+  Decision is executed at wave STEP-06 (post-OTA tunable state) and recorded in
+  the bake report either way; docs-413 documents both mechanics in the
+  checklist.

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/gates/g-411-night-temp-priority.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/gates/g-411-night-temp-priority.yaml
@@ -1,0 +1,36 @@
+---
+schema_ref: human-gate.schema.yaml
+kind: HumanGate
+schema_version: '1.0'
+gate_id: g-411-night-temp-priority
+sprint_id: s8-vanda-night-dehum
+lane_id: db-411-night-anchors
+type: decision
+status: open
+question: >-
+  Overnight center-zone (bare-root Vanda) priority — GitHub #411: deep-DIF cool
+  night (#409 Item 4, keep 62F target / higher RH) vs dry-roots warm-hold
+  (#410, hold ~66F / VPD ~0.83) vs seasonal split. Physics: mutually exclusive
+  under current outdoor humidity (62F caps VPD at ~0.71 full-exchange; ~0.83
+  needs ~64-66F). Mechanically, #410 cannot engage until the night corridor is
+  re-raised: the house (66.7F) sits above the pinched temp_high (~65F) under
+  live #409 anchors, so heat_suppressed_by_upper_band vetoes the reheat hold.
+  Envelope context: the door window stays open until fall (#412) — it is the
+  passive dryer today; #410 is its conditional replacement.
+owner: jason
+evidence_required:
+  - 'GitHub #411 body + 2026-07-03 comments (physics envelope, live-state verification, window data)'
+  - '#410 design-review comment (mechanical-gate quantification)'
+allowed_decisions:
+  - 'dry-roots-wins: revert #409 Item 4 night anchors (~65.7F target), vpd_target -> ~0.83, accept DIF ~18-21F (recommended in #411)'
+  - 'deep-dif-wins: keep 62F target, defer/deprioritize #410, accept wetter nights'
+  - 'seasonal-split: cool-DIF only in a flower-initiation window — RETURNS TO PLANNING (needs schedule/mode design)'
+decision: null
+rationale: null
+opened_at: '2026-07-03T20:05:00Z'
+resolved_at: null
+resume_state: >-
+  On dry-roots-wins: dispatch lane db-411-night-anchors with the decided values;
+  release wave STEP for migration 188 unblocks. On deep-dif-wins: cancel lane
+  db-411-night-anchors, mark #410 deferred, flag stays OFF permanently this
+  season. On seasonal-split: pause the wave and replan.

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/gates/plan-approval.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/gates/plan-approval.yaml
@@ -1,0 +1,34 @@
+---
+schema_ref: human-gate.schema.yaml
+kind: HumanGate
+schema_version: '1.0'
+gate_id: plan-approval-s8-vanda-night-dehum
+sprint_id: s8-vanda-night-dehum
+lane_id: null
+type: plan_approval
+status: open
+question: >-
+  Approve sprint S8 (vanda-night-dehum): 4 lanes (#410 firmware flag-OFF, #327
+  telemetry as bake prerequisite, #413 doc drift, #411-gated anchor migration),
+  the wave release plan (gated OTA + activation sequence with night_min>=64F
+  rollback canary), the two decision gates (g-411 night priority, g-377 pinch
+  re-pin), and the recorded exception that formal project-definition/
+  architecture-contract artifacts are substituted by the repo-native contracts?
+owner: jason
+evidence_required:
+  - sprint-plan.md (stakeholder summary)
+  - sprint-plan.yaml + lanes/lane-map.yaml + 4 lane contracts (validated)
+  - release/wave-release-plan.yaml (validated)
+  - '#410 design-review comment + #411/#377/#412/#413 board updates (2026-07-03)'
+allowed_decisions:
+  - approve
+  - revise
+  - reject
+decision: null
+rationale: null
+opened_at: '2026-07-03T19:57:21Z'
+resolved_at: null
+resume_state: >-
+  On approve (merge of the plan PR): hand off to sprint-orchestrator to dispatch
+  parallel group 1 (fw-410, data-327, docs-413); db-411-night-anchors waits on
+  gate g-411. On revise: planner updates the transaction and re-opens this gate.

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/data-327-moisture-telemetry.contract.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/data-327-moisture-telemetry.contract.yaml
@@ -1,0 +1,143 @@
+---
+schema_ref: lane-contract.schema.yaml
+kind: LaneContract
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+lane_id: data-327-moisture-telemetry
+title: '#327 moisture-estimator telemetry: migration 187 + ingestor + MCP exposure'
+status: draft
+issue_ids: [327]
+coupling_justification: null
+objective: >-
+  Make every VPD/dehum decision explainable from the DB: persist mx_action,
+  mx_reason, vent_vpd_gain_kpa, heat_vpd_gain_kpa, selected/expected gain,
+  outdoor_fresh, outdoor staleness, vent_overcools, heat_assist_corun and dwell
+  state — PLUS the two fields #410 adds (vent_held_vpd_gain_kpa, hold_required)
+  — via schema-first migration 187, the ingestor write path, and MCP/outcome_kpi
+  read surfaces used by #371 grading.
+desired_outcome: >-
+  After container promotion + rule-7 restarts, a single documented SQL query
+  classifies each overnight action row by estimator reason (vent_dehum /
+  vent_plus_heat / vent_plus_heat_hold / heat_assist / no_effective_action), so
+  the #410 activation bake is evaluated from telemetry instead of psychrometric
+  reconstruction. This lane is the bake-evaluation prerequisite (promoted W3->W1).
+non_goals:
+  - 'No firmware changes (fw-410 owns the emitter; JSON shape is additive and coordinated).'
+  - 'No dashboard/Grafana panels (follow-up under #371 if needed).'
+  - 'No second migration; 188 belongs to db-411-night-anchors.'
+  - 'No prod apply: migration 187 is applied only in the release wave.'
+baseline_sha: 0efdb2f59a8600130cd9521696e395423c86e910
+branch: data-327-moisture-telemetry
+module_contracts:
+  - verdify_schemas/tests/test_drift_guards.py
+  - docs/planner/planner-io-schema.md
+  - docs/firmware-control-contract.md
+worktree_policy:
+  one_coding_session_per_worktree: true
+  lock_required: true
+lease_policy:
+  worker_ttl_hours: 24
+  critic_ttl_hours: 8
+runtime_namespace:
+  strategy: derived_at_dispatch
+ownership:
+  domains: [db-schema, ingestor, mcp]
+  owned_paths:
+    - db/migrations/187-moisture-estimator-telemetry.sql
+    - db/migrations/tests/
+    - verdify_schemas/
+    - ingestor/entity_map.py
+    - ingestor/ingestor.py
+    - mcp/server.py
+  prohibited_paths:
+    - firmware/
+    - docs/firmware-fsm-spec.md
+    - docs/adr/
+    - docs/RELEASE-CHECKLIST.md
+    - docs/handoff/
+    - docs/runbooks/
+  coordination_required_paths:
+    - docs/planner/
+  owned_interfaces:
+    - 'climate_action_log estimator columns / source_system_state JSON contract (additive)'
+    - 'outcome_kpi() + scorecard estimator-reason fields'
+dependencies:
+  hard: []
+  soft:
+    - lane_id: fw-410-vent-reheat-hold
+      coordination: >-
+        Field-name agreement for vent_held_vpd_gain_kpa + hold_required before
+        either PR merges; the parser must tolerate their ABSENCE (live fw
+        995c9b3 predates even #385's emitter).
+acceptance_criteria:
+  - id: LANE-AC-01
+    statement: >-
+      Migration 187 lands schema-first, classified by
+      scripts/check_migration_rollback_safety.py, with a rollback-wrap (or
+      swap-COMMIT) proof recorded per its classification; no outer-transaction
+      wrap if self-committing.
+    sprint_acceptance_ids: [SPR-AC-03]
+    evidence_required:
+      - 'make migration-rollback-safety output + the rollback proof transcript'
+  - id: LANE-AC-02
+    statement: >-
+      Ingestor stores the estimator fields without breaking existing action-log
+      consumers (absent fields tolerated for pre-#410 firmware); drift guards
+      prove schema, entity map, and MCP surfaces agree.
+    sprint_acceptance_ids: [SPR-AC-03]
+    evidence_required:
+      - 'make test output (verdify_schemas drift guards + ingestor tests)'
+  - id: LANE-AC-03
+    statement: >-
+      A documented explain-query classifies each VPD/dehum action bucket by
+      mx_reason and expected-vs-observed VPD direction; recorded in the PR and
+      referenced from #327.
+    sprint_acceptance_ids: [SPR-AC-03]
+    evidence_required:
+      - 'Query text + sample output (against local/test fixture) in the PR'
+  - id: LANE-AC-04
+    statement: >-
+      Rule-7 restart documentation: PR body names verdify-ingestor + verdify-mcp
+      as post-merge bounces; service-restart-drift-guard green.
+    sprint_acceptance_ids: [SPR-AC-03, SPR-AC-06]
+    evidence_required:
+      - 'PR body restart section + CI check'
+validation_commands:
+  - id: V1
+    command: make lint
+    purpose: repo lint gate
+    required: true
+  - id: V2
+    command: make test
+    purpose: python tests incl. drift guards (known flaky test_dew_point_risk_computes tolerated)
+    required: true
+  - id: V3
+    command: make migration-rollback-safety
+    purpose: classify 187 and every migration touched
+    required: true
+  - id: V4
+    command: '.venv/bin/python scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/187-moisture-estimator-telemetry.sql'
+    purpose: preflight the rollback-validation shape before any psql use
+    required: true
+required_evidence:
+  - 'Rollback classification + proof for 187'
+  - 'Drift-guard green run'
+  - 'Explain-query with sample output'
+git_policy:
+  pull_request_required: true
+  github_checks_required: true
+  self_merge_allowed: false
+  clean_worktree_required: true
+escalation_conditions:
+  - 'Migration 187 turns out self-committing (contains a commit-forcing statement) — stop and re-plan the rollback proof per CLAUDE.md before touching any DB.'
+  - 'Any consumer break in existing action-log readers.'
+  - 'Field-name disagreement with fw-410 that cannot be resolved additively.'
+  - 'Any temptation to apply 187 to prod from the lane — forbidden.'
+definition_of_done:
+  - 'PR open, validation green, restart list in body.'
+  - 'Independent critic approval on head SHA.'
+  - 'Merged to main; migration NOT applied; #327 left open for the release wave (apply + prod verification).'
+approval:
+  status: pending
+  approver: null
+  approved_at: null

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/db-411-night-anchors.contract.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/db-411-night-anchors.contract.yaml
@@ -1,0 +1,112 @@
+---
+schema_ref: lane-contract.schema.yaml
+kind: LaneContract
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+lane_id: db-411-night-anchors
+title: '#411 night-anchor migration 188 (BLOCKED on gate g-411-night-temp-priority)'
+status: draft
+issue_ids: [411]
+coupling_justification: null
+objective: >-
+  The moment Jason resolves gate g-411 (deep-DIF cool night vs dry-roots
+  warm-hold vs seasonal split), produce ONE migration (188) that implements the
+  decision: the house night temp anchors (temp_low/target/high solar-midnight
+  values) AND the vpd_target retune toward ~0.83 together, regenerated through
+  the canonical band_defaults seed path (the migration-177 pattern from PR #409),
+  with registry/band-default sources kept in sync.
+desired_outcome: >-
+  A ready-to-apply, rollback-proven migration on its branch the same day the
+  decision lands, so #410 activation is never blocked on migration authoring.
+  Under decision option 1 (dry-roots wins) the night corridor is re-raised so
+  the served temp_target ~65.7-66F sits INSIDE the pinched band and the #410
+  hold can mechanically engage.
+non_goals:
+  - 'Do NOT pre-empt the decision: no default values are committed before g-411 resolves.'
+  - 'No prod apply; the release wave applies 188 behind the gate.'
+  - 'No firmware changes; no telemetry changes.'
+baseline_sha: 0efdb2f59a8600130cd9521696e395423c86e910
+branch: db-411-night-anchors
+module_contracts:
+  - docs/adr/0004-floating-corridor-control.md
+  - db/migrations/177-band-defaults-from-canonical-seed.sql
+worktree_policy:
+  one_coding_session_per_worktree: true
+  lock_required: true
+lease_policy:
+  worker_ttl_hours: 12
+  critic_ttl_hours: 4
+runtime_namespace:
+  strategy: derived_at_dispatch
+ownership:
+  domains: [db-schema, band-defaults]
+  owned_paths:
+    - db/migrations/188-night-anchor-priority.sql
+    - db/migrations/tests/
+    - firmware/greenhouse/band_defaults.yaml
+  prohibited_paths:
+    - firmware/lib/
+    - firmware/test/
+    - ingestor/
+    - mcp/
+    - verdify_schemas/
+  coordination_required_paths:
+    - db/migrations/
+  owned_interfaces:
+    - 'crop_band_anchors house-series night values (single source of truth for the served band)'
+dependencies:
+  hard:
+    - lane_id: data-327-moisture-telemetry
+      required_output: 'Migration 187 merged (migration numbering serialized; one migration change surface at a time)'
+  soft:
+    - lane_id: fw-410-vent-reheat-hold
+      coordination: >-
+        The decided vpd_target night value is also the estimator direction
+        boundary; confirm no firmware constant assumes 0.92.
+acceptance_criteria:
+  - id: LANE-AC-01
+    statement: >-
+      Migration 188 implements exactly the g-411 decision values for house
+      temp_low/temp_target/temp_high night anchors + vpd_target (~0.83 scaled to
+      the decision), via the canonical seed regeneration; band_defaults.yaml and
+      the migration agree (test_band_defaults_single_source green).
+    sprint_acceptance_ids: [SPR-AC-05]
+    evidence_required:
+      - 'Migration diff + test_band_defaults_single_source output'
+  - id: LANE-AC-02
+    statement: >-
+      Rollback proof recorded per classification (safe-to-wrap expected for the
+      177-pattern); make migration-rollback-safety green.
+    sprint_acceptance_ids: [SPR-AC-05]
+    evidence_required:
+      - 'Classification + rollback transcript'
+validation_commands:
+  - id: V1
+    command: make lint
+    purpose: repo gate
+    required: true
+  - id: V2
+    command: make migration-rollback-safety
+    purpose: classify 188
+    required: true
+  - id: V3
+    command: '.venv/bin/pytest tests/ -k "band_defaults_single_source or solar_band" -q'
+    purpose: band single-source + solar goldens
+    required: true
+required_evidence:
+  - 'Migration 188 + rollback proof'
+  - 'Band single-source test output'
+git_policy:
+  pull_request_required: true
+  github_checks_required: true
+  self_merge_allowed: false
+  clean_worktree_required: true
+escalation_conditions:
+  - 'g-411 resolves to option 3 (seasonal split): STOP — that outcome needs a schedule/mode design, not a static anchor migration; return to planning.'
+  - 'Any second migration needed; any anchor change outside the house night values + vpd_target.'
+definition_of_done:
+  - 'PR open only AFTER g-411 is resolved; validation green; critic approval; merged; NOT applied (release wave applies it).'
+approval:
+  status: pending
+  approver: null
+  approved_at: null

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/docs-413-freeze-drift.contract.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/docs-413-freeze-drift.contract.yaml
@@ -1,0 +1,118 @@
+---
+schema_ref: lane-contract.schema.yaml
+kind: LaneContract
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+lane_id: docs-413-freeze-drift
+title: '#413 doc/runbook drift: pinch re-pin step, OTA-reset mechanics, envelope notes, bake record'
+status: draft
+issue_ids: [413]
+coupling_justification: null
+objective: >-
+  Close the operator-facing documentation gaps found by the 2026-07-03 drift
+  sweep: (1) document that band_track_fraction is restore_value:no so every
+  OTA/reboot cold-starts it to 0.0 while live runs planner-pushed 0.25, and add
+  the explicit post-OTA re-pin/decision step; (2) add "record envelope config +
+  band_track_fraction state" to the 48h-bake checklist; (3) add dated
+  open-envelope notes (door screen-window open ~2026-06-19 until fall, #412) to
+  the three review docs whose physics/exchange assumptions predate it.
+desired_outcome: >-
+  An operator or agent following RELEASE-CHECKLIST s.B cannot run an OTA without
+  deciding and recording the pinch state, and cannot read the physics/estimator
+  review docs without seeing the envelope caveat.
+non_goals:
+  - 'docs/firmware-fsm-spec.md, docs/adr/** — behavior-coupled; owned by fw-410 (single writer per file). NOTE: this supersedes #413 item 2 file placement.'
+  - 'No decision-making: WHICH pinch state to run post-OTA is gate g-377 (Jason); this lane documents the mechanics of both outcomes.'
+  - 'No code, config, or schema changes of any kind.'
+baseline_sha: 0efdb2f59a8600130cd9521696e395423c86e910
+branch: docs-413-freeze-drift
+module_contracts:
+  - docs/RELEASE-CHECKLIST.md
+  - docs/handoff/k3s-agent-handoff.md
+worktree_policy:
+  one_coding_session_per_worktree: true
+  lock_required: true
+lease_policy:
+  worker_ttl_hours: 12
+  critic_ttl_hours: 4
+runtime_namespace:
+  strategy: derived_at_dispatch
+ownership:
+  domains: [docs]
+  owned_paths:
+    - docs/RELEASE-CHECKLIST.md
+    - docs/handoff/k3s-agent-handoff.md
+    - docs/runbooks/laptop-operator.md
+    - docs/reviews/greenhouse-physics-model-floating-control-2026-06-18.md
+    - docs/reviews/mechanical-response-matrix-overnight-dehum-2026-06-22.md
+    - docs/reviews/band-compliance-ota-signoff-2026-06-17.md
+  prohibited_paths:
+    - firmware/
+    - db/
+    - ingestor/
+    - mcp/
+    - docs/firmware-fsm-spec.md
+    - docs/adr/
+  coordination_required_paths: []
+  owned_interfaces: []
+dependencies:
+  hard: []
+  soft:
+    - lane_id: fw-410-vent-reheat-hold
+      coordination: >-
+        The checklist re-pin step must name the new dehum_vent_hold_enabled flag
+        in its post-OTA tunable-state record list; confirm final flag name.
+acceptance_criteria:
+  - id: LANE-AC-01
+    statement: >-
+      RELEASE-CHECKLIST s.B Deploy+post gains, between post-OTA sensor-health and
+      the 48h-bake line: (a) execute the g-377 pinch decision (re-pin 0.25 or
+      accept float) with the exact set_tunable/dispatcher command, (b) record
+      envelope config + band_track_fraction + dehum_vent_hold_enabled state in
+      the bake report.
+    sprint_acceptance_ids: [SPR-AC-04]
+    evidence_required:
+      - 'Checklist diff'
+  - id: LANE-AC-02
+    statement: >-
+      k3s-agent-handoff (:112-113 area, OTA steps after :138) and
+      laptop-operator.md s.3 state the restore_value:no OTA-reset mechanics and
+      point at the checklist step; note that the crop_band_anchors/NVS reconcile
+      does NOT cover this global.
+    sprint_acceptance_ids: [SPR-AC-04]
+    evidence_required:
+      - 'Handoff + runbook diffs'
+  - id: LANE-AC-03
+    statement: >-
+      The three review docs carry a dated 2026-07-03 envelope-state note (window
+      open ~06-19 -> fall, #412; ~3x passive night exchange, +5.7 -> +1.9 g/m3
+      surplus step; closed-vent assumptions weakened while open).
+    sprint_acceptance_ids: [SPR-AC-04]
+    evidence_required:
+      - 'Review-doc diffs'
+validation_commands:
+  - id: V1
+    command: git diff --check
+    purpose: docs-only whitespace/conflict gate (per CLAUDE.md verification order)
+    required: true
+  - id: V2
+    command: "grep -n 'band_track_fraction' docs/RELEASE-CHECKLIST.md docs/handoff/k3s-agent-handoff.md docs/runbooks/laptop-operator.md"
+    purpose: prove the re-pin/record steps exist where specified
+    required: true
+required_evidence:
+  - 'Diffs of the six owned files'
+  - 'grep proof of the re-pin step placement'
+git_policy:
+  pull_request_required: true
+  github_checks_required: true
+  self_merge_allowed: false
+  clean_worktree_required: true
+escalation_conditions:
+  - 'Any needed edit outside the six owned files.'
+  - 'Discovery that the dispatcher DOES auto-re-push band_track_fraction (would change the g-377 gate framing — escalate to planner, do not silently rewrite).'
+definition_of_done:
+  - 'PR open, checks green, critic approval, merged to main; #413 closed by the merge.'
+approval:
+  status: pending
+  approver: null
+  approved_at: null

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/fw-410-vent-reheat-hold.contract.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/contracts/fw-410-vent-reheat-hold.contract.yaml
@@ -1,0 +1,183 @@
+---
+schema_ref: lane-contract.schema.yaml
+kind: LaneContract
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+lane_id: fw-410-vent-reheat-hold
+title: '#410 vent+reheat held-temp dehum (flag-OFF) per the 2026-07-03 design review'
+status: draft
+issue_ids: [410]
+coupling_justification: null
+objective: >-
+  Implement issue #410 exactly as amended by the 2026-07-03 design review
+  (comment on #410): (1) held-temp gain candidate in estimate_moisture_exchange
+  with the selection ladder vent_cooled -> vent_plus_heat_hold -> heat_assist;
+  (2) can_hold actual-temp floor (temp_f >= band_heat_target_f + heat_hysteresis)
+  replacing — not deleting — the vent_overcools veto for the hold candidate, plus
+  GH_DEHUM_HOLD_REENTRY_F=1.0f entry hysteresis in the mode layer; (3)
+  resolve_equipment DEHUM_VENT heat1 gate becomes (dehum_heat_assist_active &&
+  (needs_heating_s1 || (hold_required && temp_f < temp_target))), with the 5-min
+  corun dwell bypassed for hold-flavor entries; (4) new bool tunable
+  dehum_vent_hold_enabled, default OFF, with cfg_dehum_vent_hold_enabled
+  readback; estimator returns today's exact behavior when OFF.
+desired_outcome: >-
+  A merged, unreleased firmware change that is bit-identical to origin/main when
+  the flag is OFF (replay 0 divergence at THRESHOLD_PCT=0), fully characterized
+  when ON (replay divergence buckets + synthetic cold-night fixture), and ready
+  for a Jason-gated flag-OFF OTA. heat2 never participates; the DEHUM heat<->air
+  interlock exemption is unchanged; vpd_min_safe rescue arms hold-reheat
+  immediately.
+non_goals:
+  - 'No OTA, no tunable push, no prod mutation of any kind.'
+  - 'No closed_heat_dehum enable-flag work (#383 remainder, deferred post-OTA).'
+  - 'No vpd_target/anchor value changes (db-411-night-anchors owns migration 188).'
+  - 'No ingestor/MCP changes (data-327 owns the telemetry consumers).'
+baseline_sha: 0efdb2f59a8600130cd9521696e395423c86e910
+branch: fw-410-vent-reheat-hold
+module_contracts:
+  - docs/firmware-fsm-spec.md
+  - docs/adr/0003-band-compliance-track-the-target.md
+  - docs/adr/0004-floating-corridor-control.md
+  - docs/firmware-control-contract.md
+worktree_policy:
+  one_coding_session_per_worktree: true
+  lock_required: true
+lease_policy:
+  worker_ttl_hours: 24
+  critic_ttl_hours: 8
+runtime_namespace:
+  strategy: derived_at_dispatch
+ownership:
+  domains: [firmware, firmware-tests, firmware-docs]
+  owned_paths:
+    - firmware/lib/greenhouse_logic.h
+    - firmware/lib/greenhouse_types.h
+    - firmware/greenhouse/globals.yaml
+    - firmware/greenhouse/tunables.yaml
+    - firmware/greenhouse/sensors.yaml
+    - firmware/greenhouse/controls.yaml
+    - firmware/test/
+    - docs/firmware-fsm-spec.md
+    - docs/adr/0003-band-compliance-track-the-target.md
+    - docs/adr/0004-floating-corridor-control.md
+    - docs/firmware-control-contract.md
+  prohibited_paths:
+    - db/migrations/
+    - ingestor/
+    - mcp/
+    - docs/RELEASE-CHECKLIST.md
+    - docs/handoff/
+    - docs/runbooks/
+  coordination_required_paths:
+    - verdify_schemas/
+    - docs/reviews/
+  owned_interfaces:
+    - 'MoistureExchangeEstimate struct (adds vent_held_vpd_gain_kpa, hold_required — field NAMES coordinated with data-327 before either PR merges)'
+    - 'climate_moisture_exchange published JSON shape (additive only)'
+    - 'Setpoints.dehum_vent_hold_enabled + cfg_dehum_vent_hold_enabled readback'
+dependencies:
+  hard: []
+  soft:
+    - lane_id: data-327-moisture-telemetry
+      coordination: >-
+        Agree the two new telemetry field names (vent_held_vpd_gain_kpa,
+        hold_required) and the additive JSON shape before either PR merges, so
+        migration 187 and the firmware emitter never disagree.
+acceptance_criteria:
+  - id: LANE-AC-01
+    statement: >-
+      Flag OFF is behavior-identical: make firmware-replay-worktree
+      OLD=origin/main reports 0 divergent rows at THRESHOLD_PCT=0; make
+      firmware-replay-band OLD=origin/main within threshold; full invariant
+      suite green; make test-firmware green including new tests.
+    sprint_acceptance_ids: [SPR-AC-01]
+    evidence_required:
+      - 'Rule-9 artifacts in the PR body: replay diff, invariant output, unit-test delta'
+  - id: LANE-AC-02
+    statement: >-
+      Flag ON is characterized: a flag-ON replay run (documented mechanism; if
+      none exists for forcing a non-default global in replay, BUILD it in
+      firmware/test and document it) classifies every divergent row into
+      (a) #385 heat_dehum redirects, (b) new night DEHUM_VENT+heat1 episodes,
+      (c) anything else = investigate before merge.
+    sprint_acceptance_ids: [SPR-AC-02]
+    evidence_required:
+      - 'Flag-ON replay report with bucket counts in the PR'
+  - id: LANE-AC-03
+    statement: >-
+      Synthetic cold-night fixture (new CSV under firmware/test/data/ + native
+      test): outdoor 20-40F trace proves vent_overcools routing to closed heat,
+      can_hold floor exit + GH_DEHUM_HOLD_REENTRY_F re-entry spacing, no
+      invariant-#14 breach, heat2 never without heat1, and the vpd_min_safe
+      rescue arming hold-reheat immediately (no 5-min unheated vent).
+    sprint_acceptance_ids: [SPR-AC-02]
+    evidence_required:
+      - 'Fixture file + test names in make test-firmware output'
+  - id: LANE-AC-04
+    statement: >-
+      Freeze-rule-6 compliance: dehum_vent_hold_enabled defaults false,
+      restore_value: no, entity in tunables.yaml, cfg_dehum_vent_hold_enabled
+      readback in sensors.yaml; no-new-fire-and-forget CI green. No other new
+      tunables (hold target = served temp_target; re-entry gap = named
+      constexpr).
+    sprint_acceptance_ids: [SPR-AC-01]
+    evidence_required:
+      - 'CI no-new-fire-and-forget green + globals/tunables/sensors diff'
+  - id: LANE-AC-05
+    statement: >-
+      Behavior-coupled docs updated in the same PR: fsm-spec DEHUM relay map
+      (heat1 co-run + hold candidate), fsm-spec:269/:282-284 band_track_fraction
+      default corrected to 0.0, ADR-0003 s6.4 ladder addendum, ADR-0004:55
+      selector note, firmware-control-contract dehum exit rule; heat1-electric
+      comment fixes at greenhouse_logic.h:14,:150 and greenhouse_types.h:185.
+    sprint_acceptance_ids: [SPR-AC-01, SPR-AC-04]
+    evidence_required:
+      - 'Doc diffs in the PR; git diff --check clean'
+validation_commands:
+  - id: V1
+    command: make lint
+    purpose: repo lint gate
+    required: true
+  - id: V2
+    command: make test-firmware
+    purpose: native C++ tests incl. new estimator/hold/fixture tests
+    required: true
+  - id: V3
+    command: make firmware-invariants
+    purpose: 16-invariant replay gate (esp. #14)
+    required: true
+  - id: V4
+    command: 'make firmware-replay-worktree OLD=origin/main'
+    purpose: flag-OFF zero-divergence proof (THRESHOLD_PCT=0)
+    required: true
+  - id: V5
+    command: 'make firmware-replay-band OLD=origin/main'
+    purpose: band-derived replay guard (no curve change expected)
+    required: true
+  - id: V6
+    command: 'SECRETS_SRC=$HOME/.verdify/esphome-secrets.yaml make firmware-check'
+    purpose: ESPHome compile proof
+    required: true
+required_evidence:
+  - 'PR body rule-9 artifact block (replay diff + invariants + unit delta)'
+  - 'Flag-ON replay bucket report'
+  - 'Cold-night fixture output'
+git_policy:
+  pull_request_required: true
+  github_checks_required: true
+  self_merge_allowed: false
+  clean_worktree_required: true
+escalation_conditions:
+  - 'Any invariant breach, or flag-OFF replay divergence != 0.'
+  - 'The flag-ON replay mechanism cannot be built inside firmware/test ownership.'
+  - 'Any needed edit to a prohibited path (esp. verdify_schemas/ or ingestor/).'
+  - 'Any discovery that changes the estimator ladder semantics agreed in the #410 design-review comment.'
+  - 'Anything that would require an OTA or live tunable push to verify.'
+definition_of_done:
+  - 'PR open with all validation commands green and rule-9 artifacts in the body.'
+  - 'Independent critic approval on the head SHA.'
+  - 'Merged to main with checks; NO OTA performed; #410 left open for the release wave.'
+approval:
+  status: pending
+  approver: null
+  approved_at: null

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/lane-map.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/lanes/lane-map.yaml
@@ -1,0 +1,40 @@
+---
+schema_ref: lane-map.schema.yaml
+kind: LaneMap
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+lanes:
+  - lane_id: fw-410-vent-reheat-hold
+    issue_ids: [410]
+    module_contracts:
+      - docs/firmware-fsm-spec.md
+      - docs/adr/0003-band-compliance-track-the-target.md
+      - docs/adr/0004-floating-corridor-control.md
+      - docs/firmware-control-contract.md
+    contract_path: lanes/contracts/fw-410-vent-reheat-hold.contract.yaml
+    parallel_group: 1
+  - lane_id: data-327-moisture-telemetry
+    issue_ids: [327]
+    module_contracts:
+      - verdify_schemas/tests/test_drift_guards.py
+      - docs/planner/planner-io-schema.md
+      - docs/firmware-control-contract.md
+    contract_path: lanes/contracts/data-327-moisture-telemetry.contract.yaml
+    parallel_group: 1
+  - lane_id: docs-413-freeze-drift
+    issue_ids: [413]
+    module_contracts:
+      - docs/RELEASE-CHECKLIST.md
+      - docs/handoff/k3s-agent-handoff.md
+    contract_path: lanes/contracts/docs-413-freeze-drift.contract.yaml
+    parallel_group: 1
+  - lane_id: db-411-night-anchors
+    issue_ids: [411]
+    module_contracts:
+      - docs/adr/0004-floating-corridor-control.md
+      - db/migrations/177-band-defaults-from-canonical-seed.sql
+    contract_path: lanes/contracts/db-411-night-anchors.contract.yaml
+    parallel_group: 2
+dependency_order:
+  - [fw-410-vent-reheat-hold, data-327-moisture-telemetry, docs-413-freeze-drift]
+  - [db-411-night-anchors]

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/release/wave-release-plan.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/release/wave-release-plan.yaml
@@ -1,0 +1,230 @@
+---
+schema_ref: wave-release-plan.schema.yaml
+kind: WaveReleasePlan
+schema_version: '1.0'
+wave_id: wave-s8-night-dehum
+status: draft
+scope:
+  sprint_id: s8-vanda-night-dehum
+  issue_ids: [410, 327, 413, 411, 377]
+  lane_ids: [fw-410-vent-reheat-hold, data-327-moisture-telemetry, docs-413-freeze-drift, db-411-night-anchors]
+  northstar_ids: []
+  summary: >-
+    Single-prod release of the S8 night-dehum slice: containers + migration 187
+    (telemetry) first, then the gated sequence — migration 188 (after g-411),
+    flag-OFF firmware OTA (Jason), pinch decision (g-377), flag-ON tunable
+    activation, and a 48h canary window. Track A rules throughout: the
+    greenhouse stays operational at every step, and every step is individually
+    revertible.
+  non_goals:
+    - 'No dev/staging environments exist (decommissioned 2026-06-16); prod is the only target.'
+    - '#383 remainder and any second estimator change are NOT in this wave.'
+branch_model:
+  model: per_lane_branches
+  base_ref: main
+  release_ref: null
+  merge_queue_required: false
+  concurrency_group: null
+  decision_notes: >-
+    Repo standard: PRs land on main; every push publishes digest-pinned images;
+    prod advances only via the prod-promote dispatch workflow (digests-only PR,
+    promote-diff-guard) + manual gated ArgoCD sync. Firmware is NOT deployed by
+    CI at all — hot-staged OTA behind Jason.
+github:
+  repository: VerdifyConsultancy/verdify-platform
+  milestone: Greenhouse Control Optimization
+  project: 'GitHub Project #5'
+  required_checks:
+    - lint
+    - test
+    - firmware-replay-diff
+    - migration-rollback-safety
+    - no-new-fire-and-forget
+    - service-restart-drift-guard
+  merge_group_checks_required: false
+  environment_protection_required: true
+ci:
+  workflows:
+    - name: ci.yml
+      required: true
+      event_triggers: [pull_request, push]
+      timeout_minutes: 60
+      evidence_expected:
+        - 'firmware-replay-diff vs merge-base (THRESHOLD_PCT=0 flag-OFF)'
+        - 'migration-rollback-safety classification for 187/188'
+        - 'no-new-fire-and-forget for dehum_vent_hold_enabled readback'
+        - 'service-restart-drift-guard restart list'
+    - name: prod-promote
+      required: true
+      event_triggers: [workflow_dispatch]
+      timeout_minutes: 30
+      evidence_expected:
+        - 'digests-only prod-promote PR (promote-diff-guard green) for ingestor/mcp/migrate'
+  artifacts:
+    - 'PR rule-9 blocks: replay diff, invariant suite, unit-test delta'
+    - 'Flag-ON replay bucket report'
+    - 'GHCR digest-pinned images (sha-<sha> + branch-main)'
+  required_events: [pull_request, push, workflow_dispatch]
+environments:
+  - name: verdify-prod
+    environment_type: production
+    required: true
+    namespace: verdify-prod
+    url: https://api.verdify.ai
+    quota_policy: null
+    limit_policy: null
+    network_policy: 'device VLAN isolated; ESP32 write path is single-writer (Lease-fenced)'
+    ttl: null
+    secrets_scope: 'SOPS/ksops in-repo + k3s secrets; OTA secrets via ~/.verdify/esphome-secrets.yaml — never printed'
+    protection_rules:
+      - 'ArgoCD app verdify-prod-dark is manual-sync behind the device-write gate'
+      - 'Firmware OTA is Jason-only (freeze rules: no critical alerts, <=1/week, 48h bake spacing)'
+      - 'Destructive mutations go through change-gate'
+    expected_revision_source: 'overlays/prod on main (digest-pinned)'
+gitops:
+  controller: argo_cd
+  desired_state_refs:
+    - 'deploy/k8s overlays/prod @ main (app verdify-prod-dark)'
+  sync_order:
+    - phase: containers
+      wave: 1
+      resource: 'verdify-migrate job (migration 187)'
+      purpose: 'schema-first: estimator telemetry columns before consumers'
+    - phase: containers
+      wave: 2
+      resource: 'verdify-ingestor + verdify-mcp (bounce after sync)'
+      purpose: 'rule-7 restarts so entity map + MCP read the new fields'
+    - phase: device
+      wave: 3
+      resource: 'ESP32 firmware OTA (OUTSIDE gitops; Jason hand-gate)'
+      purpose: 'flag-OFF binary; behavior-identical until activation'
+  reconciliation_checks:
+    - 'argocd app diff verdify-prod-dark empty post-sync'
+    - 'SELECT count(*) FROM climate_action_log WHERE mx-fields IS NOT NULL AND ts > sync-time (post-restart, pre-OTA: 0 rows expected until OTA; post-OTA: rows appear)'
+  remediation_policy: >-
+    Manual only. No auto-sync, no self-heal on verdify-prod-dark; any drift is
+    investigated before re-sync (2026-06-24 stale-scope gotcha #317 applies).
+deployment_strategy:
+  type: manual
+  progressive_delivery: false
+  traffic_policy: null
+  steps:
+    - id: STEP-01
+      action: 'Merge lanes fw-410, data-327, docs-413 (parallel group 1) with critic approval + checks'
+      success_criteria: 'All required checks green on main; rule-9 artifacts in PR bodies'
+      rollback_trigger: 'Any red check -> lane fix cycle, no deploy'
+    - id: STEP-02
+      action: 'prod-promote dispatch -> digests-only PR -> human merge -> gated argocd app sync verdify-prod-dark (scoped); apply migration 187 via the migrate path; bounce verdify-ingestor + verdify-mcp'
+      success_criteria: 'Sync healthy; 187 applied with recorded rollback classification; services up; drift guards unaffected'
+      rollback_trigger: '187 apply failure -> rollback per its classification; service crashloop -> repin previous digests'
+    - id: STEP-03
+      action: 'Gate g-411 decision (Jason) -> if dry-roots-wins: dispatch db-411-night-anchors, merge, apply migration 188, verify v_band_device_divergence converges'
+      success_criteria: 'Served band matches decision; divergence < 0.1F/0.01kPa'
+      rollback_trigger: '188 rollback proof; anchors are DB-only (no OTA needed to revert)'
+    - id: STEP-04
+      action: 'Jason OTA of the flag-OFF binary (make firmware-deploy preflights: no critical alerts, bake spacing, weekly cap; wait-for-version on the CORRECT backend)'
+      success_criteria: 'diagnostics.firmware_version reports the new build; sensor-health sweep clean; behavior unchanged (flag OFF)'
+      rollback_trigger: 'Re-flash firmware/artifacts/last-good.ota.bin (known-good 995c9b3 lineage)'
+    - id: STEP-05
+      action: 'Execute gate g-377 pinch decision: re-pin band_track_fraction=0.25 OR accept float 0.0; record envelope (window OPEN, #412) + pinch + flag states per the new checklist step'
+      success_criteria: 'setpoint_snapshot readback matches the decided value; states recorded in the bake-report skeleton'
+      rollback_trigger: 'n/a (tunable push, instantly revertible)'
+    - id: STEP-06
+      action: '48h flag-OFF soak (freeze-rule bake), then Jason-approved flag-ON: logged set_tunable dehum_vent_hold_enabled=true'
+      success_criteria: 'cfg_dehum_vent_hold_enabled readback true; first night shows DEHUM_VENT+heat1 episodes with mx_reason=vent_plus_heat_hold in telemetry'
+      rollback_trigger: 'Any release-health blocking signal -> set_tunable false (NO OTA needed)'
+    - id: STEP-07
+      action: '48h flag-ON canary window; then re-probe per durability gate and write docs/reviews/s8-vanda-night-dehum-bake-report.md'
+      success_criteria: '02-06h median VPD >= 0.78; RH>70% night count falls; night_min >= 64F; DIF <= 22F; invariant-14 style vent cycling <= ~10 open-cycles/night; heat2 never without heat1'
+      rollback_trigger: 'night_min < 64F at any point -> flag OFF immediately (the design-review rollback canary)'
+observability:
+  dashboards:
+    - 'graphs.verdify.ai homepage corridor/state overlay'
+    - 'graphs.verdify.ai equipment stripes (heat1/vent/fan lanes)'
+  logs:
+    - 'verdify-ingestor + verdify-mcp pod logs post-restart'
+  metrics:
+    - 'outcome_kpi(target_date): vpd misses, actuator cycles/runtime, DIF, dew margin'
+    - 'climate_action_log mx_action/mx_reason distribution 02-06h'
+    - 'setpoint_snapshot band_track_fraction + cfg_dehum_vent_hold_enabled readbacks'
+  traces: []
+  runtime_checks:
+    - "scripts/verdify-db.sh prod -c \"SELECT firmware_version, max(ts) FROM diagnostics GROUP BY 1 ORDER BY 2 DESC LIMIT 1\""
+    - "scripts/verdify-db.sh prod -c \"02-06h median VPD / RH / night_min query (bake-report canonical form)\""
+  missing_telemetry:
+    - 'mx estimator fields are EMPTY in prod until STEP-02 (consumers) + STEP-04 (emitter) complete — the reason #327 precedes the OTA'
+rollback:
+  ready: true
+  strategy: >-
+    Layered: (1) activation rollback = set_tunable dehum_vent_hold_enabled=false
+    (seconds, no OTA); (2) pinch rollback = re-push band_track_fraction
+    (seconds); (3) anchor rollback = migration 188 rollback proof (DB-only); (4)
+    firmware rollback = re-flash last-good OTA artifact; (5) container rollback
+    = repin previous digests in overlays/prod + gated sync.
+  known_good_ref: '995c9b3 (live 2026.6.23.0146) + firmware/artifacts/last-good.ota.bin'
+  procedure: >-
+    On a blocking release-health signal: flag OFF first (STEP-06 trigger), then
+    evaluate whether deeper layers are implicated before touching them; every
+    rollback action + timestamp goes in the bake report. night_min < 64F is an
+    IMMEDIATE flag-off, no discussion needed.
+  validation_steps:
+    - 'cfg_dehum_vent_hold_enabled readback false after rollback'
+    - 'Next-night 02-06h behavior matches pre-activation baseline'
+release_health:
+  stabilization_window: '48h per phase (freeze-rule bake), canaries re-probed >=60min apart per the durability gate'
+  signals:
+    - name: night-min-temp
+      source: 'climate.temp_avg 02-06h min'
+      threshold: '>= 64F'
+      blocking: true
+    - name: night-median-vpd
+      source: 'climate.vpd_avg 02-06h median'
+      threshold: '>= 0.78 kPa (acceptance; not a rollback trigger by itself)'
+      blocking: false
+    - name: dif
+      source: 'daily max - night min temp'
+      threshold: '<= 22F'
+      blocking: false
+    - name: vent-cycling
+      source: 'climate_action_log relay_truth vent open-cycles per night'
+      threshold: '<= ~10/night (gross-thrash guard; invariant-14 analogue)'
+      blocking: true
+    - name: heat2-discipline
+      source: 'relay_truth: heat2 never without heat1'
+      threshold: '0 violations'
+      blocking: true
+    - name: sensor-health-critical-alerts
+      source: 'alerts table severity=critical'
+      threshold: '0 open'
+      blocking: true
+    - name: heat1-runtime-delta
+      source: 'outcome_kpi actuator runtime vs pre-activation baseline'
+      threshold: 'watched (electric coil; report, no fixed cap this wave)'
+      blocking: false
+review_handoff:
+  review_inbox_packet_required: true
+  expected_review_packet_path: docs/reviews/s8-vanda-night-dehum-bake-report.md
+  human_test_steps:
+    - 'Run the bake-report canonical night query and compare to the 0.61/73% baseline'
+    - 'Spot-check one overnight episode end-to-end: mx_reason=vent_plus_heat_hold row -> relay_truth shows vent+heat1 -> temp held near target -> VPD rose'
+    - 'Verify recorded envelope=OPEN, pinch value, and flag state match the decisions in g-377/g-411'
+  approval_gate: 'HR-03 outcome acceptance (Jason) after the 48h flag-ON window, re-probed per the durability gate'
+risks:
+  - id: RISK-01
+    severity: high
+    statement: 'OTA resets band_track_fraction to 0.0 invisibly (float flip rides along).'
+    mitigation: 'STEP-05 executes the explicit g-377 decision and records the state; checklist step from docs-413.'
+  - id: RISK-02
+    severity: medium
+    statement: 'Wrong-backend wait-for-version false-rollback gotcha during OTA (seen 2026-06-17).'
+    mitigation: 'STEP-04 names the correct-backend check; firmware-ota-from-laptop memory/runbook procedure applies.'
+  - id: RISK-03
+    severity: medium
+    statement: 'ArgoCD stale-scope sync rewrite (#317) could partially sync the promote.'
+    mitigation: 'Scoped sync per the #408 pattern; argocd app diff must be empty post-sync (reconciliation check).'
+approval:
+  status: pending
+  approver: null
+  approved_at: null
+prepared_at: '2026-07-03T20:05:00Z'
+planner: 'claude-fable-5 (s8 sprint-planning session, 2026-07-03)'

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.md
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.md
@@ -1,0 +1,82 @@
+# Sprint S8 — vanda-night-dehum (awaiting approval)
+
+**Goal:** make the overnight center-zone (bare-root Vanda) climate dryable per the
+converged #410 analysis and the 2026-07-03 adversarial design review — land the
+firmware change flag-OFF, land the telemetry that makes the bake observable, fix
+the freeze-rule-adjacent doc drift, and pre-stage the #411 anchor migration — so
+one Jason-gated OTA + tunable-push sequence can take 02–06h median VPD from
+**0.61 → ≥ 0.78** with `night_min ≥ 64 °F` as the hard rollback canary.
+
+Baseline: `origin/main` @ `0efdb2f` (includes #385). Milestone: Greenhouse
+Control Optimization. Board: GitHub Project #5. This is the first structured
+sprint transaction under `.agent-workflow/sprints/`; S4–S7 remain tracked in the
+root docs.
+
+## Why now (one paragraph of context)
+
+Two independent reviews converged on the wet-night problem (#410); the design
+review (comment on #410) endorsed the fix with three required changes (actual-temp
+hold floor, hold-to-`temp_target` reheat with dwell bypass, OFF-default flag) and
+found two deploy confounds: the next OTA silently resets `band_track_fraction`
+0.25 → 0.0 (the #377 float flip rides along), and #410 cannot mechanically engage
+until #411 re-raises the night corridor. Separately, the door screen-window has
+been open since ~06-19 and **stays open until fall** (#412) — it is the current
+passive night dryer and the baseline for every number in this plan.
+
+## Lanes
+
+| Lane | Issue | Branch | Owner → Reviewer | Responsibility |
+|---|---|---|---|---|
+| `fw-410-vent-reheat-hold` | #410 | `fw-410-vent-reheat-hold` | worker → independent-critic | Estimator ladder + hold gate + flag + cold-night fixture + behavior-coupled docs (fsm-spec, ADR-0003 §6.4, ADR-0004, control contract) + heat1-electric comment fixes |
+| `data-327-moisture-telemetry` | #327 | `data-327-moisture-telemetry` | worker → independent-critic | Migration **187** (schema-first) + ingestor + MCP exposure incl. the two new #410 fields; rule-7 restarts documented |
+| `docs-413-freeze-drift` | #413 | `docs-413-freeze-drift` | worker → independent-critic | Checklist re-pin/record steps, OTA-reset mechanics in handoff/runbook, dated envelope notes on three review docs |
+| `db-411-night-anchors` | #411 | `db-411-night-anchors` | worker → independent-critic | **BLOCKED on gate g-411**: migration **188** (night anchors + vpd_target ~0.83, one migration), prepared not applied |
+
+**Dependency order:** group 1 = the first three lanes in parallel (disjoint owned
+paths; one soft coordination: the two new telemetry field names between fw-410 and
+data-327). Group 2 = `db-411-night-anchors`, hard-blocked on gate g-411 **and** on
+187 merging first (migrations serialized).
+
+## Gates (all owner: jason)
+
+1. **plan-approval** — this document; the plan PR is the approval vehicle.
+2. **g-411-night-temp-priority** — deep-DIF vs dry-roots vs seasonal split
+   (GitHub #411). Blocks lane 4 and the activation steps. `seasonal-split`
+   returns to planning.
+3. **g-377-pinch-repin** — post-OTA pinch state: re-pin 0.25 (clean bake) vs
+   accept float 0.0 (joint #377 trial). Executed at wave STEP-05, recorded either way.
+4. **HR-02 OTA approval** and **HR-03 outcome acceptance** — in the wave release plan.
+
+## Release sequence (details in `release/wave-release-plan.yaml`)
+
+merge lanes → prod-promote + gated sync + **migration 187** + bounce
+ingestor/mcp → *(g-411)* **migration 188** → **flag-OFF OTA** (Jason; freeze
+rules) → *(g-377)* pinch decision + record envelope/pinch/flag state → 48 h soak →
+**flag ON** (tunable push, no OTA) → 48 h canary window → bake report + HR-03.
+Every layer reverts independently; `night_min < 64 °F` ⇒ immediate flag-off.
+
+## Deferred (explicitly out)
+
+#383 remainder (post-OTA), #378 corridor widths, #379 MPC, daytime dry-side
+issue, #412 execution (fall), anything touching verdify-www/crm.
+
+## Exceptions to record
+
+- **Missing formal prerequisites:** no approved project-definition /
+  architecture-contracts / state-of-union artifacts exist in `.agent-workflow/`
+  (the repo predates the standard shape). This plan substitutes the repo-native
+  contracts (CLAUDE.md ownership + freeze rules, fsm-spec, ADRs, drift guards)
+  and the live GitHub board as its inputs. Approving this plan accepts that
+  substitution for S8.
+- **Module contracts** in lane files reference those repo-native docs, not
+  architecture-contracts artifacts.
+- `#413` item 2 file placement corrected here: `docs/firmware-fsm-spec.md`
+  belongs to the fw lane (single writer), not the docs lane.
+
+## Evidence the sprint must produce
+
+Rule-9 artifact blocks on the firmware PR (replay diff / invariants / unit
+delta), flag-ON divergence bucket report, cold-night fixture output, migration
+187/188 rollback proofs, the explain-query, doc diffs, and finally
+`docs/reviews/s8-vanda-night-dehum-bake-report.md` with the canary numbers and
+the recorded envelope + pinch + flag states.

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.yaml
@@ -1,0 +1,310 @@
+---
+schema_ref: sprint-plan.schema.yaml
+kind: SprintPlan
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+status: awaiting_approval
+goal: >-
+  Make the overnight center-zone (bare-root Vanda) climate dryable per the
+  converged #410 analysis and the 2026-07-03 adversarial design review: land the
+  vent+reheat held-temp dehum firmware change flag-OFF (replay-identical until
+  enabled), land the moisture-estimator telemetry chain (#327, migration 187) so
+  the activation bake is observable, correct the freeze-rule-adjacent doc drift
+  (band_track_fraction OTA-reset/re-pin, stale FSM defaults, open-envelope
+  notes), and pre-stage the #411-gated night-anchor migration (188) — so that a
+  single Jason-gated OTA + tunable-push activation sequence with a 48h canary
+  bake can raise 02-06h median VPD from 0.61 to >=0.78 without a night_min
+  below 64F.
+baseline_sha: 0efdb2f59a8600130cd9521696e395423c86e910
+github:
+  repository: VerdifyConsultancy/verdify-platform
+  milestone: Greenhouse Control Optimization
+  project: 'GitHub Project #5'
+issue_ids: [410, 327, 413, 411]
+scope:
+  - 'fw-410-vent-reheat-hold: implement #410 per the design-review required changes
+    A/B/C — estimator ladder (vent_cooled -> vent_plus_heat_hold -> heat_assist)
+    with can_hold actual-temp floor and GH_DEHUM_HOLD_REENTRY_F entry hysteresis;
+    resolve_equipment:2488 hold-reheat gate (needs_heating_s1 OR hold_required &&
+    temp < temp_target) with corun-dwell bypass for hold-flavor; OFF-default
+    dehum_vent_hold_enabled tunable + cfg readback; synthetic cold-night replay
+    fixture; heat1-is-electric comment fixes (greenhouse_logic.h:14,:150,
+    greenhouse_types.h:185); behavior-coupled doc updates (firmware-fsm-spec incl.
+    stale 0.50 default + DEHUM relay map, ADR-0003 s6.4, ADR-0004:55,
+    firmware-control-contract).'
+  - 'data-327-moisture-telemetry: migration 187 (schema-first, serialized after
+    186) + ingestor entity map + MCP/outcome_kpi exposure of mx_action, mx_reason,
+    vent/heat gains, outdoor_fresh, vent_overcools, heat_assist_corun, and the NEW
+    #410 fields vent_held_vpd_gain_kpa + hold_required; drift guards green;
+    rule-7 restart list (verdify-ingestor, verdify-mcp) in the PR body.'
+  - 'docs-413-freeze-drift: RELEASE-CHECKLIST s.B post-OTA re-pin + envelope/pinch
+    record steps; k3s-agent-handoff + laptop-operator OTA notes on the
+    band_track_fraction restore_value:no reset; dated open-envelope notes on the
+    physics-model, mechanical-response-matrix, and ota-signoff review docs.'
+  - 'db-411-night-anchors (BLOCKED on gate g-411): migration 188 regenerating the
+    house night band anchors per the #411 decision + vpd_target retune to ~0.83 in
+    the SAME migration; registry/band_defaults kept in sync; rollback proof.'
+non_goals:
+  - '#383 remainder (closed_heat_dehum OFF-default flag + fog/mister post-wet
+    anti-ping-pong): ships AFTER the #410 OTA so one estimator change surface is
+    baked at a time (replay baseline stays clean).'
+  - '#378 corridor widths, #379 grey-box ID/MPC, daytime dry-side (+0.2,
+    cooling-limited) issue — out of scope.'
+  - '#412 execution (closing the door screen-window) — seasonal, fall; this
+    sprint only encodes the record-and-freeze rules around it.'
+  - 'Any production apply within lanes: NO migration apply, NO ArgoCD sync, NO
+    OTA, NO tunable push happens inside a lane; every deploy step lives in the
+    wave release plan behind its gate.'
+  - 'verdify-www / verdify-crm (separate products, separate repos).'
+acceptance_criteria:
+  - id: SPR-AC-01
+    statement: >-
+      #410 firmware change merged with dehum_vent_hold_enabled defaulting OFF and
+      proven behavior-identical when OFF: make firmware-replay-worktree
+      OLD=origin/main shows 0 divergent rows at THRESHOLD_PCT=0, full invariant
+      suite green, native test delta green, firmware-check compiles.
+    lane_ids: [fw-410-vent-reheat-hold]
+    evidence_expected:
+      - 'PR body rule-9 artifacts: replay diff output, invariant suite output, unit-test delta'
+      - 'CI: firmware-replay-diff, no-new-fire-and-forget, service-restart-drift-guard green'
+  - id: SPR-AC-02
+    statement: >-
+      Flag-ON behavior is characterized before any OTA: a flag-ON replay run
+      documents the divergence buckets (redirect of #385 heat_dehum rows +
+      new night DEHUM_VENT+heat1 episodes), and a synthetic cold-night fixture
+      proves the can_hold floor exit, closed-heat fallback, and invariant #14
+      compliance on frigid traces the summer corpus cannot exercise.
+    lane_ids: [fw-410-vent-reheat-hold]
+    evidence_expected:
+      - 'Flag-ON replay report with divergence bucket classification in the PR'
+      - 'Cold-night fixture test in make test-firmware output'
+  - id: SPR-AC-03
+    statement: >-
+      Moisture-estimator telemetry is queryable end-to-end: migration 187 lands
+      schema-first with rollback-safety classification, ingestor persists the
+      estimator fields (including vent_held_vpd_gain_kpa and hold_required),
+      MCP/outcome_kpi expose them, and a documented SQL query explains each
+      VPD/dehum action row by mx_reason.
+    lane_ids: [data-327-moisture-telemetry]
+    evidence_expected:
+      - 'make migration-rollback-safety output + rollback-wrap proof for 187'
+      - 'verdify_schemas drift guards green (make test)'
+      - 'Example explain-query recorded in the PR/issue'
+  - id: SPR-AC-04
+    statement: >-
+      An operator following the OTA checklist cannot miss the pinch decision:
+      RELEASE-CHECKLIST s.B contains the band_track_fraction re-pin/record step
+      and the envelope-config record step; handoff + laptop-operator docs state
+      the restore_value:no OTA reset; the three review docs carry dated
+      open-envelope notes.
+    lane_ids: [docs-413-freeze-drift]
+    evidence_expected:
+      - 'git diff of the four doc groups + git diff --check clean'
+  - id: SPR-AC-05
+    statement: >-
+      The #411 decision is executable the day it lands: migration 188 exists on
+      its lane branch implementing the decided night anchors + vpd_target ~0.83,
+      passes rollback-safety + band single-source tests, and is NOT applied.
+    lane_ids: [db-411-night-anchors]
+    evidence_expected:
+      - 'migration 188 + make migration-rollback-safety + test_band_defaults_single_source output'
+  - id: SPR-AC-06
+    statement: >-
+      Activation is fully gated and observable: the wave release plan sequences
+      containers -> migration 187 -> restarts -> (gate) migration 188 -> (gate)
+      flag-OFF OTA -> pinch decision -> flag-ON push -> 48h canary window with
+      night_min>=64F as a blocking rollback trigger, and every step records
+      envelope + band_track_fraction state.
+    lane_ids: [fw-410-vent-reheat-hold, data-327-moisture-telemetry]
+    evidence_expected:
+      - 'release/wave-release-plan.yaml validated; bake report at docs/reviews/s8-vanda-night-dehum-bake-report.md after HR-03'
+risks:
+  - id: RISK-01
+    severity: high
+    statement: >-
+      The OTA silently resets band_track_fraction 0.25 -> 0.0 (restore_value: no;
+      planner now emits only 0), shipping the #377 float flip invisibly to the
+      corpus-fed replay and confounding the bake.
+    mitigation: >-
+      Gate g-377-pinch-repin forces an explicit Jason decision (re-pin 0.25 vs
+      joint float bake) before the OTA; docs-413 adds the re-pin/record step to
+      the checklist; the bake report must state the pinch value.
+  - id: RISK-02
+    severity: high
+    statement: >-
+      #411 unresolved: under live #409 night anchors + pinch, the house (66.7F)
+      sits above pinched temp_high (~65F), heat_suppressed_by_upper_band vetoes
+      reheat, and the #410 hold cannot mechanically engage.
+    mitigation: >-
+      Flag ships OFF; activation blocked on gate g-411; lane db-411-night-anchors
+      pre-stages the migration so the decision is executable immediately.
+  - id: RISK-03
+    severity: medium
+    statement: >-
+      Vent+reheat thrash or invariant-#14 breach on cold nights; parts 1+2 of the
+      original spec would have deleted the only dehum floor exit.
+    mitigation: >-
+      Design-review change A (can_hold actual-temp floor + 1.0F re-entry
+      hysteresis) is a lane acceptance criterion; synthetic cold-night fixture
+      proves floor exit + closed-heat fallback + #14 before merge.
+  - id: RISK-04
+    severity: medium
+    statement: >-
+      heat1 (electric) offsets only ~half of continuous-vent loss (measured
+      +0.017 vs -0.034 F/min), so the flag-ON equilibrium may land below the 0.83
+      aspiration on cool nights.
+    mitigation: >-
+      Acceptance is median >=0.78 (not 0.83); the design duty-cycles against the
+      hold floor instead of promising a hold; heat1 runtime/cycles are a watched
+      outcome_kpi signal during the bake.
+  - id: RISK-05
+    severity: medium
+    statement: Two migrations in flight (187 telemetry, 188 anchors) risk numbering/ordering collisions.
+    mitigation: >-
+      Hard serialization: db-411-night-anchors depends on data-327 landing 187;
+      migration-rollback-safety CI classifies both; one-migration-at-a-time rule
+      in both lane contracts.
+  - id: RISK-06
+    severity: low
+    statement: Envelope state change (window closed) mid-bake would invalidate every canary baseline.
+    mitigation: '#412 records the stays-open-until-fall decision and the never-change-mid-bake rule; checklist records envelope state at OTA and at bake read.'
+  - id: RISK-07
+    severity: medium
+    statement: '#327 schema/consumer drift or missed rule-7 restarts leave the bake blind (mx fields absent in prod).'
+    mitigation: >-
+      Schema-first ordering, drift guards, service-restart-drift-guard CI, and
+      wave STEP verification that mx_action rows appear in prod before the OTA
+      step is offered to Jason.
+lanes:
+  - lane_id: fw-410-vent-reheat-hold
+    issue_ids: [410]
+    contract_path: lanes/contracts/fw-410-vent-reheat-hold.contract.yaml
+    branch: fw-410-vent-reheat-hold
+    owner: verdify-platform-worker
+    reviewer: independent-critic
+    summary: >-
+      Firmware: held-temp dehum estimator ladder + hold-reheat gate + OFF-default
+      flag + cold-night fixture + behavior-coupled docs (fsm-spec, ADR-0003 s6.4,
+      ADR-0004, control contract) + heat1-electric comment fixes.
+  - lane_id: data-327-moisture-telemetry
+    issue_ids: [327]
+    contract_path: lanes/contracts/data-327-moisture-telemetry.contract.yaml
+    branch: data-327-moisture-telemetry
+    owner: verdify-platform-worker
+    reviewer: independent-critic
+    summary: >-
+      Schema-first migration 187 + ingestor/MCP persistence and exposure of the
+      moisture-estimator decision context, including the two new #410 fields.
+  - lane_id: docs-413-freeze-drift
+    issue_ids: [413]
+    contract_path: lanes/contracts/docs-413-freeze-drift.contract.yaml
+    branch: docs-413-freeze-drift
+    owner: verdify-platform-worker
+    reviewer: independent-critic
+    summary: >-
+      Docs-only: OTA re-pin/record steps in the release checklist + handoff +
+      operator runbook; dated open-envelope notes on the three review docs.
+  - lane_id: db-411-night-anchors
+    issue_ids: [411]
+    contract_path: lanes/contracts/db-411-night-anchors.contract.yaml
+    branch: db-411-night-anchors
+    owner: verdify-platform-worker
+    reviewer: independent-critic
+    summary: >-
+      BLOCKED on gate g-411: migration 188 implementing the decided night temp
+      anchors + vpd_target ~0.83 in one migration, with registry/band_defaults
+      sync and rollback proof. Prepared, not applied.
+dependency_order:
+  - [fw-410-vent-reheat-hold, data-327-moisture-telemetry, docs-413-freeze-drift]
+  - [db-411-night-anchors]
+deployment_expectations:
+  - 'No lane deploys anything. All deployment lives in release/wave-release-plan.yaml.'
+  - 'Container path: prod-promote (digests-only PR) -> human merge -> gated argocd app sync verdify-prod-dark; bounce verdify-ingestor + verdify-mcp after 187 (rule 7).'
+  - 'Migration 187 applied via the gated migrate path before the OTA; 188 only after gate g-411.'
+  - 'Firmware OTA: Jason-only, flag-OFF binary, freeze rules enforced (no critical alerts, <=1 OTA/week, 48h bake spacing); activation later via logged set_tunable push, revert without OTA.'
+  - 'Post-OTA: execute the g-377 pinch decision (re-pin 0.25 or float) and record envelope + pinch state in the bake report.'
+review_plan:
+  qa_milestones:
+    - id: QA-01
+      name: All four lane PRs green on required checks
+      due: null
+      evidence_expected:
+        - 'ci.yml checks incl. firmware-replay-diff, migration-rollback-safety, no-new-fire-and-forget, service-restart-drift-guard'
+    - id: QA-02
+      name: Flag-ON characterization complete pre-OTA
+      due: null
+      evidence_expected:
+        - 'Flag-ON replay divergence report + cold-night fixture output attached to the #410 PR'
+    - id: QA-03
+      name: Telemetry live in prod pre-OTA
+      due: null
+      evidence_expected:
+        - 'SQL evidence that climate_action_log rows carry mx_action/mx_reason after 187 + restarts'
+  human_review_milestones:
+    - id: HR-01
+      name: Sprint plan approval
+      owner: jason
+      trigger: 'This plan PR opened; gates/plan-approval.yaml open'
+      review_packet_path: .agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.md
+    - id: HR-02
+      name: OTA + activation approval (deployment gate)
+      owner: jason
+      trigger: 'Lanes merged; QA-01..03 done; gates g-411 and g-377 decided'
+      review_packet_path: .agent-workflow/sprints/s8-vanda-night-dehum/release/wave-release-plan.yaml
+    - id: HR-03
+      name: Outcome acceptance after the 48h flag-ON canary window
+      owner: jason
+      trigger: '48h flag-ON window elapsed with canaries recorded (re-probed per durability gate)'
+      review_packet_path: docs/reviews/s8-vanda-night-dehum-bake-report.md
+  user_stories_for_review:
+    - id: US-01
+      statement: >-
+        As the grower, overnight center-zone VPD reaches a >=0.78 median (02-06h)
+        so bare Vanda roots dry, while night_min stays >=64F and DIF <=22F.
+      issue_ids: [410, 411]
+      lane_ids: [fw-410-vent-reheat-hold, db-411-night-anchors]
+      acceptance_refs: [SPR-AC-01, SPR-AC-02, SPR-AC-05, SPR-AC-06]
+    - id: US-02
+      statement: >-
+        As the operator, I can query WHY the controller chose vent-hold vs
+        warm-to-dry for any overnight cycle (mx_reason per action row).
+      issue_ids: [327]
+      lane_ids: [data-327-moisture-telemetry]
+      acceptance_refs: [SPR-AC-03]
+    - id: US-03
+      statement: >-
+        As the operator running an OTA, the checklist forces the pinch re-pin
+        decision and records envelope + pinch state so no bake is silently
+        confounded again.
+      issue_ids: [413, 377]
+      lane_ids: [docs-413-freeze-drift]
+      acceptance_refs: [SPR-AC-04]
+  reporting_summary:
+    included:
+      - '#410 firmware implementation (flag-OFF) with the three design-review required changes'
+      - '#327 telemetry chain (migration 187 + ingestor + MCP) promoted W3->W1 as bake prerequisite'
+      - '#413 doc-drift bundle (re-pin step, stale defaults context, envelope notes, bake record)'
+      - '#411 anchor migration 188 pre-staged behind the Jason decision gate'
+    deferred:
+      - '#383 remainder (after the #410 OTA bake)'
+      - '#378 corridor widths, #379 MPC (need float/bake evidence first)'
+      - '#412 window closure (fall, seasonal)'
+      - 'Daytime dry-side VPD issue (separate, minor)'
+    ownership:
+      - lane_id: fw-410-vent-reheat-hold
+        owner: verdify-platform-worker
+        responsibility: 'Firmware estimator/relay change, tests, fixtures, behavior-coupled docs'
+      - lane_id: data-327-moisture-telemetry
+        owner: verdify-platform-worker
+        responsibility: 'Migration 187, ingestor entity map, MCP exposure, drift guards'
+      - lane_id: docs-413-freeze-drift
+        owner: verdify-platform-worker
+        responsibility: 'Operator-facing checklist/runbook/handoff + review-doc envelope notes'
+      - lane_id: db-411-night-anchors
+        owner: verdify-platform-worker
+        responsibility: 'Migration 188 implementing the g-411 decision; prepared not applied'
+    next_review: 'HR-01: Jason approves/revises this plan (the plan PR is the approval vehicle).'
+approval:
+  status: pending
+  approver: null
+  approved_at: null

--- a/.agent-workflow/sprints/s8-vanda-night-dehum/status.yaml
+++ b/.agent-workflow/sprints/s8-vanda-night-dehum/status.yaml
@@ -1,0 +1,16 @@
+---
+schema_ref: status.schema.yaml
+kind: SprintStatus
+schema_version: '1.0'
+sprint_id: s8-vanda-night-dehum
+state: AWAITING_APPROVAL
+updated_at: '2026-07-03T20:10:00Z'
+active_lanes: []
+blockers:
+  - 'plan-approval-s8-vanda-night-dehum open (Jason; the plan PR is the approval vehicle)'
+  - 'g-411-night-temp-priority open (blocks db-411-night-anchors + activation)'
+  - 'g-377-pinch-repin open (blocks wave STEP-05 execution semantics)'
+next_action: >-
+  Jason reviews the plan PR (HR-01). On merge, hand off to sprint-orchestrator:
+  dispatch fw-410-vent-reheat-hold, data-327-moisture-telemetry,
+  docs-413-freeze-drift in parallel; db-411-night-anchors stays parked on g-411.

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -137,3 +137,29 @@ Verification:
 - Irrigation: targeted Makefile irrigation checks from the issue.
 - Lab/site: `make site-lint`, `make site-doctor`, or relevant site command.
 - Firmware/test harness: firmware gates plus all-year/extreme scenario outputs.
+
+### S8: Vanda Night Dehum (vent+reheat + telemetry + gated activation)
+
+Status: `Awaiting approval`
+
+Goal: dry the overnight center-zone air per #410 (02-06h median VPD 0.61 ->
+>=0.78) via the design-reviewed vent+reheat held-temp path, shipped flag-OFF and
+activated behind the #411/#377 Jason gates with a 48h canary bake
+(night_min >= 64F rollback trigger).
+
+First structured sprint transaction: plan, lane contracts, gates, and the wave
+release plan live in `.agent-workflow/sprints/s8-vanda-night-dehum/`.
+
+Primary lanes:
+
+- #410 firmware vent+reheat hold (flag OFF, replay-identical).
+- #327 moisture-estimator telemetry (migration 187) — bake prerequisite.
+- #413 doc drift: pinch re-pin step, OTA-reset mechanics, envelope notes.
+- #411 night-anchor migration 188 — blocked on the gate:jason decision.
+
+Verification:
+
+- Firmware: replay (flag-OFF zero-divergence), invariants, cold-night fixture,
+  `make firmware-check`; migrations: `make migration-rollback-safety` + proofs;
+  docs: `git diff --check`; activation evidence: `outcome_kpi()` + the bake
+  report with recorded envelope + band_track_fraction + flag state.


### PR DESCRIPTION
**Merging this PR = approving sprint S8** (gate `plan-approval-s8-vanda-night-dehum`, HR-01). Read `.agent-workflow/sprints/s8-vanda-night-dehum/sprint-plan.md` first — it is the stakeholder summary.

## What this plans
The night-dehum slice, replanned around the 2026-07-03 #410 design review (verdict comment on #410) and the envelope findings (#412):

| Lane | Issue | What |
|---|---|---|
| `fw-410-vent-reheat-hold` | #410 | Held-temp estimator ladder + hold-reheat gate + OFF-default `dehum_vent_hold_enabled` flag + synthetic cold-night fixture + behavior-coupled docs + heat1-electric comment fixes |
| `data-327-moisture-telemetry` | #327 | Migration **187** schema-first + ingestor/MCP estimator-context exposure (bake prerequisite, promoted W3→W1) |
| `docs-413-freeze-drift` | #413 | Checklist re-pin/record steps, `band_track_fraction` OTA-reset mechanics, dated envelope notes |
| `db-411-night-anchors` | #411 | **Blocked on gate g-411**: migration **188** (night anchors + vpd_target ~0.83), prepared not applied |

Group 1 (first three lanes) runs parallel; lane 4 is serial behind the Jason decision + migration serialization.

## Gates opened (all Jason)
- `g-411-night-temp-priority` — deep-DIF vs dry-roots vs seasonal split (#411). Blocks activation.
- `g-377-pinch-repin` — post-OTA pinch state: re-pin 0.25 vs float 0.0 joint bake (#377 comment has the deltas).
- HR-02 (OTA + activation) and HR-03 (outcome acceptance) in `release/wave-release-plan.yaml`.

## Release shape
merge lanes → prod-promote + gated sync + migration 187 + bounce ingestor/mcp → *(g-411)* migration 188 → **flag-OFF OTA** (freeze rules) → *(g-377)* pinch decision + record envelope/pinch/flag → 48h soak → **flag ON** (tunable push) → 48h canary window (`night_min ≥ 64°F` = immediate flag-off) → bake report.

## Recorded exception
No formal project-definition/architecture-contract artifacts exist; this plan substitutes the repo-native contracts (CLAUDE.md freeze rules, fsm-spec, ADR-0003/0004, drift guards) and the live board. Approving accepts that substitution for S8.

## Validation
All 11 artifacts pass `bin/verdify artifact validate` against the vendored `verdify-skills 1.0.0` schemas (sprint-plan, lane-map, 4× lane-contract, 3× human-gate, wave-release-plan, status). Docs-only change; `git diff --check` clean.

Refs #410 #411 #327 #413 #377 #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
