### PR TITLE
prod-promote: S8 wave STEP-02 — api/mcp/ingestor/migrate/planner to post-#421 main digests

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -181,13 +181,13 @@ patches:
 # GHCR digests in-repo.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:8b7b34f6adcd33353e0f34d06c85cfd821e00e7ec5beff02b3b49aae46768015
+    digest: sha256:844106dad750494a7d82b5fadb6ecd8fb1b007e596cb7b65b1aa5ffc6d4fe3b1
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
-    digest: sha256:23f1076ad4d3428d0b151c8ef09be062daff3e01bab881ab70984573694fce76
+    digest: sha256:00bb20a8de52075b3afef2e68437a8c9a84a09164bd6675a4d78031415435802
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
-    digest: sha256:f4bb0bdf65c5fcaf920df2347b8c1784f722f3f2dc73d2bd6a66866d1f3d9a1a
+    digest: sha256:cce222f3aff83876b0916b19f4a16bc04007384486071c6437cfdf733bdeb2e9
   - name: ghcr.io/verdifyconsultancy/verdify-migrate
-    digest: sha256:3f822d9ed7cd108761881d399a0eb177a012c914e97afc196427cb495bff5970
+    digest: sha256:1656c87eef60ec7d5f4a44ec9cec04389270dd05356868f9ac49f5c2ffbd43c9
   # verdify-planner (#117): real published GHCR digest, resolved read-only via
   # `gh api orgs/VerdifyConsultancy/packages/container/verdify-planner/versions`
   # (the `branch-live-platform-main` build of planner_graph/). The planner image is
@@ -195,7 +195,7 @@ images:
   # from each overlay's verdify-config + sealed secret). prod is human-gated and
   # its digest is advanced only by a reviewed prod-promote PR.
   - name: ghcr.io/verdifyconsultancy/verdify-planner
-    digest: sha256:41d057d7b7c1f369b9c72f847417333a43ffdcbac956e1d49f9c9e9b1abdc2c7
+    digest: sha256:239f0d760ce04bddce69cc85b16f061b685fc76fc1370d3e209fd5bf51deccbf
   # verdify-setpoint-server (#118): real GHCR digest of the grow-light writer +
   # setpoint-diagnostics image built from scripts/Dockerfile.setpoint-server. The
   # `branch-live-platform-main` build is published + repo-linked to


### PR DESCRIPTION
Digests-only promotion computed and pushed by the Prod Promote workflow (run 28686248-, mode=pull-request); PR opened by the operator session because of the #320 org setting (Actions cannot create PRs — the documented fallback).

Wave: wave-s8-night-dehum STEP-02 (approved by Jason 2026-07-03). Promotes the 5 promotable images to :branch-main digests built from post-#421/post-#417 main — carries migration 187 (verdify-migrate), the entity_map wire route + telemetry normalization (verdify-ingestor), and the outcome_kpi estimator surfaces (verdify-mcp).

Post-merge (gated, per the wave plan): scoped argocd sync of verdify-prod-dark → migration 187 applies via the migrate path → bounce verdify-ingestor + verdify-mcp (rule 7) → verify v_moisture_estimator_telemetry exists + 0-row tolerance before any OTA step.

Refs #327 #410 #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)