### PR TITLE
fix(lab): preserve nginx runtime state mount

### DIFF
--- a/deploy/k8s/candidates/lab-release-runtime/workload.yaml
+++ b/deploy/k8s/candidates/lab-release-runtime/workload.yaml
@@ -136,8 +136,6 @@ spec:
               readOnly: true
             - name: nginx-cache
               mountPath: /var/cache/nginx
-            - name: nginx-run
-              mountPath: /var/run
             - name: tmp
               mountPath: /tmp
         - name: release-reconciler
@@ -187,8 +185,6 @@ spec:
             medium: Memory
             sizeLimit: 16Mi
         - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-run
           emptyDir: {}
         - name: tmp
           emptyDir: {}

--- a/site-astro/scripts/verify-rendered-stage.mjs
+++ b/site-astro/scripts/verify-rendered-stage.mjs
@@ -85,6 +85,17 @@ assert.deepEqual(runtimeInit.command, ["/app/release-runtime/entrypoint.sh"]);
 assert.deepEqual(runtimeInit.args, ["init"]);
 assert.deepEqual(runtimeSite.command, ["nginx"]);
 assert.deepEqual(runtimeSite.args, ["-g", "daemon off;"]);
+assert.equal(
+  runtimeSite.volumeMounts.find((mount) => mount.name === "release-state")?.mountPath,
+  "/run/verdify-lab-release",
+);
+assert.equal(runtimeSite.volumeMounts.find((mount) => mount.name === "release-state")?.readOnly, true);
+assert.equal(
+  runtimeSite.volumeMounts.some((mount) => mount.mountPath === "/var/run"),
+  false,
+  "nginx must not mask the shared /run/verdify-lab-release state with a broad /var/run mount",
+);
+assert.equal(runtime.spec.template.spec.volumes.some((volume) => volume.name === "nginx-run"), false);
 assert.deepEqual(runtimeReconciler.command, ["/app/release-runtime/entrypoint.sh"]);
 assert.deepEqual(runtimeReconciler.args, ["reconcile"]);
 

--- a/site-astro/tests/manifests.test.mjs
+++ b/site-astro/tests/manifests.test.mjs
@@ -183,6 +183,21 @@ test("release runtime candidate is a two-node, no-PVC, no-route read-only cache"
     deployment.spec.template.spec.containers[0].volumeMounts.find((mount) => mount.name === "release-cache").readOnly,
     true,
   );
+  const siteMounts = deployment.spec.template.spec.containers[0].volumeMounts;
+  assert.equal(
+    siteMounts.find((mount) => mount.name === "release-state")?.mountPath,
+    "/run/verdify-lab-release",
+  );
+  assert.equal(siteMounts.find((mount) => mount.name === "release-state")?.readOnly, true);
+  assert.equal(
+    siteMounts.some((mount) => mount.mountPath === "/var/run"),
+    false,
+    "a broad /var/run mount aliases /run in nginx-unprivileged and masks the release-state submount",
+  );
+  assert.equal(
+    deployment.spec.template.spec.volumes.some((volume) => volume.name === "nginx-run"),
+    false,
+  );
   for (const container of [...deployment.spec.template.spec.initContainers, ...deployment.spec.template.spec.containers]) {
     assert.equal(container.securityContext.readOnlyRootFilesystem, true);
     assert.deepEqual(container.securityContext.capabilities.drop, ["ALL"]);


### PR DESCRIPTION
Refs #480 and follows #486. This PR does not activate or route the dormant
runtime.

## What

Remove the release-site container's unused `nginx-run` volume mounted at
`/var/run`, and add source/render regression assertions for the shared runtime
state mount.

## Why

The first exact main build/pair probe (`verdify-platform-ci-9q6c8`) retained its
failed pod and exposed the real container-filesystem mismatch. In the pinned
nginx-unprivileged image, `/var/run` resolves beneath `/run`; the broad mount
masked `/run/verdify-lab-release` inside nginx even though hydration and the
reconciler shared that state correctly. Nginx consequently returned 404 for
`release.json` and `metrics` until the pair probe timed out.

## How

- Remove only the `nginx-run` emptyDir and `/var/run` mount.
- Retain writable `/tmp` (including the image's `/tmp/nginx.pid` and temp
  paths), `/var/cache/nginx`, the read-only release cache, and the read-only
  `/run/verdify-lab-release` mount.
- Assert the raw candidate and rendered Lab-stage workload retain the state
  mount and cannot reintroduce a broad `/var/run` mount.

The workload remains `replicas: 0`, unrouted, egress-denied, and without an
application/object-store credential. No stage or production sync is included.

## Test

- `node --test tests/manifests.test.mjs` — 8/8
- `npm run test:manifests` — stage 9 resources + production candidate verified
- `npm test` — passed
- targeted pre-commit and `git diff --check` — passed
- independent exact-head review — no blockers

The bare worktree has no Python `.venv`, so `make lint` stops at the repository
venv preflight; exact in-cluster PR CI remains the merge gate.

## Success

- Nginx can observe the hydrated runtime identity and metrics through the shared
  state volume.
- Required writable nginx paths remain available.
- Dormant runtime and human-gated activation boundaries remain unchanged.
