### PR TITLE
ci: prod-promote — advance API digest to latest published

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -181,7 +181,7 @@ patches:
 # GHCR digests in-repo.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:305ef0dd7c71974e653cda8433d4ecebe343d17eb85c99eebb49529a06d87f0c
+    digest: sha256:9d988f678a59483a70bd08f535e11db2e6541d0e3ad87a1c6e56cf3f689f94a4
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
     digest: sha256:b6b6ea2f7827578a9b4a8331880f6c17884c28391e9d597a8513c0446a424ac6
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor


### PR DESCRIPTION
## Prod promotion

Advances only the `verdify-api` production digest to the latest `:branch-main` image built from `a9a947d`.

### Gates

- Source CI: passed.
- Container publish: passed.
- Workflow Device-Write-Safety-Gate: passed; non-image render unchanged.
- Change surface: one digest line only.
- Live sync remains manual; this PR does not touch the cluster.

### Purpose

Deploys server-side API database query budgets: 15 seconds on every pool checkout and a fail-soft 6-second planner scorecard budget, preventing disconnected HTTP clients from leaving expensive production queries behind.