### PR TITLE
db(#411): night-anchor dry-roots revert + vpd_target 0.83 (migration 188)

### DIFF
--- a/db/migrations/177-band-defaults-from-canonical-seed.sql
+++ b/db/migrations/177-band-defaults-from-canonical-seed.sql
@@ -22,7 +22,7 @@ INSERT INTO public.crop_band_anchors (crop_type, series, anchor, value) VALUES
   ('house','temp_target','sr',67.5), ('house','temp_target','sm',78.79), ('house','temp_target','ss',77), ('house','temp_target','mid',65.71),
   ('house','temp_high','sr',72.5), ('house','temp_high','sm',83.79), ('house','temp_high','ss',82), ('house','temp_high','mid',70.71),
   ('house','vpd_low','sr',0.755), ('house','vpd_low','sm',0.862), ('house','vpd_low','ss',0.845), ('house','vpd_low','mid',0.738),
-  ('house','vpd_target','sr',0.935), ('house','vpd_target','sm',1.042), ('house','vpd_target','ss',1.025), ('house','vpd_target','mid',0.918),
+  ('house','vpd_target','sr',0.935), ('house','vpd_target','sm',1.042), ('house','vpd_target','ss',1.025), ('house','vpd_target','mid',0.83),
   ('house','vpd_high','sr',1.185), ('house','vpd_high','sm',1.292), ('house','vpd_high','ss',1.275), ('house','vpd_high','mid',1.168)
 ON CONFLICT (crop_type, growth_stage, season, series, anchor, greenhouse_id) DO UPDATE SET value = EXCLUDED.value
   WHERE public.crop_band_anchors.value IS DISTINCT FROM EXCLUDED.value;
@@ -66,7 +66,7 @@ BEGIN
       ('house','vpd_target','sr',0.935::double precision),
       ('house','vpd_target','sm',1.042::double precision),
       ('house','vpd_target','ss',1.025::double precision),
-      ('house','vpd_target','mid',0.918::double precision),
+      ('house','vpd_target','mid',0.83::double precision),
       ('house','vpd_high','sr',1.185::double precision),
       ('house','vpd_high','sm',1.292::double precision),
       ('house','vpd_high','ss',1.275::double precision),

--- a/db/migrations/188-night-anchor-dry-roots.sql
+++ b/db/migrations/188-night-anchor-dry-roots.sql
@@ -1,0 +1,89 @@
+-- 188-night-anchor-dry-roots.sql
+--
+-- #411 dry-roots decision (gate g-411, Jason 2026-07-03): the bare-root Vanda
+-- night priority is DRY ROOTS, not deep DIF. Full revert of the house night
+-- (solar-midnight 'mid') temp anchors to the pre-#409 canonical values plus
+-- the night vpd_target retune, in ONE migration:
+--
+--     temp_low    mid  58     -> 60.71   (revert of #409 Item 4)
+--     temp_target mid  62     -> 65.71   (revert of #409 Item 4)
+--     temp_high   mid  66     -> 70.71   (revert of #409 Item 4)
+--     vpd_target  mid  0.918  -> 0.83    (dry-night retune)
+--
+-- Why (#411): the 62 F night target caps achievable night VPD at ~0.71 under
+-- full outdoor exchange — the Vandas' exposed roots stay wet all night. The
+-- house naturally holds ~66.7 F on retained thermal mass, so the revert spends
+-- ZERO heat; vpd_target 0.83 is physically achievable with the measured
+-- +3 g/m3 indoor moisture source. The flower-initiation deep-DIF goal is
+-- deferred to fall (natural cooling + window closure, #412). See GitHub #411
+-- (2026-07-03 decision comment) and
+-- .agent-workflow/sprints/s8-vanda-night-dehum/gates/g-411-night-temp-priority.yaml.
+--
+-- Context: PR #409 was never merged — its Item-4 anchor edit reached prod
+-- crop_band_anchors as an out-of-band UPDATE (verified live 2026-07-03:
+-- mid = 58/62/66, vpd_target 0.918). The canonical seed
+-- (verdify_schemas/band_defaults.yaml + generated migration 177) still carries
+-- the pre-#409 temp values, so this migration is the prod reconcile back to
+-- canonical plus the one NEW canonical value (vpd_target mid 0.83 — YAML and
+-- 177 regenerated in the same change; test_band_defaults_single_source pins
+-- them together).
+--
+-- Band coherence (decision design check): vpd_low mid 0.738 < 0.83 <
+-- vpd_high mid 1.168, so low < target < high holds. sr/sm/ss anchors,
+-- vpd_low/vpd_high, and every zone row are NOT touched.
+--
+-- Safety: 177-pattern INSERT ... ON CONFLICT DO UPDATE ... WHERE the value
+-- actually DIFFERS — idempotent; a re-run updates zero rows. Only the four
+-- house 'mid' rows above are in the change surface.
+--
+-- Non-self-transactional (no top-level BEGIN/COMMIT, no CONCURRENTLY): safe to
+-- rollback-validate by wrapping in BEGIN; ... ROLLBACK;.
+
+-- House night ('mid') anchors: dry-roots revert + vpd_target retune.
+INSERT INTO public.crop_band_anchors (crop_type, series, anchor, value) VALUES
+  ('house','temp_low','mid',60.71),
+  ('house','temp_target','mid',65.71),
+  ('house','temp_high','mid',70.71),
+  ('house','vpd_target','mid',0.83)
+ON CONFLICT (crop_type, growth_stage, season, series, anchor, greenhouse_id) DO UPDATE SET value = EXCLUDED.value
+  WHERE public.crop_band_anchors.value IS DISTINCT FROM EXCLUDED.value;
+
+-- Post-apply assertion: the four decided rows match g-411 exactly, and the
+-- house night band stays coherent (low < target < high for temp and VPD).
+DO $assert$
+DECLARE
+    n_mismatch int;
+    n_incoherent int;
+BEGIN
+    SELECT count(*) INTO n_mismatch FROM (VALUES
+      ('house','temp_low','mid',60.71::double precision),
+      ('house','temp_target','mid',65.71::double precision),
+      ('house','temp_high','mid',70.71::double precision),
+      ('house','vpd_target','mid',0.83::double precision)
+    ) AS want(crop_type, series, anchor, value)
+    JOIN public.crop_band_anchors a USING (crop_type, series, anchor)
+    WHERE a.greenhouse_id = 'vallery' AND a.value IS DISTINCT FROM want.value;
+    IF n_mismatch > 0 THEN
+        RAISE EXCEPTION '188: % night anchor row(s) failed to apply the g-411 decision values', n_mismatch;
+    END IF;
+
+    SELECT count(*) INTO n_incoherent FROM (
+        SELECT
+            max(value) FILTER (WHERE series = 'temp_low')    AS t_low,
+            max(value) FILTER (WHERE series = 'temp_target') AS t_tgt,
+            max(value) FILTER (WHERE series = 'temp_high')   AS t_high,
+            max(value) FILTER (WHERE series = 'vpd_low')     AS v_low,
+            max(value) FILTER (WHERE series = 'vpd_target')  AS v_tgt,
+            max(value) FILTER (WHERE series = 'vpd_high')    AS v_high
+        FROM public.crop_band_anchors
+        WHERE crop_type = 'house' AND anchor = 'mid' AND greenhouse_id = 'vallery'
+    ) b
+    WHERE NOT (b.t_low < b.t_tgt AND b.t_tgt < b.t_high
+           AND b.v_low < b.v_tgt AND b.v_tgt < b.v_high);
+    IF n_incoherent > 0 THEN
+        RAISE EXCEPTION '188: house night band incoherent after apply (need low < target < high)';
+    END IF;
+
+    RAISE NOTICE '188: night anchors reconciled to the g-411 dry-roots decision';
+END
+$assert$;

--- a/db/migrations/tests/test-188-night-anchor-dry-roots.sql
+++ b/db/migrations/tests/test-188-night-anchor-dry-roots.sql
@@ -1,0 +1,107 @@
+-- test-188-night-anchor-dry-roots.sql
+--
+-- Manual/CI psql fixture for migration 188 (#411 dry-roots night anchors).
+--
+-- Usage from the repository root against a DISPOSABLE database (CI service
+-- container or a local docker timescale/timescaledb). Everything runs inside
+-- one transaction and rolls back, but prod DML is banned outright:
+--
+--   psql -v ON_ERROR_STOP=1 -f db/migrations/tests/test-188-night-anchor-dry-roots.sql
+--
+-- The fixture seeds the canonical band via migration 177, rewinds the four
+-- house 'mid' rows to the OBSERVED live prod pre-188 state (the #409 Item-4
+-- out-of-band edit: temp 58/62/66, vpd_target 0.918 — verified 2026-07-03),
+-- applies migration 188, asserts that exactly those four rows changed to the
+-- g-411 decision values (60.71 / 65.71 / 70.71 / 0.83) with every other
+-- anchor row untouched, proves a second apply writes ZERO rows, then rolls
+-- back.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Disposable-DB seed: the anchors FK requires the greenhouse row, and 177
+-- (the canonical reconcile) creates/aligns every canonical band row.
+INSERT INTO public.greenhouses (id, name)
+VALUES ('vallery', 'fixture greenhouse')
+ON CONFLICT (id) DO NOTHING;
+\i db/migrations/177-band-defaults-from-canonical-seed.sql
+
+-- Rewind to the observed live prod pre-188 state (#409 Item-4 out-of-band).
+UPDATE public.crop_band_anchors
+SET value = CASE series
+        WHEN 'temp_low'    THEN 58
+        WHEN 'temp_target' THEN 62
+        WHEN 'temp_high'   THEN 66
+        WHEN 'vpd_target'  THEN 0.918
+    END
+WHERE crop_type = 'house' AND anchor = 'mid' AND greenhouse_id = 'vallery'
+  AND series IN ('temp_low', 'temp_target', 'temp_high', 'vpd_target');
+
+-- Snapshot every anchor row: 188 may change ONLY the four targeted rows.
+CREATE TEMP TABLE pre_188 ON COMMIT DROP AS
+SELECT crop_type, growth_stage, season, series, anchor, greenhouse_id,
+       value, width_below, width_above
+FROM public.crop_band_anchors;
+
+\i db/migrations/188-night-anchor-dry-roots.sql
+
+-- Assert: exactly the four house night rows changed (188's own DO-block has
+-- already asserted the decided values and low < target < high coherence).
+DO $t$
+DECLARE
+    n_changed int;
+    n_offtarget int;
+BEGIN
+    SELECT count(*) INTO n_changed
+    FROM public.crop_band_anchors a
+    JOIN pre_188 p USING (crop_type, growth_stage, season, series, anchor, greenhouse_id)
+    WHERE a.value IS DISTINCT FROM p.value
+       OR a.width_below IS DISTINCT FROM p.width_below
+       OR a.width_above IS DISTINCT FROM p.width_above;
+    IF n_changed <> 4 THEN
+        RAISE EXCEPTION 'test-188: expected exactly 4 changed rows, got %', n_changed;
+    END IF;
+
+    SELECT count(*) INTO n_offtarget
+    FROM public.crop_band_anchors a
+    JOIN pre_188 p USING (crop_type, growth_stage, season, series, anchor, greenhouse_id)
+    WHERE (a.value IS DISTINCT FROM p.value
+           OR a.width_below IS DISTINCT FROM p.width_below
+           OR a.width_above IS DISTINCT FROM p.width_above)
+      AND NOT (a.crop_type = 'house' AND a.anchor = 'mid'
+               AND a.series IN ('temp_low', 'temp_target', 'temp_high', 'vpd_target'));
+    IF n_offtarget <> 0 THEN
+        RAISE EXCEPTION 'test-188: % changed row(s) outside the four house night anchors', n_offtarget;
+    END IF;
+
+    RAISE NOTICE 'test-188: exactly the four house night anchors changed';
+END
+$t$;
+
+-- Idempotence: a second apply must write ZERO rows. updated_at cannot
+-- discriminate here (now() is frozen inside one transaction), so compare
+-- ctids — any rewritten tuple gets a new ctid, same-values or not.
+CREATE TEMP TABLE pre_rerun ON COMMIT DROP AS
+SELECT crop_type, growth_stage, season, series, anchor, greenhouse_id,
+       ctid::text AS tuple_id
+FROM public.crop_band_anchors;
+
+\i db/migrations/188-night-anchor-dry-roots.sql
+
+DO $t$
+DECLARE
+    n_rewritten int;
+BEGIN
+    SELECT count(*) INTO n_rewritten
+    FROM public.crop_band_anchors a
+    JOIN pre_rerun p USING (crop_type, growth_stage, season, series, anchor, greenhouse_id)
+    WHERE a.ctid::text IS DISTINCT FROM p.tuple_id;
+    IF n_rewritten <> 0 THEN
+        RAISE EXCEPTION 'test-188: re-apply rewrote % row(s); expected an exact no-op', n_rewritten;
+    END IF;
+    RAISE NOTICE 'test-188: re-apply wrote zero rows (idempotent)';
+END
+$t$;
+
+ROLLBACK;

--- a/verdify_schemas/band_defaults.yaml
+++ b/verdify_schemas/band_defaults.yaml
@@ -31,12 +31,18 @@
 # only the phase + shape ride nature. fn_solar_phase re-derives the clock peak
 # daily from the ephemeris, so the curve adapts to the solar cycle year-round.
 # Derivation: docs/reviews/ band-nature-alignment; harmonic fit in session log.
+# DRY-ROOTS NIGHT (2026-07-03, #411 / gate g-411): night (mid) vpd_target
+# 0.918 -> 0.83 — the achievable dry-night ceiling with the measured +3 g/m³
+# indoor moisture source, so the bare-root Vandas' roots dry overnight. The
+# night temp anchors stay these researched values: the #409 Item-4 deep-DIF
+# edit (62/58/66) was a prod-only out-of-band change (PR #409 unmerged) and is
+# reverted back to canonical by migration 188. DIF goal deferred to fall (#412).
 house:
   temp_low:    [62.50, 73.79, 72.00, 60.71]
   temp_target: [67.50, 78.79, 77.00, 65.71]
   temp_high:   [72.50, 83.79, 82.00, 70.71]
   vpd_low:     [0.755, 0.862, 0.845, 0.738]
-  vpd_target:  [0.935, 1.042, 1.025, 0.918]
+  vpd_target:  [0.935, 1.042, 1.025, 0.83]
   vpd_high:    [1.185, 1.292, 1.275, 1.168]
 
 # ── Per-zone VPD-target band (seeds crop_band_anchors per crop_type) ────────


### PR DESCRIPTION
## Decision

Implements gate **g-411-night-temp-priority** exactly (Jason, 2026-07-03, decided `dry-roots-wins`; see `.agent-workflow/sprints/s8-vanda-night-dehum/gates/g-411-night-temp-priority.yaml` and the #411 decision comment): full revert of the house night (solar-midnight `mid`) temp anchors to pre-#409 values + night `vpd_target` retune, in ONE migration. The flower-initiation deep-DIF goal is deferred to fall (#412). #409 Item 4's night-anchor change is superseded.

## Anchor values (old -> new)

| row (house, anchor=`mid`) | live prod (pre-188) | decided (188) |
|---|---|---|
| `temp_low`    | 58    | **60.71** (revert of #409 Item 4) |
| `temp_target` | 62    | **65.71** (revert of #409 Item 4) |
| `temp_high`   | 66    | **70.71** (revert of #409 Item 4) |
| `vpd_target`  | 0.918 | **0.83** (dry-night retune) |

sr/sm/ss anchors, `vpd_low`/`vpd_high`, and all zone rows untouched. Coherence check: `vpd_low` mid 0.738 < 0.83 < `vpd_high` mid 1.168 holds (verified live prod values, read-only SELECT 2026-07-03).

Why: 62F night caps achievable VPD at ~0.71 (Vanda roots stay wet); the house holds ~66.7F naturally on thermal mass so the revert spends zero heat; 0.83 is physically achievable with the measured +3 g/m3 indoor source.

## Canonical seed path (single-source coupling finding)

- PR #409 was **never merged** — its Item-4 edit reached prod `crop_band_anchors` out-of-band, so main's canonical seed already carried the pre-#409 temp values. The only repo-side value change is `vpd_target` mid 0.918 -> 0.83 in `verdify_schemas/band_defaults.yaml` (note: the canonical seed lives there, NOT `firmware/greenhouse/` — the registry loads it at import).
- `test_migration_177_is_freshly_generated` pins committed 177 == `gen_band_seed_sql.py` over the **current** YAML (byte-coupling mandated), so 177 is regenerated (exactly the two `vpd_target` mid cells). 188 is the prod-apply vehicle: 177 is already recorded applied on prod and will not re-run.

## Rollback classification + proof (disposable timescaledb, NEVER prod)

- `make migration-rollback-safety`: `safe-to-wrap : 188-night-anchor-dry-roots.sql`
- `scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/188-night-anchor-dry-roots.sql`: `OK to wrap in BEGIN..ROLLBACK (non-self-transactional)` (exit 0)
- Wrapped dry-run on disposable `timescale/timescaledb:latest-pg16` (CI-parity `schema.sql`, prod-sim state 58/62/66/0.918 committed): `BEGIN; \i 188; ROLLBACK;` — IN-TXN shows 60.71/65.71/70.71/0.83, POST-ROLLBACK fully restores 58/62/66/0.918 (no self-commit leak). Real apply then lands the decided values; `188: night anchors reconciled to the g-411 dry-roots decision`.
- Fixture `db/migrations/tests/test-188-night-anchor-dry-roots.sql` (ON_ERROR_STOP=1): seeds 177, rewinds to prod-sim, applies 188 (`INSERT 0 4`), asserts **exactly** the 4 targeted rows changed, re-applies (`INSERT 0 0` — ctid-proven zero-write idempotence), rolls back. PASS.

## Single-source + goldens output

```
.venv/bin/pytest tests/ -k "band_defaults_single_source or solar_band" -q
29 passed, 761 deselected in 0.48s

.venv/bin/pytest verdify_schemas/tests/test_band_defaults_single_source.py \
  tests/test_solar_band_anchors.py tests/test_firmware_crop_agnostic_guard.py -q
37 passed in 0.32s

test_registry_house_defaults_match_yaml PASSED
test_registry_zone_defaults_match_yaml PASSED
test_migration_177_is_freshly_generated PASSED
test_firmware_coldstart_vpd_target_is_drier_or_equal PASSED   (fw 0.918 >= 0.83, drier-or-equal fail-safe holds)
test_firmware_band_anchors_within_registry_clamps PASSED
```

`make lint`: All checks passed.

## Post-merge restart (rule 7 — required)

This PR touches `verdify_schemas/**` (band_defaults.yaml -> registry `_FW2_*` defaults): bounce **verdify-ingestor** and **verdify-mcp** post-merge. The plant-facing band changes ONLY when the release wave applies migration 188 to prod (gated; NOT applied by this PR) and the dispatcher pushes the changed anchors to the device.

## Coordination

fw-410 soft dependency confirmed: no firmware constant assumes 0.92/0.918 (`grep -rnE "0\.918|0\.92\b" firmware/ tests/ verdify_schemas/` — only the canonical YAML hit).

Do NOT merge — critic review + release wave apply 188 behind the device-write gate.

Refs #411 #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)