### PR TITLE
gitops(stage): pin Verdify Lab Astro sha256:fb72e1bad7c6c57649d86214067052d145648638e4fed3e6d7cee325becbee21

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -12,7 +12,7 @@ images:
   # fleet-origin digest produced by the in-cluster Kaniko path.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:2c03489c75315f848a525700ccc93d7da7d1a9665c42d82c46c2535d6ff769b7
+    digest: sha256:fb72e1bad7c6c57649d86214067052d145648638e4fed3e6d7cee325becbee21
 
 labels:
   - pairs:


### PR DESCRIPTION
Stage-only digest pin for jvallery/agents#2930.

Source revision: 985aedc64b30cccbd157166c9695604d01d5efdb
Verified runtime image: registry.vallery.net/verdifyconsultancy/verdify-lab-astro@sha256:fb72e1bad7c6c57649d86214067052d145648638e4fed3e6d7cee325becbee21
Workflow: verdify-platform-ci-mcdlh

The build, release verification, and exact pushed-image runtime probe succeeded. The workflow pushed this branch, then its PR-creation payload failed with HTTP 400; this PR recovers that exact generated commit without rebuilding.

Review and merge do not authorize production cutover or production APPLY.