### PR TITLE
data(#327/#410): route cfg_dehum_vent_hold_enabled readback + 187 comment fix

### DIFF
--- a/db/migrations/187-moisture-estimator-telemetry.sql
+++ b/db/migrations/187-moisture-estimator-telemetry.sql
@@ -151,8 +151,12 @@ COMMENT ON VIEW public.v_moisture_estimator_telemetry IS
 'mirror: verdify_schemas.MoistureExchangeTelemetry.';
 
 COMMENT ON COLUMN public.v_moisture_estimator_telemetry.mx_present IS
-'True when the row carries a parsed moisture-exchange estimator object. False '
-'for pre-#385 firmware rows and for raw/unparseable payloads.';
+'True when the row carries a moisture-exchange JSONB OBJECT. False for '
+'pre-#385 firmware rows (no key at all) and for payloads stored as a raw '
+'STRING (never JSON-parsed). NOTE: the ingestor''s parse-failure fallback '
+'{"raw": ...} IS an object, so those rows have mx_present = true with every '
+'contract field NULL -- check mx_action/mx_reason, not just mx_present, when '
+'counting usable estimator rows.';
 
 COMMENT ON COLUMN public.v_moisture_estimator_telemetry.mx_action IS
 'Estimator-selected exchange action: none | vent_dehum | heat_assist | '

--- a/ingestor/entity_map.py
+++ b/ingestor/entity_map.py
@@ -554,10 +554,16 @@ _CFG_READBACK_ADDED_FW_V2 = {
     # #410: vent+reheat held-temp dehum enable readback (freeze rule 6). BOOL
     # switch (fw switch sw_dehum_vent_hold over global dehum_vent_hold_enabled),
     # published like the other cfg_* switch readbacks as a numeric 0/1 template
-    # sensor (NAN until cfg_first_pull_ok). Route lands one cycle AHEAD of the
+    # sensor (NAN until cfg_first_pull_ok). KEY IS THE WIRE OBJECT_ID — the
+    # NAME slug of "Cfg • Dehum Vent Hold Enabled" (ESPHome per-char slugify:
+    # space•space → three underscores), NOT the YAML id
+    # cfg_dehum_vent_hold_enabled. aioesphomeapi delivers the name slug, so an
+    # id-form key never matches on the wire (the vent_latch_timer incident in
+    # firmware/greenhouse/sensors.yaml; #420 tracks the 5 older manual routes
+    # below that are wire-dead this way). Route lands one cycle AHEAD of the
     # fw-410 OTA/merge (PR #418) — staged in test_firmware_drift.py's
     # self-shrinking allowlist until the sensor exists in firmware YAML.
-    "cfg_dehum_vent_hold_enabled": "dehum_vent_hold_enabled",
+    "cfg___dehum_vent_hold_enabled": "dehum_vent_hold_enabled",
     # Item-3 arbiter switch readback (cfg_arbiter_zone_enabled →
     # sw_arbiter_zone_enabled) now flows from the registry's cfg_readback_object_id
     # (CFG_READBACK_MAP_REG); the manual alias here was redundant and is removed.

--- a/ingestor/entity_map.py
+++ b/ingestor/entity_map.py
@@ -551,6 +551,13 @@ _CFG_READBACK_ADDED_FW_V2 = {
     # with no readback (fire-and-forget). sensors.yaml now publishes the cfg_*; map
     # it so the ingestor can confirm the device holds the operator's value.
     "cfg_sw_night_econ_heat_suppress_enabled": "sw_night_econ_heat_suppress_enabled",
+    # #410: vent+reheat held-temp dehum enable readback (freeze rule 6). BOOL
+    # switch (fw switch sw_dehum_vent_hold over global dehum_vent_hold_enabled),
+    # published like the other cfg_* switch readbacks as a numeric 0/1 template
+    # sensor (NAN until cfg_first_pull_ok). Route lands one cycle AHEAD of the
+    # fw-410 OTA/merge (PR #418) — staged in test_firmware_drift.py's
+    # self-shrinking allowlist until the sensor exists in firmware YAML.
+    "cfg_dehum_vent_hold_enabled": "dehum_vent_hold_enabled",
     # Item-3 arbiter switch readback (cfg_arbiter_zone_enabled →
     # sw_arbiter_zone_enabled) now flows from the registry's cfg_readback_object_id
     # (CFG_READBACK_MAP_REG); the manual alias here was redundant and is removed.

--- a/verdify_schemas/tests/test_firmware_drift.py
+++ b/verdify_schemas/tests/test_firmware_drift.py
@@ -293,6 +293,19 @@ KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
     if (oid := REGISTRY[name].cfg_readback_object_id) and oid not in _STAGED_FW_IDS
 )
 
+# #410 staging (data-327 follow-up, PR #418 coordination): the
+# cfg_dehum_vent_hold_enabled readback route in _CFG_READBACK_ADDED_FW_V2 lands
+# one cycle AHEAD of the fw-410 merge that adds the sensor to
+# firmware/greenhouse/sensors.yaml (freeze rule 6 readback for the
+# sw_dehum_vent_hold switch). Same self-shrinking shape as the registry-staged
+# set above: allow-listed ONLY while the firmware YAML does not yet define the
+# id, so the moment #418 merges the entry vanishes and both directions
+# (test_entity_map_keys_exist_in_firmware and test_known_drift_is_still_drifting)
+# enforce it as a real route with zero manual cleanup.
+KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
+    oid for oid in ("cfg_dehum_vent_hold_enabled",) if oid not in _STAGED_FW_IDS
+)
+
 
 @pytest.mark.parametrize("map_name", MAP_NAMES)
 def test_entity_map_keys_exist_in_firmware(map_name, fw_ids, entity_map):

--- a/verdify_schemas/tests/test_firmware_drift.py
+++ b/verdify_schemas/tests/test_firmware_drift.py
@@ -294,16 +294,20 @@ KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
 )
 
 # #410 staging (data-327 follow-up, PR #418 coordination): the
-# cfg_dehum_vent_hold_enabled readback route in _CFG_READBACK_ADDED_FW_V2 lands
-# one cycle AHEAD of the fw-410 merge that adds the sensor to
+# cfg___dehum_vent_hold_enabled readback route in _CFG_READBACK_ADDED_FW_V2
+# lands one cycle AHEAD of the fw-410 merge that adds the sensor to
 # firmware/greenhouse/sensors.yaml (freeze rule 6 readback for the
-# sw_dehum_vent_hold switch). Same self-shrinking shape as the registry-staged
-# set above: allow-listed ONLY while the firmware YAML does not yet define the
-# id, so the moment #418 merges the entry vanishes and both directions
+# sw_dehum_vent_hold switch). The key is the WIRE object_id — the name slug of
+# "Cfg • Dehum Vent Hold Enabled" (loose per-char slugify), which is what
+# aioesphomeapi actually delivers; the YAML id form would satisfy this guard's
+# id∪slug candidate set yet never match at runtime (wire-dead). Same
+# self-shrinking shape as the registry-staged set above: allow-listed ONLY
+# while the firmware YAML does not yet define the sensor, so the moment #418
+# merges the entry vanishes and both directions
 # (test_entity_map_keys_exist_in_firmware and test_known_drift_is_still_drifting)
 # enforce it as a real route with zero manual cleanup.
 KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
-    oid for oid in ("cfg_dehum_vent_hold_enabled",) if oid not in _STAGED_FW_IDS
+    oid for oid in ("cfg___dehum_vent_hold_enabled",) if oid not in _STAGED_FW_IDS
 )
 
 


### PR DESCRIPTION
Refs #410, #418, #327. Follow-up to merged #417 (lane `data-327-moisture-telemetry`, session `s8-data327-w1`), dispatched by the controller off the **fw-410 lane escalation on #418** (issuecomment-4879317900): the #410 readback route lives in `ingestor/entity_map.py`, a prohibited path for the fw lane. Branch off `origin/main` (087ab45). **Rev 2 (f3c5064) applies the critic's required fix** — see "Critic fix" below.

## 1. REQUIRED — route the #410 readback (unblocks #418's only red check)

#418 adds the freeze-rule-6 readback for the vent+reheat held-temp dehum enable: template sensor id `cfg_dehum_vent_hold_enabled`, name **"Cfg • Dehum Vent Hold Enabled"**, numeric 0/1 over the `sw_dehum_vent_hold` switch / `dehum_vent_hold_enabled` global, NAN until `cfg_first_pull_ok` — verified against the #418 diff, and shaped like the other `cfg_*` switch readbacks (`_record_cfg_readback` coerces via `float()`, NAN ignored). Route added to `_CFG_READBACK_ADDED_FW_V2`:

```python
"cfg___dehum_vent_hold_enabled": "dehum_vent_hold_enabled",
```

### Critic fix (rev 2): the key is the WIRE object_id, not the YAML id

