### PR TITLE
gitops(stage): pin Verdify Lab runtime images sha256:bab7f3882f06758a74b79b7e3f5b9399b6192265314c5315fddd5b38a5df0d81 for 64dda4dbe783ef1d1bcae2dfee1b795c50eda306

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -18,10 +18,10 @@ images:
   # reviewed activation replaces each sentinel with its exact zot digest.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
-    digest: sha256:2c6f22020ccc323d45d0a404a776354a4f866795fcc901749758f2726e5df382
+    digest: sha256:edac283cd5875a74348b1a94fc2a6838ccb024e8ab5bdd8a4dff5b4ab6d7c459
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
-    digest: sha256:bae8888cf4cee7c21ed4a186aab384cebe8f1dd3bbd00401f213e13031bbabe0
+    digest: sha256:38a95873b52ce367849fa146eb0d99eac09f7a53e78e729db0941285ce7b090b
 
 patches:
   - path: lab-release-runtime-dormant.patch.yaml


### PR DESCRIPTION
Stage-only digest pin for the dormant release-agent/nginx pair (jvallery/agents#2930). Source revision: 64dda4dbe783ef1d1bcae2dfee1b795c50eda306. The serving static Astro digest is unchanged; the release runtime remains replicas=0 and unrouted. Review and merge do not authorize runtime activation, production cutover, or production APPLY.