### PR TITLE
data(#327): moisture-estimator telemetry — migration 187 + ingestor + MCP exposure

### DIFF
--- a/db/migrations/187-moisture-estimator-telemetry.sql
+++ b/db/migrations/187-moisture-estimator-telemetry.sql
@@ -1,0 +1,266 @@
+-- 187-moisture-estimator-telemetry.sql
+--
+-- #327: make every VPD/dehum decision explainable from the DB.
+--
+-- Since #385 (fb57246) the firmware publishes the ADR-0003 §6.4
+-- moisture-exchange estimator as one JSON text sensor
+-- (climate_moisture_exchange) and the ingestor persists the parsed object
+-- under climate_action_log.source_system_state -> 'climate_moisture_exchange'.
+-- That leaves the estimator context (which action the estimator selected and
+-- WHY: vent vs heat VPD gains, outdoor freshness, overcool risk, heat-assist
+-- co-run/dwell state) queryable only via ad-hoc JSONB surgery. #410's bake
+-- evaluation and #371 grading need it FIRST-CLASS: this migration adds a typed
+-- view that promotes each estimator field to a named, typed column per action
+-- row.
+--
+-- DESIGN: typed VIEW over source_system_state, NOT promoted columns.
+-- climate_action_log is a high-rate TimescaleDB hypertable (change-triggered
+-- + interval writes on the 5 s device loop; ~128k rows as of 2026-07-03).
+-- Promoted columns would (a) widen every row for data #385 already persists
+-- per-row in JSONB (double storage), (b) add parse/validation failure surface
+-- to the hot ingestor INSERT, and (c) require ALTER TABLE on a hypertable
+-- whose older chunks are subject to the migration-158 compression policies.
+-- A view is metadata-only (no table rewrite, no lock risk, no insert-path
+-- change), additive, and tolerant of absent fields by construction: a missing
+-- JSON key extracts as NULL. Rollback is a bare DROP VIEW.
+--
+-- TOLERANCE CONTRACT (must hold for #371/#410 queries):
+--   * Rows written by pre-#385 firmware (live fw 995c9b3: ALL 128k prod rows
+--     as of 2026-07-03) have NO climate_moisture_exchange object at all
+--     -> mx_present = false, every estimator column NULL.
+--   * Rows written by the #385-era emitter carry action/reason/gains/flags
+--     but NOT the two #410 fields -> those two columns NULL.
+--   * Rows written by the #410 emitter additionally carry
+--     vent_held_vpd_gain_kpa + hold_required (field names settled with the
+--     fw-410 lane -- do not rename).
+--   * The ingestor stores {"raw": <text>} when the payload fails JSON parse,
+--     and the raw string itself when the entity snapshot predates parsing:
+--     both shapes must degrade to NULL columns, never to a query error.
+--     Hence every numeric extraction is guarded by jsonb_typeof = 'number'
+--     and every boolean by the IN ('true','false') pattern (matches the
+--     mcp/server.py outcome_kpi() parser).
+--
+-- JSON contract (single source: verdify_schemas.MoistureExchangeTelemetry;
+-- emitter: firmware/greenhouse/controls.yaml moisture_exchange snprintf):
+--   action, reason, vent_vpd_gain_kpa, heat_vpd_gain_kpa, outdoor_fresh,
+--   vent_overcools, heat_assist_corun, heat_assist_active, heat_assist_timer_s
+--   (#385-era), plus vent_held_vpd_gain_kpa, hold_required (#410-era).
+--   outdoor_age_s / outdoor_data_age_s and expected_vpd_gain_kpa are accepted
+--   if a future emitter adds them (additive-tolerant; expected gain is
+--   otherwise DERIVED below from the selected action's own gain estimate).
+--
+-- Classification: NON-self-transactional (CREATE OR REPLACE VIEW + COMMENT
+-- only; no top-level COMMIT, no commit-forcing statement) -> SAFE to
+-- rollback-validate under an outer BEGIN; ... ROLLBACK;.
+-- Rollback: DROP VIEW public.v_moisture_estimator_telemetry;
+-- Reads: agent_ro inherits SELECT via pg_read_all_data (migration 184); no
+-- explicit GRANT needed.
+
+CREATE OR REPLACE VIEW public.v_moisture_estimator_telemetry AS
+SELECT
+    l.ts,
+    l.greenhouse_id,
+    l.climate_action,
+    l.priority_axis,
+    l.vpd_target_kpa,
+    l.vpd_target_delta_kpa,
+    l.vpd_band_error_kpa,
+    (mx.obj IS NOT NULL)            AS mx_present,
+    f.mx_action,
+    f.mx_reason,
+    f.vent_vpd_gain_kpa,
+    f.heat_vpd_gain_kpa,
+    f.vent_held_vpd_gain_kpa,
+    f.hold_required,
+    -- Selected/expected gain: what the estimator projected for the action it
+    -- chose. Prefers an explicit emitter value; otherwise derived from the
+    -- selected path's own gain. vent_plus_heat_hold (and any hold_required
+    -- row) grades against the HELD-temp gain -- that is #410's whole point.
+    COALESCE(
+        f.expected_vpd_gain_kpa,
+        CASE
+            WHEN f.mx_reason = 'vent_plus_heat_hold' OR COALESCE(f.hold_required, false)
+                THEN COALESCE(f.vent_held_vpd_gain_kpa, f.vent_vpd_gain_kpa)
+            WHEN f.mx_action IN ('vent_dehum', 'vent_humidify') THEN f.vent_vpd_gain_kpa
+            WHEN f.mx_action = 'heat_assist' THEN f.heat_vpd_gain_kpa
+            ELSE NULL
+        END
+    )                               AS expected_vpd_gain_kpa,
+    f.outdoor_fresh,
+    f.outdoor_age_s,
+    f.vent_overcools,
+    f.heat_assist_corun,
+    f.heat_assist_active,
+    f.heat_assist_timer_s
+FROM public.climate_action_log l
+LEFT JOIN LATERAL (
+    SELECT l.source_system_state -> 'climate_moisture_exchange' AS obj
+    WHERE jsonb_typeof(l.source_system_state -> 'climate_moisture_exchange') = 'object'
+) mx ON true
+LEFT JOIN LATERAL (
+    SELECT
+        NULLIF(mx.obj ->> 'action', '') AS mx_action,
+        NULLIF(mx.obj ->> 'reason', '') AS mx_reason,
+        CASE WHEN jsonb_typeof(mx.obj -> 'vent_vpd_gain_kpa') = 'number'
+             THEN (mx.obj ->> 'vent_vpd_gain_kpa')::double precision
+        END AS vent_vpd_gain_kpa,
+        CASE WHEN jsonb_typeof(mx.obj -> 'heat_vpd_gain_kpa') = 'number'
+             THEN (mx.obj ->> 'heat_vpd_gain_kpa')::double precision
+        END AS heat_vpd_gain_kpa,
+        CASE WHEN jsonb_typeof(mx.obj -> 'vent_held_vpd_gain_kpa') = 'number'
+             THEN (mx.obj ->> 'vent_held_vpd_gain_kpa')::double precision
+        END AS vent_held_vpd_gain_kpa,
+        CASE WHEN mx.obj ->> 'hold_required' IN ('true', 'false')
+             THEN (mx.obj ->> 'hold_required')::boolean
+        END AS hold_required,
+        CASE WHEN jsonb_typeof(mx.obj -> 'expected_vpd_gain_kpa') = 'number'
+             THEN (mx.obj ->> 'expected_vpd_gain_kpa')::double precision
+        END AS expected_vpd_gain_kpa,
+        CASE WHEN mx.obj ->> 'outdoor_fresh' IN ('true', 'false')
+             THEN (mx.obj ->> 'outdoor_fresh')::boolean
+        END AS outdoor_fresh,
+        COALESCE(
+            CASE WHEN jsonb_typeof(mx.obj -> 'outdoor_age_s') = 'number'
+                 THEN (mx.obj ->> 'outdoor_age_s')::double precision
+            END,
+            CASE WHEN jsonb_typeof(mx.obj -> 'outdoor_data_age_s') = 'number'
+                 THEN (mx.obj ->> 'outdoor_data_age_s')::double precision
+            END
+        ) AS outdoor_age_s,
+        CASE WHEN mx.obj ->> 'vent_overcools' IN ('true', 'false')
+             THEN (mx.obj ->> 'vent_overcools')::boolean
+        END AS vent_overcools,
+        CASE WHEN mx.obj ->> 'heat_assist_corun' IN ('true', 'false')
+             THEN (mx.obj ->> 'heat_assist_corun')::boolean
+        END AS heat_assist_corun,
+        CASE WHEN mx.obj ->> 'heat_assist_active' IN ('true', 'false')
+             THEN (mx.obj ->> 'heat_assist_active')::boolean
+        END AS heat_assist_active,
+        CASE WHEN jsonb_typeof(mx.obj -> 'heat_assist_timer_s') = 'number'
+             THEN (mx.obj ->> 'heat_assist_timer_s')::double precision
+        END AS heat_assist_timer_s
+) f ON true;
+
+COMMENT ON VIEW public.v_moisture_estimator_telemetry IS
+'#327: first-class, typed projection of the ADR-0003 §6.4 moisture-exchange '
+'estimator context persisted per climate_action_log row under '
+'source_system_state -> ''climate_moisture_exchange'' (#385 emitter; #410 adds '
+'vent_held_vpd_gain_kpa + hold_required). Tolerant by construction: rows from '
+'pre-#385 firmware (mx_present = false), un-parsed raw payloads, and rows '
+'missing only the #410 fields all degrade to NULL columns. JSON contract '
+'mirror: verdify_schemas.MoistureExchangeTelemetry.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.mx_present IS
+'True when the row carries a parsed moisture-exchange estimator object. False '
+'for pre-#385 firmware rows and for raw/unparseable payloads.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.mx_action IS
+'Estimator-selected exchange action: none | vent_dehum | heat_assist | '
+'vent_humidify (firmware moisture_exchange_action_name()).';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.mx_reason IS
+'Estimator reasoning bucket: in_band | vpd_untrusted | vent_dehum | '
+'vent_plus_heat | vent_plus_heat_hold (#410) | heat_assist | vent_humidify | '
+'no_effective_action. New firmware reasons must pass through unchanged -- do '
+'not enum-constrain this column.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.vent_vpd_gain_kpa IS
+'Projected single-cycle VPD gain (kPa, + = toward target) of the VENT '
+'candidate at decision time.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.heat_vpd_gain_kpa IS
+'Projected single-cycle VPD gain (kPa, + = toward target) of the HEAT-assist '
+'candidate (sensible probe step, vapor conserved).';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.vent_held_vpd_gain_kpa IS
+'#410: projected VPD gain of venting while heat HOLDS air temperature (vapor '
+'swap at held temp). NULL for pre-#410 emitters. Field name settled with the '
+'fw-410 lane.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.hold_required IS
+'#410: true when the estimator required the heat-hold co-run for the vent '
+'path to help. NULL for pre-#410 emitters. Field name settled with the '
+'fw-410 lane.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.expected_vpd_gain_kpa IS
+'Gain the estimator expected from the action it SELECTED (kPa, + = toward '
+'target). Explicit emitter value when present, else derived: '
+'vent_plus_heat_hold/hold_required -> vent_held_vpd_gain_kpa, vent paths -> '
+'vent_vpd_gain_kpa, heat_assist -> heat_vpd_gain_kpa.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.outdoor_age_s IS
+'Outdoor (Tempest) sample age in seconds at decision time, when the emitter '
+'provides it (accepts outdoor_age_s or outdoor_data_age_s). NULL from the '
+'#385/#410 emitters; outdoor_fresh is the decision-grade staleness verdict.';
+
+COMMENT ON COLUMN public.v_moisture_estimator_telemetry.heat_assist_timer_s IS
+'Heat-assist dwell timer (seconds remaining) at decision time -- the dwell '
+'state behind heat_assist_active.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- EXPLAIN-QUERY (#327 acceptance, LANE-AC-03): classify each VPD/dehum action
+-- bucket by estimator reason and expected-vs-observed VPD direction.
+--
+-- One row per (climate_action, mx_reason) bucket over a local calendar day:
+--   decisions            -- action-log rows in the bucket
+--   expected_toward      -- rows where the estimator projected VPD movement
+--                           toward target (expected_vpd_gain_kpa > 0)
+--   observed_toward      -- rows where |vpd_target_delta| SHRANK by the next
+--                           sample 10-20 min later (moved toward target)
+--   confirmed / diverged -- expectation vs observation agreement counts
+--   avg_expected_gain_kpa / avg_observed_gain_kpa
+--
+-- Pre-#385 rows land in the 'estimator_absent' bucket (mx_present = false) --
+-- the query stays valid across the fw 995c9b3 -> #385 -> #410 rollout.
+--
+--   WITH win AS (
+--       SELECT ('2026-07-02'::date::timestamp AT TIME ZONE 'America/Denver') AS start_ts,
+--              (('2026-07-02'::date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
+--   ),
+--   rows AS (
+--       SELECT v.*
+--       FROM v_moisture_estimator_telemetry v
+--       CROSS JOIN win w
+--       WHERE v.greenhouse_id = 'vallery'
+--         AND v.ts >= w.start_ts AND v.ts < w.end_ts
+--   ),
+--   scored AS (
+--       SELECT r.*,
+--              nxt.vpd_target_delta_kpa AS vpd_target_delta_next_kpa,
+--              (abs(r.vpd_target_delta_kpa) - abs(nxt.vpd_target_delta_kpa))
+--                  AS observed_gain_kpa      -- + = moved toward target
+--       FROM rows r
+--       LEFT JOIN LATERAL (
+--           SELECT n.vpd_target_delta_kpa
+--           FROM v_moisture_estimator_telemetry n
+--           WHERE n.greenhouse_id = r.greenhouse_id
+--             AND n.ts >= r.ts + interval '10 minutes'
+--             AND n.ts <  r.ts + interval '20 minutes'
+--             AND n.vpd_target_delta_kpa IS NOT NULL
+--           ORDER BY n.ts
+--           LIMIT 1
+--       ) nxt ON true
+--   )
+--   SELECT climate_action,
+--          CASE WHEN NOT mx_present THEN 'estimator_absent'
+--               ELSE COALESCE(mx_reason, 'unknown') END        AS mx_reason,
+--          count(*)::int                                       AS decisions,
+--          count(*) FILTER (WHERE expected_vpd_gain_kpa > 0)::int AS expected_toward,
+--          count(*) FILTER (WHERE observed_gain_kpa > 0)::int  AS observed_toward,
+--          count(*) FILTER (WHERE expected_vpd_gain_kpa > 0
+--                             AND observed_gain_kpa > 0)::int  AS confirmed,
+--          count(*) FILTER (WHERE expected_vpd_gain_kpa > 0
+--                             AND observed_gain_kpa <= 0)::int AS diverged,
+--          round(avg(expected_vpd_gain_kpa)::numeric, 3)       AS avg_expected_gain_kpa,
+--          round(avg(observed_gain_kpa)::numeric, 3)           AS avg_observed_gain_kpa
+--   FROM scored
+--   WHERE priority_axis = 'vpd'
+--      OR climate_action IN ('DEHUM_VENT', 'SEALED_HUMIDIFY', 'SEALED_FOG',
+--                            'VENT_COOL_MIST_ASSIST', 'VENT_COOL_FOG_ASSIST')
+--      OR mx_action IS NOT NULL
+--   GROUP BY 1, 2
+--   ORDER BY decisions DESC, climate_action, mx_reason;
+--
+-- The same query (fixture-fed) runs in
+-- db/migrations/tests/test-187-moisture-estimator-telemetry.sql.
+-- ─────────────────────────────────────────────────────────────────────────────

--- a/db/migrations/tests/test-187-moisture-estimator-telemetry.sql
+++ b/db/migrations/tests/test-187-moisture-estimator-telemetry.sql
@@ -1,0 +1,202 @@
+-- test-187-moisture-estimator-telemetry.sql
+--
+-- Manual/CI psql fixture for migration 187 (#327 moisture-estimator telemetry).
+--
+-- Usage from the repository root against a DISPOSABLE database (CI service
+-- container or local docker verdify-timescaledb). It INSERTs fixture rows into
+-- climate_action_log inside the transaction, so do NOT run it against prod --
+-- the rollback makes it side-effect-free, but prod DML is banned outright:
+--
+--   psql -v ON_ERROR_STOP=1 -f db/migrations/tests/test-187-moisture-estimator-telemetry.sql
+--
+-- The fixture loads migration 187 inside a transaction, inserts one action-log
+-- row per emitter era (pre-#385 absent object, raw-string fallback,
+-- parse-failure {"raw": ...} fallback, #385-era object, #410-era object with
+-- vent_held_vpd_gain_kpa + hold_required), asserts the typed view's tolerance
+-- and derivations, runs the documented #327 explain-query over the fixture
+-- window, then rolls back.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+\i db/migrations/187-moisture-estimator-telemetry.sql
+
+-- Fixture rows: one local-night window on an unused historical date.
+INSERT INTO public.climate_action_log
+    (ts, greenhouse_id, climate_action, priority_axis,
+     vpd_target_kpa, vpd_target_delta_kpa, vpd_band_error_kpa,
+     source_system_state)
+VALUES
+    -- A) pre-#385 firmware (live fw 995c9b3): no estimator key at all.
+    ('2026-01-15 02:00:00-07', 'vallery', 'IDLE', 'temp',
+     0.80, -0.30, -0.10,
+     '{"climate_action": "IDLE"}'::jsonb),
+    -- B) entity snapshot stored as the RAW string (never parsed).
+    ('2026-01-15 02:05:00-07', 'vallery', 'DEHUM_VENT', 'vpd',
+     0.80, -0.28, -0.08,
+     '{"climate_moisture_exchange": "{\"action\":\"vent_dehum\",\"reason\":\"vent_dehum\"}"}'::jsonb),
+    -- C) ingestor parse-failure fallback: {"raw": <text>} object, no contract keys.
+    ('2026-01-15 02:10:00-07', 'vallery', 'DEHUM_VENT', 'vpd',
+     0.80, -0.26, -0.06,
+     '{"climate_moisture_exchange": {"raw": "unparseable"}}'::jsonb),
+    -- D) #385-era emitter: action/reason/gains/flags, NO #410 fields.
+    ('2026-01-15 02:15:00-07', 'vallery', 'DEHUM_VENT', 'vpd',
+     0.80, -0.25, -0.05,
+     '{"climate_moisture_exchange": {"action": "vent_dehum", "reason": "vent_plus_heat",
+       "vent_vpd_gain_kpa": 0.062, "heat_vpd_gain_kpa": 0.041,
+       "outdoor_fresh": true, "vent_overcools": false,
+       "heat_assist_corun": true, "heat_assist_active": true,
+       "heat_assist_timer_s": 240}}'::jsonb),
+    -- D2) observation row ~15 min after D (VPD moved toward target).
+    ('2026-01-15 02:30:00-07', 'vallery', 'DEHUM_VENT', 'vpd',
+     0.80, -0.20, 0.00,
+     '{"climate_moisture_exchange": {"action": "heat_assist", "reason": "heat_assist",
+       "vent_vpd_gain_kpa": 0.010, "heat_vpd_gain_kpa": 0.045,
+       "outdoor_fresh": false, "vent_overcools": true,
+       "heat_assist_corun": false, "heat_assist_active": true,
+       "heat_assist_timer_s": 180}}'::jsonb),
+    -- E) #410-era emitter: adds vent_held_vpd_gain_kpa + hold_required
+    --    (settled field names) and the new vent_plus_heat_hold reason.
+    ('2026-01-15 02:45:00-07', 'vallery', 'DEHUM_VENT', 'vpd',
+     0.80, -0.22, -0.02,
+     '{"climate_moisture_exchange": {"action": "vent_dehum", "reason": "vent_plus_heat_hold",
+       "vent_vpd_gain_kpa": 0.030, "heat_vpd_gain_kpa": 0.020,
+       "vent_held_vpd_gain_kpa": 0.055, "hold_required": true,
+       "outdoor_fresh": true, "vent_overcools": true,
+       "heat_assist_corun": true, "heat_assist_active": true,
+       "heat_assist_timer_s": 300}}'::jsonb),
+    -- E2) observation row ~15 min after E (VPD moved AWAY from target).
+    ('2026-01-15 03:00:00-07', 'vallery', 'IDLE', 'vpd',
+     0.80, -0.27, -0.07,
+     '{"climate_moisture_exchange": {"action": "none", "reason": "no_effective_action",
+       "vent_vpd_gain_kpa": 0.001, "heat_vpd_gain_kpa": 0.002,
+       "outdoor_fresh": true, "vent_overcools": false,
+       "heat_assist_corun": false, "heat_assist_active": false,
+       "heat_assist_timer_s": 0}}'::jsonb);
+
+DO $$
+DECLARE
+    r record;
+BEGIN
+    -- A) absent object -> mx_present false, every estimator column NULL.
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:00:00-07' AND greenhouse_id = 'vallery';
+    IF r.mx_present OR r.mx_action IS NOT NULL OR r.mx_reason IS NOT NULL
+       OR r.vent_vpd_gain_kpa IS NOT NULL OR r.hold_required IS NOT NULL
+       OR r.expected_vpd_gain_kpa IS NOT NULL THEN
+        RAISE EXCEPTION 'pre-#385 row must project as fully-NULL estimator context: %', r;
+    END IF;
+
+    -- B) raw STRING payload -> typeof guard keeps it out (mx_present false).
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:05:00-07';
+    IF r.mx_present OR r.mx_action IS NOT NULL THEN
+        RAISE EXCEPTION 'raw-string payload must not parse: %', r;
+    END IF;
+
+    -- C) {"raw": ...} fallback -> object present, contract fields all NULL.
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:10:00-07';
+    IF NOT r.mx_present OR r.mx_action IS NOT NULL OR r.vent_vpd_gain_kpa IS NOT NULL THEN
+        RAISE EXCEPTION 'raw-fallback object must yield NULL contract fields: %', r;
+    END IF;
+
+    -- D) #385-era row: parsed, #410 fields NULL, expected gain = vent gain
+    --    (vent_plus_heat selects the vent path; hold fields absent).
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:15:00-07';
+    IF r.mx_action IS DISTINCT FROM 'vent_dehum'
+       OR r.mx_reason IS DISTINCT FROM 'vent_plus_heat'
+       OR r.vent_vpd_gain_kpa IS DISTINCT FROM 0.062
+       OR r.heat_vpd_gain_kpa IS DISTINCT FROM 0.041
+       OR r.vent_held_vpd_gain_kpa IS NOT NULL
+       OR r.hold_required IS NOT NULL
+       OR r.expected_vpd_gain_kpa IS DISTINCT FROM 0.062
+       OR r.outdoor_fresh IS DISTINCT FROM true
+       OR r.vent_overcools IS DISTINCT FROM false
+       OR r.heat_assist_corun IS DISTINCT FROM true
+       OR r.heat_assist_active IS DISTINCT FROM true
+       OR r.heat_assist_timer_s IS DISTINCT FROM 240::double precision THEN
+        RAISE EXCEPTION '#385-era row mis-parsed: %', r;
+    END IF;
+
+    -- D2) heat_assist selection -> expected gain = heat gain.
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:30:00-07';
+    IF r.expected_vpd_gain_kpa IS DISTINCT FROM 0.045 THEN
+        RAISE EXCEPTION 'heat_assist expected gain must be heat_vpd_gain_kpa: %', r;
+    END IF;
+
+    -- E) #410-era row: held gain + hold_required parsed, expected gain = HELD gain.
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 02:45:00-07';
+    IF r.mx_reason IS DISTINCT FROM 'vent_plus_heat_hold'
+       OR r.vent_held_vpd_gain_kpa IS DISTINCT FROM 0.055
+       OR r.hold_required IS DISTINCT FROM true
+       OR r.expected_vpd_gain_kpa IS DISTINCT FROM 0.055 THEN
+        RAISE EXCEPTION '#410-era row mis-parsed (settled fields vent_held_vpd_gain_kpa/hold_required): %', r;
+    END IF;
+
+    -- E2) mx_action 'none' -> no expected gain.
+    SELECT * INTO STRICT r FROM public.v_moisture_estimator_telemetry
+     WHERE ts = '2026-01-15 03:00:00-07';
+    IF r.expected_vpd_gain_kpa IS NOT NULL THEN
+        RAISE EXCEPTION 'no_effective_action must not project an expected gain: %', r;
+    END IF;
+
+    RAISE NOTICE 'migration 187 view tolerance + derivation assertions passed';
+END;
+$$;
+
+-- ── The documented #327 explain-query (fixture-fed sample output) ───────────
+\echo '--- explain-query: VPD/dehum buckets by mx_reason and expected-vs-observed direction ---'
+WITH win AS (
+    SELECT ('2026-01-15'::date::timestamp AT TIME ZONE 'America/Denver') AS start_ts,
+           (('2026-01-15'::date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
+),
+rows AS (
+    SELECT v.*
+    FROM public.v_moisture_estimator_telemetry v
+    CROSS JOIN win w
+    WHERE v.greenhouse_id = 'vallery'
+      AND v.ts >= w.start_ts AND v.ts < w.end_ts
+),
+scored AS (
+    SELECT r.*,
+           nxt.vpd_target_delta_kpa AS vpd_target_delta_next_kpa,
+           (abs(r.vpd_target_delta_kpa) - abs(nxt.vpd_target_delta_kpa))
+               AS observed_gain_kpa
+    FROM rows r
+    LEFT JOIN LATERAL (
+        SELECT n.vpd_target_delta_kpa
+        FROM public.v_moisture_estimator_telemetry n
+        WHERE n.greenhouse_id = r.greenhouse_id
+          AND n.ts >= r.ts + interval '10 minutes'
+          AND n.ts <  r.ts + interval '20 minutes'
+          AND n.vpd_target_delta_kpa IS NOT NULL
+        ORDER BY n.ts
+        LIMIT 1
+    ) nxt ON true
+)
+SELECT climate_action,
+       CASE WHEN NOT mx_present THEN 'estimator_absent'
+            ELSE COALESCE(mx_reason, 'unknown') END        AS mx_reason,
+       count(*)::int                                       AS decisions,
+       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0)::int AS expected_toward,
+       count(*) FILTER (WHERE observed_gain_kpa > 0)::int  AS observed_toward,
+       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0
+                          AND observed_gain_kpa > 0)::int  AS confirmed,
+       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0
+                          AND observed_gain_kpa <= 0)::int AS diverged,
+       round(avg(expected_vpd_gain_kpa)::numeric, 3)       AS avg_expected_gain_kpa,
+       round(avg(observed_gain_kpa)::numeric, 3)           AS avg_observed_gain_kpa
+FROM scored
+WHERE priority_axis = 'vpd'
+   OR climate_action IN ('DEHUM_VENT', 'SEALED_HUMIDIFY', 'SEALED_FOG',
+                         'VENT_COOL_MIST_ASSIST', 'VENT_COOL_FOG_ASSIST')
+   OR mx_action IS NOT NULL
+GROUP BY 1, 2
+ORDER BY decisions DESC, climate_action, mx_reason;
+
+ROLLBACK;
+\echo 'test-187-moisture-estimator-telemetry: PASS (rolled back)'

--- a/ingestor/entity_map.py
+++ b/ingestor/entity_map.py
@@ -423,6 +423,10 @@ STATE_MAP: dict[str, str] = {
     "climate_fog_block_reason": "climate_fog_block_reason",
     "climate_resource_cost_estimate": "climate_resource_cost_estimate",
     "climate_next_mist_eligible_s": "climate_next_mist_eligible_s",
+    # JSON estimator payload; contract = verdify_schemas.MoistureExchangeTelemetry
+    # (#327/#385/#410) — stored parsed+normalized under
+    # climate_action_log.source_system_state, promoted to typed columns by
+    # migration 187's v_moisture_estimator_telemetry view.
     "climate_moisture_exchange": "climate_moisture_exchange",
     "gl_main_state": "gl_main_state",
     "gl_main_reason": "gl_main_reason",

--- a/ingestor/ingestor.py
+++ b/ingestor/ingestor.py
@@ -104,6 +104,7 @@ from verdify_schemas import (
     SetpointChange,
     SetpointSnapshot,
     SystemStateRow,
+    normalize_moisture_exchange_telemetry,
 )
 from verdify_schemas.tunable_registry import get as get_tunable
 
@@ -671,6 +672,17 @@ async def write_climate_action_log(pool: asyncpg.Pool, ts: datetime) -> bool:
     source_system_state = {entity: state.system.get(entity) for entity in sorted(CLIMATE_ACTION_LOG_ENTITIES)}
     moisture_exchange = _parse_json_object(state.system.get("climate_moisture_exchange"))
     if moisture_exchange:
+        # #327: normalize through the shared JSON contract
+        # (verdify_schemas.MoistureExchangeTelemetry) so migration 187's
+        # v_moisture_estimator_telemetry view and the MCP outcome_kpi() parser
+        # read consistent types. Tolerant by contract: normalization never
+        # raises — payloads that don't validate (e.g. the {"raw": ...}
+        # parse-failure fallback) pass through unchanged, unknown keys are
+        # preserved (only non-finite numbers are dropped, keeping JSONB
+        # castable), and the two #410 fields (vent_held_vpd_gain_kpa,
+        # hold_required) are optional like everything else (live fw 995c9b3
+        # emits none of these fields).
+        moisture_exchange = normalize_moisture_exchange_telemetry(moisture_exchange)
         source_system_state["climate_moisture_exchange"] = moisture_exchange
     resource_cost = _parse_json_object(state.system.get("climate_resource_cost_estimate"))
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -461,7 +461,13 @@ async def outcome_kpi(target_date: str = "") -> str:
     demand from one-minute climate samples plus the active setpoint/readback
     state. Moisture-estimator buckets are computed from
     climate_action_log.source_system_state->climate_moisture_exchange when the
-    OTA/deploy path has produced rows. Pass date as YYYY-MM-DD or omit for today."""
+    OTA/deploy path has produced rows; #327 makes that context first-class:
+    per-(action, reason) buckets now include the #410 held-temp fields
+    (vent_held_vpd_gain_kpa, hold_required), the selected/expected VPD gain,
+    and outdoor age, and vpd_policy carries episode counters by estimator
+    reason (episodes_by_mx_reason; pre-#385 rows bucket as estimator_absent).
+    Migration 187's v_moisture_estimator_telemetry view is the equivalent
+    typed SQL surface. Pass date as YYYY-MM-DD or omit for today."""
     greenhouse_id = "vallery"
     conn = await _db()
     try:
@@ -911,6 +917,27 @@ async def outcome_kpi(target_date: str = "") -> str:
                         AS vent_vpd_gain_kpa,
                     NULLIF(mx ->> 'heat_vpd_gain_kpa', '')::double precision
                         AS heat_vpd_gain_kpa,
+                    -- #327/#410 fields (settled names; NULL from pre-#410
+                    -- emitters). typeof-guarded like migration 187's
+                    -- v_moisture_estimator_telemetry so raw/odd payloads
+                    -- degrade to NULL instead of erroring.
+                    CASE WHEN jsonb_typeof(mx -> 'vent_held_vpd_gain_kpa') = 'number'
+                        THEN (mx ->> 'vent_held_vpd_gain_kpa')::double precision
+                    END AS vent_held_vpd_gain_kpa,
+                    CASE WHEN mx ->> 'hold_required' IN ('true', 'false')
+                        THEN (mx ->> 'hold_required')::boolean
+                    END AS hold_required,
+                    CASE WHEN jsonb_typeof(mx -> 'expected_vpd_gain_kpa') = 'number'
+                        THEN (mx ->> 'expected_vpd_gain_kpa')::double precision
+                    END AS expected_vpd_gain_kpa_raw,
+                    COALESCE(
+                        CASE WHEN jsonb_typeof(mx -> 'outdoor_age_s') = 'number'
+                            THEN (mx ->> 'outdoor_age_s')::double precision
+                        END,
+                        CASE WHEN jsonb_typeof(mx -> 'outdoor_data_age_s') = 'number'
+                            THEN (mx ->> 'outdoor_data_age_s')::double precision
+                        END
+                    ) AS outdoor_age_s,
                     CASE WHEN mx ->> 'outdoor_fresh' IN ('true', 'false')
                         THEN (mx ->> 'outdoor_fresh')::boolean
                     END AS outdoor_fresh,
@@ -926,6 +953,24 @@ async def outcome_kpi(target_date: str = "") -> str:
                     NULLIF(mx ->> 'heat_assist_timer_s', '')::double precision
                         AS heat_assist_timer_s
                 FROM estimator
+            ),
+            enriched AS (
+                -- Selected/expected gain: explicit emitter value if present,
+                -- else the selected path's own projection (held-temp gain for
+                -- the #410 vent_plus_heat_hold / hold_required co-run).
+                SELECT parsed.*,
+                    COALESCE(
+                        expected_vpd_gain_kpa_raw,
+                        CASE
+                            WHEN reason = 'vent_plus_heat_hold'
+                                 OR COALESCE(hold_required, false)
+                                THEN COALESCE(vent_held_vpd_gain_kpa, vent_vpd_gain_kpa)
+                            WHEN action IN ('vent_dehum', 'vent_humidify')
+                                THEN vent_vpd_gain_kpa
+                            WHEN action = 'heat_assist' THEN heat_vpd_gain_kpa
+                        END
+                    ) AS expected_vpd_gain_kpa
+                FROM parsed
             )
             SELECT
                 action,
@@ -935,13 +980,20 @@ async def outcome_kpi(target_date: str = "") -> str:
                     AS avg_vent_vpd_gain_kpa,
                 round(avg(heat_vpd_gain_kpa)::numeric, 3)::double precision
                     AS avg_heat_vpd_gain_kpa,
+                round(avg(vent_held_vpd_gain_kpa)::numeric, 3)::double precision
+                    AS avg_vent_held_vpd_gain_kpa,
+                round(avg(expected_vpd_gain_kpa)::numeric, 3)::double precision
+                    AS avg_expected_vpd_gain_kpa,
+                count(*) FILTER (WHERE hold_required)::int AS hold_required_decisions,
                 count(*) FILTER (WHERE outdoor_fresh)::int AS outdoor_fresh_decisions,
+                round(avg(outdoor_age_s)::numeric, 0)::double precision
+                    AS avg_outdoor_age_s,
                 count(*) FILTER (WHERE vent_overcools)::int AS vent_overcool_decisions,
                 count(*) FILTER (WHERE heat_assist_corun)::int AS heat_assist_corun_decisions,
                 count(*) FILTER (WHERE heat_assist_active)::int AS heat_assist_active_decisions,
                 round(avg(heat_assist_timer_s)::numeric, 0)::double precision
                     AS avg_heat_assist_timer_s
-            FROM parsed
+            FROM enriched
             GROUP BY action, reason
             ORDER BY decisions DESC, action, reason
             """,
@@ -1067,6 +1119,83 @@ async def outcome_kpi(target_date: str = "") -> str:
             greenhouse_id,
         )
 
+        # #327: VPD-policy episode counters by estimator reason (mx_reason).
+        # One row per modal estimator reason across the day's action episodes;
+        # pre-#385 rows (no parsed object) land in 'estimator_absent' so the
+        # counters stay meaningful across the fw 995c9b3 -> #385 -> #410
+        # rollout. This is the #371 grading surface for "did the cycle take
+        # vent_plus_heat_hold or heat_assist?".
+        vpd_policy_reason_rows = await conn.fetch(
+            """
+            WITH bounds AS (
+                SELECT
+                    ($1::date::timestamp AT TIME ZONE 'America/Denver') AS start_ts,
+                    (($1::date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
+            ),
+            ordered AS (
+                SELECT
+                    l.ts,
+                    l.climate_action,
+                    l.priority_axis,
+                    lag(l.climate_action) OVER (ORDER BY l.ts) AS prev_action,
+                    CASE WHEN jsonb_typeof(
+                             l.source_system_state -> 'climate_moisture_exchange'
+                         ) = 'object'
+                        THEN NULLIF(
+                            l.source_system_state -> 'climate_moisture_exchange' ->> 'reason',
+                            ''
+                        )
+                    END AS mx_reason
+                FROM climate_action_log l
+                CROSS JOIN bounds b
+                WHERE l.greenhouse_id = $2
+                  AND l.ts >= b.start_ts
+                  AND l.ts < b.end_ts
+            ),
+            tagged AS (
+                SELECT
+                    *,
+                    sum(CASE WHEN prev_action IS DISTINCT FROM climate_action THEN 1 ELSE 0 END)
+                        OVER (ORDER BY ts ROWS UNBOUNDED PRECEDING) AS episode_id
+                FROM ordered
+            ),
+            episodes AS (
+                SELECT
+                    episode_id,
+                    climate_action,
+                    count(*)::int AS sample_count,
+                    bool_or(priority_axis = 'vpd') AS vpd_priority,
+                    COALESCE(
+                        mode() WITHIN GROUP (ORDER BY mx_reason),
+                        'estimator_absent'
+                    ) AS mx_reason
+                FROM tagged
+                GROUP BY episode_id, climate_action
+            )
+            SELECT
+                mx_reason,
+                count(*)::int AS episodes,
+                COALESCE(sum(sample_count), 0)::int AS samples,
+                count(*) FILTER (WHERE climate_action = 'DEHUM_VENT')::int
+                    AS vent_dehum_episodes,
+                count(*) FILTER (WHERE climate_action = 'HEAT' AND vpd_priority)::int
+                    AS heat_dehum_episodes,
+                count(*) FILTER (
+                    WHERE climate_action IN (
+                        'SEALED_HUMIDIFY',
+                        'SEALED_FOG',
+                        'VENT_COOL_MIST_ASSIST',
+                        'VENT_COOL_FOG_ASSIST'
+                    )
+                )::int AS wetting_episodes
+            FROM episodes
+            GROUP BY mx_reason
+            ORDER BY episodes DESC, mx_reason
+            """,
+            d,
+            greenhouse_id,
+        )
+
         moisture_sample_count = sum(row["decisions"] for row in moisture_rows)
         moisture_estimator = {
             "sample_count": moisture_sample_count,
@@ -1076,6 +1205,7 @@ async def outcome_kpi(target_date: str = "") -> str:
         vpd_policy = dict(vpd_policy_row) if vpd_policy_row else {}
         if vpd_policy:
             vpd_policy["transition_window_min"] = 30
+            vpd_policy["episodes_by_mx_reason"] = [dict(row) for row in vpd_policy_reason_rows]
         pending_metrics = []
         if not moisture_sample_count:
             pending_metrics.append("moisture_estimator: source path wired; waiting for OTA/deploy/live rows")

--- a/verdify_schemas/__init__.py
+++ b/verdify_schemas/__init__.py
@@ -187,6 +187,8 @@ from .system_infra import (
     UtilityCost,
 )
 from .telemetry import (
+    MX_ACTIONS,
+    MX_REASONS,
     OVERRIDE_EVENT_TYPES,
     ClimateActionLogRow,
     ClimateRow,
@@ -194,8 +196,11 @@ from .telemetry import (
     EnergySample,
     EquipmentId,
     EquipmentStateEvent,
+    MoistureEstimatorTelemetryRow,
+    MoistureExchangeTelemetry,
     OverrideEvent,
     SystemStateRow,
+    normalize_moisture_exchange_telemetry,
 )
 from .topology import (
     Equipment,
@@ -375,7 +380,12 @@ __all__ = [
     "MaintenanceLog",
     "MountType",
     "MoistureAssistState",
+    "MoistureEstimatorTelemetryRow",
+    "MoistureExchangeTelemetry",
     "MoistureZone",
+    "MX_ACTIONS",
+    "MX_REASONS",
+    "normalize_moisture_exchange_telemetry",
     "NUMERIC_TUNABLES",
     "NutrientRecipe",
     "Observation",

--- a/verdify_schemas/telemetry.py
+++ b/verdify_schemas/telemetry.py
@@ -17,9 +17,10 @@ Principles:
 
 from __future__ import annotations
 
+import math
 from typing import Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from .climate_intent import ClimateAction, ClimatePriorityAxis, MoistureAssistState, MoistureZone
 
@@ -369,6 +370,140 @@ class ClimateActionLogRow(BaseModel):
     sensor_status: dict = Field(default_factory=dict)
     candidate_summary: str | None = None
     source_system_state: dict = Field(default_factory=dict)
+
+
+# ── #327 moisture-estimator telemetry (ADR-0003 §6.4 / ADR-0004) ────────────
+#
+# The firmware publishes the moisture-exchange estimator as ONE JSON text
+# sensor (climate_moisture_exchange, #385); the ingestor parses it and stores
+# the object under climate_action_log.source_system_state; migration 187's
+# v_moisture_estimator_telemetry view promotes it to typed columns.
+# These constants document the values the firmware emits today — consumers
+# must NOT enum-constrain on them (a new firmware reason has to flow through
+# ingest/queries unchanged; see MoistureExchangeTelemetry tolerance notes).
+
+MX_ACTIONS: frozenset[str] = frozenset({"none", "vent_dehum", "heat_assist", "vent_humidify"})
+
+MX_REASONS: frozenset[str] = frozenset(
+    {
+        "in_band",
+        "vpd_untrusted",
+        "vent_dehum",
+        "vent_plus_heat",
+        "vent_plus_heat_hold",  # 410 vent+heat-hold co-run
+        "heat_assist",
+        "vent_humidify",
+        "no_effective_action",
+    }
+)
+
+# Alternate emitter spellings the SQL surfaces (migration 187 view, mcp
+# outcome_kpi()) accept via COALESCE, mapped to the canonical contract field.
+# Firmware names the input `outdoor_data_age_s` internally; either spelling
+# lands in `outdoor_age_s`.
+MX_ACCEPTED_KEY_ALIASES: dict[str, str] = {"outdoor_data_age_s": "outdoor_age_s"}
+
+
+class MoistureExchangeTelemetry(BaseModel):
+    """JSON contract of the firmware `climate_moisture_exchange` text sensor.
+
+    Single source of truth for the estimator-payload key names shared by the
+    firmware emitter (firmware/greenhouse/controls.yaml), the ingestor write
+    path (climate_action_log.source_system_state), migration 187's
+    v_moisture_estimator_telemetry view, and the mcp outcome_kpi() parser.
+
+    TOLERANCE (binding for #327/#410):
+    - Every field is optional: live fw 995c9b3 predates even the #385 emitter
+      (all fields absent), and the #385-era emitter lacks the two #410 fields.
+    - `extra="allow"`: unknown keys from newer firmware pass through unchanged.
+    - Non-finite floats normalize to None so the stored JSONB stays castable.
+    - `vent_held_vpd_gain_kpa` and `hold_required` names are SETTLED with the
+      fw-410 lane — do not rename.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    action: str | None = None  # MX_ACTIONS values today; permissive by design
+    reason: str | None = None  # MX_REASONS values today; permissive by design
+    vent_vpd_gain_kpa: float | None = None
+    heat_vpd_gain_kpa: float | None = None
+    vent_held_vpd_gain_kpa: float | None = None  # 410 (settled name)
+    hold_required: bool | None = None  # 410 (settled name)
+    expected_vpd_gain_kpa: float | None = None  # optional explicit emitter value
+    outdoor_fresh: bool | None = None
+    outdoor_age_s: float | None = None  # optional; outdoor_fresh is the verdict
+    vent_overcools: bool | None = None
+    heat_assist_corun: bool | None = None
+    heat_assist_active: bool | None = None
+    heat_assist_timer_s: float | None = None
+
+    @field_validator(
+        "vent_vpd_gain_kpa",
+        "heat_vpd_gain_kpa",
+        "vent_held_vpd_gain_kpa",
+        "expected_vpd_gain_kpa",
+        "outdoor_age_s",
+        "heat_assist_timer_s",
+    )
+    @classmethod
+    def finite_or_none(cls, v: float | None) -> float | None:
+        if v is not None and not math.isfinite(v):
+            return None
+        return v
+
+
+def normalize_moisture_exchange_telemetry(payload: dict) -> dict:
+    """Normalize a parsed climate_moisture_exchange payload for storage.
+
+    Coerces known fields to their contract types (numeric strings → float,
+    "true"/"false" → bool), drops non-finite numbers, and preserves unknown
+    keys verbatim. Absent stays absent: None fields are omitted rather than
+    written as JSON nulls, so a pre-#385/#410 payload never grows keys its
+    emitter did not send (this is what keeps the tolerance contract visible in
+    the stored rows). NEVER raises: a payload that does not validate
+    (wrong-typed field, {"raw": ...}-style oddities) is returned unchanged —
+    migration 187's view degrades it to NULL columns via its typeof guards.
+    """
+
+    try:
+        model = MoistureExchangeTelemetry.model_validate(payload)
+    except ValidationError:
+        return payload
+    return model.model_dump(mode="json", exclude_none=True)
+
+
+class MoistureEstimatorTelemetryRow(BaseModel):
+    """v_moisture_estimator_telemetry row (migration 187, #327).
+
+    Typed per-action-row projection of the estimator context used by #371
+    grading and the #410 bake evaluation. mx_* columns are NULL-tolerant by
+    construction: mx_present=False rows (pre-#385 firmware) carry no estimator
+    context at all; #385-era rows lack the two #410 fields.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    ts: AwareDatetime
+    greenhouse_id: str = "vallery"
+    climate_action: ClimateAction
+    priority_axis: ClimatePriorityAxis
+    vpd_target_kpa: float | None = None
+    vpd_target_delta_kpa: float | None = None
+    vpd_band_error_kpa: float | None = None
+    mx_present: bool = False
+    mx_action: str | None = None
+    mx_reason: str | None = None
+    vent_vpd_gain_kpa: float | None = None
+    heat_vpd_gain_kpa: float | None = None
+    vent_held_vpd_gain_kpa: float | None = None
+    hold_required: bool | None = None
+    expected_vpd_gain_kpa: float | None = None
+    outdoor_fresh: bool | None = None
+    outdoor_age_s: float | None = None
+    vent_overcools: bool | None = None
+    heat_assist_corun: bool | None = None
+    heat_assist_active: bool | None = None
+    heat_assist_timer_s: float | None = None
 
 
 class OverrideEvent(BaseModel):

--- a/verdify_schemas/tests/test_drift_guards.py
+++ b/verdify_schemas/tests/test_drift_guards.py
@@ -74,6 +74,7 @@ from verdify_schemas.telemetry import (
     Diagnostics,
     EnergySample,
     EquipmentStateEvent,
+    MoistureEstimatorTelemetryRow,
     OverrideEvent,
     SystemStateRow,
 )
@@ -164,6 +165,10 @@ DB_BACKED = [
     # Sprint 20/21 — telemetry + plan + setpoint + crops + lessons
     (ClimateRow, "climate"),
     (ClimateActionLogRow, "climate_action_log"),
+    # Migration 187 (#327): typed VIEW over climate_action_log's estimator
+    # JSONB. information_schema.columns covers views, so the same subset guard
+    # applies; until 187 lands the guard skips (view not found), then enforces.
+    (MoistureEstimatorTelemetryRow, "v_moisture_estimator_telemetry"),
     (Diagnostics, "diagnostics"),
     (EquipmentStateEvent, "equipment_state"),
     (EnergySample, "energy"),

--- a/verdify_schemas/tests/test_mcp_responses.py
+++ b/verdify_schemas/tests/test_mcp_responses.py
@@ -167,11 +167,17 @@ class TestOutcomeKpi:
                 "by_action_reason": [
                     {
                         "action": "vent_dehum",
-                        "reason": "vent_plus_heat",
+                        "reason": "vent_plus_heat_hold",
                         "decisions": 7,
                         "avg_vent_vpd_gain_kpa": 0.12,
                         "avg_heat_vpd_gain_kpa": 0.2,
+                        # #327/#410: held-temp co-run fields + selected gain
+                        # + outdoor age (NULL-tolerant for pre-#410 emitters).
+                        "avg_vent_held_vpd_gain_kpa": 0.16,
+                        "avg_expected_vpd_gain_kpa": 0.16,
+                        "hold_required_decisions": 7,
                         "outdoor_fresh_decisions": 7,
+                        "avg_outdoor_age_s": None,
                         "vent_overcool_decisions": 0,
                         "heat_assist_corun_decisions": 7,
                         "heat_assist_active_decisions": 3,
@@ -187,6 +193,26 @@ class TestOutcomeKpi:
                 "wet_to_dehum_episodes_30m": 3,
                 "dehum_to_wet_episodes_30m": 1,
                 "transition_window_min": 30,
+                # #327: episode counters by estimator reason; pre-#385 rows
+                # bucket as estimator_absent.
+                "episodes_by_mx_reason": [
+                    {
+                        "mx_reason": "vent_plus_heat_hold",
+                        "episodes": 4,
+                        "samples": 120,
+                        "vent_dehum_episodes": 4,
+                        "heat_dehum_episodes": 0,
+                        "wetting_episodes": 0,
+                    },
+                    {
+                        "mx_reason": "estimator_absent",
+                        "episodes": 38,
+                        "samples": 900,
+                        "vent_dehum_episodes": 0,
+                        "heat_dehum_episodes": 2,
+                        "wetting_episodes": 6,
+                    },
+                ],
             },
             source_tables=["daily_summary", "v_climate_action_daily_scorecard", "climate_action_log"],
         )
@@ -202,7 +228,11 @@ class TestOutcomeKpi:
         assert dumped["action_scorecard"][0]["decisions"] == 7
         assert dumped["moisture_estimator"]["sample_count"] == 7
         assert dumped["moisture_estimator"]["by_action_reason"][0]["action"] == "vent_dehum"
+        assert dumped["moisture_estimator"]["by_action_reason"][0]["hold_required_decisions"] == 7
+        assert dumped["moisture_estimator"]["by_action_reason"][0]["avg_vent_held_vpd_gain_kpa"] == 0.16
         assert dumped["vpd_policy"]["wet_to_dehum_episodes_30m"] == 3
+        assert dumped["vpd_policy"]["episodes_by_mx_reason"][0]["mx_reason"] == "vent_plus_heat_hold"
+        assert dumped["vpd_policy"]["episodes_by_mx_reason"][1]["mx_reason"] == "estimator_absent"
         assert '"date":"2026-06-23"' in r.model_dump_json()
 
     def test_action_row_rejects_extra_fields(self):

--- a/verdify_schemas/tests/test_moisture_telemetry.py
+++ b/verdify_schemas/tests/test_moisture_telemetry.py
@@ -1,0 +1,250 @@
+"""#327 moisture-estimator telemetry contract tests.
+
+Two layers, no DB required:
+
+1. Behavioral: `normalize_moisture_exchange_telemetry()` tolerance — every
+   emitter era (pre-#385 absent fields, #385-era payload, #410-era payload
+   with the settled `vent_held_vpd_gain_kpa` + `hold_required` names, and the
+   ingestor's `{"raw": ...}` parse-failure fallback) must flow through
+   without raising and without losing data.
+
+2. Static drift guards: the JSON keys referenced by the firmware emitter
+   (firmware/greenhouse/controls.yaml — read-only here), migration 187's
+   v_moisture_estimator_telemetry view, and the mcp/server.py outcome_kpi()
+   parser must all be declared on `MoistureExchangeTelemetry`. This is the
+   schema/entity-map/MCP agreement gate for #327: a new estimator key added
+   in any one layer without the shared contract fails loud here.
+
+The DB-backed column guard for the view itself lives in test_drift_guards.py
+(`MoistureEstimatorTelemetryRow` vs v_moisture_estimator_telemetry), and the
+fixture proof in db/migrations/tests/test-187-moisture-estimator-telemetry.sql.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from verdify_schemas import (
+    MX_REASONS,
+    MoistureEstimatorTelemetryRow,
+    MoistureExchangeTelemetry,
+    normalize_moisture_exchange_telemetry,
+)
+from verdify_schemas.telemetry import MX_ACCEPTED_KEY_ALIASES
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_187 = REPO_ROOT / "db" / "migrations" / "187-moisture-estimator-telemetry.sql"
+MCP_SERVER = REPO_ROOT / "mcp" / "server.py"
+FIRMWARE_CONTROLS = REPO_ROOT / "firmware" / "greenhouse" / "controls.yaml"
+
+# The two #410 fields whose NAMES are settled with the fw-410 lane. Renaming
+# either side breaks the bake-evaluation contract — do not "fix" this test by
+# renaming; coordinate through the lane contracts.
+SETTLED_410_FIELDS = ("vent_held_vpd_gain_kpa", "hold_required")
+
+# #385-era emitter payload (firmware/greenhouse/controls.yaml snprintf today).
+PAYLOAD_385 = {
+    "action": "vent_dehum",
+    "reason": "vent_plus_heat",
+    "vent_vpd_gain_kpa": 0.062,
+    "heat_vpd_gain_kpa": 0.041,
+    "outdoor_fresh": True,
+    "vent_overcools": False,
+    "heat_assist_corun": True,
+    "heat_assist_active": True,
+    "heat_assist_timer_s": 240.0,
+}
+
+# #410-era payload: adds the settled held-temp co-run fields + new reason.
+PAYLOAD_410 = {
+    **PAYLOAD_385,
+    "reason": "vent_plus_heat_hold",
+    "vent_held_vpd_gain_kpa": 0.055,
+    "hold_required": True,
+}
+
+
+class TestNormalizeTolerance:
+    def test_385_era_payload_round_trips(self):
+        out = normalize_moisture_exchange_telemetry(dict(PAYLOAD_385))
+        assert out == PAYLOAD_385
+
+    def test_410_era_payload_round_trips_with_settled_names(self):
+        out = normalize_moisture_exchange_telemetry(dict(PAYLOAD_410))
+        assert out == PAYLOAD_410
+        for field in SETTLED_410_FIELDS:
+            assert field in out
+
+    def test_missing_410_fields_stay_absent(self):
+        """#385-era rows must not grow the #410 keys (absent stays absent)."""
+        out = normalize_moisture_exchange_telemetry(dict(PAYLOAD_385))
+        for field in SETTLED_410_FIELDS:
+            assert field not in out
+
+    def test_raw_parse_failure_fallback_passes_through(self):
+        """The ingestor stores {"raw": <text>} when JSON parse fails; it must
+        survive normalization unchanged (extra='allow')."""
+        payload = {"raw": "unparseable garbage"}
+        assert normalize_moisture_exchange_telemetry(dict(payload)) == payload
+
+    def test_unknown_future_keys_preserved(self):
+        payload = {**PAYLOAD_385, "future_estimator_key": 1.25}
+        out = normalize_moisture_exchange_telemetry(dict(payload))
+        assert out["future_estimator_key"] == 1.25
+
+    def test_numeric_and_boolean_strings_coerced(self):
+        out = normalize_moisture_exchange_telemetry(
+            {"action": "heat_assist", "heat_vpd_gain_kpa": "0.045", "hold_required": "true"}
+        )
+        assert out["heat_vpd_gain_kpa"] == 0.045
+        assert out["hold_required"] is True
+
+    def test_non_finite_floats_dropped(self):
+        """C-side %.3f of NaN/inf can only reach storage as numbers via lax
+        parsing; the contract drops them so JSONB stays castable."""
+        out = normalize_moisture_exchange_telemetry(
+            {**PAYLOAD_385, "vent_vpd_gain_kpa": float("nan"), "heat_vpd_gain_kpa": float("inf")}
+        )
+        assert "vent_vpd_gain_kpa" not in out
+        assert "heat_vpd_gain_kpa" not in out
+
+    def test_unvalidatable_payload_returned_unchanged_never_raises(self):
+        payload = {"action": ["not", "a", "string"], "vent_vpd_gain_kpa": "abc"}
+        assert normalize_moisture_exchange_telemetry(dict(payload)) == payload
+
+    def test_model_accepts_empty_payload(self):
+        model = MoistureExchangeTelemetry.model_validate({})
+        assert model.action is None
+        assert model.hold_required is None
+
+    def test_finite_validator_keeps_finite_values(self):
+        model = MoistureExchangeTelemetry.model_validate(PAYLOAD_410)
+        assert model.vent_held_vpd_gain_kpa == 0.055
+        assert math.isfinite(model.heat_assist_timer_s)
+
+
+class TestViewRowModel:
+    def test_pre_385_row_shape(self):
+        """A pre-#385 action row projects with mx_present false / all-NULL."""
+        row = MoistureEstimatorTelemetryRow.model_validate(
+            {
+                "ts": datetime(2026, 7, 3, 3, 0, tzinfo=UTC),
+                "greenhouse_id": "vallery",
+                "climate_action": "DEHUM_VENT",
+                "priority_axis": "vpd",
+                "mx_present": False,
+            }
+        )
+        assert row.mx_action is None
+        assert row.vent_held_vpd_gain_kpa is None
+        assert row.hold_required is None
+        assert row.expected_vpd_gain_kpa is None
+
+    def test_410_row_shape(self):
+        row = MoistureEstimatorTelemetryRow.model_validate(
+            {
+                "ts": datetime(2026, 7, 3, 3, 0, tzinfo=UTC),
+                "greenhouse_id": "vallery",
+                "climate_action": "DEHUM_VENT",
+                "priority_axis": "vpd",
+                "mx_present": True,
+                "mx_action": "vent_dehum",
+                "mx_reason": "vent_plus_heat_hold",
+                "vent_vpd_gain_kpa": 0.03,
+                "heat_vpd_gain_kpa": 0.02,
+                "vent_held_vpd_gain_kpa": 0.055,
+                "hold_required": True,
+                "expected_vpd_gain_kpa": 0.055,
+            }
+        )
+        assert row.mx_reason in MX_REASONS
+        assert row.expected_vpd_gain_kpa == row.vent_held_vpd_gain_kpa
+
+
+def _extracted_json_keys(text: str) -> set[str]:
+    """JSON keys pulled out of the climate_moisture_exchange object in SQL.
+
+    Matches the two extraction shapes used by migration 187 (`mx.obj ->> 'k'`
+    / `mx.obj -> 'k'`), the mcp outcome_kpi() parser (`mx ->> 'k'` /
+    `mx -> 'k'`), and the inline `-> 'climate_moisture_exchange' ->> 'k'` form.
+    """
+
+    keys: set[str] = set()
+    keys.update(re.findall(r"mx(?:\.obj)?\s*->>?\s*'([a-z0-9_]+)'", text))
+    keys.update(re.findall(r"'climate_moisture_exchange'\s*->>?\s*'([a-z0-9_]+)'", text))
+    return keys
+
+
+def _firmware_emitted_keys() -> set[str]:
+    """JSON keys in the firmware moisture_exchange snprintf format string."""
+
+    src = FIRMWARE_CONTROLS.read_text()
+    start = src.index("snprintf(moisture_exchange")
+    block = src[start : src.index(");", start)]
+    return set(re.findall(r'\\"([a-z0-9_]+)\\":', block))
+
+
+class TestKeyAgreementDriftGuards:
+    """Schema ⇄ migration ⇄ MCP ⇄ firmware key agreement (#327 LANE-AC-02)."""
+
+    def test_migration_187_keys_are_modeled(self):
+        keys = _extracted_json_keys(MIGRATION_187.read_text())
+        assert keys, "migration 187 must extract estimator JSON keys"
+        declared = set(MoistureExchangeTelemetry.model_fields) | set(MX_ACCEPTED_KEY_ALIASES)
+        unmodeled = sorted(keys - declared)
+        assert unmodeled == [], (
+            f"migration 187 extracts JSON key(s) {unmodeled} that "
+            "verdify_schemas.MoistureExchangeTelemetry does not declare — add the "
+            "field to the shared contract first (schema lands first)."
+        )
+
+    def test_mcp_outcome_kpi_keys_are_modeled(self):
+        keys = _extracted_json_keys(MCP_SERVER.read_text())
+        assert keys, "mcp/server.py must extract estimator JSON keys"
+        declared = set(MoistureExchangeTelemetry.model_fields) | set(MX_ACCEPTED_KEY_ALIASES)
+        unmodeled = sorted(keys - declared)
+        assert unmodeled == [], (
+            f"mcp/server.py outcome_kpi() parses JSON key(s) {unmodeled} that "
+            "verdify_schemas.MoistureExchangeTelemetry does not declare — add the "
+            "field to the shared contract first (schema lands first)."
+        )
+
+    def test_firmware_emitted_keys_are_modeled(self):
+        """Read-only guard on the emitter: every key the firmware publishes in
+        climate_moisture_exchange must be declared on the shared contract, so
+        a fw-lane key addition without the schema fails loud here (and vice
+        versa the schema stays a superset — absence-tolerant by design)."""
+        keys = _firmware_emitted_keys()
+        assert keys >= {"action", "reason", "vent_vpd_gain_kpa", "heat_vpd_gain_kpa"}
+        unmodeled = sorted(keys - set(MoistureExchangeTelemetry.model_fields))
+        assert unmodeled == [], (
+            f"firmware emits climate_moisture_exchange key(s) {unmodeled} not declared "
+            "on verdify_schemas.MoistureExchangeTelemetry — coordinate the contract "
+            "(field names for #410 are settled: vent_held_vpd_gain_kpa, hold_required)."
+        )
+
+    def test_settled_410_names_everywhere(self):
+        """The two #410 fields keep their settled names in every consumer."""
+        migration = MIGRATION_187.read_text()
+        mcp_src = MCP_SERVER.read_text()
+        for field in SETTLED_410_FIELDS:
+            assert field in MoistureExchangeTelemetry.model_fields
+            assert field in MoistureEstimatorTelemetryRow.model_fields
+            assert field in migration, f"migration 187 must extract {field!r}"
+            assert field in mcp_src, f"mcp outcome_kpi() must surface {field!r}"
+        assert "vent_plus_heat_hold" in MX_REASONS
+        assert "vent_plus_heat_hold" in migration
+        assert "vent_plus_heat_hold" in mcp_src
+
+    def test_view_row_model_covers_promoted_estimator_fields(self):
+        """Every payload field the view promotes appears on the row model
+        (action/reason are promoted under the mx_ prefix)."""
+        payload_fields = set(MoistureExchangeTelemetry.model_fields)
+        row_fields = set(MoistureEstimatorTelemetryRow.model_fields)
+        promoted = {f for f in payload_fields if f not in {"action", "reason"}}
+        missing = sorted(promoted - row_fields)
+        assert missing == [], f"MoistureEstimatorTelemetryRow missing promoted field(s): {missing}"
+        assert {"mx_action", "mx_reason", "mx_present"} <= row_fields


### PR DESCRIPTION
Refs #327 (stays OPEN — migration 187 is applied by the release wave, not this PR). Lane `data-327-moisture-telemetry`, sprint `s8-vanda-night-dehum`, baseline 0efdb2f. Soft-coordinated with the fw-410 lane (field names below are settled).

## What

Make every VPD/dehum decision explainable from the DB. #385 (fb57246) already persists the firmware's ADR-0003 §6.4 moisture-exchange estimator JSON under `climate_action_log.source_system_state -> 'climate_moisture_exchange'`; this PR promotes that context to first-class queryable surfaces for #371 grading and the #410 held-temp-gain bake evaluation:

- **Migration 187** (`db/migrations/187-moisture-estimator-telemetry.sql`): typed view `v_moisture_estimator_telemetry` extracting `mx_action`, `mx_reason`, `vent_vpd_gain_kpa`, `heat_vpd_gain_kpa`, **`vent_held_vpd_gain_kpa` (NEW, #410)**, **`hold_required` (NEW, #410)**, derived `expected_vpd_gain_kpa` (selected path's own projection; held-temp gain for `vent_plus_heat_hold`/`hold_required` rows), `outdoor_fresh`, `outdoor_age_s`, `vent_overcools`, `heat_assist_corun`, `heat_assist_active`, `heat_assist_timer_s`, plus `mx_present` and band-delta context columns.
- **verdify_schemas**: `MoistureExchangeTelemetry` (the JSON contract — single source for the key names shared by the firmware emitter, ingestor, view, and MCP), `normalize_moisture_exchange_telemetry()`, `MoistureEstimatorTelemetryRow` (view row model) wired into the DB drift guards, and new key-agreement guards (`verdify_schemas/tests/test_moisture_telemetry.py`) that fail loud if firmware/migration/MCP ever parse a key the contract doesn't declare.
- **ingestor**: parsed payload is normalized through the shared contract before storage (types coerced, non-finite numbers dropped, unknown keys preserved, never raises). No new entity: the #385 `climate_moisture_exchange` route already carries the #410 fields additively.
- **mcp `outcome_kpi()`**: `moisture_estimator.by_action_reason` rows gain `avg_vent_held_vpd_gain_kpa`, `hold_required_decisions`, `avg_expected_vpd_gain_kpa`, `avg_outdoor_age_s`; `vpd_policy` gains **`episodes_by_mx_reason`** (episode counters by modal estimator reason — the #371 surface answering "did the cycle take `vent_plus_heat_hold` or `heat_assist`?"). Pre-#385 rows bucket as `estimator_absent`.

## Design: typed VIEW, not promoted columns (why)

`climate_action_log` is a high-rate TimescaleDB hypertable (change-triggered + interval writes off the 5 s device loop; 128,389 rows in prod as of 2026-07-03). Promoted columns would (a) widen every row for data #385 already persists per-row in JSONB (double storage), (b) add parse/validation failure surface to the hot ingestor INSERT, and (c) require `ALTER TABLE` on a hypertable whose older chunks fall under the migration-158 compression policies. The view is metadata-only (no rewrite, no lock risk, no insert-path change), additive, tolerant by construction (missing key → NULL), and rollback is a bare `DROP VIEW`. No index added: grading queries are day-window scans already served by hypertable chunk exclusion on `ts`, and today the estimator-object row count is 0 (live fw 995c9b3 predates the emitter — verified against prod, read-only, 2026-07-03: `total=128389, mx_object_rows=0`).

## Tolerance contract (binding for the #410 bake)

- Pre-#385 firmware rows (ALL current prod rows): `mx_present=false`, every estimator column NULL.
- #385-era emitter rows: parsed, the two #410 columns NULL.
- #410-era rows: all columns populated; **field names `vent_held_vpd_gain_kpa` + `hold_required` are SETTLED with the fw-410 lane — do not rename.**
- Raw-string / `{"raw": ...}` parse-failure payloads degrade to NULL columns (typeof-guarded extraction in both the view and `outcome_kpi()`), never to a query error.

## Explain-query (#327 acceptance)

Documented in migration 187 (bottom comment block) and executed fixture-fed in `db/migrations/tests/test-187-moisture-estimator-telemetry.sql` — classifies each VPD/dehum action bucket by `mx_reason` and expected-vs-observed VPD direction:

```sql
WITH win AS (
    SELECT ('2026-07-02'::date::timestamp AT TIME ZONE 'America/Denver') AS start_ts,
           (('2026-07-02'::date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
),
rows AS (
    SELECT v.* FROM v_moisture_estimator_telemetry v CROSS JOIN win w
    WHERE v.greenhouse_id = 'vallery' AND v.ts >= w.start_ts AND v.ts < w.end_ts
),
scored AS (
    SELECT r.*, (abs(r.vpd_target_delta_kpa) - abs(nxt.vpd_target_delta_kpa)) AS observed_gain_kpa
    FROM rows r
    LEFT JOIN LATERAL (
        SELECT n.vpd_target_delta_kpa FROM v_moisture_estimator_telemetry n
        WHERE n.greenhouse_id = r.greenhouse_id
          AND n.ts >= r.ts + interval '10 minutes' AND n.ts < r.ts + interval '20 minutes'
          AND n.vpd_target_delta_kpa IS NOT NULL
        ORDER BY n.ts LIMIT 1) nxt ON true
)
SELECT climate_action,
       CASE WHEN NOT mx_present THEN 'estimator_absent' ELSE COALESCE(mx_reason, 'unknown') END AS mx_reason,
       count(*)::int AS decisions,
       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0)::int AS expected_toward,
       count(*) FILTER (WHERE observed_gain_kpa > 0)::int AS observed_toward,
       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0 AND observed_gain_kpa > 0)::int AS confirmed,
       count(*) FILTER (WHERE expected_vpd_gain_kpa > 0 AND observed_gain_kpa <= 0)::int AS diverged,
       round(avg(expected_vpd_gain_kpa)::numeric, 3) AS avg_expected_gain_kpa,
       round(avg(observed_gain_kpa)::numeric, 3) AS avg_observed_gain_kpa
FROM scored
WHERE priority_axis = 'vpd'
   OR climate_action IN ('DEHUM_VENT','SEALED_HUMIDIFY','SEALED_FOG','VENT_COOL_MIST_ASSIST','VENT_COOL_FOG_ASSIST')
   OR mx_action IS NOT NULL
GROUP BY 1, 2
ORDER BY decisions DESC, climate_action, mx_reason;
```

Sample output (fixture run, disposable timescaledb, 2026-07-03T20:44Z):

```
 climate_action |      mx_reason      | decisions | expected_toward | observed_toward | confirmed | diverged | avg_expected_gain_kpa | avg_observed_gain_kpa
----------------+---------------------+-----------+-----------------+-----------------+-----------+----------+-----------------------+-----------------------
 DEHUM_VENT     | estimator_absent    |         1 |               0 |               1 |         0 |        0 |                       |                 0.030
 DEHUM_VENT     | heat_assist         |         1 |               1 |               0 |         0 |        1 |                 0.045 |                -0.020
 DEHUM_VENT     | unknown             |         1 |               0 |               0 |         0 |        0 |                       |
 DEHUM_VENT     | vent_plus_heat      |         1 |               1 |               1 |         1 |        0 |                 0.062 |                 0.050
 DEHUM_VENT     | vent_plus_heat_hold |         1 |               1 |               0 |         0 |        1 |                 0.055 |                -0.050
 IDLE           | no_effective_action |         1 |               0 |               0 |         0 |        0 |                       |
```

## Migration safety (#23 discipline)

- `make migration-rollback-safety`: `safe-to-wrap : 187-moisture-estimator-telemetry.sql` (non-self-transactional: `CREATE OR REPLACE VIEW` + `COMMENT` only; no top-level COMMIT, no commit-forcing statements).
- Preflight: `scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/187-moisture-estimator-telemetry.sql` → `OK to wrap in BEGIN..ROLLBACK (non-self-transactional)`.
- Rollback proof (disposable timescaledb loaded with `db/schema.sql` + all migrations, CI-parity): `BEGIN; \i 187; ROLLBACK;` replayed cleanly; `pg_views` count for the view after rollback = 0, after real apply = 1. Fixture `db/migrations/tests/test-187-moisture-estimator-telemetry.sql` passes (`migration 187 view tolerance + derivation assertions passed`).
- **NOT applied to prod.** Release wave applies 187 (rollback = `DROP VIEW public.v_moisture_estimator_telemetry;`).

## Validation (all 2026-07-03, re-probed 20:50:03Z)

- `make lint` → All checks passed.
- `pytest verdify_schemas/tests/ --ignore=verdify_schemas/tests/test_views.py` (CI-parity ignore: TestLiveProjection needs live rows) → 130 passed, 4 skipped, incl. the new `test_moisture_telemetry.py` (19 tests) and `test_drift_guards.py` (139 passed against the migrated disposable DB, incl. the new `MoistureEstimatorTelemetryRow` ↔ `v_moisture_estimator_telemetry` guard).
- `pytest tests/test_12_fidelity.py tests/test_db_solar_sql_contract.py` → 174 passed (incl. `test_climate_action_log_persists_moisture_exchange_telemetry` and the outcome_kpi docstring/source-token guards).
- `VERDIFY_DB_QUERY_MODE=direct pytest tests/test_02_database.py::TestSchemaIntegrity` → 5 passed.
- `make test` (broad) → 90 failed, 684 passed, 6 skipped, 10 errors — **failure set byte-identical to baseline 0efdb2f run on the same host** (`diff` of sorted FAILED/ERROR lists: empty). Failures are the known retired-Docker/systemd/live-stack assumptions on this machine (systemd services, MQTT broker, live climate rows, website/API reachability) plus the tolerated flaky `test_dew_point_risk_computes`. GitHub CI is the broad gate.

## Post-merge restart (rule 7 — required)

This PR touches `verdify_schemas/**`, `ingestor/`, and `mcp/server.py`. After merge + image promotion, **restart (bounce) these services**:

- `verdify-mcp`
- `verdify-ingestor`

Release-wave ordering: apply migration 187 **before** bouncing `verdify-mcp` (the outcome_kpi queries do not depend on the view, but graders/operators reading `v_moisture_estimator_telemetry` do).

## Non-goals

No firmware changes (fw-410 owns the emitter), no Grafana panels (follow-up under #371), no second migration (188 belongs to db-411-night-anchors), no prod apply from this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
