### PR TITLE
ci(grafana): generated-CM == dashboard-source gate (#392)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,9 @@ grafana-brand-check: ## Verify embedded Grafana panels use Verdify Lab styling r
 grafana-brand-check-live: ## Verify live embedded Grafana panels use Verdify Lab styling rules
 	$(PYTHON) scripts/brand-grafana-embeds.py --check --live
 
+grafana-cm-check: ## Verify generated dashboard ConfigMaps match grafana/dashboards JSON sources (#392)
+	$(PYTHON) scripts/gen-grafana-dashboard-cms.py --check
+
 site-lint: ## Run cheap lint for public-site content and routes
 	$(PYTHON) scripts/lint_public_site.py
 

--- a/docs/grafana-graph-authoring.md
+++ b/docs/grafana-graph-authoring.md
@@ -74,7 +74,9 @@ Key facts:
    `scripts/verdify-db.sh prod` kubectl-execs psql in the `verdify-db-0` pod
    (read-only SELECTs are safe; never run destructive prod DB work without a gate).
 3. **Regenerate the CMs:** `python3 scripts/gen-grafana-dashboard-cms.py`
-   (validates JSON, warns near the 1 MiB limit).
+   (validates JSON, warns near the 1 MiB limit). CI enforces this:
+   `make grafana-cm-check` (`--check` mode, run by `scripts/ci-local.sh`)
+   fails on any source↔CM drift (#392).
 4. **Commit + push** (`grafana/dashboards/*.json` + the regenerated CM) so
    git == live.
 5. **Deploy the CM** (server-side):

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -57,6 +57,7 @@ $PY -m pytest -q \
   tests/test_forecast_action_engine_path.py \
   tests/test_g5_dualwrite_validation.py \
   tests/test_generate_daily_plan.py \
+  tests/test_grafana_cm_check.py \
   tests/test_grafana_manifest_security.py \
   tests/test_lab_publish_k3s_guard.py \
   tests/test_mqtt_fanout.py \
@@ -79,6 +80,9 @@ $PY -m pytest -q \
 
 step "migration rollback safety classification"
 $PY scripts/check_migration_rollback_safety.py
+
+step "grafana dashboard CMs match JSON sources (#392)"
+$PY scripts/gen-grafana-dashboard-cms.py --check
 
 step "twin vendored source compiles (the initContainer's exact build)"
 if command -v g++ >/dev/null; then

--- a/scripts/gen-grafana-dashboard-cms.py
+++ b/scripts/gen-grafana-dashboard-cms.py
@@ -15,10 +15,15 @@ grafana/provisioning/dashboards/json/.
 Idempotent: run after editing any provisioned dashboard JSON, then commit the
 CMs. Validates each source is parseable JSON and warns if a CM nears the 1 MiB
 limit.
+
+`--check` (the #392 CI gate) renders every CM in-memory and compares
+byte-for-byte against the committed file — writes nothing, exits 1 on drift
+(a dashboard JSON edited without regenerating, or a hand-edited CM data key).
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -51,30 +56,45 @@ def source_for_key(key: str) -> Path | None:
     return None
 
 
-def main() -> int:
+def render_cm(cm_path: Path) -> tuple[str, int]:
+    """Re-render cm_path's .json data keys from their sources; return (yaml text, dashboard count)."""
+    doc = yaml.safe_load(cm_path.read_text())
+    data = doc.get("data") or {}
+    new_data: dict[str, str] = {}
+    for key in data:
+        if key.endswith(".json"):
+            src = source_for_key(key)
+            if src is None:
+                print(f"WARN: {cm_path.name} key {key} has no dashboard source — keeping existing")
+                new_data[key] = data[key]
+                continue
+            raw = src.read_text()
+            json.loads(raw)  # parse-validate
+            new_data[key] = LiteralStr(raw if raw.endswith("\n") else raw + "\n")
+        else:
+            new_data[key] = LiteralStr(data[key]) if isinstance(data[key], str) and "\n" in data[key] else data[key]
+    doc["data"] = new_data
+    out = yaml.dump(doc, sort_keys=False, width=10**9, allow_unicode=True)
+    return out, sum(1 for k in new_data if k.endswith(".json"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify committed CMs match a fresh render from dashboard sources; write nothing, exit 1 on drift",
+    )
+    args = parser.parse_args(argv)
+
     cms = sorted(GEN.glob("dashboards-cm-*.yaml"))
     if not cms:
         print("no dashboards-cm-*.yaml found", file=sys.stderr)
         return 1
     changed = 0
+    drifted: list[str] = []
     for cm_path in cms:
-        doc = yaml.safe_load(cm_path.read_text())
-        data = doc.get("data") or {}
-        new_data: dict[str, str] = {}
-        for key in data:
-            if key.endswith(".json"):
-                src = source_for_key(key)
-                if src is None:
-                    print(f"WARN: {cm_path.name} key {key} has no dashboard source — keeping existing")
-                    new_data[key] = data[key]
-                    continue
-                raw = src.read_text()
-                json.loads(raw)  # parse-validate
-                new_data[key] = LiteralStr(raw if raw.endswith("\n") else raw + "\n")
-            else:
-                new_data[key] = LiteralStr(data[key]) if isinstance(data[key], str) and "\n" in data[key] else data[key]
-        doc["data"] = new_data
-        out = yaml.dump(doc, sort_keys=False, width=10**9, allow_unicode=True)
+        out, n_dashboards = render_cm(cm_path)
         size = len(out.encode())
         if size > CM_LIMIT:
             print(f"ERROR: {cm_path.name} is {size} bytes (> 1 MiB limit) — re-shard", file=sys.stderr)
@@ -82,11 +102,25 @@ def main() -> int:
         if size > CM_LIMIT * 0.9:
             print(f"WARN: {cm_path.name} is {size} bytes (>90% of 1 MiB)")
         if out != cm_path.read_text():
-            cm_path.write_text(out)
-            changed += 1
+            if args.check:
+                drifted.append(cm_path.name)
+            else:
+                cm_path.write_text(out)
+                changed += 1
+                print(f"regenerated {cm_path.name} ({size} bytes, {n_dashboards} dashboards)")
+    if args.check:
+        if drifted:
             print(
-                f"regenerated {cm_path.name} ({size} bytes, {sum(1 for k in new_data if k.endswith('.json'))} dashboards)"
+                f"DRIFT: {', '.join(drifted)} out of sync with grafana dashboard JSON sources.",
+                file=sys.stderr,
             )
+            print(
+                "Fix: python3 scripts/gen-grafana-dashboard-cms.py  (then commit the regenerated ConfigMaps)",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"check OK: {len(cms)} ConfigMap(s) match dashboard sources")
+        return 0
     print(f"done: {changed} ConfigMap(s) updated")
     return 0
 

--- a/tests/test_grafana_cm_check.py
+++ b/tests/test_grafana_cm_check.py
@@ -1,0 +1,72 @@
+"""#392 gate: gen-grafana-dashboard-cms.py --check catches source/CM drift."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def load_generator():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "gen-grafana-dashboard-cms.py"
+    spec = importlib.util.spec_from_file_location("gen_grafana_dashboard_cms_under_test", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def fixture_tree(tmp_path, monkeypatch):
+    """A tiny source-dashboard + generated-CM tree, normalized by a write-mode run."""
+    gen_mod = load_generator()
+    src = tmp_path / "grafana" / "dashboards"
+    legacy = tmp_path / "grafana" / "provisioning" / "dashboards" / "json"
+    gen = tmp_path / "generated"
+    for d in (src, legacy, gen):
+        d.mkdir(parents=True)
+    monkeypatch.setattr(gen_mod, "SRC", src)
+    monkeypatch.setattr(gen_mod, "LEGACY_SRC", legacy)
+    monkeypatch.setattr(gen_mod, "GEN", gen)
+
+    (src / "site-home.json").write_text(json.dumps({"title": "Home", "panels": []}) + "\n")
+    cm = gen / "dashboards-cm-0.yaml"
+    cm.write_text(
+        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: grafana-dashboards-0\ndata:\n  site-home.json: |\n    {}\n"
+    )
+    assert gen_mod.main([]) == 0  # write mode normalizes the fixture CM
+    return gen_mod, src, cm
+
+
+def test_check_passes_on_clean_tree(fixture_tree):
+    gen_mod, _src, _cm = fixture_tree
+    assert gen_mod.main(["--check"]) == 0
+
+
+def test_check_fails_when_dashboard_source_edited_without_regenerating(fixture_tree, capsys):
+    gen_mod, src, _cm = fixture_tree
+    (src / "site-home.json").write_text(json.dumps({"title": "Home EDITED", "panels": []}) + "\n")
+    assert gen_mod.main(["--check"]) == 1
+    err = capsys.readouterr().err
+    assert "dashboards-cm-0.yaml" in err
+    assert "gen-grafana-dashboard-cms.py" in err  # names the fix command
+
+
+def test_check_fails_when_generated_cm_hand_edited(fixture_tree):
+    gen_mod, _src, cm = fixture_tree
+    cm.write_text(cm.read_text().replace('"title": "Home"', '"title": "HAND-EDIT"'))
+    assert gen_mod.main(["--check"]) == 1
+
+
+def test_check_writes_nothing_and_regeneration_clears_drift(fixture_tree):
+    gen_mod, src, cm = fixture_tree
+    (src / "site-home.json").write_text(json.dumps({"title": "v2"}) + "\n")
+    before = cm.read_text()
+    assert gen_mod.main(["--check"]) == 1
+    assert cm.read_text() == before  # --check must not modify the CM
+    assert gen_mod.main([]) == 0  # regenerate…
+    assert gen_mod.main(["--check"]) == 0  # …clears the drift


### PR DESCRIPTION
Closes #392.

## What

The manual-discipline invariant from the PR #385 review — "generated Grafana dashboard ConfigMaps must match their JSON sources" — is now a CI gate:

- **`scripts/gen-grafana-dashboard-cms.py --check`**: re-renders every `deploy/k8s/components/grafana/generated/dashboards-cm-*.yaml` in-memory from `grafana/dashboards/` (+ legacy `grafana/provisioning/dashboards/json/`) and byte-compares against the committed file. Writes nothing; exits 1 on drift with a message naming the fix command (`python3 scripts/gen-grafana-dashboard-cms.py`, then commit). Write-mode behavior is unchanged — the render logic was extracted to `render_cm()` and the 1 MiB size guards still apply in both modes.
- **`scripts/ci-local.sh`**: new unconditional gate step (`grafana dashboard CMs match JSON sources (#392)`, ~3 s) — GitHub Actions is removed, so the gate lives in the local/in-cluster script per the current CI model. The new test is added to the pure-logic suite.
- **`make grafana-cm-check`**: convenience target.
- **`tests/test_grafana_cm_check.py`**: 4 tests on a tmp fixture tree — clean pass, source-edit drift, hand-edited CM drift, and `--check` is read-only + regeneration clears drift.
- **`docs/grafana-graph-authoring.md`**: one-line note in the authoring flow.

The >256 KB-CM SSA apply machinery is untouched — this gate only compares repo files.

## Acceptance / verification (all run in a clean worktree off origin/main)

- [x] **Clean tree passes**: `python3 scripts/gen-grafana-dashboard-cms.py --check` → `check OK: 4 ConfigMap(s) match dashboard sources`, exit 0.
- [x] **Hand-edited CM fails**: mutated a data-key token in `dashboards-cm-0.yaml` → `DRIFT: dashboards-cm-0.yaml out of sync ... Fix: python3 scripts/gen-grafana-dashboard-cms.py`, exit 1; restored → exit 0.
- [x] **Edited source without regenerating fails**: added a key to `grafana/dashboards/site-home.json` → same DRIFT failure, exit 1; restored → exit 0.
- [x] `make lint` green; `pytest tests/test_grafana_cm_check.py` → 4 passed.
- [x] Full `CI_BASE_REF=origin/main bash scripts/ci-local.sh` → `ALL GATES GREEN` (including the new step, the service-restart drift guard, and fire-and-forget/replay triggers).

Restart: none — CI-only change, no runtime services affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu