### PR TITLE
feat(site): add closed offline graph occurrence producer

### DIFF
--- a/site-astro/README.md
+++ b/site-astro/README.md
@@ -189,6 +189,18 @@ least-privilege credential, occurrence-store access, and egress limited to that
 store plus `api.verdify.ai:443`. Existing anonymous `graphs.verdify.ai` and the
 Track A primary database role are explicitly ineligible.
 
+The inert graph-producer library adds one pure planner that verifies the exact
+occurrence-manifest bytes against that policy and emits all 143 render targets in
+manifest order without an endpoint. Its producer has no default renderer or network,
+service, credential, database, Kubernetes, Grafana, or object-store client: an
+approved policy and an explicitly injected renderer are required before any call.
+At most four calls run concurrently; bounded PNG responses are decoded and
+deterministically re-encoded as metadata-free RGB PNG, then published through the
+same canonical content-addressed candidate store used by camera capture. Stable,
+URL-free results include every graph once on mixed failures. This source-only slice
+does not provide or activate the reporting feed, renderer, watermark/alert path,
+S3 delivery, workload, or stage rollout.
+
 ## Complete built-site releases
 
 The full Astro output now also has a local release and cache path. Run

--- a/site-astro/README.md
+++ b/site-astro/README.md
@@ -194,15 +194,21 @@ occurrence-manifest bytes against that policy and emits all 143 render targets i
 manifest order without an endpoint. Its producer has no default renderer or network,
 service, credential, database, Kubernetes, Grafana, or object-store client: an
 approved policy and an explicitly injected renderer are required before any call.
-That renderer must use the exact abort-cooperative v1 contract and settle promptly
-after the producer aborts it. The producer enforces the claim: a renderer or response
-body that does not settle and clean up within the short bounded grace period stops
+The producer also requires the full closed reporting-feed envelope and derives its
+canonical digest itself. Only that digest enters the v2 plan and all 143 requests;
+the feed identity, watermark, endpoint, and credential details do not. The injected
+renderer must declare the same digest through the exact abort-cooperative v2 contract
+and settle promptly after the producer aborts it. The producer enforces the claim: a
+renderer or response body that does not settle and clean up within the short bounded grace period stops
 all new scheduling and fails the whole batch closed, while still returning all 143
 ordered null records. At most four calls can remain unsettled, including after the
 producer returns. Bounded PNG responses are decoded and
 deterministically re-encoded as metadata-free RGB PNG, then published through the
 same canonical content-addressed candidate store used by camera capture. Stable,
-URL-free results include every graph once on mixed failures. This source-only slice
+URL-free v3 results include every graph once on mixed failures and repeat only the
+feed-envelope digest for the later 143+2 assembler to verify. The offline real-build
+verifier uses an explicit non-live envelope solely to prove planning; it makes no
+feed-existence or freshness claim. This source-only slice
 does not provide or activate the reporting feed, renderer, watermark/alert path,
 S3 delivery, workload, or stage rollout.
 

--- a/site-astro/README.md
+++ b/site-astro/README.md
@@ -194,7 +194,12 @@ occurrence-manifest bytes against that policy and emits all 143 render targets i
 manifest order without an endpoint. Its producer has no default renderer or network,
 service, credential, database, Kubernetes, Grafana, or object-store client: an
 approved policy and an explicitly injected renderer are required before any call.
-At most four calls run concurrently; bounded PNG responses are decoded and
+That renderer must use the exact abort-cooperative v1 contract and settle promptly
+after the producer aborts it. The producer enforces the claim: a renderer or response
+body that does not settle and clean up within the short bounded grace period stops
+all new scheduling and fails the whole batch closed, while still returning all 143
+ordered null records. At most four calls can remain unsettled, including after the
+producer returns. Bounded PNG responses are decoded and
 deterministically re-encoded as metadata-free RGB PNG, then published through the
 same canonical content-addressed candidate store used by camera capture. Stable,
 URL-free results include every graph once on mixed failures. This source-only slice

--- a/site-astro/package.json
+++ b/site-astro/package.json
@@ -32,7 +32,7 @@
     "build:fixture": "LAB_SNAPSHOT=tests/fixtures/snapshot ALLOW_SYNTHETIC_FIXTURE=true SITE_ORIGIN=https://lab-stage.verdify.ai npm run build",
     "build:production": "node scripts/build-production.mjs",
     "build:production:fixture": "node scripts/build-production.mjs --fixture",
-    "test:unit": "node --test tests/build-lock.test.mjs tests/camera-export-producer.test.mjs tests/compiler.test.mjs tests/manifests.test.mjs tests/occurrence-export.test.mjs tests/occurrence-release.test.mjs tests/site-release.test.mjs tests/snapshot-hydrator.test.mjs",
+    "test:unit": "node --test tests/build-lock.test.mjs tests/camera-export-producer.test.mjs tests/compiler.test.mjs tests/graph-export-producer.test.mjs tests/manifests.test.mjs tests/occurrence-export.test.mjs tests/occurrence-release.test.mjs tests/site-release.test.mjs tests/snapshot-hydrator.test.mjs",
     "test:parity": "python3 -m unittest discover -s tests -p 'test_site_build_parity_limits.py'",
     "test:manifests:stage": "kubectl kustomize ../deploy/k8s/overlays/lab-stage | node scripts/verify-rendered-stage.mjs",
     "test:manifests:production": "kubectl kustomize ../deploy/k8s/candidates/lab-astro-production | node scripts/verify-rendered-production-candidate.mjs",

--- a/site-astro/scripts/lib/camera-export-producer.mjs
+++ b/site-astro/scripts/lib/camera-export-producer.mjs
@@ -1,5 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants, link, lstat, mkdir, open, realpath, unlink } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 
 import sharp from "sharp";
@@ -8,6 +7,11 @@ import {
   occurrenceExportPolicySha256,
   validateOccurrenceExportPolicy,
 } from "./occurrence-export-contract.mjs";
+import {
+  canonicalCandidateDirectory,
+  occurrenceCandidateFileOperations,
+  persistOccurrenceCandidate,
+} from "./occurrence-candidate-store.mjs";
 import { decodePng, validatePngFile } from "./png-validation.mjs";
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
@@ -15,13 +19,6 @@ const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const MAX_TIMEOUT_MS = 15_000;
 const DEFAULT_TIMEOUT_MS = 10_000;
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-const CANDIDATE_FILE_OPERATION_NAMES = new Set(["writeFile", "sync", "link", "unlink"]);
-const DEFAULT_CANDIDATE_FILE_OPERATIONS = Object.freeze({
-  writeFile: (handle, bytes) => handle.writeFile(bytes),
-  sync: (handle) => handle.sync(),
-  link: (source, target) => link(source, target),
-  unlink: (target) => unlink(target),
-});
 
 // #483 deliberately approved exactly these two public, read-only requests. Keep
 // this producer closed if a later policy is broadened accidentally.