The ingestor matches readbacks on the **aioesphomeapi object_id, which is the NAME slug**: `"Cfg • Dehum Vent Hold Enabled"` → `cfg___dehum_vent_hold_enabled` (ESPHome per-char slugify; space-bullet-space → three underscores). Rev 1 keyed the route on the YAML id `cfg_dehum_vent_hold_enabled`, which **satisfies the drift guard** (its candidate set is id ∪ name-slugs) **yet never matches on the wire** — a wire-dead route. Precedents: the `vent_latch_timer` incident comment in `firmware/greenhouse/sensors.yaml`; working registry readbacks are keyed by loose name slug (`cfg___vent_exchange_fraction`: 1407 prod snapshot rows/24 h); all 5 older manual `_CFG_READBACK_ADDED_FW_V2` routes are id≠slug mismatched with **zero** prod rows. Key corrected in **both** `ingestor/entity_map.py` and the staged-allowlist tuple in `verdify_schemas/tests/test_firmware_drift.py`; with the corrected key the readback genuinely feeds the in-memory divergence/force-push loop once #418's sensor publishes (persistence to `setpoint_snapshot` remains separately blocked — see #420).

**Merge-order safety (the #295 `cfg_gl_*` incident class):** the route lands ahead of the fw merge, so the reverse guard `test_entity_map_keys_exist_in_firmware(CFG_READBACK_MAP)` would turn main red. Staged with the **same self-shrinking allowlist shape** as the registry-staged set in `test_firmware_drift.py`: the slug is allow-listed only while the firmware YAML lacks the sensor (`_firmware_entity_ids()` includes name slugs, so the entry auto-retires the moment #418 merges and `test_known_drift_is_still_drifting` can never fire). Zero manual cleanup in either merge order.

**Proof (re-run at rev 2, fw-410 firmware YAMLs overlaid from `pull/418/head`; no firmware files in this diff):**
- origin/main entity_map + #418 YAMLs → `test_cfg_readback_sensors_are_routed_to_entity_map` **FAILS** with exactly #418's error — failure mode reproduced (rev-1 evidence, unchanged).
- this branch + #418 YAMLs → **all 12 `test_firmware_drift.py` tests pass** (slug route live, allowlist self-shrunk, inverse guard green).
- this branch at main-state firmware → **65 targeted tests pass** (`test_firmware_drift.py`, `test_tunable_registry.py`, `test_tunables.py`, `test_moisture_telemetry.py`).
- Slug math verified against the guard's own `_slugify`: loose per-char slug of the #418 sensor name == the new key.

## 2. Doc-only — migration 187 `mx_present` COMMENT fix (critic residual from #417)

The `COMMENT ON COLUMN ... mx_present` claimed `False ... for raw/unparseable payloads`; in fact the ingestor's `{"raw": ...}` parse-failure fallback **is** a JSONB object, so those rows read `mx_present = true` with every contract field NULL (fixture case C asserts exactly this). Comment now states that and points readers at `mx_action`/`mx_reason` for counting usable estimator rows. Migration 187 is merged but **not applied anywhere**, so the edit is safe; classification unchanged (`safe-to-wrap`, preflight `OK to wrap in BEGIN..ROLLBACK`), and the fixture re-passes against a disposable timescaledb (`test-187-moisture-estimator-telemetry: PASS (rolled back)`).

## Discovered work — #420 (deliberately NOT fixed here)

Manual CFG readbacks have **two independent breaks in series** (see #420, extended with the critic's findings): (a) all 5 pre-existing manual routes are keyed on id/param forms that mismatch the wire name-slug (wire-dead before validation is even reached), and (b) even with a matching key, `SetpointSnapshot`'s registry-derived `TunableParameter` rejects params outside `ALL_TUNABLES` (0 prod rows verified read-only). Plus a structural guard hole: the drift guard's id∪slug candidate matching lets id-form keys pass while being wire-dead. Registry rows + guard tightening are contract decisions → #420.

## Validation (rev 2: 2026-07-03T21:38:32Z; rev 1 evidence retained above)

- `make lint` → All checks passed.
- Targeted suites both firmware states as listed under "Proof".
- Rev-1 full CI-parity schema suite vs rebuilt disposable timescaledb (schema.sql + all migrations incl. 187) was green; rev-2 delta is a string constant in two files — GitHub CI re-executes the full matrix on f3c5064.
- No firmware files in the diff; diff surface: `ingestor/entity_map.py`, `verdify_schemas/tests/test_firmware_drift.py`, `db/migrations/187-moisture-estimator-telemetry.sql`.

## Post-merge restart (rule 7 — required)

This PR touches `ingestor/entity_map.py`: **restart (bounce) `verdify-ingestor`** after merge + image promotion. (`verdify-mcp` is NOT required by this diff; the #417 restart set still applies to the release wave.)

## Sequencing

Merge this before re-running #418's checks: it greens `Pydantic Schemas + Drift Guards` there. #327 and #410 stay open (release wave: apply 187, promote, bounce, bake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
