### PR TITLE
ci(solar): value-equality SSOT drift guard for site constants (#393)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,9 @@ grafana-brand-check-live: ## Verify live embedded Grafana panels use Verdify Lab
 grafana-cm-check: ## Verify generated dashboard ConfigMaps match grafana/dashboards JSON sources (#392)
 	$(PYTHON) scripts/gen-grafana-dashboard-cms.py --check
 
+solar-constants-check: ## Verify solar site constants (lat/lon/zenith) agree across ingestor/firmware/DB surfaces (#393)
+	$(PYTHON) scripts/check-solar-constants.py
+
 site-lint: ## Run cheap lint for public-site content and routes
 	$(PYTHON) scripts/lint_public_site.py
 

--- a/docs/design/firmware-v2-contract-2026-06-10.md
+++ b/docs/design/firmware-v2-contract-2026-06-10.md
@@ -18,6 +18,15 @@ float solar_phase(int now_minute, const SolarTimes& st);  // [0,4): 0=SR 1=SM 2=
 
 - Greenhouse constants: lat 40.167, lon −105.102 (Longmont CO). `utc_offset_min`
   comes from the time component each cycle (DST-correct by construction).
+- **Site-constant SSOT contract (#393):** `ingestor/solar.py`
+  (`GREENHOUSE_LAT_DEG` / `GREENHOUSE_LON_DEG` / `_ZENITH_DEG` 90.833) is the
+  single editable source for lat/lon/zenith. The mirrored literals in
+  `firmware/lib/greenhouse_solar.h` (+ the vendored firmware-twin copy),
+  `db/migrations/186-noaa-solar-phase-parity.sql`, and the dumped
+  `db/schema.sql` `fn_solar_*` bodies must carry the same numeric values.
+  `make solar-constants-check` (`scripts/check-solar-constants.py`, run by
+  `make ci`) parses the values out of every surface and fails on any
+  divergence — to change the site constants, change all surfaces in one PR.
 - Phase mapping: day half SR→SM→SS spans [0,2]; night half SS→midnight→nextSR
   spans [2,4). Solar-midnight ≈ midpoint(SS, SR+24h).
 - Lives in the pure header so ESP32, unit tests, and the replay harness share

--- a/scripts/check-solar-constants.py
+++ b/scripts/check-solar-constants.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""check-solar-constants.py — cross-surface drift guard for solar site constants (#393).
+
+The Longmont greenhouse site constants — latitude 40.167, longitude -105.102,
+sunrise/sunset zenith 90.833 — are intentionally triplicated (contract:
+docs/design/firmware-v2-contract-2026-06-10.md §B1):
+
+  * ingestor/solar.py                                  — the editable SSOT
+  * firmware/lib/greenhouse_solar.h                    — on-chip NOAA engine
+  * deploy/k8s/components/firmware-twin/src/greenhouse_solar.h — vendored twin copy
+  * db/migrations/186-noaa-solar-phase-parity.sql      — fn_solar_* helper bodies
+  * db/schema.sql                                      — dumped fn_solar_* bodies
+
+This guard parses the numeric VALUES out of every surface (formatting-tolerant:
+40.167 == 40.167f == RADIANS(40.167)) and fails if any occurrence diverges from
+the canonical values in ingestor/solar.py. It is deliberately read-only: it
+never rewrites firmware or SQL sources.
+
+The SQL patterns scan ALL of db/migrations/*.sql, so a future migration that
+redefines the fn_solar_* helpers with a drifted literal is caught without
+updating this script. Missing files or zero pattern matches are errors too —
+the guard must not rot into a silent pass.
+
+Exit 0 = all surfaces agree. Exit 1 = divergence/parse failure; every mismatch
+names BOTH locations (the divergent surface and the canonical source).
+
+Run via `make solar-constants-check`; wired into scripts/ci-local.sh (make ci).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CANONICAL_REL = "ingestor/solar.py"
+TOLERANCE = 1e-6
+
+# constant key -> canonical assignment pattern in ingestor/solar.py
+_CANONICAL_PATTERNS = {
+    "latitude": re.compile(r"^GREENHOUSE_LAT_DEG\s*=\s*(-?\d+(?:\.\d+)?)\s*$", re.M),
+    "longitude": re.compile(r"^GREENHOUSE_LON_DEG\s*=\s*(-?\d+(?:\.\d+)?)\s*$", re.M),
+    "zenith": re.compile(r"^_ZENITH_DEG\s*=\s*(-?\d+(?:\.\d+)?)\s*$", re.M),
+}
+
+# C++ headers (firmware + the byte-identical twin vendored copy).
+_HEADER_PATTERNS = {
+    "latitude": re.compile(r"GH_LATITUDE_DEG\s*=\s*(-?\d+(?:\.\d+)?)f?\b"),
+    "longitude": re.compile(r"GH_LONGITUDE_DEG\s*=\s*(-?\d+(?:\.\d+)?)f?\b"),
+    # `const float zenith = 90.833f * PI_F / 180.0f;`
+    "zenith": re.compile(r"\bzenith\s*=\s*(-?\d+(?:\.\d+)?)f?\s*\*\s*PI_F"),
+}
+
+# plpgsql DECLARE assignments in the fn_solar_* helper bodies. Literal-only:
+# `lat_rad := RADIANS(lat)` (a variable, e.g. compute_solar_position) never
+# matches, and neither does the unrelated `lat CONSTANT ... := 40.1672`.
+_SQL_PATTERNS = {
+    "latitude": re.compile(r"lat_rad\s+(?:double\s+precision\s+)?:=\s*RADIANS\(\s*(-?\d+(?:\.\d+)?)\s*\)", re.I),
+    "longitude": re.compile(r"lon_deg\s+(?:double\s+precision\s+)?:=\s*(-?\d+(?:\.\d+)?)\s*;", re.I),
+    "zenith": re.compile(r"zenith_rad\s+(?:double\s+precision\s+)?:=\s*RADIANS\(\s*(-?\d+(?:\.\d+)?)\s*\)", re.I),
+}
+
+
+@dataclass(frozen=True)
+class Occurrence:
+    rel_path: str
+    line: int
+    key: str
+    value: float
+
+
+def _line_of(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def _extract(rel_path: str, text: str, patterns: dict[str, re.Pattern[str]]) -> list[Occurrence]:
+    found: list[Occurrence] = []
+    for key, pattern in patterns.items():
+        for match in pattern.finditer(text):
+            found.append(Occurrence(rel_path, _line_of(text, match.start()), key, float(match.group(1))))
+    return found
+
+
+def _read(rel_path: str, errors: list[str]) -> str | None:
+    path = ROOT / rel_path
+    if not path.is_file():
+        errors.append(f"MISSING SURFACE: {rel_path} not found under {ROOT}")
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _canonical(errors: list[str]) -> dict[str, Occurrence]:
+    text = _read(CANONICAL_REL, errors)
+    if text is None:
+        return {}
+    canonical: dict[str, Occurrence] = {}
+    for key, pattern in _CANONICAL_PATTERNS.items():
+        matches = list(pattern.finditer(text))
+        if len(matches) != 1:
+            errors.append(
+                f"CANONICAL PARSE FAILURE: expected exactly 1 {key} assignment in {CANONICAL_REL}, found {len(matches)}"
+            )
+            continue
+        match = matches[0]
+        canonical[key] = Occurrence(CANONICAL_REL, _line_of(text, match.start()), key, float(match.group(1)))
+    return canonical
+
+
+def _surface_occurrences(errors: list[str]) -> list[Occurrence]:
+    occurrences: list[Occurrence] = []
+
+    header_rels = [
+        "firmware/lib/greenhouse_solar.h",
+        "deploy/k8s/components/firmware-twin/src/greenhouse_solar.h",
+    ]
+    for rel in header_rels:
+        text = _read(rel, errors)
+        if text is None:
+            continue
+        found = _extract(rel, text, _HEADER_PATTERNS)
+        for key in _HEADER_PATTERNS:
+            if not any(o.key == key for o in found):
+                errors.append(f"PARSE FAILURE: no {key} literal found in {rel} (guard pattern rotted?)")
+        occurrences.extend(found)
+
+    migrations_dir = ROOT / "db" / "migrations"
+    if not migrations_dir.is_dir():
+        errors.append(f"MISSING SURFACE: db/migrations not found under {ROOT}")
+    else:
+        migration_found: list[Occurrence] = []
+        for sql_path in sorted(migrations_dir.glob("*.sql")):
+            rel = sql_path.relative_to(ROOT).as_posix()
+            migration_found.extend(_extract(rel, sql_path.read_text(encoding="utf-8"), _SQL_PATTERNS))
+        for key in _SQL_PATTERNS:
+            if not any(o.key == key for o in migration_found):
+                errors.append(
+                    f"PARSE FAILURE: no {key} DECLARE literal found in any db/migrations/*.sql "
+                    "(expected at least 186-noaa-solar-phase-parity.sql)"
+                )
+        occurrences.extend(migration_found)
+
+    schema_text = _read("db/schema.sql", errors)
+    if schema_text is not None:
+        found = _extract("db/schema.sql", schema_text, _SQL_PATTERNS)
+        for key in _SQL_PATTERNS:
+            if not any(o.key == key for o in found):
+                errors.append(f"PARSE FAILURE: no {key} DECLARE literal found in db/schema.sql fn_solar_* bodies")
+        occurrences.extend(found)
+
+    return occurrences
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # no options; keeps the CLI shape stable for make/ci wiring
+    errors: list[str] = []
+    canonical = _canonical(errors)
+    occurrences = _surface_occurrences(errors)
+
+    for occ in occurrences:
+        canon = canonical.get(occ.key)
+        if canon is None:
+            continue  # canonical parse failure already reported
+        if abs(occ.value - canon.value) > TOLERANCE:
+            errors.append(
+                f"DRIFT: {occ.rel_path}:{occ.line} {occ.key} = {occ.value!r} "
+                f"!= canonical {canon.rel_path}:{canon.line} = {canon.value!r}"
+            )
+
+    if errors:
+        print("solar site-constant SSOT guard FAILED (#393):", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+        print(
+            "  fix: edit ingestor/solar.py (the SSOT) and update every mirrored surface "
+            "to the same values — see docs/design/firmware-v2-contract-2026-06-10.md §B1",
+            file=sys.stderr,
+        )
+        return 1
+
+    surfaces = sorted({o.rel_path for o in occurrences})
+    values = ", ".join(f"{key}={canonical[key].value}" for key in sorted(canonical))
+    print(f"solar site constants agree across {len(surfaces)} surfaces ({len(occurrences)} occurrences): {values}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -75,6 +75,7 @@ $PY -m pytest -q \
   tests/test_slack_ops.py \
   tests/test_soil_dryout_alert.py \
   tests/test_solar_band_anchors.py \
+  tests/test_solar_constants_check.py \
   tests/test_tempest_sync.py \
   tests/test_writer_lease_fence.py
 
@@ -83,6 +84,9 @@ $PY scripts/check_migration_rollback_safety.py
 
 step "grafana dashboard CMs match JSON sources (#392)"
 $PY scripts/gen-grafana-dashboard-cms.py --check
+
+step "solar site constants SSOT guard (#393)"
+$PY scripts/check-solar-constants.py
 
 step "twin vendored source compiles (the initContainer's exact build)"
 if command -v g++ >/dev/null; then

--- a/tests/test_solar_constants_check.py
+++ b/tests/test_solar_constants_check.py
@@ -1,0 +1,129 @@
+"""#393 gate: check-solar-constants.py catches cross-surface solar-constant drift.
+
+Value-equality guard over the intentionally-triplicated Longmont site constants
+(lat 40.167 / lon -105.102 / zenith 90.833): ingestor/solar.py (SSOT),
+firmware/lib/greenhouse_solar.h + the vendored twin copy, migration 186, and
+the dumped db/schema.sql fn_solar_* bodies. Mutation tests copy the real
+surfaces into a tmp tree so firmware/SQL sources are never modified in place.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SURFACE_RELS = [
+    "ingestor/solar.py",
+    "firmware/lib/greenhouse_solar.h",
+    "deploy/k8s/components/firmware-twin/src/greenhouse_solar.h",
+    "db/migrations/186-noaa-solar-phase-parity.sql",
+    "db/schema.sql",
+]
+
+
+def load_guard():
+    script_path = REPO_ROOT / "scripts" / "check-solar-constants.py"
+    spec = importlib.util.spec_from_file_location("check_solar_constants_under_test", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def guard_tree(tmp_path, monkeypatch):
+    """The real surface files copied into an isolated tree the tests may mutate."""
+    for rel in SURFACE_RELS:
+        dst = tmp_path / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(REPO_ROOT / rel, dst)
+    guard = load_guard()
+    monkeypatch.setattr(guard, "ROOT", tmp_path)
+    return guard, tmp_path
+
+
+def _mutate(root: Path, rel: str, old: str, new: str) -> None:
+    path = root / rel
+    text = path.read_text(encoding="utf-8")
+    assert old in text, f"mutation anchor missing from {rel}: {old!r}"
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def test_guard_passes_on_real_repo():
+    guard = load_guard()
+    assert guard.main([]) == 0
+
+
+def test_guard_passes_on_copied_tree(guard_tree):
+    guard, _root = guard_tree
+    assert guard.main([]) == 0
+
+
+def test_firmware_latitude_drift_fails_naming_both_locations(guard_tree, capsys):
+    guard, root = guard_tree
+    _mutate(root, "firmware/lib/greenhouse_solar.h", "40.167f", "40.168f")
+    assert guard.main([]) == 1
+    err = capsys.readouterr().err
+    assert "firmware/lib/greenhouse_solar.h" in err
+    assert "ingestor/solar.py" in err  # names the canonical side too
+    assert "latitude" in err
+
+
+def test_migration_longitude_drift_fails(guard_tree, capsys):
+    guard, root = guard_tree
+    _mutate(
+        root,
+        "db/migrations/186-noaa-solar-phase-parity.sql",
+        "lon_deg double precision := -105.102;",
+        "lon_deg double precision := -105.2;",
+    )
+    assert guard.main([]) == 1
+    err = capsys.readouterr().err
+    assert "db/migrations/186-noaa-solar-phase-parity.sql" in err
+    assert "ingestor/solar.py" in err
+    assert "longitude" in err
+
+
+def test_canonical_zenith_drift_fails_every_mirror(guard_tree, capsys):
+    guard, root = guard_tree
+    _mutate(root, "ingestor/solar.py", "_ZENITH_DEG = 90.833", "_ZENITH_DEG = 90.0")
+    assert guard.main([]) == 1
+    err = capsys.readouterr().err
+    for rel in SURFACE_RELS[1:]:
+        if "greenhouse_solar.h" in rel or "186-noaa" in rel or rel == "db/schema.sql":
+            assert rel in err
+
+
+def test_formatting_change_without_value_change_still_passes(guard_tree):
+    """Acceptance: value comparison, not string grep — 40.167f vs 40.1670f is no drift."""
+    guard, root = guard_tree
+    _mutate(root, "firmware/lib/greenhouse_solar.h", "40.167f", "40.1670f")
+    assert guard.main([]) == 0
+
+
+def test_removed_constant_fails_instead_of_silently_passing(guard_tree, capsys):
+    guard, root = guard_tree
+    _mutate(
+        root,
+        "firmware/lib/greenhouse_solar.h",
+        "static constexpr float GH_LATITUDE_DEG  = 40.167f;",
+        "// latitude now comes from NVS (hypothetical refactor)",
+    )
+    assert guard.main([]) == 1
+    err = capsys.readouterr().err
+    assert "PARSE FAILURE" in err
+    assert "firmware/lib/greenhouse_solar.h" in err
+
+
+def test_missing_surface_file_fails(guard_tree, capsys):
+    guard, root = guard_tree
+    (root / "db/schema.sql").unlink()
+    assert guard.main([]) == 1
+    assert "MISSING SURFACE" in capsys.readouterr().err


### PR DESCRIPTION
Closes #393

## What

`scripts/check-solar-constants.py` — a cross-surface drift guard for the Longmont site constants (latitude **40.167**, longitude **-105.102**, sunrise/sunset zenith **90.833**). It parses the numeric **values** (not string-grep; `40.167` == `40.167f` == `RADIANS(40.167)`, tolerance 1e-6) out of every mirrored surface and fails — naming **both** the divergent location and the canonical source, file:line — on any divergence.

**Canonical source chosen:** `ingestor/solar.py` (`GREENHOUSE_LAT_DEG` / `GREENHOUSE_LON_DEG` / `_ZENITH_DEG`), per the issue's preference. Mirrored surfaces guarded:

- `firmware/lib/greenhouse_solar.h` (`GH_LATITUDE_DEG`, `GH_LONGITUDE_DEG`, the `90.833f * PI_F` zenith)
- `deploy/k8s/components/firmware-twin/src/greenhouse_solar.h` (vendored twin copy — byte-sync is already guarded by test_19, but the value guard is self-contained)
- **all** of `db/migrations/*.sql` (`lat_rad := RADIANS(…)`, `lon_deg := …`, `zenith_rad := RADIANS(…)` DECLARE literals — today only `186-noaa-solar-phase-parity.sql` matches; a future migration redefining `fn_solar_*` with a drifted literal is caught without touching the script)
- `db/schema.sql` (the dumped `fn_solar_*` bodies — the migration-186 rollback source)

22 literal occurrences across 4 mirrored surfaces + the canonical source. Missing files or zero pattern matches are hard failures too, so the guard cannot rot into a silent pass.

Generation-from-one-source was deliberately **not** done: rewriting `firmware/lib/greenhouse_solar.h` from a generator would make this a firmware-source change (replay-diff gates, bake rules) for a pure consistency task. The guard is read-only over existing sources; **no behavior changes anywhere**.

## Wiring

- `make solar-constants-check` (Makefile target, next to `grafana-cm-check`)
- `scripts/ci-local.sh` step `"solar site constants SSOT guard (#393)"` — ci.yml named in the issue is retired (GitHub Actions removed 2026-07-11); ci-local.sh IS the gate
- `tests/test_solar_constants_check.py` added to the pure-logic suite: clean-pass, per-surface mutation (firmware lat, migration lon, canonical zenith), formatting-tolerance (`40.167f` → `40.1670f` still passes), pattern-rot (removed constant fails), missing-file
- SSOT contract documented in `docs/design/firmware-v2-contract-2026-06-10.md` §B1 (the firmware-solar contract note that migration 186 and `solar.py` both cite)

## Finding: pre-existing higher-precision coordinate family (NOT guarded, NOT changed)

The three issue-named surfaces all agree exactly, so the full agreeing set is guarded. But a **second, higher-precision coordinate family exists** in the repo — `40.1672 / -105.1019` — used by the weather/registry/astral paths, distinct from the NOAA solar-engine family `40.167 / -105.102`:

- `ingestor/config.py:96` (`LATITUDE` env default `40.1672`)
- `config/zones.yaml:8` (`latitude: 40.1672`)
- `ingestor/tasks/forecast.py:442` and `ingestor/tasks/_common.py:1066,1162` (astral `LocationInfo` + open-meteo URL, `40.1672, -105.1019`)
- `db/migrations/075-greenhouses-registry.sql:28` (registry seed `40.1672, -105.1019, 4979`)
- `db/schema.sql:91-92` (legacy `compute_solar_position()` trigger, `40.1672 / -105.1019`)
- `verdify_schemas/tests/test_topology.py:43`

Per the issue's scope (the three solar-engine surfaces) and the no-behavior-change constraint, this divergence is **reported, not resolved**: the guard's SQL/header patterns are literal-specific (`lat_rad := RADIANS(<number>)` etc.) so they never match the `40.1672` family. ~5e-4° (~40 m) — no practical effect on sunrise/sunset, but unifying the two families (or extending the guard over the second family) is a candidate follow-up issue.

## Evidence

Clean tree:
```
$ make solar-constants-check
solar site constants agree across 4 surfaces (22 occurrences): latitude=40.167, longitude=-105.102, zenith=90.833
```

Mutation → fails naming both locations (restored afterwards):
```
$ sed -i 's/GH_LATITUDE_DEG  = 40.167f/GH_LATITUDE_DEG  = 40.168f/' firmware/lib/greenhouse_solar.h
$ python scripts/check-solar-constants.py
solar site-constant SSOT guard FAILED (#393):
  DRIFT: firmware/lib/greenhouse_solar.h:24 latitude = 40.168 != canonical ingestor/solar.py:25 = 40.167
  fix: edit ingestor/solar.py (the SSOT) and update every mirrored surface to the same values — see docs/design/firmware-v2-contract-2026-06-10.md §B1
```
Same verified for migration-186 `lon_deg` (`-105.2` → DRIFT at `db/migrations/186-noaa-solar-phase-parity.sql:104`) and for canonical `_ZENITH_DEG` (`90.0` → 6 DRIFT lines, one per mirrored occurrence).

Gates:
- `tests/test_solar_constants_check.py` — 8 passed
- ruff check + format — clean
- Full `CI_BASE_REF=origin/main bash scripts/ci-local.sh` — **ALL GATES GREEN** (incl. the new step, schema suites, pure-logic suite, migration rollback-safety classification, twin compile, prod overlay render, service-restart drift guard, replay trigger check: "no firmware-logic diff; replay gates not required")

## Acceptance checklist

- [x] `make solar-constants-check` (and the CI-gate step) passes today and fails if any one of the three literals is edited in isolation
- [x] Guard compares parsed numeric VALUES, tolerant of formatting (`40.167` vs `40.167f`)
- [x] Documented in the firmware-solar contract note (`docs/design/firmware-v2-contract-2026-06-10.md` §B1) as the SSOT contract

Restart: none — CI/guard tooling and docs only; no runtime service code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu