### PR TITLE
data(#420): register sw_dehum_vent_hold_enabled (operator-only) — sanctioned push path for the S8 flag-ON

### DIFF
--- a/ingestor/entity_map.py
+++ b/ingestor/entity_map.py
@@ -551,19 +551,16 @@ _CFG_READBACK_ADDED_FW_V2 = {
     # with no readback (fire-and-forget). sensors.yaml now publishes the cfg_*; map
     # it so the ingestor can confirm the device holds the operator's value.
     "cfg_sw_night_econ_heat_suppress_enabled": "sw_night_econ_heat_suppress_enabled",
-    # #410: vent+reheat held-temp dehum enable readback (freeze rule 6). BOOL
-    # switch (fw switch sw_dehum_vent_hold over global dehum_vent_hold_enabled),
-    # published like the other cfg_* switch readbacks as a numeric 0/1 template
-    # sensor (NAN until cfg_first_pull_ok). KEY IS THE WIRE OBJECT_ID — the
-    # NAME slug of "Cfg • Dehum Vent Hold Enabled" (ESPHome per-char slugify:
-    # space•space → three underscores), NOT the YAML id
-    # cfg_dehum_vent_hold_enabled. aioesphomeapi delivers the name slug, so an
-    # id-form key never matches on the wire (the vent_latch_timer incident in
-    # firmware/greenhouse/sensors.yaml; #420 tracks the 5 older manual routes
-    # below that are wire-dead this way). Route lands one cycle AHEAD of the
-    # fw-410 OTA/merge (PR #418) — staged in test_firmware_drift.py's
-    # self-shrinking allowlist until the sensor exists in firmware YAML.
-    "cfg___dehum_vent_hold_enabled": "dehum_vent_hold_enabled",
+    # #410/#420: the vent+reheat held-temp dehum enable readback
+    # (cfg___dehum_vent_hold_enabled → sw_dehum_vent_hold_enabled) now flows
+    # from the registry's cfg_readback_object_id (CFG_READBACK_MAP_REG). The
+    # PR #421 manual route here was retired when the registry row landed —
+    # this dict merges LAST into CFG_READBACK_MAP, so keeping it would have
+    # shadowed the registry-derived route with a conflicting canonical name
+    # (dehum_vent_hold_enabled has no registry row; SetpointSnapshot would
+    # keep rejecting it — issue #420 break (b)). The 5 manual routes above
+    # remain #420 scope (their keys are id-form and wire-dead as documented
+    # in the issue).
     # Item-3 arbiter switch readback (cfg_arbiter_zone_enabled →
     # sw_arbiter_zone_enabled) now flows from the registry's cfg_readback_object_id
     # (CFG_READBACK_MAP_REG); the manual alias here was redundant and is removed.

--- a/verdify_schemas/tests/test_firmware_drift.py
+++ b/verdify_schemas/tests/test_firmware_drift.py
@@ -293,22 +293,11 @@ KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
     if (oid := REGISTRY[name].cfg_readback_object_id) and oid not in _STAGED_FW_IDS
 )
 
-# #410 staging (data-327 follow-up, PR #418 coordination): the
-# cfg___dehum_vent_hold_enabled readback route in _CFG_READBACK_ADDED_FW_V2
-# lands one cycle AHEAD of the fw-410 merge that adds the sensor to
-# firmware/greenhouse/sensors.yaml (freeze rule 6 readback for the
-# sw_dehum_vent_hold switch). The key is the WIRE object_id — the name slug of
-# "Cfg • Dehum Vent Hold Enabled" (loose per-char slugify), which is what
-# aioesphomeapi actually delivers; the YAML id form would satisfy this guard's
-# id∪slug candidate set yet never match at runtime (wire-dead). Same
-# self-shrinking shape as the registry-staged set above: allow-listed ONLY
-# while the firmware YAML does not yet define the sensor, so the moment #418
-# merges the entry vanishes and both directions
-# (test_entity_map_keys_exist_in_firmware and test_known_drift_is_still_drifting)
-# enforce it as a real route with zero manual cleanup.
-KNOWN_PRE_EXISTING_DRIFT.setdefault("CFG_READBACK_MAP", set()).update(
-    oid for oid in ("cfg___dehum_vent_hold_enabled",) if oid not in _STAGED_FW_IDS
-)
+# (#410 staging stanza removed: PR #418 merged the cfg_dehum_vent_hold_enabled
+# sensor into firmware/greenhouse/sensors.yaml, so the self-shrinking allowlist
+# entry for cfg___dehum_vent_hold_enabled had already shrunk to nothing, and
+# the route itself now derives from the sw_dehum_vent_hold_enabled registry
+# row's cfg_readback_object_id — #420.)
 
 
 @pytest.mark.parametrize("map_name", MAP_NAMES)

--- a/verdify_schemas/tests/test_tunable_registry.py
+++ b/verdify_schemas/tests/test_tunable_registry.py
@@ -626,6 +626,59 @@ class TestPlannerWriteContractLockout:
         mcp_text = (REPO_ROOT / "mcp" / "server.py").read_text()
         assert 'FORCED_ON_SWITCH_PARAMS = frozenset({"sw_fsm_controller_enabled"})' in mcp_text
 
+    def test_dehum_vent_hold_flag_is_operator_only(self) -> None:
+        """#410/#420: the S8 vent+reheat hold activation flag is operator-gated.
+
+        OFF-default switch; activation is a Jason-gated wave step (STEP-06)
+        through the sanctioned logged push path. Iris must never toggle it:
+        controller_safety class, absent from every planner-writable surface
+        (MCP set_tunable gates on PLANNER_PUSHABLE_REG). The canonical name is
+        sw_-prefixed because the dispatcher/RT-listener push paths select
+        switch_command by that prefix; the esp/cfg object_ids are the wire
+        NAME slugs per the #421 critic finding.
+        """
+        row = REGISTRY["sw_dehum_vent_hold_enabled"]
+        assert row.kind == "switch"
+        assert row.default == 0
+        assert row.push_owner == "operator"
+        assert not row.planner_pushable
+        assert row.tier == 2
+        assert row.control_class == "controller_safety"
+        assert "sw_dehum_vent_hold_enabled" not in PLANNER_PUSHABLE_REG
+        assert "sw_dehum_vent_hold_enabled" not in TIER1_REG
+        # Wire forms (aioesphomeapi delivers NAME slugs, not YAML ids).
+        assert row.esp_object_id == "dehum_vent_hold_enabled"
+        assert row.cfg_readback_object_id == "cfg___dehum_vent_hold_enabled"
+        # The sanctioned push path validates through the shared boundary check.
+        assert registry_value_error("sw_dehum_vent_hold_enabled", 1.0) is None
+        assert registry_value_error("sw_dehum_vent_hold_enabled", 0.0) is None
+        assert registry_value_error("sw_dehum_vent_hold_enabled", 0.5) is not None
+        # Never planner-named: the assembled iris prompt must not offer it.
+        planner_src = (REPO_ROOT / "ingestor" / "iris_planner.py").read_text()
+        assert "dehum_vent_hold_enabled" not in planner_src
+
+    def test_dehum_vent_hold_readback_route_is_registry_derived_only(self) -> None:
+        """#420 reconciliation: exactly ONE authoritative CFG route.
+
+        The manual PR #421 entry in _CFG_READBACK_ADDED_FW_V2 merges LAST into
+        CFG_READBACK_MAP, so a leftover copy would shadow the registry-derived
+        route with the old unregistered param name and setpoint_snapshot rows
+        would keep being rejected (issue #420 break (b)).
+        """
+        from verdify_schemas.tunable_registry import CFG_READBACK_MAP_REG
+
+        assert CFG_READBACK_MAP_REG["cfg___dehum_vent_hold_enabled"] == "sw_dehum_vent_hold_enabled"
+        for p in reversed((str(REPO_ROOT / "ingestor"), "/srv/verdify/ingestor", "/mnt/iris/verdify/ingestor")):
+            if p not in sys.path:
+                sys.path.insert(0, p)
+        from entity_map import _CFG_READBACK_ADDED_FW_V2, CFG_READBACK_MAP
+
+        assert "cfg___dehum_vent_hold_enabled" not in _CFG_READBACK_ADDED_FW_V2, (
+            "manual #421 route resurrected — it shadows the registry-derived route "
+            "(merge order puts _CFG_READBACK_ADDED_FW_V2 last in CFG_READBACK_MAP)"
+        )
+        assert CFG_READBACK_MAP["cfg___dehum_vent_hold_enabled"] == "sw_dehum_vent_hold_enabled"
+
     def test_set_plan_drops_band_owned_before_insert_and_rejects_non_policy(self) -> None:
         """set_plan's write path enforces the contract: band-owned params are
         dropped (band_params_dropped) BEFORE the setpoint_plan INSERT, any param

--- a/verdify_schemas/tunable_registry.py
+++ b/verdify_schemas/tunable_registry.py
@@ -1057,6 +1057,27 @@ REGISTRY: dict[str, TunableDef] = {
         tier=2,
         notes="Margin below vpd_low that upgrades dehumidification demand; validate_setpoints also caps it below vpd_low.",
     ),
+    "sw_dehum_vent_hold_enabled": TunableDef(
+        name="sw_dehum_vent_hold_enabled",
+        kind="switch",
+        default=0,
+        esp_object_id="dehum_vent_hold_enabled",
+        cfg_readback_object_id="cfg___dehum_vent_hold_enabled",
+        push_owner="operator",
+        planner_pushable=False,
+        tier=2,
+        notes="#410/#420: OFF-default activation flag for the S8 vent+reheat "
+        "held-temp dehum hold. Activation is Jason-gated (wave STEP-06) via the "
+        "sanctioned logged push path; iris must never toggle it "
+        "(controller_safety — MCP set_tunable rejects non-planner_policy rows). "
+        "Wire object_ids are the aioesphomeapi NAME slugs (the #421 wire-slug "
+        "lesson): switch 'Dehum Vent Hold Enabled' → dehum_vent_hold_enabled "
+        "(YAML id sw_dehum_vent_hold), sensor 'Cfg • Dehum Vent Hold Enabled' → "
+        "cfg___dehum_vent_hold_enabled. Canonical name is sw_-prefixed because "
+        "the dispatcher/RT-listener push paths route switch_command by that "
+        "prefix (entity_map SWITCH_TO_ENTITY); an unprefixed name would push a "
+        "wire-dead number_command at the switch entity.",
+    ),
     "vent_latch_timeout_ms": TunableDef(
         name="vent_latch_timeout_ms",
         kind="numeric",


### PR DESCRIPTION
Lane `data-420-flag-registry` (sprint `s8-vanda-night-dehum`, session s8-data420-w1), approved under **Jason's flag-on-now directive**: the S8 vent+reheat hold ships flag-OFF (#418 OTA'd at STEP-04) and the Jason-approved STEP-06 activation must go through the **sanctioned logged push path** — not an out-of-band device write. That path was blocked because the flag had no tunable-registry row (issue #420 break (b): `SetpointSnapshot.parameter` rejects unregistered params) and no dispatcher route. Branch off baseline 217f74b per the lane contract.

## What

**1. Registry row `sw_dehum_vent_hold_enabled`** (`verdify_schemas/tunable_registry.py`, dehum section): `kind=switch`, `default=0` (OFF), `push_owner="operator"`, `planner_pushable=False`, `tier=2` → `control_class == "controller_safety"`.
- **Iris cannot toggle it**: MCP `set_tunable` gates on `PLANNER_PUSHABLE_REG` (`mcp/server.py:1456`), which is exactly the `planner_policy` class — proven live: `n in PLANNER_PUSHABLE_REG → False`, `n in TIER1_REG → False`, no mention in the assembled iris prompt (`ingestor/iris_planner.py`), and the pre-existing `test_hard_safety_rails_locked_out` already asserts the whole `controller_safety` class is absent from the planner-writable surface. Registry visibility (read-only context) is the model's documented intent — visibility ≠ writeability.
- **Operator writes validate**: `registry_value_error('sw_dehum_vent_hold_enabled', 1.0) → None` (0.5 correctly rejected); the row lands in `ALL_TUNABLES`, so snapshot rows now persist for the STEP-06 OFF→ON evidence trail.
- `esp_object_id="dehum_vent_hold_enabled"`, `cfg_readback_object_id="cfg___dehum_vent_hold_enabled"` — both are the **wire (aioesphomeapi NAME-slug) forms**, verified against the drift guard's own `_slugify` and present in `_firmware_entity_ids()` on main (#418 merged): switch name "Dehum Vent Hold Enabled" (YAML id `sw_dehum_vent_hold`), sensor name "Cfg • Dehum Vent Hold Enabled". The #421 critic's wire-slug lesson applied to both directions.

**2. DELIBERATE naming deviation from the contract's literal `dehum_vent_hold_enabled`** — the canonical name is `sw_`-prefixed because the push path routes on it: `ingestor/tasks/dispatcher.py:1158` and `ingestor/ingestor.py:2276` (RT listener) select `switch_command` vs `number_command` by `param.startswith("sw_")`, and `entity_map.SWITCH_TO_ENTITY`/`PARAM_TO_ENTITY` split the same way (`entity_map.py:581-582`). An unprefixed name would fall to the number branch and emit a `number_command` at the switch's entity key — a **silent wire-dead push** (`push_to_esp32` counts it as pushed), the push-side twin of the #421 rev-1 wire-dead readback key. All 26 existing `kind=switch` rows are `sw_`-prefixed; the shape template `sw_summer_vent_enabled` (sw_-name over unprefixed `esp_object_id`) is the exact precedent. Proven live: `SWITCH_TO_ENTITY['sw_dehum_vent_hold_enabled'] == 'dehum_vent_hold_enabled'`, not in `PARAM_TO_ENTITY`.
- **Consequence for STEP-06**: the logged flip must use the registered name — `sw_dehum_vent_hold_enabled=1` (wave-release-plan STEP-06 text says `dehum_vent_hold_enabled`; controller should use the sw_ name).

**3. Route reconciliation — registry-derived route is THE route** (`ingestor/entity_map.py`): the registry row auto-derives `cfg___dehum_vent_hold_enabled → sw_dehum_vent_hold_enabled` via `CFG_READBACK_MAP_REG` (same mechanism as the working `cfg___vent_exchange_fraction` precedent and the retired arbiter alias). The manual PR #421 entry is **removed** — `_CFG_READBACK_ADDED_FW_V2` merges LAST into `CFG_READBACK_MAP`, so keeping it would have shadowed the registry route with the old unregistered param name and snapshot rows would keep being rejected. Proven: exactly one merged route, and no CFG route anywhere maps to the unregistered `dehum_vent_hold_enabled`. The 5 older manual routes stay (full #420 fix = out of lane scope, non-goal).

**4. Staged allowlist removed** (`verdify_schemas/tests/test_firmware_drift.py`): the #410 self-shrinking stanza had already shrunk to nothing when #418 merged (`cfg___dehum_vent_hold_enabled in _firmware_entity_ids() → True`, verified) — deleted as dead staging code, replaced with a pointer comment.

**5. Tests** (`verdify_schemas/tests/test_tunable_registry.py`): `test_dehum_vent_hold_flag_is_operator_only` (shape, planner lockout, wire ids, switch bounds, iris-prompt non-mention) and `test_dehum_vent_hold_readback_route_is_registry_derived_only` (anti-resurrection guard: manual route back in `_CFG_READBACK_ADDED_FW_V2` fails loudly with the shadowing explanation).

## Validation (2026-07-04, UTC)

- `make lint` → All checks passed.
- `pytest verdify_schemas/tests/ --ignore=verdify_schemas/tests/test_views.py` vs a disposable `verdify-timescaledb` (timescale/timescaledb:latest-pg16, `db/schema.sql` + all `db/migrations/*.sql`, CI-parity): **642 passed, 5 skipped** at 14:15Z.
- Baseline parity at 217f74b, identical command/DB: **640 passed, 5 skipped** — delta is exactly the 2 new tests; the 5 skips pre-exist.
- No firmware/, db/migrations/, mcp/, docs/ files in the diff. Diff surface: `verdify_schemas/tunable_registry.py`, `ingestor/entity_map.py`, `verdify_schemas/tests/{test_tunable_registry.py,test_firmware_drift.py}`.

## Post-merge restarts (rule 7 — required)

The registry and entity map load at import: **restart (bounce) `verdify-mcp` AND `verdify-ingestor`** after merge + image promotion, before the STEP-06 flip.

## No device writes from this lane

Nothing here touches the device; the flip itself is the controller's STEP-06 action post-promote, behind Jason's gate.

Refs #420 #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)