### PR TITLE
test(lab): retry transient browser stalls once

### DIFF
--- a/site-astro/playwright.config.mjs
+++ b/site-astro/playwright.config.mjs
@@ -5,6 +5,9 @@ export default defineConfig({
   testMatch: "*.browser.test.mjs",
   fullyParallel: false,
   workers: 1,
+  // Stage CI shares worker nodes. Retry once so a transient scheduling stall
+  // is visible as flaky while a reproducible performance regression stays red.
+  retries: 1,
   reporter: "line",
   expect: {
     timeout: 5_000,


### PR DESCRIPTION
Two retained exact in-cluster builds exposed the same shared-node timing flake in the strict browser quality gate:

- `verdify-platform-ci-f9z54`: 10/12 passed; unrelated home/forecast pages reported aggregate long-task durations of 176ms/199ms versus 150ms.
- `verdify-platform-ci-cjq92`: 11/12 passed; evidence reported 162ms.
- Adjacent workflow `74v62`, the reviewed cold-cache run `mcdlh`, and repeated local runs pass with unchanged product output.

This keeps every existing accessibility, functionality, visual, byte, DOM, CSP, and strict 150ms performance assertion unchanged. Playwright retries a failed test once, serially. A transient scheduling stall remains visible as `flaky`; a reproducible regression fails both attempts and remains red.

Evidence while evaluating alternatives: a 36-case repeat run produced one shared-node timing outlier and the next repetition of the same route passed. The temporary metric change was discarded; this PR changes only the retry policy.

Checks:

- `npm run test:quality:built` — 12/12 PASS
- `npm test` — 58 unit + 7 parity + manifests/output + 12/12 quality, PASS
- `git diff --check` — PASS

This is CI reliability only. No runtime image behavior, stage desired state, production, DNS/edge, database, or device behavior changes.