### PR TITLE
gitops(stage): pin Verdify Lab Astro sha256:95c569745e9d00e88e87c0854c40d873c836bbc44905581afaca469b2fa24a62

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -12,7 +12,7 @@ images:
   # fleet-origin digest produced by the in-cluster Kaniko path.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99
+    digest: sha256:95c569745e9d00e88e87c0854c40d873c836bbc44905581afaca469b2fa24a62
 
 labels:
   - pairs:


### PR DESCRIPTION
Stage-only digest pin for jvallery/agents#2930. Source revision: a2564bb360f1da7f92163add9ede4f11e069fbf2. Review and merge do not authorize production cutover or production APPLY.