### PR TITLE
fix(lab): resolve exported Playwright CLI

### DIFF
--- a/site-astro/scripts/ensure-playwright-browser.mjs
+++ b/site-astro/scripts/ensure-playwright-browser.mjs
@@ -4,6 +4,7 @@ import { chromium } from "@playwright/test";
 
 const require = createRequire(import.meta.url);
 const executable = chromium.executablePath();
+const playwrightCli = require.resolve("@playwright/test/cli");
 
 async function browserIsReady() {
   let browser;
@@ -20,7 +21,6 @@ async function browserIsReady() {
 if (await browserIsReady()) {
   process.stdout.write(`[lab-stage] pinned Playwright Chromium is ready: ${executable}\n`);
 } else {
-  const playwrightCli = require.resolve("playwright/cli");
   process.stdout.write(
     "[lab-stage] pinned Playwright Chromium is absent; installing browser and OS dependencies\n",
   );


### PR DESCRIPTION
The exact cold-cache `node:22-bookworm` run caught that `playwright/cli` is not exported by Playwright 1.61.1, so #463 failed before browser installation. The direct pinned dependency `@playwright/test` does export `./cli`.

This moves resolution of `@playwright/test/cli` to startup. Warm and cold paths now both fail early on dependency/export drift while the installer remains package-local and pinned.

Validation:
- empty `PLAYWRIGHT_BROWSERS_PATH`: installed OS dependencies, Chromium 1228, headless shell 1228, and FFmpeg; smoke launch passed
- warm `npm run playwright:ensure`: passed
- `npm test`: 58 unit, 7 parity, rendered manifests, fixture output, 12/12 Playwright quality tests passed
- `make PYTHON=/workspace/verdify-platform/repo/.venv/bin/python RUFF=/workspace/verdify-platform/repo/.venv/bin/ruff ci`: ALL GATES GREEN
- `git diff --check`: passed

Stage CI only. No production, device, database, DNS, or credential mutation.