### PR TITLE
docs(recovery): approve production wave release plan

### DIFF
--- a/.agent-workflow/sprints/software-recovery-2026-07-09/execution/sprint-execution-runbook.yaml
+++ b/.agent-workflow/sprints/software-recovery-2026-07-09/execution/sprint-execution-runbook.yaml
@@ -33,11 +33,10 @@ prerequisites:
     - .verdify/sprints/software-recovery-2026-07-09/lanes/planner-delivery/lane.yaml
     - .verdify/sprints/software-recovery-2026-07-09/lanes/firmware-control/lane.yaml
     - .verdify/sprints/software-recovery-2026-07-09/lanes/release-control/lane.yaml
-  wave_release_plan: null
+  wave_release_plan: .agent-workflow/sprints/software-recovery-2026-07-09/release/wave-release-plan.yaml
   platform_readiness: .agent-workflow/platform/platform-readiness.yaml
   open_blockers:
     - Native Agent Platform worktree-agent creation and removal are disabled post-MVP and return structured HTTP 501 responses.
-    - A current-sprint wave release plan is required before production delivery.
 platform:
   mcp_server: agent-fleet MCP in repo-verdifyconsultancy-verdify-platform-0
   api_ref: agents.vallery.net dashboard API and in-pod agent-fleet MCP

