### PR TITLE
docs(#413): band_track_fraction OTA-reset + re-pin step, envelope notes, bake-report record

### DIFF
--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Verdify Release Checklist
 
-Last updated: 2026-06-16. Companion to `docs/runbooks/laptop-operator.md` (the how-to) and
+Last updated: 2026-07-03 (#413: §B pinch-decision + bake-record steps). Companion to `docs/runbooks/laptop-operator.md` (the how-to) and
 `docs/reviews/lane1-architecture-audit-2026-06-16.md` (the why). Single-env-prod model: `main`
 is the only branch; prod is ArgoCD app `verdify-prod-dark` (ns `verdify-prod`), manual-sync
 behind the device-write gate.
@@ -68,6 +68,31 @@ prod `argocd app sync`, device-VLAN actions, destructive prod DB work, and outwa
 **Deploy + post:**
 - [ ] `make firmware-deploy` → confirm post-OTA `sensor-health` PASS; expected-firmware pin bumped.
       (Fail → auto-rollback to last-good; investigate before retry.)
+- [ ] **Pinch state — execute the g-377 decision (#377, Jason gate; mechanics per #413).**
+      `band_track_fraction` is `restore_value: no` with `initial_value: '0.0'`
+      (`firmware/greenhouse/globals.yaml`), so the flash just **cold-started the pinch to 0.0**
+      regardless of what was live (as of 2026-07-03 the live pre-#385 binary boots 0.25 and runs
+      planner-pushed 0.25). The `crop_band_anchors`→NVS reconcile does **NOT** re-assert it — that
+      path only protects `restore_value: yes` band globals (`docs/CONTROL-ARCHITECTURE.md` §7).
+      Execute ONE of the two g-377 outcomes:
+      - **Accept float 0.0** (the ADR-0004 planner default): nothing to push — confirm the readback:
+        `scripts/verdify-db.sh prod -c "SELECT ts, value FROM setpoint_snapshot WHERE parameter='band_track_fraction' ORDER BY ts DESC LIMIT 1;"`
+      - **Re-pin 0.25:** there is **no push-only command on current `main`** — ADR-0004 pinned the
+        registry bounds to `[0.0, 0.0]` (`verdify_schemas/tunable_registry.py`), so MCP
+        `set_tunable` rejects 0.25, the dispatcher clamps a direct `setpoint_plan` row back to 0.0
+        (`ingestor/tasks/dispatcher.py::_coerce_registry_value`), and the RT listener rejects it
+        (`ingestor/ingestor.py::_accept_outbound_setpoint`). Re-pinning therefore means:
+        (1) widen the `band_track_fraction` registry `min`/`max` (schema change; bounce
+        `verdify-mcp` + `verdify-ingestor` per freeze rule 7); (2) push
+        `set_tunable('band_track_fraction', 0.25, reason=…, trigger_id=<audited MANUAL trigger>,
+        planner_instance=…)` via MCP (or insert one `setpoint_plan` row) — dispatcher applies
+        within ~5 min; (3) confirm the readback query above returns 0.25. **Never** push a raw
+        ESPHome `number_command` from an operator host — that is a second device writer.
+- [ ] **Bake report records the config** (required for every bake/KPI comparison window): the
+      executed `band_track_fraction` state (+ readback proof), `dehum_vent_hold_enabled` state
+      (`cfg_*` readback; OFF-default flag from #410), and the **envelope config** — door
+      screen-window OPEN/CLOSED (open ~2026-06-19 → fall per #412; ~3× passive night air exchange
+      while open). **Never change the window state mid-bake.**
 - [ ] PR body / commit carries the **required artifacts**: replay-diff output, invariant-suite
       output, unit-test delta (CLAUDE.md firmware rule 9).
 - [ ] **Bake 48 h** with no critical alert, then `make firmware-promote-last-good FW_VERSION=<v>`.

--- a/docs/handoff/k3s-agent-handoff.md
+++ b/docs/handoff/k3s-agent-handoff.md
@@ -111,6 +111,18 @@ flash. The procedure and its traps:
 - **Device:** ESP32 `192.168.10.111` (OTA `:3232`, native API `:6053`). It
   currently runs **`2026.6.17.2042.dcc6078`** (the band-compliance firmware; pinch
   wired, `band_track_fraction=0.25` live).
+- **Pinch resets on every flash (#413/#377, verified 2026-07-03):**
+  `band_track_fraction` is `restore_value: no` in `firmware/greenhouse/globals.yaml`
+  — an OTA/reboot **cold-starts it to the compiled `initial_value`, `0.0` on
+  current `main`** (the ADR-0004 float flip), silently dropping the live
+  planner-pushed 0.25. The `crop_band_anchors`→NVS reconcile does **NOT** cover it
+  (it only re-asserts `restore_value: yes` band globals —
+  `docs/CONTROL-ARCHITECTURE.md` §7), and no dispatcher path re-pushes it: the
+  registry pins its bounds to `[0.0, 0.0]`, so MCP `set_tunable` rejects a nonzero
+  value and the dispatcher clamps a direct `setpoint_plan` row back to 0.0.
+  Post-OTA, execute the g-377 pinch decision (re-pin 0.25 — which first requires a
+  registry-bounds change — vs accept float 0.0) per the checklist step in
+  `docs/RELEASE-CHECKLIST.md` §B "Deploy + post".
 - **VERIFY the running firmware from telemetry — `diagnostics.firmware_version`
   — NEVER from `firmware/artifacts/last-good.version`.** `last-good` is the
   **rollback floor**, which deliberately lags the running binary through the 48 h
@@ -136,6 +148,13 @@ flash. The procedure and its traps:
   3. `ESPHOME_BIN=<esphome> SECRETS_SRC=<secrets.yaml> scripts/firmware-esphome-worktree.sh -s fw_version "$FW_VERSION" compile && … upload --device 192.168.10.111`
   4. `VERDIFY_DB_BACKEND=kube bash scripts/wait-for-firmware-version.sh "$FW_VERSION" --timeout 180` then `VERDIFY_DB_BACKEND=kube EXPECTED_FW_VERSION="$FW_VERSION" make sensor-health SINCE='5 minutes'`
   5. `bash scripts/archive-firmware-artifacts.sh "$FW_VERSION"` — **NOT** `--promote-last-good` (last-good stays on the prior baked binary through the 48 h bake; promote only after).
+  6. **Pinch decision + bake record (#413):** the flash just cold-started
+     `band_track_fraction` to `0.0` (see the pinch-reset bullet above). Execute the
+     g-377 decision, then record in the bake report: `band_track_fraction`
+     (readback proof from `setpoint_snapshot`), `dehum_vent_hold_enabled`
+     (`cfg_*` readback; OFF-default flag from #410), and the **envelope config**
+     (door screen-window open/closed — open ~2026-06-19 → fall per #412; never
+     change it mid-bake). Full step: `docs/RELEASE-CHECKLIST.md` §B "Deploy + post".
 - **The gates are real** (`scripts/firmware-deploy-preflight.sh`): no OTA while
   `alert_log` has unresolved critical/legacy-high rows; 48 h bake on
   `last-good.ota.bin` mtime; ≤1 OTA/calendar week; telemetry <300 s; action-log

--- a/docs/reviews/band-compliance-ota-signoff-2026-06-17.md
+++ b/docs/reviews/band-compliance-ota-signoff-2026-06-17.md
@@ -25,6 +25,16 @@ The greenhouse controller now implements Jason's control story end-to-end:
 | WS-G | **Metric reshape** (data) | `fn_grade_credit` is a tent peaking AT target — killed the flat-1.0-in-band saturation; `|actual−target|` headline metric (`fn_band_deviation`). (`0ed898c`) |
 | PR-9 | **CI gate fixes** | Band-derive gate widened; the no-op `no-new-fire-and-forget` guard fixed. (`cf9a1e6`) |
 
+> **2026-07-03 envelope note (#412, added by #413):** WS-C's moisture-exchange
+> estimator (and its `vent_exchange_fraction` tunable) models air exchange as
+> vent-driven mixing against an otherwise closed envelope — true when this was
+> signed off. Since ~2026-06-19 the door screen-window is OPEN (and stays open
+> until fall), ~3×-ing passive night air exchange (indoor−outdoor moisture surplus
+> stepped +5.7 → +1.9 g/m³ at flat fog/mister source duty), so the closed-vent
+> baseline this sign-off assumed is weakened while it is open. Record the envelope
+> config in every bake/KPI comparison window; never change the window state
+> mid-bake.
+
 **Net device behavior:** the homepage band-trace will show actual *tracking* the diurnal
 target curve 24/7 instead of floating, with the night VPD wet-drift eliminated.
 

--- a/docs/reviews/greenhouse-physics-model-floating-control-2026-06-18.md
+++ b/docs/reviews/greenhouse-physics-model-floating-control-2026-06-18.md
@@ -5,6 +5,19 @@ the environment the crop actually experiences*, while respecting the floating pr
 (let the air roam, intervene minimally). Companion to the nature-alignment work
 (`band-single-source-of-truth`, `docs/adr/0003`).
 
+> **2026-07-03 envelope note (#412, added by #413):** the door screen-window has been
+> OPEN since ~2026-06-19 and **stays open until fall** (Jason, 2026-07-03). Until it
+> closes, the envelope exchange terms below — `U·A·(T_air − T_out)` in the energy
+> balance and the `infiltration` term in the moisture balance — include a large
+> **fixed open-window leak**, not the tight-envelope values this model assumed:
+> passive night air exchange is ~3× higher (the standing indoor−outdoor moisture
+> surplus stepped **+5.7 → +1.9 g/m³** at ~06-19/20 with flat fog/mister source duty
+> ~22%→~20% and no heat1 night-duty increase). Any parameter identification of
+> `U·A` / `k_vent` / infiltration over post-06-19 data reflects the open-window
+> regime, and closed-vent exchange assumptions are weakened while it is open.
+> **Never change the window state mid-bake/mid-experiment**; every bake/KPI
+> comparison window must record the envelope config (window open/closed).
+
 ## 0. The resolution in one line
 
 > **Float the air; constrain the plant.** Consistency is enforced on the crop's

--- a/docs/reviews/mechanical-response-matrix-overnight-dehum-2026-06-22.md
+++ b/docs/reviews/mechanical-response-matrix-overnight-dehum-2026-06-22.md
@@ -32,6 +32,19 @@ Primary data window:
 The companion before/after architecture review is
 `docs/reviews/firmware-band-performance-review-2026-06-22.md`.
 
+> **2026-07-03 envelope note (#412, added by #413):** the door screen-window opened
+> ~2026-06-19 — i.e. **inside this review's evidence window** — and stays open until
+> fall. It ~3×'d passive night air exchange (the standing indoor−outdoor moisture
+> surplus stepped **+5.7 → +1.9 g/m³** at flat fog/mister source duty ~22%→~20%,
+> with no heat1 night-duty increase), so the night baselines observed here blend
+> pre- and post-open regimes. The estimator's closed-vent assumption — that indoor
+> air mixes toward outdoor only when `DEHUM_VENT` opens the vent by
+> `vent_exchange_fraction` (below) — is weakened while the window is open: a large
+> passive exchange path exists even with the vent closed. Re-read the projected
+> vent-gain and vent-selection conclusions with that in mind. Every bake/KPI
+> comparison window must record the envelope config; never change the window state
+> mid-bake.
+
 ## Current Firmware Behavior
 
 The current controller does not simply compare against the served low/high band.

--- a/docs/runbooks/laptop-operator.md
+++ b/docs/runbooks/laptop-operator.md
@@ -100,6 +100,19 @@ healthy OTA) are documented in
 [`../handoff/k3s-agent-handoff.md`](../handoff/k3s-agent-handoff.md) §4 — read it
 before flashing.
 
+**Pinch resets on every flash (#413/#377):** `band_track_fraction` is
+`restore_value: no` in `firmware/greenhouse/globals.yaml`, so an OTA/reboot
+cold-starts it to the compiled `initial_value` — **`0.0` on current `main`**
+(ADR-0004) — regardless of the live planner-pushed 0.25. The
+`crop_band_anchors`→NVS reconcile does **NOT** re-assert it (that path only
+protects `restore_value: yes` band globals — `docs/CONTROL-ARCHITECTURE.md` §7),
+and the registry pins its bounds to `[0.0, 0.0]`, so no current push path can
+restore 0.25 without a registry-bounds change first. Post-flash, execute the
+g-377 pinch decision (re-pin vs accept float) and record `band_track_fraction` +
+`dehum_vent_hold_enabled` (#410) + the envelope config (door screen-window
+open/closed, #412) in the bake report — step-by-step in
+`docs/RELEASE-CHECKLIST.md` §B "Deploy + post".
+
 ```bash
 # Validate + compile (laptop venv esphome 2026.5.x):
 SECRETS_SRC=$HOME/.verdify/esphome-secrets.yaml \


### PR DESCRIPTION
Closes #413

Docs-only lane `docs-413-freeze-drift` (sprint `s8-vanda-night-dehum`). Six owned files, no code/config/schema changes.

## What

1. **`docs/RELEASE-CHECKLIST.md` §B "Deploy + post"** (between post-OTA sensor-health and the 48h-bake line):
   - **g-377 pinch-decision step**: `band_track_fraction` is `restore_value: no` / `initial_value: '0.0'` (`firmware/greenhouse/globals.yaml`) → every OTA/reboot cold-starts the pinch to 0.0 while live (fw pre-#385) runs planner-pushed 0.25; the `crop_band_anchors`→NVS reconcile does NOT cover it. Mechanics of **both** g-377 outcomes documented (no recommendation — the decision stays Jason's gate):
     - accept float 0.0 → readback confirmation query (`setpoint_snapshot`);
     - re-pin 0.25 → **no push-only command exists on current `main`**: ADR-0004 pinned the registry bounds to `[0.0, 0.0]` (`verdify_schemas/tunable_registry.py`), and all three push paths enforce it (MCP `set_tunable` bounds gate; dispatcher `_coerce_registry_value` clamp, `ingestor/tasks/dispatcher.py`; RT `_accept_outbound_setpoint` reject, `ingestor/ingestor.py`). Re-pin = registry-bounds change + bounce `verdify-mcp`/`verdify-ingestor`, then the audited `set_tunable` push, then readback proof.
   - **Bake-report record step**: `band_track_fraction` (+ readback proof), `dehum_vent_hold_enabled` (#410, OFF-default), envelope config (window open/closed); never change the window state mid-bake.
2. **`docs/handoff/k3s-agent-handoff.md`**: pinch-reset mechanics bullet next to the live `band_track_fraction=0.25` statement + new OTA step 6 (decision + bake record), both pointing at the checklist step.
3. **`docs/runbooks/laptop-operator.md` §3**: same reset warning + checklist pointer.
4-6. **Dated 2026-07-03 envelope notes** (#412) added to `docs/reviews/greenhouse-physics-model-floating-control-2026-06-18.md` (infiltration/U·A term is now a large fixed open-window leak), `docs/reviews/mechanical-response-matrix-overnight-dehum-2026-06-22.md` (evidence window straddles the ~06-19 opening; `vent_exchange_fraction` closed-vent assumption weakened), and `docs/reviews/band-compliance-ota-signoff-2026-06-17.md` (WS-C estimator closed-envelope baseline predates the opening). Historical content untouched — additive notes only.

## Verified mechanics (baseline 0efdb2f)

- `firmware/greenhouse/globals.yaml:66-69` — `restore_value: no`, `initial_value: '0.0'`.
- `verdify_schemas/tunable_registry.py` `band_track_fraction` — `min=0.0, max=0.0` (ADR-0004).
- Dispatcher does **NOT** auto-re-push 0.25 post-OTA (reconnect reconcile seeds `_last_pushed` from cfg readbacks and force-pushes only `BAND_DRIVEN_PARAMS`; plan rows are registry-clamped to 0.0) — the #413/g-377 framing stands.

## Validation

- `git diff --check` — clean.
- `grep -n 'band_track_fraction' docs/RELEASE-CHECKLIST.md docs/handoff/k3s-agent-handoff.md docs/runbooks/laptop-operator.md` — new steps present in all three.
- `git status` — only the six owned docs files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)