### PR TITLE
ci: promote fenced MCP digest to prod

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -183,7 +183,7 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
     digest: sha256:305ef0dd7c71974e653cda8433d4ecebe343d17eb85c99eebb49529a06d87f0c
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
-    digest: sha256:42ccd79bcb520b3c2f244da27a5bd9a4cc9d93e1f292c1ca0ef5f881823b5e49
+    digest: sha256:b6b6ea2f7827578a9b4a8331880f6c17884c28391e9d597a8513c0446a424ac6
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor
     digest: sha256:dafd11e24050a0e90d827b60bd07913d51599852b272ab034ad95a9d72fde8f5
   - name: ghcr.io/verdifyconsultancy/verdify-migrate


### PR DESCRIPTION
## Outcome
Promotes only `verdify-mcp` to the immutable image published from `70e75a88e33b2f11aa1b501099bb6ac44ef75a74`.

- old: `sha256:42ccd79bcb520b3c2f244da27a5bd9a4cc9d93e1f292c1ca0ef5f881823b5e49`
- new: `sha256:b6b6ea2f7827578a9b4a8331880f6c17884c28391e9d597a8513c0446a424ac6`

The image adds a server-side 15s statement timeout to MCP DB sessions and explicit scorecard/forecast timeout degradation. The prod-promote workflow passed its local digest-only and device-write safety gates; it could not open the PR only because GitHub Actions PR creation is disabled.

Merging does not sync Argo. Release control will selectively sync `Deployment/verdify-mcp`, verify the running digest and query fence, then retry the audited planner acceptance trigger.