--- a/.agent-workflow/sprints/software-recovery-2026-07-09/release/wave-release-plan.yaml
+++ b/.agent-workflow/sprints/software-recovery-2026-07-09/release/wave-release-plan.yaml
@@ -1,0 +1,455 @@
+schema_ref: wave-release-plan.schema.yaml
+kind: WaveReleasePlan
+schema_version: "1.0"
+wave_id: wave-software-recovery-implementation
+status: approved
+scope:
+  sprint_id: software-recovery-2026-07-09
+  issue_ids: [293, 299, 377, 383, 386, 389, 390, 410, 419, 424, 427, 428, 433, 434, 435, 437, 438]
+  lane_ids:
+    - security-hygiene
+    - device-writer
+    - evidence-core
+    - resource-accounting
+    - dli-availability
+    - planner-delivery
+    - firmware-control
+    - release-control
+  northstar_ids: [NSR-001, NSR-002, NSR-003, NSR-004, NSR-005, NSR-006, NSR-007]
+  summary: >-
+    Release the exact independently accepted 17-issue greenhouse recovery from
+    per-lane PRs through current main, serialized production migrations, one
+    digest-only production promotion and manual prune:false Argo CD sync, one
+    gated combined firmware OTA, and immediate plus settled production proof.
+  non_goals:
+    - Add or replace physical sensors, meters, fans, shades, dehumidifiers, plumbing, or other greenhouse hardware.
+    - Enable automatic fertilizer before the wall path has current chemistry, injector, flow, distribution, volume, and flush commissioning.
+    - Claim numeric interior crop DLI while the broken sensor is invalid, or use climate mist as deliberate Vanda irrigation.
+    - Grant planner_graph plan or device-write authority, introduce a second live device writer, or move deterministic control into AI.
+    - Waive a migration, critic, CI, alert, weekly OTA, 48-hour bake, heap, cycling, telemetry, rollback, or runtime acceptance gate.
+branch_model:
+  model: per_lane_branches
+  base_ref: main
+  release_ref: main
+  merge_queue_required: false
+  concurrency_group: verdify-prod-promote
+  decision_notes: >-
+    Each contracted lane uses its own branch, worktree, independent critic, and
+    PR to main in dependency order. Main is the sole integration and image
+    publication ref. There is no wave branch or merge queue. Production moves
+    only through the single-concurrency prod-promote workflow, its digest-only
+    PR, and the later controller-owned manual Argo CD sync.
+github:
+  repository: VerdifyConsultancy/verdify-platform
+  milestone: Cross-milestone recovery label sprint:software-recovery-2026-07-09
+  project: GitHub Issues and the repository Project Board fallback indexes
+  required_checks:
+    - lint
+    - test
+    - migration-rollback-safety
+    - firmware-replay-diff
+    - no-new-fire-and-forget
+    - service-restart-drift-guard
+    - k8s-manifests
+    - promote-diff-guard
+  merge_group_checks_required: false
+  environment_protection_required: true
+ci:
+  workflows:
+    - name: .github/workflows/ci.yml
+      required: true
+      event_triggers: [pull_request, push, workflow_dispatch]
+      timeout_minutes: 120
+      evidence_expected:
+        - Exact-head lint, tests, schema drift, migration rollback safety, firmware replay, readback, and service-restart guards.
+        - Firmware PR evidence for unit tests, invariants, stock replay, band replay where applicable, and the intended divergence disposition.
+    - name: .github/workflows/container-publish.yml
+      required: true
+      event_triggers: [pull_request, push, workflow_dispatch]
+      timeout_minutes: 120
+      evidence_expected:
+        - Trusted main push publishes immutable sha tags and branch-main digests for every impacted promotable image.
+        - Recorded GHCR digests for verdify-api, verdify-mcp, verdify-ingestor, verdify-migrate, and verdify-planner; setpoint-server and lab remain hand-pinned.
+    - name: .github/workflows/k8s-manifests.yml
+      required: true
+      event_triggers: [pull_request, push, workflow_dispatch]
+      timeout_minutes: 30
+      evidence_expected:
+        - Kustomize renders and kubeconform validates the base and production overlay at the accepted main revision.
+    - name: .github/workflows/prod-promote.yml
+      required: true
+      event_triggers: [workflow_dispatch]
+      timeout_minutes: 30
+      evidence_expected:
+        - Dry-run evidence precedes mode=pull-request dispatch.
+        - One prod-promote PR resolves only accepted main branch-main images to immutable GHCR digests.
+    - name: .github/workflows/promote-diff-guard.yml
+      required: true
+      event_triggers: [pull_request, workflow_dispatch]
+      timeout_minutes: 30
+      evidence_expected:
+        - The prod-promote PR changes only digest pins in deploy/k8s/overlays/prod/kustomization.yaml.
+        - The rendered device-write surface is byte-identical except for the reviewed application images.
+  artifacts:
+    - Immutable critic verdict and required-check links for every lane PR head.
+    - Main integration SHA and GHCR image digest manifest.
+    - Migration 186 and 189-196 classification, rollback proof, apply transcript, and live version evidence with no secret material.
+    - Digest-only prod-promote PR, reviewed overlay diff, Argo operation, pod image, health, and endpoint evidence.
+    - Exact firmware source SHA, binary checksum/version, map/heap packet, replay/invariant/cycling results, rollback binary, and OTA record.
+    - Immediate, two-hour, eligible-night, and 48-hour settled production evidence plus final review packet.
+  required_events: [pull_request, push, workflow_dispatch, deployment]
+environments:
+  - name: verdify-prod
+    environment_type: production
+    required: true
+    namespace: verdify-prod
+    url: https://api.verdify.ai
+    quota_policy: Existing namespace allocation; verify current ResourceQuota before release and create no generated namespace.
+    limit_policy: Existing workload requests and limits remain unchanged unless an accepted lane PR explicitly owns the change.
+    network_policy: Existing production NetworkPolicies retain the one-ingestor device-egress path and scoped database access.
+    ttl: null
+    secrets_scope: >-
+      Existing verdify-prod Secrets and the reviewed production SOPS authority
+      only. The scoped POSTGRES_PASSWORD rotation preserves every unrelated key;
+      neither old nor new material may enter Git, command arguments, logs, or evidence.
+    protection_rules:
+      - Jason's 2026-07-10 objective authorizes the scoped credential rotation, production rollout, and one OTA; every deterministic gate remains mandatory.
+      - ArgoCD application verdify-prod-dark stays manual-sync with prune:false and no unrelated drift.
+      - Ingestor remains one replica with Recreate semantics and is the sole sanctioned ESP32 writer.
+      - Database backup and migration-specific rollback evidence are required before the first schema mutation.
+    expected_revision_source: main plus the merged digest-only deploy/k8s/overlays/prod promotion PR
+  - name: no-preview-dev-or-staging
+    environment_type: none
+    required: false
+    namespace: null
+    url: null
+    quota_policy: null
+    limit_policy: null
+    network_policy: null
+    ttl: null
+    secrets_scope: none; Verdify is intentionally single-environment production-only
+    protection_rules:
+      - No disposable, dev, staging, or shadow writer environment may be invented for this release.
+    expected_revision_source: null
+gitops:
+  controller: argo_cd
+  desired_state_refs:
+    - Accepted per-lane PR heads merged to main with required CI and critic evidence.
+    - jvallery/agents production SOPS authority PR #2904 merged at deae5f508 with 33 green checks; the live Secret and DB role remain unchanged until STEP-03.
+    - Immutable GHCR digests published from the accepted main integration SHA.
+    - Digest-only prod-promote PR updating deploy/k8s/overlays/prod/kustomization.yaml.
+    - ArgoCD Application verdify-prod-dark targeting main with manual sync and prune:false.
+  sync_order:
+    - phase: protected-security-precondition
+      wave: 0
+      resource: verdify role plus verdify-prod/verdify-app-secrets through the reviewed production SOPS authority
+      purpose: >-
+        Before the first product release mutation, execute the now-authorized
+        scoped rotation runbook, restore ingestor first, then API, MCP, planner,
+        setpoint-server, and Grafana one at a time, resume controlled CronJobs,
+        and record only replacement-uri-safe, new-valid, and old-invalid booleans.
+    - phase: serialized-schema
+      wave: 1
+      resource: db/migrations/186-noaa-solar-phase-parity.sql
+      purpose: Classify, rollback-prove, apply once, and verify live firmware-parity solar semantics before dependent evidence.
+    - phase: serialized-schema
+      wave: 2
+      resource: db/migrations/189-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify device-served VPD divergence semantics.
+    - phase: serialized-schema
+      wave: 3
+      resource: db/migrations/190-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify the evidence-core contract before the next migration.
+    - phase: serialized-schema
+      wave: 4
+      resource: db/migrations/191-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify the evidence-core contract before the next migration.
+    - phase: serialized-schema
+      wave: 5
+      resource: db/migrations/192-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify the evidence-core contract before resource consumers.
+    - phase: serialized-schema
+      wave: 6
+      resource: db/migrations/193-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify canonical equipment/resource provenance.
+    - phase: serialized-schema
+      wave: 7
+      resource: db/migrations/194-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify water/energy ledger conservation and freshness.
+    - phase: serialized-schema
+      wave: 8
+      resource: db/migrations/195-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify DLI availability and historical provenance before consumers.
+    - phase: serialized-schema
+      wave: 9
+      resource: db/migrations/196-*.sql
+      purpose: Classify, rollback-prove, apply once, and verify planner terminal lifecycle, singularity, and expiry.
+    - phase: digest-promotion
+      wave: 10
+      resource: prod-promote PR for api, mcp, ingestor, migrate, and planner
+      purpose: Merge only immutable accepted-main digests after promote-diff-guard proves a digests-only surface.
+    - phase: production-sync
+      wave: 11
+      resource: ArgoCD Application verdify-prod-dark
+      purpose: >-
+        After a clean kustomize/kubectl diff, initiate exactly one reviewed
+        manual application sync with prune:false; no auto-sync, force, resource
+        prune, or unrelated-drift reconciliation is permitted.
+    - phase: service-verification
+      wave: 12
+      resource: verdify-mcp, verdify-ingestor, verdify-planner, verdify-api, and verdify-grafana
+      purpose: >-
+        Verify or restart consumers serially after schema readiness: MCP first,
+        then the single-writer ingestor with Recreate semantics, the
+        non-authoritative planner, API, and finally Grafana/dashboard reload;
+        stop after any unhealthy rollout, auth failure, or second writer.
+    - phase: device-release
+      wave: 13
+      resource: one ESP32 greenhouse controller
+      purpose: >-
+        After service acceptance, planner-alert clearance, stale-intent
+        retirement, and all firmware gates, upload exactly one reviewed combined
+        image; a second flash is permitted only as the documented rollback.
+  reconciliation_checks:
+    - Confirm the production credential gate is approved, the reviewed production SOPS authority is current, every caller passes with the replacement, and the old credential is rejected before migration 186.
+    - Confirm every migration is uniquely resolved, classified by migration-rollback-safety, proved by its permitted rollback method, applied in order, and visible live before continuing.
+    - Confirm the prod-promote PR contains only digest-line changes and every digest resolves to the accepted main publication.
+    - Run kustomize build deploy/k8s/overlays/prod piped to kubectl diff and stop on any unrelated or second-writer change.
+    - Capture the Argo operation requested with sync.prune=false, then require Synced and Healthy at the merged promotion revision.
+    - Match each running pod imageID to the promoted digest and prove ingestor replica/strategy/Lease plus endpoint health.
+    - Verify diagnostics.firmware_version against the intended OTA build; never use last-good.version as running-version evidence.
+  remediation_policy: >-
+    Manual only. Stop at the first unexpected migration result, authentication
+    failure, unrelated Argo drift, unhealthy rollout, second writer, critical
+    alert, or firmware gate failure. Use the layer-specific rollback, capture
+    evidence, and do not retry or broaden the sync until an independently
+    reviewed disposition exists.
+deployment_strategy:
+  type: manual
+  progressive_delivery: false
+  traffic_policy: null
+  steps:
+    - id: STEP-01
+      action: >-
+        Merge each independently approved lane PR to main in the approved DAG;
+        rerun required CI after rebases and at the exact integrated main head.
+      success_criteria: Every issue is owned once, every critic verdict matches the immutable merged head, required checks are green, and main is clean.
+      rollback_trigger: Any scope, contract, critic, check, or immutable-head mismatch returns the owning lane to fixes before production.
+    - id: STEP-02
+      action: >-
+        Publish the impacted accepted-main container images and freeze an exact
+        release manifest of Git SHA, image digests, migration files, firmware
+        artifact, prior production refs, and evidence links.
+      success_criteria: All required images have immutable GHCR digests tied to the accepted main SHA and the retained pre-release rollback refs are complete.
+      rollback_trigger: Missing, mutable, untrusted, or revision-mismatched artifacts block the release.
+    - id: STEP-03
+      action: >-
+        Execute the authorized database credential rotation runbook before the
+        first product release mutation, including backup, CronJob suspension,
+        production SOPS correction, caller-ordered recreation, new-valid and
+        old-invalid proof, and deliberate resumption.
+      success_criteria: replacement_uri_safe, new_credential_valid, and old_credential_rejected are true; every caller is Ready/authenticated and ingestor remains the sole writer.
+      rollback_trigger: Any unidentified caller, auth failure, old credential acceptance, new critical alert, second writer, or raw secret exposure invokes the credential rollback/incident path.
+    - id: STEP-04
+      action: >-
+        For migration 186 and each migration 189 through 196, run the classifier
+        and migration-specific rollback proof, take the required backup, apply
+        exactly one migration, verify its live contract, and only then advance.
+      success_criteria: All nine migrations are applied in numerical order with source/live parity and no self-committing migration wrapped in an outer transaction.
+      rollback_trigger: Classification ambiguity, proof failure, apply error, parity failure, or consumer incompatibility stops the sequence and uses that migration's recorded rollback.
+    - id: STEP-05
+      action: >-
+        Dispatch prod-promote first in dry-run and then mode=pull-request, review
+        and merge the one digests-only PR, run the production render/diff, and
+        issue one manual ArgoCD sync for verdify-prod-dark with prune:false.
+      success_criteria: promote-diff-guard and manifest validation pass; Argo is Synced/Healthy; running imageIDs equal the manifest; no unrelated resource or second writer changed.
+      rollback_trigger: Unexpected diff, failed pull, crash loop, Argo degradation, auth failure, or writer ambiguity repins the previous digest set through the same reviewed prune:false path.
+    - id: STEP-06
+      action: >-
+        Verify or restart MCP, ingestor, planner, API, and Grafana serially; then
+        prove writer cadence, DLI unavailable with lighting intact, a valid
+        terminal bounded planner action, truthful planner runtime health,
+        resource ledger freshness/scopes, and dry-out evidence availability.
+      success_criteria: Services are healthy; writer cadence stays within contract; zero false DLI or forbidden routes exist; resource scopes are provenance-bearing; planner-required critical alerts are correctly cleared.
+      rollback_trigger: Any false-green service, writer storm/starvation, false numeric DLI, resource scalar leakage, unresolved planner blocker, or forbidden irrigation path rolls back affected service digests before device work.
+    - id: STEP-07
+      action: >-
+        After repaired writer/planner consumers are live, atomically retire the
+        stale band_track_fraction=0.25 intent and observe effective and device
+        value zero with no repin; capture a completed trustworthy pre-OTA
+        topology-aware cycling baseline.
+      success_criteria: Effective and readback band_track_fraction equal zero, the stale row cannot repin, and the cycling baseline is complete and comparable.
+      rollback_trigger: Repin, nonzero readback, transaction ambiguity, incomplete window, or a declared pre-OTA cycling blocker stops before firmware preflight; do not restore the stale experiment as a routine rollback.
+    - id: STEP-08
+      action: >-
+        Run the exact-head firmware unit, invariant, replay, band-replay,
+        compile/map, irrigation, lighting, heap, cycling, critical-alert,
+        weekly, bake, telemetry, action-log, and rollback preflights; then OTA
+        the exact reviewed combined image once with VERDIFY_DB_BACKEND=kube
+        retained for version and sensor verification.
+      success_criteria: diagnostics.firmware_version reports the intended version, sensor-health is clean, cfg readbacks match, center mist is climate-only, dormant routes stay disabled, and wall feed remains fail-closed while uncommissioned.
+      rollback_trigger: Upload, boot, telemetry, sensor-health, route, heap, WDT, readback, or critical-alert failure immediately invokes the retained last-good firmware procedure.
+    - id: STEP-09
+      action: >-
+        Run immediate post-sync/post-OTA probes, a complete two-hour steady
+        writer window, at least one eligible sunset-to-sunrise dry-out episode,
+        and the full 48-hour settled firmware/cycling/heap/alert watch.
+      success_criteria: Every release-health blocking signal passes, the dry-out episode has an explicit disposition, no stale repin or forbidden route appears, and the evidence cites exact production revisions.
+      rollback_trigger: Any blocking signal during the observation window invokes the narrowest safe rollback and resets the applicable settling window.
+    - id: STEP-10
+      action: >-
+        Obtain an independent final release/runtime verdict on the immutable
+        packet, reconcile all 17 issues and lifecycle state to production truth,
+        and place the review packet in the review inbox for Jason.
+      success_criteria: Final critic approves; Git, GitHub, Argo, pods, DB, device, alerts, and evidence agree; the greenhouse is live and ready for review.
+      rollback_trigger: Evidence mismatch or critic changes-requested reopens the owning lane and prevents final completion.
+observability:
+  dashboards:
+    - graphs.verdify.ai climate, equipment, water, and DLI/resource panels using provenance-gated values
+    - ArgoCD application verdify-prod-dark sync, operation, and health surfaces
+    - agents.vallery.net authenticated controller/session visibility
+  logs:
+    - verdify-ingestor reconnect, reconcile, queue, confirmation, planner-trigger, alert, and relay-attribution logs
+    - verdify-mcp, verdify-planner, verdify-api, migration, Grafana, and Kubernetes event logs
+    - ESPHome OTA, boot/reset, heap guard, WDT, cfg readback, and sensor-health output
+  metrics:
+    - Writer connection generation, queue age/depth, batch duration, task cadence, requested/sent/confirmed/cancelled totals, and unchanged broad repush count
+    - Terminal planner action/status/expiry, MCP tool readiness, planner_graph worker health or absence, and critical planner alert count
+    - DLI availability/reason/provenance plus qualified-light-minute and photoperiod continuity
+    - Per-origin relay attribution, zero south/west climate cycles, no legacy 10:30 eligibility, and wall commissioning/feed block reason
+    - Resource ledger freshness, conservation, attribution/confidence, measured/model coverage, and unavailable scalar state
+    - Solar-night episode admission/stop reason, indoor/outdoor absolute-humidity advantage, temperature response, duty, and effectiveness disposition
+    - Firmware version, current/minimum free heap, largest block, loop duration, reset reason, Task WDT count, cycle/runtime/short-cycle/peak-rate comparison, and band_track_fraction readback
+  traces: []
+  runtime_checks:
+    - Exact Git main SHA, merged promotion SHA, Argo target revision, running pod imageIDs, migration identities, and diagnostics.firmware_version correlate to one release manifest.
+    - Two steady-state hours contain zero unchanged broad anchor pushes; deliberate drift and reconnect probes terminate truthfully without starving tasks.
+    - Required SUNRISE and SUNSET work terminates in a valid expiring full plan or explicit neutral fallback; tool loss self-heals and no false-green planner process remains.
+    - Crop DLI remains unavailable with reason/provenance while lighting qualified minutes, minimum-on boundary, and photoperiod remain operational.
+    - Climate/VPD wetting is center-only; center mist has no non-climate origin; center drip and dormant south/west routes stay disabled; uncommissioned wall fertilizer cannot actuate.
+    - Water/energy outputs retain freshness, conservation, scope, provenance, confidence, command-only, ambiguous, and unattributed distinctions.
+    - One eligible night records realized dry-out response and an explicit effective, ineffective, blocked, or insufficient_evidence disposition without calling weak evidence a pass.
+    - Immediate and 48-hour checks show no critical alert, Task WDT, heap-guard reboot, stale repin, false DLI, forbidden route, writer storm, or declared cycling regression.
+  missing_telemetry:
+    - The broken interior light sensor intentionally leaves crop DLI unavailable; sensor replacement/calibration is outside this software release.
+    - Wall fertilizer delivery cannot be physically commissioned without current chemistry, injector, flow, distribution, volume, and flush measurements, so automatic feed must remain disabled and fail-closed.
+    - Eligible-night proof is weather and solar-window dependent; final acceptance waits for a qualifying sunset-to-sunrise episode rather than substituting a fixed-clock or projected-intent claim.
+rollback:
+  ready: true
+  strategy: >-
+    Layered rollback retains the prior encrypted production Secret revision and
+    role credential during the protected rotation window, migration-specific
+    reverse procedures and a fresh backup, the prior digest-pinned production
+    overlay, and firmware/artifacts/last-good.ota.bin. Use only the narrowest
+    implicated layer; a firmware rollback is the only permitted second flash.
+  known_good_ref: >-
+    Capture the exact pre-release production overlay SHA, running image digests,
+    Secret resource version/SOPS revision, database backup reference, current
+    device firmware version, and firmware/artifacts/last-good.ota.bin in the
+    immutable release manifest immediately before mutation.
+  procedure: >-
+    Stop forward progress and preserve evidence. For credential failure, restore
+    the prior role password and encrypted production Secret through the secure
+    runbook, then recreate only moved callers starting with the single writer.
+    For schema failure, use the affected migration's classified rollback and
+    never wrap a self-committing migration. For application failure, repin the
+    prior digests in a reviewed promotion and manual prune:false sync. For
+    device failure, flash last-good and re-run kube-backed version/sensor checks.
+    Do not restore stale 0.25 intent, expose secrets, force sync, or prune.
+  validation_steps:
+    - Confirm the implicated layer is back on its exact recorded pre-state and every unaffected layer remained unchanged.
+    - Require ingestor one-replica/Recreate/Lease truth, authenticated DB calls, healthy pods/endpoints, and zero new critical alerts.
+    - Re-run schema parity or application imageID checks appropriate to the rollback and capture Argo Synced/Healthy with prune:false.
+    - For firmware rollback, require diagnostics.firmware_version equals the recorded last-good build and sensor-health, heap/reset, route, and writer checks are clean.
+    - Record rollback used/not-used, timestamps, reason, refs, and final disposition in the release packet without secret material.
+release_health:
+  stabilization_window: Immediate probes, a complete two-hour writer window, one eligible sunset-to-sunrise episode, and 48 hours settled after the OTA
+  signals:
+    - name: credential-rotation-integrity
+      source: Redacted issue-438 rotation evidence and per-caller authenticated probes
+      threshold: replacement_uri_safe=true, new_credential_valid=true, old_credential_rejected=true, and every intended caller Ready/authenticated
+      blocking: true
+    - name: migration-and-release-revision
+      source: Migration ledger/proofs, release manifest, GitHub, GHCR, ArgoCD, and Kubernetes imageIDs
+      threshold: Migrations 186 and 189-196 applied once in order; all running refs exactly match the accepted release manifest
+      blocking: true
+    - name: sole-writer-cadence
+      source: Ingestor deployment/Lease, writer telemetry, delivery lifecycle, and two-hour logs
+      threshold: Exactly one writer; zero unchanged broad repushes; task cadence no worse than twice intended; probes terminally truthful
+      blocking: true
+    - name: planner-delivery-health
+      source: MCP readiness, terminal planner ledger, effective plan, planner runtime health, and alert_log
+      threshold: Valid terminal full plan or neutral fallback, strict bounds/expiry, truthful planner health, and zero open planner_required_plan_missed critical alerts
+      blocking: true
+    - name: dli-and-lighting-truth
+      source: DB, firmware telemetry, MCP, API, dashboards, site, and lighting evidence
+      threshold: Crop DLI unavailable with provenance everywhere while qualified-minute, minimum-on, and photoperiod controls remain operational
+      blocking: true
+    - name: irrigation-authority
+      source: Relay intent/owner attribution, scheduler/job ledger, readbacks, and irrigation audit
+      threshold: Zero south/west climate cycles, zero non-climate center-mist origins, zero legacy 10:30 eligibility, and zero uncommissioned fertilizer actuation
+      blocking: true
+    - name: resource-accounting-truth
+      source: Water/energy ledger freshness, conservation fixtures, API/MCP, Grafana, and generated site
+      threshold: No stale or false zero scalar; measured, modeled, command-only, ambiguous, unattributed, confidence, and availability scopes remain distinct
+      blocking: true
+    - name: stale-intent-retirement
+      source: Active plan rows, effective setpoint view, device cfg readback, and immediate/settled writer logs
+      threshold: band_track_fraction effective and device value equal 0.0 with zero repin
+      blocking: true
+    - name: firmware-runtime-safety
+      source: Firmware preflight, diagnostics, reset history, heap telemetry, alert ledger, and 48-hour observation
+      threshold: Exact reviewed version; zero Task WDT or heap-guard reboot; defensible heap floor; zero deploy-blocking alerts
+      blocking: true
+    - name: topology-aware-cycling
+      source: Completed raw equipment_state transition windows and immutable firmware-cycling-gate artifacts
+      threshold: Windows are complete/nonoverlapping/comparable; zero forbidden cycles; center compared to prior combined climate envelope; no declared canary/tolerance regression
+      blocking: true
+    - name: realized-night-dryout
+      source: One eligible sunset-to-sunrise episode ledger and representative-night report
+      threshold: Solar-night admission only, heat2 forbidden, bounded guards/temperature response recorded, and explicit effectiveness disposition present
+      blocking: true
+review_handoff:
+  review_inbox_packet_required: true
+  expected_review_packet_path: .agent-workflow/sprints/software-recovery-2026-07-09/review/review-inbox-packet.yaml
+  human_test_steps:
+    - Review the release manifest and verify main SHA, promotion PR/SHA, Argo revision, running digests, migrations, firmware version/checksum, and rollback refs correlate.
+    - "Verify greenhouse operator behavior: center mist is climate-only, dormant irrigation remains off, wall fertilizer remains fail-closed, DLI is unavailable, lighting remains operational, and band_track_fraction remains zero."
+    - Review writer/planner service evidence, the completed two-hour quiet-writer window, one realized eligible-night dry-out episode, and the 48-hour heap/WDT/cycling/alert report.
+    - Confirm issue #438 evidence contains only redacted booleans/refs, the old credential is invalid, no deploy-blocking alert remains, and all 17 issues match production reality.
+  approval_gate: >-
+    Jason Vallery receives the live review packet after the independent final
+    release/runtime critic approves the immutable immediate, two-hour,
+    eligible-night, and 48-hour evidence. Deployment authorization is already
+    granted; this is the final operator review handoff, not a waived safety gate.
+risks:
+  - id: RISK-01
+    severity: critical
+    statement: Credential rotation could strand an undiscovered production database caller or expose material.
+    mitigation: Refresh the caller matrix, use only the reviewed production SOPS authority and secure interactive paths, roll callers in the documented order, store booleans only, and retain the scoped rollback until old-invalid proof passes.
+  - id: RISK-02
+    severity: critical
+    statement: A schema, service, or Argo change could disturb the only live writer or include unrelated drift.
+    mitigation: Rotate before product mutation, apply migrations one at a time, require schema readiness before consumers, inspect the full render/diff, sync once with prune:false, and stop on any second writer or unrelated resource.
+  - id: RISK-03
+    severity: critical
+    statement: The combined firmware could worsen heap, cycling, relay routing, or night behavior on the only controller.
+    mitigation: One independently reviewed image, every deterministic firmware/preflight gate, one OTA, immediate and 48-hour evidence, and a retained last-good rollback binary.
+  - id: RISK-04
+    severity: high
+    statement: Broken or absent physical evidence could be converted into a false DLI, fertilizer, water, energy, or dry-out success claim.
+    mitigation: Preserve explicit unavailable/fail-closed/provenance states, require a complete eligible night, distinguish measured/model/command scopes, and accept insufficient_evidence instead of inventing a pass.
+  - id: RISK-05
+    severity: high
+    statement: The stale 0.25 row may repin during consumer transition or a rollback.
+    mitigation: Retire it only after repaired consumers are live, make the transaction auditable, watch immediate and settled effective/device state, and never restore it as a routine rollback.
+  - id: RISK-06
+    severity: high
+    statement: Native Agent Platform session lifecycle remains unavailable and its shared stale clone is unsafe for lane execution.
+    mitigation: Continue only through the approved isolated local worktree fallback; this release plan does not relax worker production boundaries or platform restoration gates.
+approval:
+  status: approved
+  approver: Jason Vallery
+  approved_at: "2026-07-10T12:35:20Z"
+prepared_at: "2026-07-10T12:35:20Z"
+planner: codex release-plan worker under the approved software-recovery controller


### PR DESCRIPTION
## Summary
- add the approved schema-valid wave release plan for the exact 17-issue production recovery
- sequence per-lane PRs, required CI, authorized credential rotation, migrations 186 and 189-196, digest-only promotion, manual prune:false Argo sync, service verification, and one gated OTA
- define rollback, observability, immediate/two-hour/eligible-night/48-hour proof, and final review inbox handoff
- wire the execution runbook to the release plan and remove only the satisfied missing-plan blocker

Production and device state are untouched by this planning-only PR. Native Agent Platform lifecycle HTTP 501 remains an explicit blocker for native dispatch; the approved isolated local fallback is unchanged.

## Validation
- wave-release-plan schema: PASS
- sprint-execution-runbook schema: PASS
- exact 17-issue/eight-lane coverage and migration order: PASS
- git diff --check: PASS