### PR TITLE
gitops(stage): pin Verdify Lab runtime images sha256:c958fdb362a1c221868f4c74b10841c1e8b72d85cb1d678f665d7d03b044b6e2 for b0601faadd5fa9d8c905fdba19a25bc676e1e508

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -18,10 +18,10 @@ images:
   # reviewed activation replaces each sentinel with its exact zot digest.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:bfd3b7bbfac90e4af38057b84a360b6642a9cea34d8ab5fdfaa24cdb97f3c2ae
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
-    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    digest: sha256:501444dc8c662a7491de8bbb92118967facaa416f97cf72bb0c32440a2efe637
 
 patches:
   - path: lab-release-runtime-dormant.patch.yaml


### PR DESCRIPTION
Stage-only digest pin for the dormant release-agent/nginx pair (jvallery/agents#2930). Source revision: b0601faadd5fa9d8c905fdba19a25bc676e1e508. The serving static Astro digest is unchanged; the release runtime remains replicas=0 and unrouted. Review and merge do not authorize runtime activation, production cutover, or production APPLY.