### PR TITLE
gitops(stage): pin Verdify Lab Astro sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -12,7 +12,7 @@ images:
   # fleet-origin digest produced by the in-cluster Kaniko path.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:fb72e1bad7c6c57649d86214067052d145648638e4fed3e6d7cee325becbee21
+    digest: sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99
 
 labels:
   - pairs:


### PR DESCRIPTION
Stage-only digest pin for jvallery/agents#2930. Source revision: 38ccd5edecd0a82799dc901da2b7d8638ac287d5. Review and merge do not authorize production cutover or production APPLY.