### PR TITLE
ci: fix service-restart-drift-guard false-pass; port it to the local gate

### DIFF
--- a/scripts/check-service-restart-drift.sh
+++ b/scripts/check-service-restart-drift.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# check-service-restart-drift.sh — service-restart-drift-guard (CLAUDE.md rule 7).
+#
+# Observed need from the 2026-04-21 MCP staleness incident: MCP ran 40+ hours
+# with a stale schema because nobody restarted it post-merge. Any change that
+# touches verdify_schemas/**, ingestor/entity_map.py, or mcp/server.py must
+# document which services bounce post-merge.
+#
+# History: this guard lived in .github/workflows/ci.yml (retired 2026-07-11,
+# commit 6c7abe1) and matched /(restart|bounce|service|systemctl)/i — the bare
+# word "service" appears in nearly every PR body, so it false-passed (#391).
+# The contract is now structural:
+#
+#   PASS when the documentation text (commit messages BASE..HEAD, plus $PR_BODY
+#   when the caller provides one) either
+#     - names at least one known bounceable service (verdify-mcp,
+#       verdify-ingestor, verdify-api) alongside restart/bounce wording, e.g.
+#         Post-merge restart: verdify-mcp, verdify-ingestor
+#         bounce verdify-mcp after merge
+#     - or explicitly documents that no bounce is needed, WITH a reason:
+#         Restart: none — <reason>
+#   FAIL otherwise (incidental words like "service" or "restart" alone no
+#   longer count).
+#
+# Usage:
+#   check-service-restart-drift.sh <base> [head]     # diff mode (make ci)
+#   check-service-restart-drift.sh --check-text FILE # text contract only,
+#                                                    # assumes guarded paths
+#                                                    # changed (test harness)
+set -euo pipefail
+
+GUARDED_PATHSPECS=('verdify_schemas/' 'ingestor/entity_map.py' 'mcp/server.py')
+KNOWN_SERVICES_RE='verdify-(mcp|ingestor|api)'
+RESTART_WORDS_RE='(restart|bounce)'
+# "Restart: none" (or "Post-merge restart: none") must carry a reason after a
+# separator, e.g. "Restart: none — schema comment only".
+RESTART_NONE_RE='restart:[[:space:]]*none[^[:alnum:]]+[[:alnum:]]'
+
+usage() { sed -n '2,29p' "${BASH_SOURCE[0]}"; }
+
+fail_with_guidance() {
+  cat >&2 <<'EOF'
+FAIL: change touches verdify_schemas/**, ingestor/entity_map.py, or
+mcp/server.py but the commit message / PR body does not document the
+post-merge service restart (CLAUDE.md rule 7).
+
+Add one of:
+  Post-merge restart: verdify-mcp, verdify-ingestor
+  Restart: none — <reason no consumer needs a bounce>
+
+Naming a known service (verdify-mcp / verdify-ingestor / verdify-api) next to
+restart/bounce wording also passes; incidental words like "service" do not.
+EOF
+  exit 1
+}
+
+check_text() {
+  local file="$1"
+  if grep -Eiq "$RESTART_NONE_RE" "$file"; then
+    echo "OK: explicit 'Restart: none' with a documented reason"
+    return 0
+  fi
+  if grep -Eiq "$KNOWN_SERVICES_RE" "$file" && grep -Eiq "$RESTART_WORDS_RE" "$file"; then
+    echo "OK: restart documentation names a known bounceable service"
+    return 0
+  fi
+  return 1
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "${1:-}" = "--check-text" ]; then
+  [ -n "${2:-}" ] || { echo "usage: $0 --check-text FILE" >&2; exit 2; }
+  check_text "$2" || fail_with_guidance
+  exit 0
+fi
+
+BASE="${1:-}"
+HEAD_REF="${2:-HEAD}"
+[ -n "$BASE" ] || { usage >&2; exit 2; }
+
+CHANGED=$(git diff --name-only "$BASE" "$HEAD_REF" -- "${GUARDED_PATHSPECS[@]}")
+if [ -z "$CHANGED" ]; then
+  echo "OK: no schema/entity_map/mcp files changed; restart documentation not required"
+  exit 0
+fi
+echo "Schema-touching files changed:"
+printf '  %s\n' $CHANGED
+
+TEXT_FILE=$(mktemp)
+trap 'rm -f "$TEXT_FILE"' EXIT
+git log --format=%B "$BASE".."$HEAD_REF" > "$TEXT_FILE"
+if [ -n "${PR_BODY:-}" ]; then
+  printf '%s\n' "$PR_BODY" >> "$TEXT_FILE"
+fi
+
+check_text "$TEXT_FILE" || fail_with_guidance

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -68,6 +68,7 @@ $PY -m pytest -q \
   tests/test_public_output_policy.py \
   tests/test_public_output_remediation.py \
   tests/test_public_zone_renderer.py \
+  tests/test_service_restart_drift_guard.py \
   tests/test_site_content_refresh.py \
   tests/test_slack_config.py \
   tests/test_slack_ops.py \
@@ -110,6 +111,11 @@ if [ -n "${CI_BASE_REF:-}" ]; then
     grep -qE "id: cfg_(sw_)?${id}\b" firmware/greenhouse/sensors.yaml || MISSING="$MISSING $id"
   done
   [ -z "$MISSING" ] || { echo "New tunables without cfg_* readback:$MISSING" >&2; exit 1; }
+
+  step "service-restart drift guard (rule 7, schema -> runtime) vs ${BASE}"
+  # #391: the retired ci.yml job grepped the bare word 'service' and
+  # false-passed on ~every PR body. The structural contract lives in the guard.
+  bash scripts/check-service-restart-drift.sh "$BASE" HEAD
 
   step "firmware replay-diff trigger check vs ${BASE}"
   CHANGED=$(git diff --name-only "$BASE" HEAD -- 'firmware/lib/*.h' 'firmware/lib/*.cpp' \

--- a/tests/test_service_restart_drift_guard.py
+++ b/tests/test_service_restart_drift_guard.py
@@ -1,0 +1,155 @@
+"""Tests for the service-restart drift guard (CLAUDE.md rule 7, #391).
+
+The retired ci.yml job matched ``/(restart|bounce|service|systemctl)/i`` — the
+bare word "service" appears in nearly every PR body, so any schema-touching
+change false-passed and the verdify-mcp/verdify-ingestor bounce was never
+actually documented (the 2026-04-21 MCP-staleness incident class). These tests
+pin the structural contract of ``scripts/check-service-restart-drift.sh`` so a
+future edit can't silently re-open that hole.
+
+No database, no network, no device — diff-mode cases run against throwaway git
+repos under tmp_path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD = REPO_ROOT / "scripts" / "check-service-restart-drift.sh"
+
+GIT_ENV_OVERRIDES = {
+    "GIT_AUTHOR_NAME": "guard-test",
+    "GIT_AUTHOR_EMAIL": "guard-test@example.invalid",
+    "GIT_COMMITTER_NAME": "guard-test",
+    "GIT_COMMITTER_EMAIL": "guard-test@example.invalid",
+}
+
+
+def _env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k != "PR_BODY"}
+    env.update(GIT_ENV_OVERRIDES)
+    env.update(extra or {})
+    return env
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", *args],
+        cwd=repo,
+        env=_env(),
+        check=True,
+        capture_output=True,
+    )
+
+
+def _make_repo(tmp_path: Path, touched: str, message: str) -> tuple[Path, str]:
+    """Base commit + one commit touching ``touched`` with ``message``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "README.md").write_text("base\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "base")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, env=_env(), check=True, capture_output=True, text=True
+    ).stdout.strip()
+    target = repo / touched
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("changed\n")
+    _git(repo, "add", touched)
+    _git(repo, "commit", "-q", "-m", message)
+    return repo, base
+
+
+def _run_guard(repo: Path, base: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(GUARD), base, "HEAD"],
+        cwd=repo,
+        env=_env(extra_env),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── The false-pass that motivated #391 ───────────────────────────────────────
+
+
+def test_incidental_word_service_fails(tmp_path):
+    repo, base = _make_repo(tmp_path, "mcp/server.py", "improved service quality")
+    result = _run_guard(repo, base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "CLAUDE.md rule 7" in result.stderr
+
+
+def test_bare_restart_without_named_service_fails(tmp_path):
+    repo, base = _make_repo(tmp_path, "verdify_schemas/events.py", "restart stuff later maybe")
+    result = _run_guard(repo, base)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_restart_none_without_reason_fails(tmp_path):
+    repo, base = _make_repo(tmp_path, "mcp/server.py", "Restart: none")
+    result = _run_guard(repo, base)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+# ── Documentation forms that must PASS ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "schema: add soil sensor\n\nPost-merge restart: verdify-mcp, verdify-ingestor",
+        "bounce verdify-mcp after merge",
+        "entity map: rename fan\n\nRestart: none — comment-only change, no consumer bounce needed",
+    ],
+)
+def test_documented_restart_passes(tmp_path, message):
+    repo, base = _make_repo(tmp_path, "ingestor/entity_map.py", message)
+    result = _run_guard(repo, base)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_pr_body_env_supplies_documentation(tmp_path):
+    repo, base = _make_repo(tmp_path, "mcp/server.py", "tighten payload validation")
+    result = _run_guard(repo, base, {"PR_BODY": "Post-merge restart: verdify-mcp"})
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ── Guard scope: only schema/entity_map/mcp paths trigger it ─────────────────
+
+
+def test_unguarded_paths_pass_untouched(tmp_path):
+    repo, base = _make_repo(tmp_path, "api/routes.py", "improved service quality")
+    result = _run_guard(repo, base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "not required" in result.stdout
+
+
+# ── --check-text harness mode ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("this service is great", 1),
+        ("Post-merge restart: verdify-mcp, verdify-ingestor", 0),
+        ("Restart: none — no consumer bounce needed", 0),
+        ("systemctl restart something", 1),
+    ],
+)
+def test_check_text_mode(tmp_path, text, expected):
+    fixture = tmp_path / "body.txt"
+    fixture.write_text(text + "\n")
+    result = subprocess.run(
+        ["bash", str(GUARD), "--check-text", str(fixture)],
+        env=_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == expected, result.stdout + result.stderr


### PR DESCRIPTION
Closes #391

## Root cause

Two-layer failure:

1. **The false-pass #391 reported:** the `service-restart-drift-guard` job in the old `.github/workflows/ci.yml` (~line 597) matched the PR body against `/(restart|bounce|service|systemctl)/i`. The bare word "service" appears in nearly every PR body, so any schema-touching PR passed and the verdify-mcp/verdify-ingestor restart was never actually documented — the exact 2026-04-21 MCP-staleness incident class the guard exists to prevent.
2. **Since 2026-07-11 the guard did not run at all:** commit 6c7abe1 removed all GitHub Actions ("make ci / scripts/ci-local.sh is the gate") but never ported this job into `scripts/ci-local.sh`.

## Fix

- **`scripts/check-service-restart-drift.sh`** (new): structural contract. When the `BASE..HEAD` diff touches `verdify_schemas/**`, `ingestor/entity_map.py`, or `mcp/server.py`, the commit messages (plus `$PR_BODY` when the caller provides one) must either:
  - name a known bounceable service (`verdify-mcp` / `verdify-ingestor` / `verdify-api`) alongside restart/bounce wording — e.g. `Post-merge restart: verdify-mcp, verdify-ingestor` or "bounce verdify-mcp after merge" (keeps genuinely-documented existing PRs passing), or
  - carry an explicit `Restart: none — <reason>` (reason required; bare `Restart: none` fails).

  Incidental words like "service" (or even "restart" without a named service) no longer pass. `--check-text FILE` mode exposes the contract to the test harness.
- **`scripts/ci-local.sh`**: runs the guard in the `CI_BASE_REF` diff-scoped section (rule 7 restored to `make ci`), and the new pytest is added to the contract-test list so the guard is self-tested on every gate run.
- **`tests/test_service_restart_drift_guard.py`** (new, 12 tests): pins the contract against throwaway git repos — no DB/network/device.

## Verification (issue acceptance criteria)

Guard run against fixture repos (guarded path `mcp/server.py` / `verdify_schemas/` touched unless noted):

| scenario | message | result |
|---|---|---|
| (a) old false-pass | `improved service quality` | **FAIL exit 1** ✓ |
| (b) prose naming service | `bounce verdify-mcp after merge` | PASS ✓ |
| (c) diff not touching guarded paths | `improved service quality` | PASS (`restart documentation not required`) ✓ |
| structured line | `Post-merge restart: verdify-mcp, verdify-ingestor` | PASS ✓ |
| none-marker with reason | `Restart: none — docstring-only change, no consumer bounce needed` | PASS ✓ |
| none-marker without reason | `Restart: none` | FAIL exit 1 ✓ |

- `pytest -q tests/test_service_restart_drift_guard.py` → 12 passed
- `ruff check` + `ruff format --check` on the new test → clean
- Full gate: `CI_BASE_REF=origin/main bash scripts/ci-local.sh` → **ALL GATES GREEN**, with the new step visible:

```
== service-restart drift guard (rule 7, schema -> runtime) vs b4ec5bf... ==
OK: no schema/entity_map/mcp files changed; restart documentation not required
```

Restart: none — CI tooling and tests only; no schema/entity_map/mcp surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu