### PR TITLE
fix(lab): avoid stale Pagefind worker CSP

### DIFF
--- a/site-astro/src/components/LabNavigation.astro
+++ b/site-astro/src/components/LabNavigation.astro
@@ -116,7 +116,7 @@ const active = (href: string) => {
 
     const input = document.querySelector("#lab-search");
     const output = document.querySelector("#lab-search-results");
-    let pagefind;
+    let pagefindReady;
     let searchSequence = 0;
     input?.addEventListener("input", async () => {
       const query = input.value.trim();
@@ -129,8 +129,15 @@ const active = (href: string) => {
       }
       output.setAttribute("aria-busy", "true");
       try {
-        pagefind ??= await import("/pagefind/pagefind.js");
-        await pagefind.init();
+        pagefindReady ??= import("/pagefind/pagefind.js").then(async (pagefind) => {
+          // Pagefind's worker URL is not content-addressed. Running the index on
+          // the document avoids an old immutable edge response pinning the
+          // worker to a superseded CSP after a stage release.
+          await pagefind.options({ noWorker: true });
+          await pagefind.init();
+          return pagefind;
+        });
+        const pagefind = await pagefindReady;
         const search = await pagefind.search(query);
         const details = await Promise.all(search.results.slice(0, 6).map((result) => result.data()));
         if (sequence !== searchSequence) return;

--- a/site-astro/tests/runtime.browser.test.mjs
+++ b/site-astro/tests/runtime.browser.test.mjs
@@ -83,11 +83,19 @@ function collectBrowserFailures(page) {
 
 test("Pagefind searches under CSP and KaTeX fonts remain same-origin", async ({ page }) => {
   const failures = collectBrowserFailures(page);
+  const pagefindRequests = [];
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (pathname.startsWith("/pagefind/")) pagefindRequests.push(pathname);
+  });
   const response = await page.goto(`${origin}/start/about`);
   expect(response.headers()["content-security-policy"]).toContain("'wasm-unsafe-eval'");
   await page.locator("#lab-search").fill("greenhouse");
   await expect(page.locator("#lab-search-results li").first()).toBeVisible();
   await expect(page.locator("#lab-search-results")).not.toContainText("Search index unavailable");
+  expect(pagefindRequests).toContain("/pagefind/pagefind.js");
+  expect(pagefindRequests.some((pathname) => pathname.endsWith("/pagefind-worker.js"))).toBe(false);
+  expect(pagefindRequests.some((pathname) => pathname.endsWith(".pagefind"))).toBe(true);
   await page.goto(`${origin}/`);
   await page.evaluate(() => document.fonts.ready);
   expect(await page.locator('link[href*="katex.min"]').count()).toBe(1);


### PR DESCRIPTION
T0 acceptance on the exact shell-1.1 stage rollout found Pagefind metadata/JS/WASM all returned 200, but the functional search failed.

Root cause: `/pagefind/pagefind-worker.js` is an unversioned Pagefind runtime path served as immutable. Cloudflare still returns the shell-1.0 response (age >28,000 seconds) with the old CSP, so WebAssembly compilation inside the worker is blocked even though the HTML document and current origin response have `wasm-unsafe-eval`. A cache-busting request returns the new CSP.

This change uses Pagefind 1.5.2s supported `noWorker` option before one memoized initialization. Search executes under the current document CSP and no longer depends on stale edge metadata for an unversioned worker. A live browser proof against stage with this option returned all 324 indexed results.

Regression coverage asserts functional search, Pagefind JS/WASM requests, and no worker request.

Checks:

- `npm test` — 58 unit + 7 parity + manifests/output + 12/12 quality, PASS
- `./node_modules/.bin/playwright test --config=playwright.config.mjs tests/runtime.browser.test.mjs` — 2/2 PASS
- repo `make ci` — ALL GATES GREEN
- `git diff --check` — PASS

Stage-only delivery follow-up for jvallery/agents#2930. Production cutover, DNS/edge, Quartz, database, and device behavior are untouched.