### PR TITLE
ci: prod-promote — advance bounded public evidence API

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -181,7 +181,7 @@ patches:
 # GHCR digests in-repo.
 images:
   - name: ghcr.io/verdifyconsultancy/verdify-api
-    digest: sha256:77bc462d1bafa33d7597fd57667ff4a09bfe98cb1953b732fea03d5e3f11ba6b
+    digest: sha256:7d4610c087720989d186060b5deb1bf8f74b3d60aaf25c38280ae16e4871c97d
   - name: ghcr.io/verdifyconsultancy/verdify-mcp
     digest: sha256:b6b6ea2f7827578a9b4a8331880f6c17884c28391e9d597a8513c0446a424ac6
   - name: ghcr.io/verdifyconsultancy/verdify-ingestor


### PR DESCRIPTION
## Prod promotion

Advances only the `verdify-api` production digest to the latest fully green `:branch-main` image built from `b9fe44d`.

### Gates

- Source CI: passed.
- Container publish: passed.
- Workflow Device-Write-Safety-Gate: passed; non-image render unchanged.
- Change surface: one digest line only.
- Live sync remains manual; this PR does not touch the cluster.

### Purpose

Completes fail-soft public evidence delivery: scorecard 6s, optional resource views 3s, trust-ledger rows 3s, with a 15s universal API query ceiling. Slow optional evidence returns null/empty while core controller and planner proof stays available.