@@ -55,81 +52,6 @@ function canonicalInstant(value, label) {
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function candidateFileOperations(overrides) {
-  if (overrides === undefined) return DEFAULT_CANDIDATE_FILE_OPERATIONS;
-  if (
-    overrides === null
-    || typeof overrides !== "object"
-    || Array.isArray(overrides)
-    || Object.getPrototypeOf(overrides) !== Object.prototype
-    || Object.keys(overrides).some((name) => !CANDIDATE_FILE_OPERATION_NAMES.has(name))
-    || Object.values(overrides).some((operation) => typeof operation !== "function")
-  ) throw new Error("camera candidate file operations are invalid");
-  return { ...DEFAULT_CANDIDATE_FILE_OPERATIONS, ...overrides };
-}
-
-async function canonicalDirectory(directory, label) {
-  let metadata;
-  let resolved;
-  try {
-    metadata = await lstat(directory);
-    resolved = await realpath(directory);
-  } catch {
-    throw new Error(`${label} is not a canonical real directory`);
-  }
-  if (!metadata.isDirectory() || metadata.isSymbolicLink() || resolved !== directory) {
-    throw new Error(`${label} is not a canonical real directory`);
-  }
-  return directory;
-}
-
-async function ensureCanonicalDirectory(directory, label) {
-  try {
-    await mkdir(directory, { mode: 0o700 });
-  } catch (error) {
-    if (error.code !== "EEXIST") throw error;
-  }
-  return canonicalDirectory(directory, label);
-}
-
-async function unlinkIfPresent(file, fileOperations) {
-  try {
-    await fileOperations.unlink(file);
-  } catch (error) {
-    if (error.code !== "ENOENT") throw error;
-  }
-}
-
-async function writeTemporaryCandidate(temporary, png, fileOperations) {
-  let handle;
-  const failures = [];
-  try {
-    handle = await open(
-      temporary,
-      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
-      0o600,
-    );
-    await fileOperations.writeFile(handle, png);
-    await fileOperations.sync(handle);
-  } catch (error) {
-    failures.push(error);
-  }
-  if (handle) {
-    try {
-      await handle.close();
-    } catch (error) {
-      failures.push(error);
-    }
-  }
-  if (failures.length === 0) return;
-  try {
-    await unlinkIfPresent(temporary, fileOperations);
-  } catch (error) {
-    failures.push(error);
-  }
-  throw new AggregateError(failures, "camera candidate temporary write failed");
 }
 
 function assertApprovedPolicy(policy) {
@@ -398,60 +320,6 @@ function stripPngAncillaryChunks(bytes) {
   return Buffer.concat(chunks);
 }
 
-async function persistCandidate(outputRoot, occurrenceId, png, fileOperations) {
-  const root = await canonicalDirectory(path.resolve(outputRoot), "camera candidate output root");
-  const mediaRoot = await ensureCanonicalDirectory(
-    path.join(root, "current-media"),
-    "camera candidate media directory",
-  );
-  const occurrenceRoot = await ensureCanonicalDirectory(
-    path.join(mediaRoot, occurrenceId),
-    "camera candidate occurrence directory",
-  );
-  const digest = sha256(png);
-  const relativePath = `current-media/${occurrenceId}/${digest}.png`;
-  const target = path.join(occurrenceRoot, `${digest}.png`);
-  const temporary = path.join(occurrenceRoot, `.${digest}.${randomUUID()}.tmp`);
-  await writeTemporaryCandidate(temporary, png, fileOperations);
-  let linkedTarget = false;
-  let temporaryPresent = true;
-  try {
-    await canonicalDirectory(occurrenceRoot, "camera candidate occurrence directory");
-    try {
-      await fileOperations.link(temporary, target);
-      linkedTarget = true;
-    } catch (error) {
-      if (error.code !== "EEXIST") throw error;
-    }
-    await fileOperations.unlink(temporary);
-    temporaryPresent = false;
-    const verified = await validatePngFile(root, relativePath);
-    if (verified.sha256 !== digest || verified.bytes !== png.length) {
-      throw new Error("camera candidate does not match its content address");
-    }
-    return { root, relativePath, verified };
-  } catch (error) {
-    const failures = [error];
-    if (linkedTarget) {
-      try {
-        await unlinkIfPresent(target, fileOperations);
-        linkedTarget = false;
-      } catch (cleanupError) {
-        failures.push(cleanupError);
-      }
-    }
-    if (temporaryPresent) {
-      try {
-        await unlinkIfPresent(temporary, fileOperations);
-        temporaryPresent = false;
-      } catch (cleanupError) {
-        failures.push(cleanupError);
-      }
-    }
-    throw new AggregateError(failures, "camera candidate publication failed");
-  }
-}
-
 async function fetchCameraTransport(options) {
   const response = await fetch(options.url, {
     method: options.method,
@@ -494,8 +362,8 @@ export async function captureCameraOccurrence({
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_TIMEOUT_MS) {
     throw new Error("camera exporter timeout is invalid");
   }
-  const fileOperations = candidateFileOperations(fileOperationOverrides);
-  const canonicalOutputRoot = await canonicalDirectory(
+  const fileOperations = occurrenceCandidateFileOperations(fileOperationOverrides, "camera candidate");
+  const canonicalOutputRoot = await canonicalCandidateDirectory(
     path.resolve(outputRoot),
     "camera candidate output root",
   );
@@ -510,7 +378,15 @@ export async function captureCameraOccurrence({
   if (Date.parse(sanitizedAt) < Date.parse(capturedAt)) {
     throw new Error("camera sanitization time predates capture");
   }
-  const persisted = await persistCandidate(canonicalOutputRoot, request.occurrenceId, png, fileOperations);
+  const persisted = await persistOccurrenceCandidate({
+    outputRoot: canonicalOutputRoot,
+    collection: "current-media",
+    occurrenceId: request.occurrenceId,
+    png,
+    fileOperations,
+    label: "camera candidate",
+    collectionLabel: "media",
+  });
   const candidate = {
     relativePath: persisted.relativePath,
     mediaType: "image/png",

--- a/site-astro/scripts/lib/graph-export-producer.mjs
+++ b/site-astro/scripts/lib/graph-export-producer.mjs
@@ -19,13 +19,23 @@ const MAX_CONCURRENCY = 4;
 const DEFAULT_CONCURRENCY = 4;
 const MAX_TIMEOUT_MS = 15_000;
 const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_SETTLEMENT_GRACE_MS = 250;
+const DEFAULT_SETTLEMENT_GRACE_MS = 50;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const WAIT_TIMEOUT = Symbol("wait-timeout");
 
 class GraphProbeError extends Error {
   constructor(probeStatus, message) {
     super(message);
     this.probeStatus = probeStatus;
+  }
+}
+
+class RendererContractError extends Error {
+  constructor(failure) {
+    super(`graph renderer contract failed: ${failure}`);
+    this.failure = failure;
   }
 }
 
@@ -93,12 +103,95 @@ function assertApprovedPolicy(policy) {
   ) throw new Error("graph export policy is not activated");
 }
 
-async function cancelBody(body) {
+function validateRenderer(renderer) {
+  if (
+    !exactKeys(renderer, ["contract", "schemaVersion", "abortCooperation", "render"])
+    || renderer.contract !== "verdify.lab-graph-renderer"
+    || renderer.schemaVersion !== 1
+    || renderer.abortCooperation !== "settle-within-grace-after-abort"
+    || typeof renderer.render !== "function"
+  ) throw new Error("graph exporter renderer does not use the closed abort-cooperative v1 contract");
+  return renderer;
+}
+
+function outcome(promise) {
+  return promise.then(
+    (value) => ({ state: "fulfilled", value }),
+    (error) => ({ state: "rejected", error }),
+  );
+}
+
+async function waitWithin(outcomePromise, timeoutMs) {
+  if (timeoutMs <= 0) return WAIT_TIMEOUT;
+  let timeout;
   try {
-    if (body?.cancel instanceof Function) await body.cancel();
-    else if (body?.return instanceof Function) await body.return();
-  } catch {
-    // The stable probe classification must not reflect renderer-specific errors.
+    return await Promise.race([
+      outcomePromise,
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve(WAIT_TIMEOUT), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function remainingMilliseconds(deadline) {
+  return Math.max(0, deadline - Date.now());
+}
+
+function emptyCleanup() {
+  return Promise.resolve();
+}
+
+function unsupportedCleanup() {
+  return Promise.reject(new Error("graph renderer body does not expose bounded cleanup"));
+}
+
+function rawBodyCleanup(body) {
+  try {
+    if (Buffer.isBuffer(body) || body instanceof Uint8Array || body === undefined || body === null) {
+      return emptyCleanup;
+    }
+    if (body.cancel instanceof Function) return () => body.cancel();
+    if (body[Symbol.asyncIterator] instanceof Function) {
+      let iterator;
+      return async () => {
+        iterator ??= body[Symbol.asyncIterator]();
+        if (!(iterator?.return instanceof Function)) return unsupportedCleanup();
+        await iterator.return();
+      };
+    }
+    if (body.return instanceof Function) return () => body.return();
+    return unsupportedCleanup;
+  } catch (error) {
+    return () => Promise.reject(error);
+  }
+}
+
+async function requireBoundedCleanup({ cleanup, pendingOutcome = null, graceMs }) {
+  const deadline = Date.now() + graceMs;
+  const cleanupResult = await waitWithin(
+    outcome(Promise.resolve().then(cleanup)),
+    remainingMilliseconds(deadline),
+  );
+  if (cleanupResult === WAIT_TIMEOUT) throw new RendererContractError("body-cleanup-timeout");
+  if (cleanupResult.state !== "fulfilled") throw new RendererContractError("body-cleanup-rejected");
+  if (pendingOutcome !== null) {
+    const pendingResult = await waitWithin(pendingOutcome, remainingMilliseconds(deadline));
+    if (pendingResult === WAIT_TIMEOUT) throw new RendererContractError("body-settlement-timeout");
+  }
+}
+
+async function settleRendererAfterAbort(renderOutcome, graceMs) {
+  const deadline = Date.now() + graceMs;
+  const settled = await waitWithin(renderOutcome, remainingMilliseconds(deadline));
+  if (settled === WAIT_TIMEOUT) throw new RendererContractError("renderer-settlement-timeout");
+  if (settled.state === "fulfilled") {
+    await requireBoundedCleanup({
+      cleanup: rawBodyCleanup(settled.value?.body),
+      graceMs: remainingMilliseconds(deadline),
+    });
   }
 }
 
@@ -119,102 +212,172 @@ function validateRendererResponse(response) {
   ) throw new GraphProbeError("http-error", "graph renderer response content length is invalid");
 }
 
-async function boundedBody(body, maximumBytes) {
+function appendChunk(chunks, chunk, length, maximumBytes) {
+  if (!(Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) || chunk.length === 0) {
+    throw new GraphProbeError("http-error", "graph renderer response body contains an invalid chunk");
+  }
+  const nextLength = length + chunk.length;
+  if (nextLength > maximumBytes) {
+    throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+  }
+  chunks.push(Buffer.from(chunk));
+  return nextLength;
+}
+
+function boundedBodyOperation(body, maximumBytes) {
   if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
-    if (body.length === 0 || body.length > maximumBytes) {
-      throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
-    }
-    return Buffer.from(body);
+    return {
+      read: async () => {
+        if (body.length === 0 || body.length > maximumBytes) {
+          throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+        }
+        return Buffer.from(body);
+      },
+      cleanup: emptyCleanup,
+    };
   }
 
-  let iterable = body;
   if (body?.getReader instanceof Function) {
-    iterable = {
-      async *[Symbol.asyncIterator]() {
-        const reader = body.getReader();
+    let reader;
+    try {
+      reader = body.getReader();
+    } catch {
+      throw new GraphProbeError("http-error", "graph renderer response body is not readable");
+    }
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      reader.releaseLock();
+    };
+    return {
+      read: async () => {
+        const chunks = [];
+        let length = 0;
         try {
           while (true) {
             const { done, value } = await reader.read();
-            if (done) return;
-            yield value;
+            if (done) {
+              if (length === 0) {
+                throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+              }
+              release();
+              return Buffer.concat(chunks, length);
+            }
+            length = appendChunk(chunks, value, length, maximumBytes);
           }
+        } catch (error) {
+          if (error instanceof GraphProbeError) throw error;
+          throw new GraphProbeError("http-error", "graph renderer response body could not be read");
+        }
+      },
+      cleanup: async () => {
+        try {
+          await reader.cancel();
         } finally {
-          reader.releaseLock();
+          release();
         }
       },
     };
   }
-  if (!iterable || !(Symbol.asyncIterator in Object(iterable))) {
+  if (!body || !(body[Symbol.asyncIterator] instanceof Function)) {
     throw new GraphProbeError("http-error", "graph renderer response body is not readable");
   }
-  const chunks = [];
-  let length = 0;
+  let iterator;
   try {
-    for await (const chunk of iterable) {
-      if (!(Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) || chunk.length === 0) {
-        throw new GraphProbeError("http-error", "graph renderer response body contains an invalid chunk");
-      }
-      length += chunk.length;
-      if (length > maximumBytes) {
-        throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
-      }
-      chunks.push(Buffer.from(chunk));
-    }
-  } catch (error) {
-    if (error instanceof GraphProbeError) throw error;
-    throw new GraphProbeError("http-error", "graph renderer response body could not be read");
+    iterator = body[Symbol.asyncIterator]();
+  } catch {
+    throw new GraphProbeError("http-error", "graph renderer response body is not readable");
   }
-  if (length === 0) throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
-  return Buffer.concat(chunks, length);
+  if (!iterator || !(iterator.next instanceof Function)) {
+    throw new GraphProbeError("http-error", "graph renderer response body is not readable");
+  }
+  return {
+    read: async () => {
+      const chunks = [];
+      let length = 0;
+      try {
+        while (true) {
+          const { done, value } = await iterator.next();
+          if (done) {
+            if (length === 0) {
+              throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+            }
+            return Buffer.concat(chunks, length);
+          }
+          length = appendChunk(chunks, value, length, maximumBytes);
+        }
+      } catch (error) {
+        if (error instanceof GraphProbeError) throw error;
+        throw new GraphProbeError("http-error", "graph renderer response body could not be read");
+      }
+    },
+    cleanup: async () => {
+      if (!(iterator.return instanceof Function)) return unsupportedCleanup();
+      await iterator.return();
+    },
+  };
 }
 
-async function timedRendererResponse({ renderer, request, maximumBytes, timeoutMs }) {
+async function timedRendererResponse({ renderer, request, maximumBytes, timeoutMs, settlementGraceMs }) {
   const abortController = new AbortController();
-  let timeout;
-  let timedOut = false;
-  let responseBody;
-  const expired = new Promise((_, reject) => {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      abortController.abort();
-      reject(new GraphProbeError("timeout", "graph renderer exceeded the time limit"));
-    }, timeoutMs);
-  });
+  const deadline = Date.now() + timeoutMs;
+  const renderOutcome = outcome(Promise.resolve().then(() => renderer.render({
+    request,
+    signal: abortController.signal,
+  })));
   try {
-    return await Promise.race([
-      (async () => {
-        let response;
-        try {
-          response = await renderer({ request, signal: abortController.signal });
-        } catch {
-          throw new GraphProbeError("missing", "graph renderer did not return a response");
-        }
-        responseBody = response?.body;
-        try {
-          validateRendererResponse(response);
-          if (response.contentLength !== null && response.contentLength > maximumBytes) {
-            throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
-          }
-          const bytes = await boundedBody(response.body, maximumBytes);
-          if (response.contentLength !== null && response.contentLength !== bytes.length) {
-            throw new GraphProbeError("http-error", "graph renderer response length does not match its bytes");
-          }
-          return bytes;
-        } catch (error) {
-          await cancelBody(response?.body);
-          throw error;
-        }
-      })(),
-      expired,
-    ]);
-  } catch (error) {
-    if (timedOut) {
-      await cancelBody(responseBody);
+    const renderResult = await waitWithin(renderOutcome, remainingMilliseconds(deadline));
+    if (renderResult === WAIT_TIMEOUT) {
+      abortController.abort();
+      await settleRendererAfterAbort(renderOutcome, settlementGraceMs);
       throw new GraphProbeError("timeout", "graph renderer exceeded the time limit");
     }
-    throw error;
+    if (renderResult.state !== "fulfilled") {
+      throw new GraphProbeError("missing", "graph renderer did not return a response");
+    }
+    const response = renderResult.value;
+    try {
+      validateRendererResponse(response);
+      if (response.contentLength !== null && response.contentLength > maximumBytes) {
+        throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+      }
+    } catch (error) {
+      abortController.abort();
+      await requireBoundedCleanup({ cleanup: rawBodyCleanup(response?.body), graceMs: settlementGraceMs });
+      throw error;
+    }
+
+    let bodyOperation;
+    try {
+      bodyOperation = boundedBodyOperation(response.body, maximumBytes);
+    } catch (error) {
+      abortController.abort();
+      await requireBoundedCleanup({ cleanup: rawBodyCleanup(response.body), graceMs: settlementGraceMs });
+      throw error;
+    }
+    const bodyOutcome = outcome(Promise.resolve().then(bodyOperation.read));
+    const bodyResult = await waitWithin(bodyOutcome, remainingMilliseconds(deadline));
+    if (bodyResult === WAIT_TIMEOUT) {
+      abortController.abort();
+      await requireBoundedCleanup({
+        cleanup: bodyOperation.cleanup,
+        pendingOutcome: bodyOutcome,
+        graceMs: settlementGraceMs,
+      });
+      throw new GraphProbeError("timeout", "graph renderer exceeded the time limit");
+    }
+    if (bodyResult.state !== "fulfilled") {
+      abortController.abort();
+      await requireBoundedCleanup({ cleanup: bodyOperation.cleanup, graceMs: settlementGraceMs });
+      throw bodyResult.error;
+    }
+    const bytes = bodyResult.value;
+    if (response.contentLength !== null && response.contentLength !== bytes.length) {
+      throw new GraphProbeError("http-error", "graph renderer response length does not match its bytes");
+    }
+    return bytes;
   } finally {
-    clearTimeout(timeout);
     if (!abortController.signal.aborted) abortController.abort();
   }
 }
@@ -309,13 +472,23 @@ async function normalizeGraphPng(bytes, bounds) {
   return png;
 }
 
-async function renderOne({ request, policy, outputRoot, renderer, now, timeoutMs, fileOperations }) {
+async function renderOne({
+  request,
+  policy,
+  outputRoot,
+  renderer,
+  now,
+  timeoutMs,
+  settlementGraceMs,
+  fileOperations,
+}) {
   try {
     const source = await timedRendererResponse({
       renderer,
       request,
       maximumBytes: policy.imagePolicy.graphs.maxBytes,
       timeoutMs,
+      settlementGraceMs,
     });
     const capturedAt = canonicalInstant(now(), "graph capture time");
     if (Date.parse(capturedAt) < Date.parse(policy.activation.approvedAt)) {
@@ -341,6 +514,7 @@ async function renderOne({ request, policy, outputRoot, renderer, now, timeoutMs
       },
     };
   } catch (error) {
+    if (error instanceof RendererContractError) throw error;
     return {
       occurrenceId: request.occurrenceId,
       probeStatus: error instanceof GraphProbeError ? error.probeStatus : "missing",
@@ -357,12 +531,14 @@ export async function produceGraphExportCandidates({
   renderer,
   now = () => new Date().toISOString(),
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  settlementGraceMs = DEFAULT_SETTLEMENT_GRACE_MS,
   concurrency = DEFAULT_CONCURRENCY,
   fileOperations: fileOperationOverrides,
 }) {
   const plan = planGraphExportRequests({ policy, manifest, manifestSha256 });
   assertApprovedPolicy(policy);
-  if (typeof renderer !== "function" || typeof now !== "function") throw new Error("graph exporter dependency is invalid");
+  const validatedRenderer = validateRenderer(renderer);
+  if (typeof now !== "function") throw new Error("graph exporter dependency is invalid");
   if (
     typeof outputRoot !== "string"
     || outputRoot.length === 0
@@ -372,6 +548,11 @@ export async function produceGraphExportCandidates({
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_TIMEOUT_MS) {
     throw new Error("graph exporter timeout is invalid");
   }
+  if (
+    !Number.isSafeInteger(settlementGraceMs)
+    || settlementGraceMs < 1
+    || settlementGraceMs > MAX_SETTLEMENT_GRACE_MS
+  ) throw new Error("graph exporter settlement grace is invalid");
   if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > MAX_CONCURRENCY) {
     throw new Error("graph exporter concurrency is invalid");
   }
@@ -381,30 +562,50 @@ export async function produceGraphExportCandidates({
     "graph candidate output root",
   );
   const results = new Array(plan.requests.length);
+  const rendererContractFailures = new Array(plan.requests.length);
   let nextIndex = 0;
+  let stopScheduling = false;
   async function worker() {
-    while (nextIndex < plan.requests.length) {
+    while (!stopScheduling && nextIndex < plan.requests.length) {
       const index = nextIndex;
       nextIndex += 1;
-      results[index] = await renderOne({
-        request: plan.requests[index],
-        policy,
-        outputRoot: canonicalOutputRoot,
-        renderer,
-        now,
-        timeoutMs,
-        fileOperations,
-      });
+      try {
+        results[index] = await renderOne({
+          request: plan.requests[index],
+          policy,
+          outputRoot: canonicalOutputRoot,
+          renderer: validatedRenderer,
+          now,
+          timeoutMs,
+          settlementGraceMs,
+          fileOperations,
+        });
+      } catch (error) {
+        if (!(error instanceof RendererContractError)) throw error;
+        rendererContractFailures[index] = error.failure;
+        stopScheduling = true;
+      }
     }
   }
   await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  const rendererContractFailure = rendererContractFailures.find((failure) => failure !== undefined) ?? null;
+  const contractFailed = rendererContractFailure !== null;
+  const graphResults = contractFailed
+    ? plan.requests.map(({ occurrenceId }) => ({ occurrenceId, probeStatus: "missing", candidate: null }))
+    : results;
   return {
     contract: "verdify.lab-graph-export-result",
-    schemaVersion: 1,
+    schemaVersion: 2,
     policyVersion: plan.policyVersion,
     policySha256: plan.policySha256,
     sourceOccurrenceManifestSha256: plan.sourceOccurrenceManifestSha256,
-    graphs: results,
+    rendererContract: {
+      contract: "verdify.lab-graph-renderer-runtime-status",
+      schemaVersion: 1,
+      status: contractFailed ? "failed" : "satisfied",
+      failure: rendererContractFailure,
+    },
+    graphs: graphResults,
   };
 }
 
@@ -414,5 +615,12 @@ export const graphExportProducerContract = Object.freeze({
   maxConcurrency: MAX_CONCURRENCY,
   defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
   maxTimeoutMs: MAX_TIMEOUT_MS,
+  defaultSettlementGraceMs: DEFAULT_SETTLEMENT_GRACE_MS,
+  maxSettlementGraceMs: MAX_SETTLEMENT_GRACE_MS,
+  renderer: Object.freeze({
+    contract: "verdify.lab-graph-renderer",
+    schemaVersion: 1,
+    abortCooperation: "settle-within-grace-after-abort",
+  }),
   probeStatuses: Object.freeze(["success", "timeout", "http-error", "decode-error", "missing"]),
 });

--- a/site-astro/scripts/lib/graph-export-producer.mjs
+++ b/site-astro/scripts/lib/graph-export-producer.mjs
@@ -1,0 +1,418 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import sharp from "sharp";
+
+import {
+  occurrenceExportPolicySha256,
+  validatePolicyManifestBinding,
+} from "./occurrence-export-contract.mjs";
+import {
+  canonicalCandidateDirectory,
+  occurrenceCandidateFileOperations,
+  persistOccurrenceCandidate,
+} from "./occurrence-candidate-store.mjs";
+import { decodePng } from "./png-validation.mjs";
+
+const EXPECTED_GRAPH_COUNT = 143;
+const MAX_CONCURRENCY = 4;
+const DEFAULT_CONCURRENCY = 4;
+const MAX_TIMEOUT_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+class GraphProbeError extends Error {
+  constructor(probeStatus, message) {
+    super(message);
+    this.probeStatus = probeStatus;
+  }
+}
+
+function exactKeys(value, keys) {
+  return value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype
+    && Object.keys(value).join(",") === keys.join(",");
+}
+
+function canonicalInstant(value, label) {
+  if (typeof value !== "string" || !ISO_INSTANT_RE.test(value)) throw new Error(`${label} is invalid`);
+  const milliseconds = Date.parse(value);
+  const normalized = Number.isFinite(milliseconds) ? new Date(milliseconds).toISOString() : "";
+  const expected = value.includes(".") ? normalized : normalized.replace(".000Z", "Z");
+  if (value !== expected) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function cloneQuery(value) {
+  return Object.fromEntries(Object.entries(value).map(([key, values]) => [key, [...values]]));
+}
+
+export function planGraphExportRequests({ policy, manifest, manifestSha256 }) {
+  const discovered = validatePolicyManifestBinding(policy, manifest, manifestSha256);
+  const canonicalManifestSha256 = createHash("sha256")
+    .update(Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`))
+    .digest("hex");
+  if (canonicalManifestSha256 !== manifestSha256) {
+    throw new Error("graph export manifest object does not match its canonical byte digest");
+  }
+  if (discovered.graphs.length !== EXPECTED_GRAPH_COUNT || policy.graphs.length !== EXPECTED_GRAPH_COUNT) {
+    throw new Error(`graph export plan must contain exactly ${EXPECTED_GRAPH_COUNT} requests`);
+  }
+  const approvedById = new Map(policy.graphs.map((record) => [record.occurrenceId, record.occurrenceSha256]));
+  const requests = discovered.graphs.map((occurrence) => ({
+    contract: "verdify.lab-graph-render-request",
+    schemaVersion: 1,
+    occurrenceId: occurrence.occurrenceId,
+    occurrenceSha256: approvedById.get(occurrence.occurrenceId),
+    target: {
+      uid: occurrence.uid,
+      panelId: occurrence.panelId,
+      query: cloneQuery(occurrence.query),
+      variables: cloneQuery(occurrence.variables),
+      timeRange: { ...occurrence.timeRange },
+    },
+  }));
+  return {
+    contract: "verdify.lab-graph-export-plan",
+    schemaVersion: 1,
+    policyVersion: policy.policyVersion,
+    policySha256: occurrenceExportPolicySha256(policy),
+    sourceOccurrenceManifestSha256: manifestSha256,
+    requests,
+  };
+}
+
+function assertApprovedPolicy(policy) {
+  if (
+    policy.activation.state !== "approved"
+    || policy.activation.approvedBy !== "jason"
+    || !policy.activation.approvedAt
+  ) throw new Error("graph export policy is not activated");
+}
+
+async function cancelBody(body) {
+  try {
+    if (body?.cancel instanceof Function) await body.cancel();
+    else if (body?.return instanceof Function) await body.return();
+  } catch {
+    // The stable probe classification must not reflect renderer-specific errors.
+  }
+}
+
+function validateRendererResponse(response) {
+  if (!exactKeys(response, ["status", "contentType", "contentLength", "body"])) {
+    throw new GraphProbeError("http-error", "graph renderer response does not use the closed v1 shape");
+  }
+  if (!Number.isSafeInteger(response.status) || response.status !== 200) {
+    throw new GraphProbeError("http-error", "graph renderer did not return HTTP 200");
+  }
+  if (
+    typeof response.contentType !== "string"
+    || response.contentType.toLowerCase().split(";", 1)[0].trim() !== "image/png"
+  ) throw new GraphProbeError("http-error", "graph renderer response MIME type is not image/png");
+  if (
+    response.contentLength !== null
+    && (!Number.isSafeInteger(response.contentLength) || response.contentLength < 0)
+  ) throw new GraphProbeError("http-error", "graph renderer response content length is invalid");
+}
+
+async function boundedBody(body, maximumBytes) {
+  if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
+    if (body.length === 0 || body.length > maximumBytes) {
+      throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+    }
+    return Buffer.from(body);
+  }
+
+  let iterable = body;
+  if (body?.getReader instanceof Function) {
+    iterable = {
+      async *[Symbol.asyncIterator]() {
+        const reader = body.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) return;
+            yield value;
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      },
+    };
+  }
+  if (!iterable || !(Symbol.asyncIterator in Object(iterable))) {
+    throw new GraphProbeError("http-error", "graph renderer response body is not readable");
+  }
+  const chunks = [];
+  let length = 0;
+  try {
+    for await (const chunk of iterable) {
+      if (!(Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) || chunk.length === 0) {
+        throw new GraphProbeError("http-error", "graph renderer response body contains an invalid chunk");
+      }
+      length += chunk.length;
+      if (length > maximumBytes) {
+        throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+  } catch (error) {
+    if (error instanceof GraphProbeError) throw error;
+    throw new GraphProbeError("http-error", "graph renderer response body could not be read");
+  }
+  if (length === 0) throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+  return Buffer.concat(chunks, length);
+}
+
+async function timedRendererResponse({ renderer, request, maximumBytes, timeoutMs }) {
+  const abortController = new AbortController();
+  let timeout;
+  let timedOut = false;
+  let responseBody;
+  const expired = new Promise((_, reject) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      abortController.abort();
+      reject(new GraphProbeError("timeout", "graph renderer exceeded the time limit"));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      (async () => {
+        let response;
+        try {
+          response = await renderer({ request, signal: abortController.signal });
+        } catch {
+          throw new GraphProbeError("missing", "graph renderer did not return a response");
+        }
+        responseBody = response?.body;
+        try {
+          validateRendererResponse(response);
+          if (response.contentLength !== null && response.contentLength > maximumBytes) {
+            throw new GraphProbeError("http-error", "graph renderer response is outside the byte limit");
+          }
+          const bytes = await boundedBody(response.body, maximumBytes);
+          if (response.contentLength !== null && response.contentLength !== bytes.length) {
+            throw new GraphProbeError("http-error", "graph renderer response length does not match its bytes");
+          }
+          return bytes;
+        } catch (error) {
+          await cancelBody(response?.body);
+          throw error;
+        }
+      })(),
+      expired,
+    ]);
+  } catch (error) {
+    if (timedOut) {
+      await cancelBody(responseBody);
+      throw new GraphProbeError("timeout", "graph renderer exceeded the time limit");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    if (!abortController.signal.aborted) abortController.abort();
+  }
+}
+
+function stripPngAncillaryChunks(bytes) {
+  if (!Buffer.isBuffer(bytes) || !bytes.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new GraphProbeError("decode-error", "normalized graph PNG has invalid framing");
+  }
+  const chunks = [PNG_SIGNATURE];
+  let offset = PNG_SIGNATURE.length;
+  let ended = false;
+  while (offset < bytes.length) {
+    if (offset + 12 > bytes.length) throw new GraphProbeError("decode-error", "normalized graph PNG has invalid framing");
+    const length = bytes.readUInt32BE(offset);
+    const end = offset + 12 + length;
+    if (end > bytes.length) throw new GraphProbeError("decode-error", "normalized graph PNG has invalid framing");
+    const type = bytes.subarray(offset + 4, offset + 8).toString("ascii");
+    if (!/^[A-Za-z]{4}$/.test(type)) throw new GraphProbeError("decode-error", "normalized graph PNG has invalid framing");
+    if (["IHDR", "IDAT", "IEND"].includes(type)) chunks.push(bytes.subarray(offset, end));
+    else if (type[0] === type[0].toUpperCase()) {
+      throw new GraphProbeError("decode-error", "normalized graph PNG contains an unexpected critical chunk");
+    }
+    offset = end;
+    if (type === "IEND") {
+      ended = true;
+      break;
+    }
+  }
+  if (!ended || offset !== bytes.length) throw new GraphProbeError("decode-error", "normalized graph PNG has invalid framing");
+  return Buffer.concat(chunks);
+}
+
+async function normalizeGraphPng(bytes, bounds) {
+  const inputPixels = bounds.maxWidth * bounds.maxHeight;
+  let metadata;
+  try {
+    metadata = await sharp(bytes, {
+      failOn: "error",
+      limitInputPixels: inputPixels,
+      sequentialRead: true,
+    }).metadata();
+  } catch {
+    throw new GraphProbeError("decode-error", "graph image could not be decoded within bounds");
+  }
+  if (
+    metadata.format !== "png"
+    || !Number.isSafeInteger(metadata.width)
+    || !Number.isSafeInteger(metadata.height)
+    || metadata.width < bounds.minWidth
+    || metadata.width > bounds.maxWidth
+    || metadata.height < bounds.minHeight
+    || metadata.height > bounds.maxHeight
+  ) throw new GraphProbeError("decode-error", "graph image dimensions are outside the approved bounds");
+
+  let encoded;
+  try {
+    encoded = await sharp(bytes, {
+      failOn: "error",
+      limitInputPixels: inputPixels,
+      sequentialRead: true,
+    })
+      .rotate()
+      .removeAlpha()
+      .toColourspace("srgb")
+      .png({
+        adaptiveFiltering: false,
+        compressionLevel: 9,
+        effort: 10,
+        palette: false,
+      })
+      .toBuffer();
+  } catch {
+    throw new GraphProbeError("decode-error", "graph image could not be normalized within bounds");
+  }
+  const png = stripPngAncillaryChunks(encoded);
+  if (png.length === 0 || png.length > bounds.maxBytes) {
+    throw new GraphProbeError("decode-error", "normalized graph PNG is outside the byte limit");
+  }
+  let decoded;
+  try {
+    decoded = decodePng(png);
+  } catch {
+    throw new GraphProbeError("decode-error", "normalized graph PNG failed the release contract");
+  }
+  if (
+    decoded.colorType !== 2
+    || decoded.width < bounds.minWidth
+    || decoded.width > bounds.maxWidth
+    || decoded.height < bounds.minHeight
+    || decoded.height > bounds.maxHeight
+  ) throw new GraphProbeError("decode-error", "normalized graph PNG is outside the approved bounds");
+  return png;
+}
+
+async function renderOne({ request, policy, outputRoot, renderer, now, timeoutMs, fileOperations }) {
+  try {
+    const source = await timedRendererResponse({
+      renderer,
+      request,
+      maximumBytes: policy.imagePolicy.graphs.maxBytes,
+      timeoutMs,
+    });
+    const capturedAt = canonicalInstant(now(), "graph capture time");
+    if (Date.parse(capturedAt) < Date.parse(policy.activation.approvedAt)) {
+      throw new GraphProbeError("missing", "graph capture time predates policy activation");
+    }
+    const png = await normalizeGraphPng(source, policy.imagePolicy.graphs);
+    const persisted = await persistOccurrenceCandidate({
+      outputRoot,
+      collection: "graphs",
+      occurrenceId: request.occurrenceId,
+      png,
+      fileOperations,
+      label: "graph candidate",
+      collectionLabel: "graph",
+    });
+    return {
+      occurrenceId: request.occurrenceId,
+      probeStatus: "success",
+      candidate: {
+        relativePath: persisted.relativePath,
+        mediaType: "image/png",
+        capturedAt,
+      },
+    };
+  } catch (error) {
+    return {
+      occurrenceId: request.occurrenceId,
+      probeStatus: error instanceof GraphProbeError ? error.probeStatus : "missing",
+      candidate: null,
+    };
+  }
+}
+
+export async function produceGraphExportCandidates({
+  policy,
+  manifest,
+  manifestSha256,
+  outputRoot,
+  renderer,
+  now = () => new Date().toISOString(),
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  concurrency = DEFAULT_CONCURRENCY,
+  fileOperations: fileOperationOverrides,
+}) {
+  const plan = planGraphExportRequests({ policy, manifest, manifestSha256 });
+  assertApprovedPolicy(policy);
+  if (typeof renderer !== "function" || typeof now !== "function") throw new Error("graph exporter dependency is invalid");
+  if (
+    typeof outputRoot !== "string"
+    || outputRoot.length === 0
+    || outputRoot.length > 4096
+    || /[\u0000-\u001f\u007f]/u.test(outputRoot)
+  ) throw new Error("graph exporter output root is invalid");
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_TIMEOUT_MS) {
+    throw new Error("graph exporter timeout is invalid");
+  }
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > MAX_CONCURRENCY) {
+    throw new Error("graph exporter concurrency is invalid");
+  }
+  const fileOperations = occurrenceCandidateFileOperations(fileOperationOverrides, "graph candidate");
+  const canonicalOutputRoot = await canonicalCandidateDirectory(
+    path.resolve(outputRoot),
+    "graph candidate output root",
+  );
+  const results = new Array(plan.requests.length);
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < plan.requests.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await renderOne({
+        request: plan.requests[index],
+        policy,
+        outputRoot: canonicalOutputRoot,
+        renderer,
+        now,
+        timeoutMs,
+        fileOperations,
+      });
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return {
+    contract: "verdify.lab-graph-export-result",
+    schemaVersion: 1,
+    policyVersion: plan.policyVersion,
+    policySha256: plan.policySha256,
+    sourceOccurrenceManifestSha256: plan.sourceOccurrenceManifestSha256,
+    graphs: results,
+  };
+}
+
+export const graphExportProducerContract = Object.freeze({
+  expectedGraphCount: EXPECTED_GRAPH_COUNT,
+  defaultConcurrency: DEFAULT_CONCURRENCY,
+  maxConcurrency: MAX_CONCURRENCY,
+  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+  maxTimeoutMs: MAX_TIMEOUT_MS,
+  probeStatuses: Object.freeze(["success", "timeout", "http-error", "decode-error", "missing"]),
+});

--- a/site-astro/scripts/lib/graph-export-producer.mjs
+++ b/site-astro/scripts/lib/graph-export-producer.mjs
@@ -5,6 +5,7 @@ import sharp from "sharp";
 
 import {
   occurrenceExportPolicySha256,
+  reportingFeedEnvelopeSha256,
   validatePolicyManifestBinding,
 } from "./occurrence-export-contract.mjs";
 import {
@@ -21,6 +22,7 @@ const MAX_TIMEOUT_MS = 15_000;
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_SETTLEMENT_GRACE_MS = 250;
 const DEFAULT_SETTLEMENT_GRACE_MS = 50;
+const SHA256_RE = /^[0-9a-f]{64}$/;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
 const WAIT_TIMEOUT = Symbol("wait-timeout");
@@ -60,8 +62,14 @@ function cloneQuery(value) {
   return Object.fromEntries(Object.entries(value).map(([key, values]) => [key, [...values]]));
 }
 
-export function planGraphExportRequests({ policy, manifest, manifestSha256 }) {
+export function planGraphExportRequests({
+  policy,
+  manifest,
+  manifestSha256,
+  reportingFeedSha256,
+}) {
   const discovered = validatePolicyManifestBinding(policy, manifest, manifestSha256);
+  if (!SHA256_RE.test(reportingFeedSha256)) throw new Error("graph export reporting feed digest is invalid");
   const canonicalManifestSha256 = createHash("sha256")
     .update(Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`))
     .digest("hex");
@@ -74,9 +82,10 @@ export function planGraphExportRequests({ policy, manifest, manifestSha256 }) {
   const approvedById = new Map(policy.graphs.map((record) => [record.occurrenceId, record.occurrenceSha256]));
   const requests = discovered.graphs.map((occurrence) => ({
     contract: "verdify.lab-graph-render-request",
-    schemaVersion: 1,
+    schemaVersion: 2,
     occurrenceId: occurrence.occurrenceId,
     occurrenceSha256: approvedById.get(occurrence.occurrenceId),
+    reportingFeedSha256,
     target: {
       uid: occurrence.uid,
       panelId: occurrence.panelId,
@@ -87,10 +96,11 @@ export function planGraphExportRequests({ policy, manifest, manifestSha256 }) {
   }));
   return {
     contract: "verdify.lab-graph-export-plan",
-    schemaVersion: 1,
+    schemaVersion: 2,
     policyVersion: policy.policyVersion,
     policySha256: occurrenceExportPolicySha256(policy),
     sourceOccurrenceManifestSha256: manifestSha256,
+    reportingFeedSha256,
     requests,
   };
 }
@@ -103,14 +113,15 @@ function assertApprovedPolicy(policy) {
   ) throw new Error("graph export policy is not activated");
 }
 
-function validateRenderer(renderer) {
+function validateRenderer(renderer, reportingFeedSha256) {
   if (
-    !exactKeys(renderer, ["contract", "schemaVersion", "abortCooperation", "render"])
+    !exactKeys(renderer, ["contract", "schemaVersion", "reportingFeedSha256", "abortCooperation", "render"])
     || renderer.contract !== "verdify.lab-graph-renderer"
-    || renderer.schemaVersion !== 1
+    || renderer.schemaVersion !== 2
+    || renderer.reportingFeedSha256 !== reportingFeedSha256
     || renderer.abortCooperation !== "settle-within-grace-after-abort"
     || typeof renderer.render !== "function"
-  ) throw new Error("graph exporter renderer does not use the closed abort-cooperative v1 contract");
+  ) throw new Error("graph exporter renderer does not use the feed-bound abort-cooperative v2 contract");
   return renderer;
 }
 
@@ -527,6 +538,7 @@ export async function produceGraphExportCandidates({
   policy,
   manifest,
   manifestSha256,
+  reportingFeed,
   outputRoot,
   renderer,
   now = () => new Date().toISOString(),
@@ -535,9 +547,15 @@ export async function produceGraphExportCandidates({
   concurrency = DEFAULT_CONCURRENCY,
   fileOperations: fileOperationOverrides,
 }) {
-  const plan = planGraphExportRequests({ policy, manifest, manifestSha256 });
+  const reportingFeedSha256 = reportingFeedEnvelopeSha256(reportingFeed);
+  const plan = planGraphExportRequests({
+    policy,
+    manifest,
+    manifestSha256,
+    reportingFeedSha256,
+  });
   assertApprovedPolicy(policy);
-  const validatedRenderer = validateRenderer(renderer);
+  const validatedRenderer = validateRenderer(renderer, reportingFeedSha256);
   if (typeof now !== "function") throw new Error("graph exporter dependency is invalid");
   if (
     typeof outputRoot !== "string"
@@ -595,10 +613,11 @@ export async function produceGraphExportCandidates({
     : results;
   return {
     contract: "verdify.lab-graph-export-result",
-    schemaVersion: 2,
+    schemaVersion: 3,
     policyVersion: plan.policyVersion,
     policySha256: plan.policySha256,
     sourceOccurrenceManifestSha256: plan.sourceOccurrenceManifestSha256,
+    reportingFeedSha256,
     rendererContract: {
       contract: "verdify.lab-graph-renderer-runtime-status",
       schemaVersion: 1,
@@ -619,7 +638,8 @@ export const graphExportProducerContract = Object.freeze({
   maxSettlementGraceMs: MAX_SETTLEMENT_GRACE_MS,
   renderer: Object.freeze({
     contract: "verdify.lab-graph-renderer",
-    schemaVersion: 1,
+    schemaVersion: 2,
+    reportingFeedSha256: "required-exact-plan-digest",
     abortCooperation: "settle-within-grace-after-abort",
   }),
   probeStatuses: Object.freeze(["success", "timeout", "http-error", "decode-error", "missing"]),

--- a/site-astro/scripts/lib/occurrence-candidate-store.mjs
+++ b/site-astro/scripts/lib/occurrence-candidate-store.mjs
@@ -1,0 +1,177 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, link, lstat, mkdir, open, realpath, unlink } from "node:fs/promises";
+import path from "node:path";
+
+import { validatePngFile } from "./png-validation.mjs";
+
+const OCCURRENCE_ID_BY_COLLECTION = new Map([
+  ["graphs", /^graph_[0-9a-f]{24}$/],
+  ["current-media", /^media_[0-9a-f]{24}$/],
+]);
+const FILE_OPERATION_NAMES = new Set(["writeFile", "sync", "link", "unlink"]);
+const DEFAULT_FILE_OPERATIONS = Object.freeze({
+  writeFile: (handle, bytes) => handle.writeFile(bytes),
+  sync: (handle) => handle.sync(),
+  link: (source, target) => link(source, target),
+  unlink: (target) => unlink(target),
+});
+
+function safeLabel(value) {
+  if (typeof value !== "string" || !/^[a-z][a-z -]{0,63}$/.test(value)) {
+    throw new Error("occurrence candidate label is invalid");
+  }
+  return value;
+}
+
+export function occurrenceCandidateFileOperations(overrides, label = "occurrence candidate") {
+  safeLabel(label);
+  if (overrides === undefined) return DEFAULT_FILE_OPERATIONS;
+  if (
+    overrides === null
+    || typeof overrides !== "object"
+    || Array.isArray(overrides)
+    || Object.getPrototypeOf(overrides) !== Object.prototype
+    || Object.keys(overrides).some((name) => !FILE_OPERATION_NAMES.has(name))
+    || Object.values(overrides).some((operation) => typeof operation !== "function")
+  ) throw new Error(`${label} file operations are invalid`);
+  return { ...DEFAULT_FILE_OPERATIONS, ...overrides };
+}
+
+export async function canonicalCandidateDirectory(directory, label) {
+  safeLabel(label);
+  let metadata;
+  let resolved;
+  try {
+    metadata = await lstat(directory);
+    resolved = await realpath(directory);
+  } catch {
+    throw new Error(`${label} is not a canonical real directory`);
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink() || resolved !== directory) {
+    throw new Error(`${label} is not a canonical real directory`);
+  }
+  return directory;
+}
+
+async function ensureCanonicalDirectory(directory, label) {
+  try {
+    await mkdir(directory, { mode: 0o700 });
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+  }
+  return canonicalCandidateDirectory(directory, label);
+}
+
+async function unlinkIfPresent(file, fileOperations) {
+  try {
+    await fileOperations.unlink(file);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+async function writeTemporaryCandidate(temporary, png, fileOperations, label) {
+  let handle;
+  const failures = [];
+  try {
+    handle = await open(
+      temporary,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
+    await fileOperations.writeFile(handle, png);
+    await fileOperations.sync(handle);
+  } catch (error) {
+    failures.push(error);
+  }
+  if (handle) {
+    try {
+      await handle.close();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length === 0) return;
+  try {
+    await unlinkIfPresent(temporary, fileOperations);
+  } catch (error) {
+    failures.push(error);
+  }
+  throw new AggregateError(failures, `${label} temporary write failed`);
+}
+
+export async function persistOccurrenceCandidate({
+  outputRoot,
+  collection,
+  occurrenceId,
+  png,
+  fileOperations: fileOperationOverrides,
+  label = "occurrence candidate",
+  collectionLabel = collection,
+}) {
+  safeLabel(label);
+  safeLabel(collectionLabel);
+  if (
+    typeof outputRoot !== "string"
+    || outputRoot.length === 0
+    || outputRoot.length > 4096
+    || /[\u0000-\u001f\u007f]/u.test(outputRoot)
+  ) throw new Error(`${label} output root is invalid`);
+  const occurrencePattern = OCCURRENCE_ID_BY_COLLECTION.get(collection);
+  if (!occurrencePattern || !occurrencePattern.test(occurrenceId)) {
+    throw new Error(`${label} occurrence identity is invalid`);
+  }
+  if (!Buffer.isBuffer(png) || png.length === 0) throw new Error(`${label} PNG bytes are invalid`);
+  const fileOperations = occurrenceCandidateFileOperations(fileOperationOverrides, label);
+  const root = await canonicalCandidateDirectory(path.resolve(outputRoot), `${label} output root`);
+  const collectionRoot = await ensureCanonicalDirectory(
+    path.join(root, collection),
+    `${label} ${collectionLabel} directory`,
+  );
+  const occurrenceRoot = await ensureCanonicalDirectory(
+    path.join(collectionRoot, occurrenceId),
+    `${label} occurrence directory`,
+  );
+  const digest = createHash("sha256").update(png).digest("hex");
+  const relativePath = `${collection}/${occurrenceId}/${digest}.png`;
+  const target = path.join(occurrenceRoot, `${digest}.png`);
+  const temporary = path.join(occurrenceRoot, `.${digest}.${randomUUID()}.tmp`);
+  await writeTemporaryCandidate(temporary, png, fileOperations, label);
+  let linkedTarget = false;
+  let temporaryPresent = true;
+  try {
+    await canonicalCandidateDirectory(occurrenceRoot, `${label} occurrence directory`);
+    try {
+      await fileOperations.link(temporary, target);
+      linkedTarget = true;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+    }
+    await fileOperations.unlink(temporary);
+    temporaryPresent = false;
+    const verified = await validatePngFile(root, relativePath);
+    if (verified.sha256 !== digest || verified.bytes !== png.length) {
+      throw new Error(`${label} does not match its content address`);
+    }
+    return { root, relativePath, verified };
+  } catch (error) {
+    const failures = [error];
+    if (linkedTarget) {
+      try {
+        await unlinkIfPresent(target, fileOperations);
+        linkedTarget = false;
+      } catch (cleanupError) {
+        failures.push(cleanupError);
+      }
+    }
+    if (temporaryPresent) {
+      try {
+        await unlinkIfPresent(temporary, fileOperations);
+        temporaryPresent = false;
+      } catch (cleanupError) {
+        failures.push(cleanupError);
+      }
+    }
+    throw new AggregateError(failures, `${label} publication failed`);
+  }
+}

--- a/site-astro/scripts/lib/occurrence-export-contract.mjs
+++ b/site-astro/scripts/lib/occurrence-export-contract.mjs
@@ -603,6 +603,11 @@ function validateBatchFeed(feed) {
   instant(feed.sourceWatermarkAt, "reporting feed source watermark time");
 }
 
+export function reportingFeedEnvelopeSha256(feed) {
+  validateBatchFeed(feed);
+  return sha256(canonicalBytes(feed));
+}
+
 function validateCandidate(candidate, label, requestProvenanceSha256 = null) {
   const keys = label === "current-media"
     ? ["relativePath", "mediaType", "capturedAt", "requestProvenanceSha256"]

--- a/site-astro/scripts/verify-real-build.mjs
+++ b/site-astro/scripts/verify-real-build.mjs
@@ -1,11 +1,26 @@
+import { createHash } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { planGraphExportRequests } from "./lib/graph-export-producer.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DIST = path.join(ROOT, "dist");
 const build = JSON.parse(await readFile(path.join(DIST, "static-build.json"), "utf8"));
 const routes = JSON.parse(await readFile(path.join(DIST, "route-manifest.json"), "utf8"));
+const occurrenceManifestBytes = await readFile(path.join(DIST, "occurrence-manifest.json"));
+const occurrenceManifest = JSON.parse(occurrenceManifestBytes.toString("utf8"));
+const occurrencePolicy = JSON.parse(await readFile(
+  path.join(ROOT, "config/lab-stage-occurrence-export-policy.json"),
+  "utf8",
+));
+const occurrenceManifestSha256 = createHash("sha256").update(occurrenceManifestBytes).digest("hex");
+const graphPlan = planGraphExportRequests({
+  policy: occurrencePolicy,
+  manifest: occurrenceManifest,
+  manifestSha256: occurrenceManifestSha256,
+});
 
 if (
   build.contract !== "verdify.lab-astro-stage-build"
@@ -26,6 +41,15 @@ if (
 ) {
   throw new Error("dist is not the reviewed 429-file sanitized Lab stage build");
 }
+if (
+  occurrenceManifestSha256 !== occurrencePolicy.sourceOccurrenceManifestSha256
+  || graphPlan.requests.length !== 143
+  || JSON.stringify(graphPlan.requests.map(({ occurrenceId }) => occurrenceId))
+    !== JSON.stringify(occurrenceManifest.graphs.map(({ occurrenceId }) => occurrenceId))
+  || /https?:|graphs\.verdify\.ai/i.test(JSON.stringify(graphPlan))
+) {
+  throw new Error("real occurrence manifest is not byte-bound to the exact 143-request graph plan");
+}
 
 let htmlFiles = 0;
 const pending = [DIST];
@@ -38,4 +62,4 @@ while (pending.length > 0) {
   }
 }
 if (htmlFiles !== 324) throw new Error("real Lab stage HTML route count changed");
-process.stdout.write(`verified real sanitized Lab build: routes=${routes.routes.length} html=${htmlFiles} media=${build.preservedMediaCount}\n`);
+process.stdout.write(`verified real sanitized Lab build: routes=${routes.routes.length} html=${htmlFiles} media=${build.preservedMediaCount} graphPlan=${graphPlan.requests.length}\n`);

--- a/site-astro/scripts/verify-real-build.mjs
+++ b/site-astro/scripts/verify-real-build.mjs
@@ -3,6 +3,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { reportingFeedEnvelopeSha256 } from "./lib/occurrence-export-contract.mjs";
 import { planGraphExportRequests } from "./lib/graph-export-producer.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -16,10 +17,24 @@ const occurrencePolicy = JSON.parse(await readFile(
   "utf8",
 ));
 const occurrenceManifestSha256 = createHash("sha256").update(occurrenceManifestBytes).digest("hex");
+// This canonical envelope is an offline planning fixture only. It proves the
+// digest binding and makes no claim that a live feed exists or is fresh.
+const OFFLINE_NON_LIVE_REPORTING_FEED = Object.freeze({
+  contract: "verdify.operator-public-reporting-feed",
+  schemaVersion: 1,
+  sourceId: "operator-public-reporting-feed-offline-planning-proof",
+  sourceClass: "public-reporting-projection",
+  credentialClass: "reporting-read-only",
+  direction: "one-way-read-only",
+  sourceWatermark: "wm_offline_non_live_planning_proof",
+  sourceWatermarkAt: "2026-07-13T00:00:00Z",
+});
+const reportingFeedSha256 = reportingFeedEnvelopeSha256(OFFLINE_NON_LIVE_REPORTING_FEED);
 const graphPlan = planGraphExportRequests({
   policy: occurrencePolicy,
   manifest: occurrenceManifest,
   manifestSha256: occurrenceManifestSha256,
+  reportingFeedSha256,
 });
 
 if (
@@ -43,10 +58,12 @@ if (
 }
 if (
   occurrenceManifestSha256 !== occurrencePolicy.sourceOccurrenceManifestSha256
+  || graphPlan.reportingFeedSha256 !== reportingFeedSha256
   || graphPlan.requests.length !== 143
+  || graphPlan.requests.some((request) => request.reportingFeedSha256 !== reportingFeedSha256)
   || JSON.stringify(graphPlan.requests.map(({ occurrenceId }) => occurrenceId))
     !== JSON.stringify(occurrenceManifest.graphs.map(({ occurrenceId }) => occurrenceId))
-  || /https?:|graphs\.verdify\.ai/i.test(JSON.stringify(graphPlan))
+  || /sourceId|sourceWatermark|endpoint|https?:|graphs\.verdify\.ai|credential/i.test(JSON.stringify(graphPlan))
 ) {
   throw new Error("real occurrence manifest is not byte-bound to the exact 143-request graph plan");
 }

--- a/site-astro/tests/graph-export-producer.test.mjs
+++ b/site-astro/tests/graph-export-producer.test.mjs
@@ -97,6 +97,15 @@ function response(bytes, overrides = {}) {
   };
 }
 
+function rendererContract(render) {
+  return {
+    contract: "verdify.lab-graph-renderer",
+    schemaVersion: 1,
+    abortCooperation: "settle-within-grace-after-abort",
+    render,
+  };
+}
+
 test("the pure planner byte-binds exactly 143 manifest-ordered, endpoint-free targets", () => {
   const { graphs, manifest, manifestSha256, blocked } = fixture();
   const plan = planGraphExportRequests({ policy: blocked, manifest, manifestSha256 });
@@ -162,10 +171,10 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
     manifest,
     manifestSha256,
     outputRoot: root,
-    renderer: async () => {
+    renderer: rendererContract(async () => {
       calls += 1;
       return response(await graphPng());
-    },
+    }),
   }), /not activated/);
   assert.equal(calls, 0);
 
@@ -174,7 +183,22 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
     manifest,
     manifestSha256,
     outputRoot: root,
-  }), /dependency is invalid/);
+  }), /closed abort-cooperative v1 contract/);
+
+  const validRenderer = rendererContract(async () => response(await graphPng()));
+  for (const candidate of [
+    validRenderer.render,
+    { ...validRenderer, endpoint: "not-accepted" },
+    { ...validRenderer, abortCooperation: "best-effort" },
+  ]) {
+    await assert.rejects(produceGraphExportCandidates({
+      policy: active,
+      manifest,
+      manifestSha256,
+      outputRoot: root,
+      renderer: candidate,
+    }), /closed abort-cooperative v1 contract/);
+  }
 });
 
 test("the injected renderer never exceeds four calls and normalizes every graph to the same metadata-free RGB PNG", async (context) => {
@@ -193,7 +217,7 @@ test("the injected renderer never exceeds four calls and normalizes every graph 
     outputRoot: root,
     now: () => CAPTURED_AT,
     concurrency: 4,
-    renderer: async (options) => {
+    renderer: rendererContract(async (options) => {
       activeCalls += 1;
       maximumActive = Math.max(maximumActive, activeCalls);
       observedCalls.push(options);
@@ -201,10 +225,12 @@ test("the injected renderer never exceeds four calls and normalizes every graph 
       activeCalls -= 1;
       const index = graphs.findIndex(({ occurrenceId }) => occurrenceId === options.request.occurrenceId);
       return response(index % 2 === 0 ? plain : tagged);
-    },
+    }),
   });
 
   assert.equal(maximumActive, 4);
+  assert.equal(result.rendererContract.status, "satisfied");
+  assert.equal(result.rendererContract.failure, null);
   assert.equal(observedCalls.length, 143);
   assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
   assert.equal(result.graphs.filter(({ probeStatus }) => probeStatus === "success").length, 143);
@@ -244,7 +270,7 @@ test("mixed renderer failures classify deterministically and still return every 
     outputRoot: root,
     now: () => CAPTURED_AT,
     timeoutMs: 10,
-    renderer: async ({ request, signal }) => {
+    renderer: rendererContract(async ({ request, signal }) => {
       switch (indexById.get(request.occurrenceId)) {
         case 0:
           throw new Error("renderer-specific details must not escape");
@@ -263,9 +289,10 @@ test("mixed renderer failures classify deterministically and still return every 
         default:
           return response(valid);
       }
-    },
+    }),
   });
 
+  assert.equal(result.rendererContract.status, "satisfied");
   assert.equal(result.graphs.length, 143);
   assert.equal(new Set(result.graphs.map(({ occurrenceId }) => occurrenceId)).size, 143);
   assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
@@ -282,6 +309,104 @@ test("mixed renderer failures classify deterministically and still return every 
   assert.equal(result.graphs.slice(0, 7).every(({ candidate }) => candidate === null), true);
   assert.equal(result.graphs.slice(7).every(({ candidate }) => candidate?.mediaType === "image/png"), true);
   assert.doesNotMatch(JSON.stringify(result), /renderer-specific|stopped|url|https?:|credential|authorization|cookie|secret/i);
+});
+
+test("a renderer that ignores abort stops the batch at four unsettled calls and returns a complete closed result", async (context) => {
+  const root = await workspace(context);
+  const { graphs, manifest, manifestSha256, active } = fixture();
+  let calls = 0;
+  let activeCalls = 0;
+  let maximumActive = 0;
+  const startedAt = Date.now();
+  const result = await produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+    timeoutMs: 10,
+    settlementGraceMs: 20,
+    concurrency: 4,
+    renderer: rendererContract(async () => {
+      calls += 1;
+      activeCalls += 1;
+      maximumActive = Math.max(maximumActive, activeCalls);
+      return new Promise(() => {});
+    }),
+  });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(calls, 4);
+  assert.equal(activeCalls, 4);
+  assert.equal(maximumActive, 4);
+  assert.ok(elapsedMs < 500, `non-cooperative batch exceeded its bound: ${elapsedMs}ms`);
+  assert.deepEqual(result.rendererContract, {
+    contract: "verdify.lab-graph-renderer-runtime-status",
+    schemaVersion: 1,
+    status: "failed",
+    failure: "renderer-settlement-timeout",
+  });
+  assert.equal(result.graphs.length, 143);
+  assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
+  assert.equal(result.graphs.every(({ probeStatus, candidate }) => probeStatus === "missing" && candidate === null), true);
+  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(calls, 4, "returning must not release workers to schedule more calls");
+  assert.equal(activeCalls, 4, "the four unsettled calls remain the absolute upper bound");
+});
+
+test("a body whose read and cleanup never settle stops scheduling and returns all 143 null records within bounds", async (context) => {
+  const root = await workspace(context);
+  const { graphs, manifest, manifestSha256, active } = fixture();
+  let calls = 0;
+  let activeReads = 0;
+  let maximumActiveReads = 0;
+  let cleanups = 0;
+  const stuckBody = () => {
+    const iterator = {
+      next: () => {
+        activeReads += 1;
+        maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+        return new Promise(() => {});
+      },
+      return: () => {
+        cleanups += 1;
+        return new Promise(() => {});
+      },
+    };
+    return { [Symbol.asyncIterator]: () => iterator };
+  };
+  const startedAt = Date.now();
+  const result = await produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+    timeoutMs: 10,
+    settlementGraceMs: 20,
+    concurrency: 4,
+    renderer: rendererContract(async () => {
+      calls += 1;
+      return response(Buffer.alloc(1), { contentLength: null, body: stuckBody() });
+    }),
+  });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(calls, 4);
+  assert.equal(activeReads, 4);
+  assert.equal(maximumActiveReads, 4);
+  assert.equal(cleanups, 4);
+  assert.ok(elapsedMs < 500, `non-cooperative cleanup exceeded its bound: ${elapsedMs}ms`);
+  assert.equal(result.rendererContract.status, "failed");
+  assert.equal(result.rendererContract.failure, "body-cleanup-timeout");
+  assert.equal(result.graphs.length, 143);
+  assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
+  assert.equal(result.graphs.every(({ probeStatus, candidate }) => probeStatus === "missing" && candidate === null), true);
+  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(calls, 4);
+  assert.equal(activeReads, 4);
 });
 
 test("the shared candidate store rejects linked paths and cleans interrupted graph writes", async (context) => {
@@ -349,7 +474,7 @@ test("the shared candidate store rejects linked paths and cleans interrupted gra
 test("the graph producer has no default network, service, credential, database, or object-store client", async () => {
   const source = await readFile(path.join(ROOT, "scripts/lib/graph-export-producer.mjs"), "utf8");
   assert.doesNotMatch(source, /\bfetch\s*\(|https?:\/\/|from ["']@aws-sdk|kubectl|grafana|postgres|secret(?:name|key)?/i);
-  assert.match(source, /renderer\(\{ request, signal:/);
+  assert.match(source, /renderer\.render\(\{/);
 });
 
 function* pngChunkTypes(bytes) {

--- a/site-astro/tests/graph-export-producer.test.mjs
+++ b/site-astro/tests/graph-export-producer.test.mjs
@@ -11,6 +11,7 @@ import sharp from "sharp";
 import {
   draftBlockedOccurrenceExportPolicy,
   occurrenceExportPolicySha256,
+  reportingFeedEnvelopeSha256,
 } from "../scripts/lib/occurrence-export-contract.mjs";
 import {
   graphExportProducerContract,
@@ -28,6 +29,17 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const REVIEWED_AT = "2026-07-13T11:59:00Z";
 const APPROVED_AT = "2026-07-13T12:00:00Z";
 const CAPTURED_AT = "2026-07-13T12:01:00Z";
+const REPORTING_FEED = Object.freeze({
+  contract: "verdify.operator-public-reporting-feed",
+  schemaVersion: 1,
+  sourceId: "operator-public-reporting-feed-graph-offline",
+  sourceClass: "public-reporting-projection",
+  credentialClass: "reporting-read-only",
+  direction: "one-way-read-only",
+  sourceWatermark: "wm_graph_offline_fixture_0001",
+  sourceWatermarkAt: APPROVED_AT,
+});
+const REPORTING_FEED_SHA256 = reportingFeedEnvelopeSha256(REPORTING_FEED);
 
 function canonicalBytes(value) {
   return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
@@ -97,21 +109,29 @@ function response(bytes, overrides = {}) {
   };
 }
 
-function rendererContract(render) {
+function rendererContract(render, reportingFeedSha256 = REPORTING_FEED_SHA256) {
   return {
     contract: "verdify.lab-graph-renderer",
-    schemaVersion: 1,
+    schemaVersion: 2,
+    reportingFeedSha256,
     abortCooperation: "settle-within-grace-after-abort",
     render,
   };
 }
 
-test("the pure planner byte-binds exactly 143 manifest-ordered, endpoint-free targets", () => {
+test("the pure planner byte-binds exactly 143 manifest-ordered, feed-bound endpoint-free targets", () => {
   const { graphs, manifest, manifestSha256, blocked } = fixture();
-  const plan = planGraphExportRequests({ policy: blocked, manifest, manifestSha256 });
+  const plan = planGraphExportRequests({
+    policy: blocked,
+    manifest,
+    manifestSha256,
+    reportingFeedSha256: REPORTING_FEED_SHA256,
+  });
   assert.equal(plan.contract, "verdify.lab-graph-export-plan");
+  assert.equal(plan.schemaVersion, 2);
   assert.equal(plan.policySha256, occurrenceExportPolicySha256(blocked));
   assert.equal(plan.sourceOccurrenceManifestSha256, manifestSha256);
+  assert.equal(plan.reportingFeedSha256, REPORTING_FEED_SHA256);
   assert.equal(plan.requests.length, 143);
   assert.deepEqual(plan.requests.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
   assert.equal(new Set(plan.requests.map(({ occurrenceId }) => occurrenceId)).size, 143);
@@ -121,37 +141,65 @@ test("the pure planner byte-binds exactly 143 manifest-ordered, endpoint-free ta
       "schemaVersion",
       "occurrenceId",
       "occurrenceSha256",
+      "reportingFeedSha256",
       "target",
     ]);
+    assert.equal(request.schemaVersion, 2);
     assert.equal(request.occurrenceId, graphs[index].occurrenceId);
+    assert.equal(request.reportingFeedSha256, REPORTING_FEED_SHA256);
     assert.equal(request.target.uid, graphs[index].uid);
     assert.equal(request.target.panelId, graphs[index].panelId);
     assert.deepEqual(request.target.query, graphs[index].query);
     assert.deepEqual(request.target.variables, graphs[index].variables);
     assert.deepEqual(request.target.timeRange, graphs[index].timeRange);
   }
-  assert.doesNotMatch(JSON.stringify(plan), /https?:|graphs\.verdify\.ai|credential|authorization|cookie|secret/i);
+  assert.doesNotMatch(
+    JSON.stringify(plan),
+    /sourceId|sourceWatermark|endpoint|https?:|graphs\.verdify\.ai|credential|authorization|cookie|secret/i,
+  );
+
+  const driftedFeed = { ...REPORTING_FEED, sourceWatermark: "wm_graph_offline_fixture_0002" };
+  assert.notEqual(reportingFeedEnvelopeSha256(driftedFeed), REPORTING_FEED_SHA256);
+  assert.throws(
+    () => reportingFeedEnvelopeSha256({ ...REPORTING_FEED, endpoint: "not-accepted" }),
+    /closed v1 shape/,
+  );
 });
 
 test("manifest, byte-digest, and policy drift fail before a plan or renderer call", async (context) => {
   const root = await workspace(context);
   const { manifest, manifestSha256, blocked, active } = fixture();
   assert.throws(
-    () => planGraphExportRequests({ policy: blocked, manifest, manifestSha256: "b".repeat(64) }),
+    () => planGraphExportRequests({
+      policy: blocked,
+      manifest,
+      manifestSha256: "b".repeat(64),
+      reportingFeedSha256: REPORTING_FEED_SHA256,
+    }),
     /does not match the supplied manifest bytes/,
   );
 
   const driftedManifest = structuredClone(manifest);
   driftedManifest.graphs[0].semanticRole = "Drifted graph";
   assert.throws(
-    () => planGraphExportRequests({ policy: blocked, manifest: driftedManifest, manifestSha256 }),
+    () => planGraphExportRequests({
+      policy: blocked,
+      manifest: driftedManifest,
+      manifestSha256,
+      reportingFeedSha256: REPORTING_FEED_SHA256,
+    }),
     /not canonical|not exactly allowlisted/,
   );
 
   const reducedManifest = structuredClone(manifest);
   reducedManifest.graphs.pop();
   assert.throws(
-    () => planGraphExportRequests({ policy: blocked, manifest: reducedManifest, manifestSha256 }),
+    () => planGraphExportRequests({
+      policy: blocked,
+      manifest: reducedManifest,
+      manifestSha256,
+      reportingFeedSha256: REPORTING_FEED_SHA256,
+    }),
     /allowlist is not complete/,
   );
 
@@ -161,7 +209,12 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
     reorderedManifest.graphs[0],
   ];
   assert.throws(
-    () => planGraphExportRequests({ policy: blocked, manifest: reorderedManifest, manifestSha256 }),
+    () => planGraphExportRequests({
+      policy: blocked,
+      manifest: reorderedManifest,
+      manifestSha256,
+      reportingFeedSha256: REPORTING_FEED_SHA256,
+    }),
     /does not match its canonical byte digest/,
   );
 
@@ -170,6 +223,7 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
     policy: blocked,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
     renderer: rendererContract(async () => {
       calls += 1;
@@ -182,10 +236,14 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
     policy: active,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
-  }), /closed abort-cooperative v1 contract/);
+  }), /feed-bound abort-cooperative v2 contract/);
 
-  const validRenderer = rendererContract(async () => response(await graphPng()));
+  const validRenderer = rendererContract(async () => {
+    calls += 1;
+    return response(await graphPng());
+  });
   for (const candidate of [
     validRenderer.render,
     { ...validRenderer, endpoint: "not-accepted" },
@@ -195,10 +253,48 @@ test("manifest, byte-digest, and policy drift fail before a plan or renderer cal
       policy: active,
       manifest,
       manifestSha256,
+      reportingFeed: REPORTING_FEED,
       outputRoot: root,
       renderer: candidate,
-    }), /closed abort-cooperative v1 contract/);
+    }), /feed-bound abort-cooperative v2 contract/);
   }
+
+  let writes = 0;
+  const countedFileOperations = { writeFile: async () => { writes += 1; } };
+  for (const candidate of [
+    { ...REPORTING_FEED, endpoint: "not-accepted" },
+    { ...REPORTING_FEED, sourceWatermark: "not-opaque" },
+  ]) {
+    await assert.rejects(produceGraphExportCandidates({
+      policy: active,
+      manifest,
+      manifestSha256,
+      reportingFeed: candidate,
+      outputRoot: root,
+      renderer: validRenderer,
+      fileOperations: countedFileOperations,
+    }), /reporting feed/);
+  }
+  await assert.rejects(produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    reportingFeed: REPORTING_FEED,
+    outputRoot: root,
+    renderer: rendererContract(validRenderer.render, "0".repeat(64)),
+    fileOperations: countedFileOperations,
+  }), /feed-bound abort-cooperative v2 contract/);
+  await assert.rejects(produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    reportingFeedSha256: REPORTING_FEED_SHA256,
+    outputRoot: root,
+    renderer: validRenderer,
+    fileOperations: countedFileOperations,
+  }), /reporting feed/);
+  assert.equal(calls, 0);
+  assert.equal(writes, 0);
 });
 
 test("the injected renderer never exceeds four calls and normalizes every graph to the same metadata-free RGB PNG", async (context) => {
@@ -214,6 +310,7 @@ test("the injected renderer never exceeds four calls and normalizes every graph 
     policy: active,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
     now: () => CAPTURED_AT,
     concurrency: 4,
@@ -229,6 +326,18 @@ test("the injected renderer never exceeds four calls and normalizes every graph 
   });
 
   assert.equal(maximumActive, 4);
+  assert.deepEqual(Object.keys(result), [
+    "contract",
+    "schemaVersion",
+    "policyVersion",
+    "policySha256",
+    "sourceOccurrenceManifestSha256",
+    "reportingFeedSha256",
+    "rendererContract",
+    "graphs",
+  ]);
+  assert.equal(result.schemaVersion, 3);
+  assert.equal(result.reportingFeedSha256, REPORTING_FEED_SHA256);
   assert.equal(result.rendererContract.status, "satisfied");
   assert.equal(result.rendererContract.failure, null);
   assert.equal(observedCalls.length, 143);
@@ -248,9 +357,13 @@ test("the injected renderer never exceeds four calls and normalizes every graph 
   const bytes = await readFile(path.join(root, ...result.graphs[0].candidate.relativePath.split("/")));
   assert.equal(decodePng(bytes).colorType, 2);
   assert.deepEqual([...pngChunkTypes(bytes)], ["IHDR", "IDAT", "IEND"]);
-  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /sourceId|sourceWatermark|endpoint|url|https?:|credential|authorization|cookie|secret/i,
+  );
   for (const call of observedCalls) {
     assert.deepEqual(Object.keys(call), ["request", "signal"]);
+    assert.equal(call.request.reportingFeedSha256, REPORTING_FEED_SHA256);
     assert.equal(call.signal.aborted, true);
   }
 });
@@ -267,9 +380,10 @@ test("mixed renderer failures classify deterministically and still return every 
     policy: active,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
     now: () => CAPTURED_AT,
-    timeoutMs: 10,
+    timeoutMs: 500,
     renderer: rendererContract(async ({ request, signal }) => {
       switch (indexById.get(request.occurrenceId)) {
         case 0:
@@ -292,6 +406,7 @@ test("mixed renderer failures classify deterministically and still return every 
     }),
   });
 
+  assert.equal(result.reportingFeedSha256, REPORTING_FEED_SHA256);
   assert.equal(result.rendererContract.status, "satisfied");
   assert.equal(result.graphs.length, 143);
   assert.equal(new Set(result.graphs.map(({ occurrenceId }) => occurrenceId)).size, 143);
@@ -308,7 +423,10 @@ test("mixed renderer failures classify deterministically and still return every 
   assert.equal(result.graphs.slice(7).every(({ probeStatus }) => probeStatus === "success"), true);
   assert.equal(result.graphs.slice(0, 7).every(({ candidate }) => candidate === null), true);
   assert.equal(result.graphs.slice(7).every(({ candidate }) => candidate?.mediaType === "image/png"), true);
-  assert.doesNotMatch(JSON.stringify(result), /renderer-specific|stopped|url|https?:|credential|authorization|cookie|secret/i);
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /renderer-specific|stopped|sourceId|sourceWatermark|endpoint|url|https?:|credential|authorization|cookie|secret/i,
+  );
 });
 
 test("a renderer that ignores abort stops the batch at four unsettled calls and returns a complete closed result", async (context) => {
@@ -322,6 +440,7 @@ test("a renderer that ignores abort stops the batch at four unsettled calls and 
     policy: active,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
     timeoutMs: 10,
     settlementGraceMs: 20,
@@ -335,6 +454,7 @@ test("a renderer that ignores abort stops the batch at four unsettled calls and 
   });
   const elapsedMs = Date.now() - startedAt;
 
+  assert.equal(result.reportingFeedSha256, REPORTING_FEED_SHA256);
   assert.equal(calls, 4);
   assert.equal(activeCalls, 4);
   assert.equal(maximumActive, 4);
@@ -348,7 +468,10 @@ test("a renderer that ignores abort stops the batch at four unsettled calls and 
   assert.equal(result.graphs.length, 143);
   assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
   assert.equal(result.graphs.every(({ probeStatus, candidate }) => probeStatus === "missing" && candidate === null), true);
-  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /sourceId|sourceWatermark|endpoint|url|https?:|credential|authorization|cookie|secret/i,
+  );
 
   await new Promise((resolve) => setTimeout(resolve, 30));
   assert.equal(calls, 4, "returning must not release workers to schedule more calls");
@@ -381,6 +504,7 @@ test("a body whose read and cleanup never settle stops scheduling and returns al
     policy: active,
     manifest,
     manifestSha256,
+    reportingFeed: REPORTING_FEED,
     outputRoot: root,
     timeoutMs: 10,
     settlementGraceMs: 20,
@@ -392,6 +516,7 @@ test("a body whose read and cleanup never settle stops scheduling and returns al
   });
   const elapsedMs = Date.now() - startedAt;
 
+  assert.equal(result.reportingFeedSha256, REPORTING_FEED_SHA256);
   assert.equal(calls, 4);
   assert.equal(activeReads, 4);
   assert.equal(maximumActiveReads, 4);
@@ -402,7 +527,10 @@ test("a body whose read and cleanup never settle stops scheduling and returns al
   assert.equal(result.graphs.length, 143);
   assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
   assert.equal(result.graphs.every(({ probeStatus, candidate }) => probeStatus === "missing" && candidate === null), true);
-  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /sourceId|sourceWatermark|endpoint|url|https?:|credential|authorization|cookie|secret/i,
+  );
 
   await new Promise((resolve) => setTimeout(resolve, 30));
   assert.equal(calls, 4);

--- a/site-astro/tests/graph-export-producer.test.mjs
+++ b/site-astro/tests/graph-export-producer.test.mjs
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import sharp from "sharp";
+
+import {
+  draftBlockedOccurrenceExportPolicy,
+  occurrenceExportPolicySha256,
+} from "../scripts/lib/occurrence-export-contract.mjs";
+import {
+  graphExportProducerContract,
+  planGraphExportRequests,
+  produceGraphExportCandidates,
+} from "../scripts/lib/graph-export-producer.mjs";
+import { persistOccurrenceCandidate } from "../scripts/lib/occurrence-candidate-store.mjs";
+import {
+  discoverGraphOccurrence,
+  staticOccurrenceManifest,
+} from "../scripts/lib/occurrence-release.mjs";
+import { decodePng, validatePngFile } from "../scripts/lib/png-validation.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REVIEWED_AT = "2026-07-13T11:59:00Z";
+const APPROVED_AT = "2026-07-13T12:00:00Z";
+const CAPTURED_AT = "2026-07-13T12:01:00Z";
+
+function canonicalBytes(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function digest(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fixture() {
+  const graphs = Array.from({ length: graphExportProducerContract.expectedGraphCount }, (_, index) => discoverGraphOccurrence({
+    route: `/evidence/graph-${String(index).padStart(3, "0")}`,
+    ordinal: index,
+    liveUrl: `https://graphs.verdify.ai/d-solo/public-reporting/approved?orgId=1&panelId=${index + 1}&theme=light&from=now-24h&to=now&var-zone=greenhouse`,
+    title: `Approved graph ${index + 1}`,
+  }));
+  const manifest = staticOccurrenceManifest({
+    snapshotId: `sanitized-content-sha256:${"a".repeat(64)}`,
+    discoveredGraphs: graphs,
+    discoveredCurrentMedia: [],
+  });
+  const manifestSha256 = digest(canonicalBytes(manifest));
+  const blocked = draftBlockedOccurrenceExportPolicy({
+    manifest,
+    manifestSha256,
+    policyVersion: "offline-graph-producer-v1",
+    approvedAt: REVIEWED_AT,
+  });
+  const active = structuredClone(blocked);
+  active.activation = {
+    ...active.activation,
+    state: "approved",
+    approvedBy: "jason",
+    approvedAt: APPROVED_AT,
+  };
+  return { graphs, manifest, manifestSha256, blocked, active };
+}
+
+async function workspace(context, prefix = "verdify-graph-export-") {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+async function graphPng({ compressionLevel = 6, metadata = false } = {}) {
+  const width = 320;
+  const height = 180;
+  const pixels = Buffer.alloc(width * height * 4);
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    pixels[offset] = 24;
+    pixels[offset + 1] = 96;
+    pixels[offset + 2] = 144;
+    pixels[offset + 3] = 128;
+  }
+  let image = sharp(pixels, { raw: { width, height, channels: 4 } });
+  if (metadata) image = image.withMetadata({ orientation: 1, density: 144 });
+  return image.png({ compressionLevel, adaptiveFiltering: compressionLevel > 0 }).toBuffer();
+}
+
+function response(bytes, overrides = {}) {
+  return {
+    status: 200,
+    contentType: "image/png",
+    contentLength: bytes.length,
+    body: bytes,
+    ...overrides,
+  };
+}
+
+test("the pure planner byte-binds exactly 143 manifest-ordered, endpoint-free targets", () => {
+  const { graphs, manifest, manifestSha256, blocked } = fixture();
+  const plan = planGraphExportRequests({ policy: blocked, manifest, manifestSha256 });
+  assert.equal(plan.contract, "verdify.lab-graph-export-plan");
+  assert.equal(plan.policySha256, occurrenceExportPolicySha256(blocked));
+  assert.equal(plan.sourceOccurrenceManifestSha256, manifestSha256);
+  assert.equal(plan.requests.length, 143);
+  assert.deepEqual(plan.requests.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
+  assert.equal(new Set(plan.requests.map(({ occurrenceId }) => occurrenceId)).size, 143);
+  for (const [index, request] of plan.requests.entries()) {
+    assert.deepEqual(Object.keys(request), [
+      "contract",
+      "schemaVersion",
+      "occurrenceId",
+      "occurrenceSha256",
+      "target",
+    ]);
+    assert.equal(request.occurrenceId, graphs[index].occurrenceId);
+    assert.equal(request.target.uid, graphs[index].uid);
+    assert.equal(request.target.panelId, graphs[index].panelId);
+    assert.deepEqual(request.target.query, graphs[index].query);
+    assert.deepEqual(request.target.variables, graphs[index].variables);
+    assert.deepEqual(request.target.timeRange, graphs[index].timeRange);
+  }
+  assert.doesNotMatch(JSON.stringify(plan), /https?:|graphs\.verdify\.ai|credential|authorization|cookie|secret/i);
+});
+
+test("manifest, byte-digest, and policy drift fail before a plan or renderer call", async (context) => {
+  const root = await workspace(context);
+  const { manifest, manifestSha256, blocked, active } = fixture();
+  assert.throws(
+    () => planGraphExportRequests({ policy: blocked, manifest, manifestSha256: "b".repeat(64) }),
+    /does not match the supplied manifest bytes/,
+  );
+
+  const driftedManifest = structuredClone(manifest);
+  driftedManifest.graphs[0].semanticRole = "Drifted graph";
+  assert.throws(
+    () => planGraphExportRequests({ policy: blocked, manifest: driftedManifest, manifestSha256 }),
+    /not canonical|not exactly allowlisted/,
+  );
+
+  const reducedManifest = structuredClone(manifest);
+  reducedManifest.graphs.pop();
+  assert.throws(
+    () => planGraphExportRequests({ policy: blocked, manifest: reducedManifest, manifestSha256 }),
+    /allowlist is not complete/,
+  );
+
+  const reorderedManifest = structuredClone(manifest);
+  [reorderedManifest.graphs[0], reorderedManifest.graphs[1]] = [
+    reorderedManifest.graphs[1],
+    reorderedManifest.graphs[0],
+  ];
+  assert.throws(
+    () => planGraphExportRequests({ policy: blocked, manifest: reorderedManifest, manifestSha256 }),
+    /does not match its canonical byte digest/,
+  );
+
+  let calls = 0;
+  await assert.rejects(produceGraphExportCandidates({
+    policy: blocked,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+    renderer: async () => {
+      calls += 1;
+      return response(await graphPng());
+    },
+  }), /not activated/);
+  assert.equal(calls, 0);
+
+  await assert.rejects(produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+  }), /dependency is invalid/);
+});
+
+test("the injected renderer never exceeds four calls and normalizes every graph to the same metadata-free RGB PNG", async (context) => {
+  const root = await workspace(context);
+  const { graphs, manifest, manifestSha256, active } = fixture();
+  const plain = await graphPng({ compressionLevel: 0 });
+  const tagged = await graphPng({ compressionLevel: 9, metadata: true });
+  assert.notDeepEqual(plain, tagged);
+  let activeCalls = 0;
+  let maximumActive = 0;
+  const observedCalls = [];
+  const result = await produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+    now: () => CAPTURED_AT,
+    concurrency: 4,
+    renderer: async (options) => {
+      activeCalls += 1;
+      maximumActive = Math.max(maximumActive, activeCalls);
+      observedCalls.push(options);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      activeCalls -= 1;
+      const index = graphs.findIndex(({ occurrenceId }) => occurrenceId === options.request.occurrenceId);
+      return response(index % 2 === 0 ? plain : tagged);
+    },
+  });
+
+  assert.equal(maximumActive, 4);
+  assert.equal(observedCalls.length, 143);
+  assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
+  assert.equal(result.graphs.filter(({ probeStatus }) => probeStatus === "success").length, 143);
+  const outputDigests = new Set();
+  for (const item of result.graphs) {
+    assert.match(item.candidate.relativePath, new RegExp(`^graphs/${item.occurrenceId}/[0-9a-f]{64}\\.png$`));
+    assert.deepEqual(Object.keys(item.candidate), ["relativePath", "mediaType", "capturedAt"]);
+    assert.equal(item.candidate.mediaType, "image/png");
+    assert.equal(item.candidate.capturedAt, CAPTURED_AT);
+    outputDigests.add(path.basename(item.candidate.relativePath));
+  }
+  assert.equal(outputDigests.size, 1, "source encoding and metadata must not change normalized bytes");
+  const verified = await validatePngFile(root, result.graphs[0].candidate.relativePath);
+  assert.equal(verified.colorType, 2);
+  const bytes = await readFile(path.join(root, ...result.graphs[0].candidate.relativePath.split("/")));
+  assert.equal(decodePng(bytes).colorType, 2);
+  assert.deepEqual([...pngChunkTypes(bytes)], ["IHDR", "IDAT", "IEND"]);
+  assert.doesNotMatch(JSON.stringify(result), /url|https?:|credential|authorization|cookie|secret/i);
+  for (const call of observedCalls) {
+    assert.deepEqual(Object.keys(call), ["request", "signal"]);
+    assert.equal(call.signal.aborted, true);
+  }
+});
+
+test("mixed renderer failures classify deterministically and still return every graph exactly once", async (context) => {
+  const root = await workspace(context);
+  const { graphs, manifest, manifestSha256, active } = fixture();
+  const valid = await graphPng();
+  const tooSmall = await sharp({
+    create: { width: 319, height: 180, channels: 3, background: { r: 1, g: 2, b: 3 } },
+  }).png().toBuffer();
+  const indexById = new Map(graphs.map(({ occurrenceId }, index) => [occurrenceId, index]));
+  const result = await produceGraphExportCandidates({
+    policy: active,
+    manifest,
+    manifestSha256,
+    outputRoot: root,
+    now: () => CAPTURED_AT,
+    timeoutMs: 10,
+    renderer: async ({ request, signal }) => {
+      switch (indexById.get(request.occurrenceId)) {
+        case 0:
+          throw new Error("renderer-specific details must not escape");
+        case 1:
+          return response(valid, { status: 503 });
+        case 2:
+          return response(Buffer.from("not a PNG"));
+        case 3:
+          return new Promise((_, reject) => signal.addEventListener("abort", () => reject(new Error("stopped")), { once: true }));
+        case 4:
+          return response(valid, { contentLength: active.imagePolicy.graphs.maxBytes + 1 });
+        case 5:
+          return response(tooSmall);
+        case 6:
+          return response(valid, { contentType: "image/jpeg" });
+        default:
+          return response(valid);
+      }
+    },
+  });
+
+  assert.equal(result.graphs.length, 143);
+  assert.equal(new Set(result.graphs.map(({ occurrenceId }) => occurrenceId)).size, 143);
+  assert.deepEqual(result.graphs.map(({ occurrenceId }) => occurrenceId), graphs.map(({ occurrenceId }) => occurrenceId));
+  assert.deepEqual(result.graphs.slice(0, 7).map(({ probeStatus }) => probeStatus), [
+    "missing",
+    "http-error",
+    "decode-error",
+    "timeout",
+    "http-error",
+    "decode-error",
+    "http-error",
+  ]);
+  assert.equal(result.graphs.slice(7).every(({ probeStatus }) => probeStatus === "success"), true);
+  assert.equal(result.graphs.slice(0, 7).every(({ candidate }) => candidate === null), true);
+  assert.equal(result.graphs.slice(7).every(({ candidate }) => candidate?.mediaType === "image/png"), true);
+  assert.doesNotMatch(JSON.stringify(result), /renderer-specific|stopped|url|https?:|credential|authorization|cookie|secret/i);
+});
+
+test("the shared candidate store rejects linked paths and cleans interrupted graph writes", async (context) => {
+  const root = await workspace(context);
+  const external = await workspace(context, "verdify-graph-external-");
+  const linked = path.join(root, "linked");
+  const png = strictPng(await graphPng());
+  const occurrenceId = "graph_aaaaaaaaaaaaaaaaaaaaaaaa";
+  await symlink(external, linked, "dir");
+  await assert.rejects(persistOccurrenceCandidate({
+    outputRoot: linked,
+    collection: "graphs",
+    occurrenceId,
+    png,
+    label: "graph candidate",
+    collectionLabel: "graph",
+  }), /canonical real directory/);
+  assert.deepEqual(await readdir(external), []);
+
+  const output = path.join(root, "output");
+  await mkdir(output);
+  await symlink(external, path.join(output, "graphs"), "dir");
+  await assert.rejects(persistOccurrenceCandidate({
+    outputRoot: output,
+    collection: "graphs",
+    occurrenceId,
+    png,
+    label: "graph candidate",
+    collectionLabel: "graph",
+  }), /canonical real directory/);
+  assert.deepEqual(await readdir(external), []);
+
+  await rm(path.join(output, "graphs"));
+  await assert.rejects(persistOccurrenceCandidate({
+    outputRoot: output,
+    collection: "graphs",
+    occurrenceId,
+    png,
+    label: "graph candidate",
+    collectionLabel: "graph",
+    fileOperations: { writeFile: async () => { throw new Error("injected write failure"); } },
+  }), /temporary write failed/);
+  assert.deepEqual(await readdir(path.join(output, "graphs", occurrenceId)), []);
+
+  const first = await persistOccurrenceCandidate({
+    outputRoot: output,
+    collection: "graphs",
+    occurrenceId,
+    png,
+    label: "graph candidate",
+    collectionLabel: "graph",
+  });
+  const second = await persistOccurrenceCandidate({
+    outputRoot: output,
+    collection: "graphs",
+    occurrenceId,
+    png,
+    label: "graph candidate",
+    collectionLabel: "graph",
+  });
+  assert.equal(first.relativePath, second.relativePath);
+  assert.deepEqual(await readdir(path.join(output, "graphs", occurrenceId)), [`${first.verified.sha256}.png`]);
+});
+
+test("the graph producer has no default network, service, credential, database, or object-store client", async () => {
+  const source = await readFile(path.join(ROOT, "scripts/lib/graph-export-producer.mjs"), "utf8");
+  assert.doesNotMatch(source, /\bfetch\s*\(|https?:\/\/|from ["']@aws-sdk|kubectl|grafana|postgres|secret(?:name|key)?/i);
+  assert.match(source, /renderer\(\{ request, signal:/);
+});
+
+function* pngChunkTypes(bytes) {
+  let offset = 8;
+  while (offset < bytes.length) {
+    const length = bytes.readUInt32BE(offset);
+    const type = bytes.subarray(offset + 4, offset + 8).toString("ascii");
+    yield type;
+    offset += 12 + length;
+    if (type === "IEND") return;
+  }
+}
+
+function strictPng(bytes) {
+  const chunks = [bytes.subarray(0, 8)];
+  let offset = 8;
+  while (offset < bytes.length) {
+    const length = bytes.readUInt32BE(offset);
+    const end = offset + 12 + length;
+    const type = bytes.subarray(offset + 4, offset + 8).toString("ascii");
+    if (["IHDR", "IDAT", "IEND"].includes(type)) chunks.push(bytes.subarray(offset, end));
+    offset = end;
+    if (type === "IEND") break;
+  }
+  return Buffer.concat(chunks);
+}


### PR DESCRIPTION
Refs #476. This PR intentionally does not close it.

## What

Add a source-only graph occurrence planner and producer for all 143 graph
occurrences approved in #483, sharing the hardened content-addressed candidate
store with the merged camera producer.

## Why

Lab Astro must materialize immutable same-origin graph fallbacks without giving
the static site, producer contract, or result documents a reporting endpoint,
credential, database client, or control-plane path.

## How

- Require the exact canonical occurrence manifest, approved policy, and full
  closed reporting-feed envelope; derive and bind its SHA-256 internally.
- Produce exactly 143 manifest-ordered, endpoint-free render requests and carry
  only the feed digest through the plan, renderer contract, and URL-free result.
- Accept only an injected, feed-bound renderer that cooperates with abort and
  settles within a bounded grace interval.
- Enforce at most four active renderer/body operations. If render or cleanup
  does not settle after abort, stop scheduling, retain the absolute four-call
  bound, and return a complete ordered null result with a closed contract status.
- Bound status, MIME, declared/actual bytes, time, dimensions, decode, response
  lifecycle, and cleanup before deterministic RGB PNG normalization.
- Strip ancillary metadata and persist only validated content-addressed
  candidates beneath canonical pre-existing directories with retry-safe cleanup.
- Keep camera behavior unchanged while moving its candidate persistence onto
  the same tested local helper.

No reporting endpoint/client, live request, database/object-store client,
workload, route, egress policy, Secret reference, credential access, cluster
mutation, stage sync, or runtime activation is added.

## Test

- focused camera+graph tests: 18/18
- `npm run test:unit`: 93/93
- `npm test`: passed, including parity 7/7, rendered manifests, output 4/4,
  browser quality 12/12, and production output 4/4
- verified immutable local snapshot, then real build: 152 sources, 143 graph
  occurrences, 324 HTML files / 323 routes; `verify:real` reports
  `graphPlan=143`
- targeted pre-commit and `git diff --check`: passed
- exact-head in-cluster PR CI remains the repository merge gate

Tests cover exact count/order/feed binding, policy and manifest drift, maximum
concurrency, mixed render failures, abort settlement, non-settling render/body
cleanup, response and image bounds, deterministic ancillary-free RGB PNG,
canonical output paths, interrupted writes, retries, complete URL-free results,
and absence of a default network/service/credential client.

## Success

- The inert producer can produce a complete, deterministic 143-record candidate
  result only from the exact approved policy/manifest/feed/renderer contracts.
- Invalid or drifted inputs fail before renderer calls or writes.
- A non-cooperative renderer cannot expand work beyond four unsettled calls.
- Failed items never claim a candidate, and contract failure cannot select a
  partial batch.
- The slice remains inert until the separately recorded human gates are met.

## Remaining on #476

Keep #476 open for the operator-owned one-way public reporting feed,
anonymous-disabled reporting tier and scoped read credential, concrete renderer,
S3 occurrence delivery and exact-generation caller, freshness metrics/alerts,
deployment/network activation, LKG recovery, and joint live-stage T0/T+10 proof
of 143/143 graphs plus 2/2 approved cameras. Those actions remain human-gated.
