### PR TITLE
gitops(stage): pin Verdify Lab Astro sha256:2c03489c75315f848a525700ccc93d7da7d1a9665c42d82c46c2535d6ff769b7

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -12,7 +12,7 @@ images:
   # fleet-origin digest produced by the in-cluster Kaniko path.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:2c03489c75315f848a525700ccc93d7da7d1a9665c42d82c46c2535d6ff769b7
 
 labels:
   - pairs:


### PR DESCRIPTION
Stage-only digest pin for jvallery/agents#2930. Source revision: 6df4b5af65ecba2dd452671170f22b911c42ad8c. The immutable candidate image and release snapshot have passed the repository validation, release verification, and exact runtime probe. Review and merge do not authorize production cutover or production APPLY.