### PR TITLE
fix(rag): repoint site_content corpus off dead iris-VM vault mount; alert on stale refresh (#400)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -53,11 +53,15 @@ site/quartz/.quartz-cache
 site/node_modules
 !site/docs
 !site/docs/**
-# Long-form docs / design / audits — not runtime.
-docs
-# Exception: the Iris planner playbook IS runtime (packaged into the ingestor
-# image; iris_planner.PLANNER_PLAYBOOK_PATH reads it). #339/#210.
-!docs/planner/greenhouse-playbook.md
+# Long-form docs ARE runtime for the ingestor image since #43/#400: the daily
+# site_content RAG refresh walks the in-repo docs tree (populate-site-content
+# SITE_DOC_ROOTS) now that the iris-VM vault mount is decommissioned, and the
+# Iris planner playbook (docs/planner/greenhouse-playbook.md, #339/#210) was
+# already packaged. ~2 MB of Markdown — negligible context weight. The tree is
+# re-included after the repo-wide `*.md` exclusion below (same kaniko-safe
+# dance as site/docs; a bare `!docs/planner/greenhouse-playbook.md` under an
+# excluded `docs` directory is exactly the kaniko empty-COPY quirk documented
+# at the db/ block).
 
 # --- other infra dirs not needed by the api/mcp/ingestor images ---
 grafana
@@ -106,6 +110,10 @@ db/migrations/*
 # must remain after the repo-wide Markdown exclusion above.
 !site/docs
 !site/docs/**
+# The ingestor image COPYs docs/ (RAG corpus + planner playbook, #43/#400);
+# re-include it after the repo-wide Markdown exclusion, kaniko-safe.
+!docs
+!docs/**
 !verdify_schemas/README.md
 README.md
 GOAL.md

--- a/ingestor/Dockerfile
+++ b/ingestor/Dockerfile
@@ -79,11 +79,15 @@ COPY verdify_schemas/ /app/verdify_schemas/
 # its imports resolve at this in-container location.
 COPY scripts/ /app/scripts/
 
-# k3s cleanup (#339/#210): the Iris planner playbook moved off the decommissioned
-# iris-VM mount (/mnt/agents). Package the canonical repo copy into the image so
-# iris_planner.PLANNER_PLAYBOOK_PATH resolves /app/docs/planner/greenhouse-playbook.md
-# at runtime instead of silently degrading without tuning guidance.
-COPY docs/planner/greenhouse-playbook.md /app/docs/planner/greenhouse-playbook.md
+# k3s cleanup (#339/#210 + #43/#400): docs/ is runtime for TWO consumers now.
+# (1) iris_planner.PLANNER_PLAYBOOK_PATH reads /app/docs/planner/greenhouse-playbook.md
+# (moved off the decommissioned iris-VM /mnt/agents mount). (2) The daily
+# site_content_refresh task (ingestor/tasks/ha.py) walks the populate-site-content
+# SITE_DOC_ROOTS — repointed to the in-repo docs tree after the iris-VM vault
+# mount (/mnt/iris/verdify-vault/website) died; without docs/ in the image the
+# RAG corpus walk touches 0 rows and site_content rots stale (#43). The tree is
+# ~2 MB of Markdown; .dockerignore re-includes it (kaniko-safe pattern).
+COPY docs/ /app/docs/
 
 # slack.yaml is the NON-SECRET Slack config (channel IDs + credential FILE
 # PATHS, never tokens). slack_config.DEFAULT_CONFIG_PATH resolves it next to

--- a/ingestor/tasks/ha.py
+++ b/ingestor/tasks/ha.py
@@ -16,6 +16,7 @@ from ._common import (
     _SHELLY_ENTITIES,
     _TEMPEST_MAP,
     FEEDBACK_VALUE_RANGES,
+    GREENHOUSE_ID,
     HA_TOKEN_FILE,
     INFRA_TELEMETRY_GREENHOUSE_ID,
     LEAK_CLEAR_GPM,
@@ -23,6 +24,7 @@ from ._common import (
     LEAK_TRIGGER_GPM,
     SITE_CONTENT_FRESHNESS_WINDOW_S,
     UTC,
+    AlertEnvelope,
     ClimateRow,
     EnergySample,
     EquipmentStateEvent,
@@ -208,14 +210,75 @@ def site_content_is_fresh(max_updated_at: datetime | None, now: datetime | None 
     return 0 <= age_s <= SITE_CONTENT_FRESHNESS_WINDOW_S
 
 
-async def site_content_refresh(pool: asyncpg.Pool) -> None:
-    """Daily refresh of the site_content RAG snapshot from the vault corpus.
+async def _raise_site_content_stale_alert(conn, populator, written: int, max_updated_at: datetime | None) -> None:
+    """Record stale-after-refresh as a warning alert_log row (#43/#400).
 
-    Re-materializes the public docs/website corpus into site_content (advancing
-    updated_at), then verifies max(updated_at) is back inside the cadence
-    freshness window. A stale watermark after a refresh attempt means the corpus
-    roots were unavailable (e.g. vault unmounted) — logged loudly but never
-    raised, since this RAG-maintenance task must never block greenhouse ops.
+    The original task only log.warning()'d, which is how the corpus source
+    rotted unobserved for a month after the iris-VM vault mount was
+    decommissioned. Deduped on the open row (the dispatcher
+    band_anchor_db_read_failed pattern), so a corpus outage holds ONE open
+    alert instead of stacking one per daily pass. Severity is 'warning', never
+    'critical' — RAG staleness must not trip the firmware-deploy alert gate.
+    """
+    existing = await conn.fetchval(
+        "SELECT id FROM alert_log WHERE alert_type = 'site_content_stale' AND disposition = 'open' LIMIT 1"
+    )
+    if existing is not None:
+        return
+    if max_updated_at is not None and max_updated_at.tzinfo is None:
+        max_updated_at = max_updated_at.replace(tzinfo=UTC)
+    age_s = None
+    if max_updated_at is not None:
+        age_s = max(0, int((datetime.now(UTC) - max_updated_at).total_seconds()))
+    alert = AlertEnvelope.model_validate(
+        {
+            "alert_type": "site_content_stale",
+            "severity": "warning",
+            "category": "system",
+            "sensor_id": "site_content",
+            "message": (
+                "site_content RAG snapshot stale after refresh: "
+                f"max(updated_at)={max_updated_at.isoformat() if max_updated_at else 'none'} "
+                f"(rows refreshed={written}, window={SITE_CONTENT_FRESHNESS_WINDOW_S // 3600}h) "
+                "— corpus roots unavailable; Iris is serving a stale corpus"
+            ),
+            "details": {
+                "age_s": age_s,
+                "max_updated_at": max_updated_at,
+                "rows_refreshed": written,
+                "window_s": SITE_CONTENT_FRESHNESS_WINDOW_S,
+                "corpus_roots": [str(root) for root, _ in populator.SITE_DOC_ROOTS],
+            },
+            "metric_value": float(age_s) if age_s is not None else None,
+            "threshold_value": float(SITE_CONTENT_FRESHNESS_WINDOW_S),
+        }
+    )
+    await conn.execute(
+        "INSERT INTO alert_log (alert_type, severity, category, sensor_id, message, details, "
+        "source, metric_value, threshold_value, greenhouse_id) "
+        "VALUES ($1,$2,$3,$4,$5,$6::jsonb,'ingestor',$7,$8,$9)",
+        alert.alert_type,
+        alert.severity,
+        alert.category,
+        alert.sensor_id,
+        alert.message,
+        json.dumps(alert.details),
+        alert.metric_value,
+        alert.threshold_value,
+        GREENHOUSE_ID,
+    )
+
+
+async def site_content_refresh(pool: asyncpg.Pool) -> None:
+    """Daily refresh of the site_content RAG snapshot from the in-repo corpus.
+
+    Re-materializes the docs corpus (plus the optional env-mounted website
+    corpus — see populator SITE_DOC_ROOTS, #43/#400) into site_content
+    (advancing updated_at), then verifies max(updated_at) is back inside the
+    cadence freshness window. A stale watermark after a refresh attempt means
+    the corpus roots were unavailable — logged AND raised as a warning-severity
+    site_content_stale alert row so the failure is observable, but never
+    raised as an exception: RAG maintenance must never block greenhouse ops.
     """
     try:
         populator = _load_site_content_populator()
@@ -227,14 +290,14 @@ async def site_content_refresh(pool: asyncpg.Pool) -> None:
         written = await _refresh_site_content_corpus(conn, populator)
         max_updated_at = await conn.fetchval("SELECT max(updated_at) FROM site_content")
 
-    if site_content_is_fresh(max_updated_at):
-        log.info(
-            "site_content_refresh: %d rows refreshed; max(updated_at)=%s within %dh window",
-            written,
-            max_updated_at.isoformat() if max_updated_at else "none",
-            SITE_CONTENT_FRESHNESS_WINDOW_S // 3600,
-        )
-    else:
+        if site_content_is_fresh(max_updated_at):
+            log.info(
+                "site_content_refresh: %d rows refreshed; max(updated_at)=%s within %dh window",
+                written,
+                max_updated_at.isoformat() if max_updated_at else "none",
+                SITE_CONTENT_FRESHNESS_WINDOW_S // 3600,
+            )
+            return
         log.warning(
             "site_content_refresh: snapshot still stale after refresh "
             "(rows touched=%d, max(updated_at)=%s, window=%dh) — corpus roots may be unavailable",
@@ -242,6 +305,10 @@ async def site_content_refresh(pool: asyncpg.Pool) -> None:
             max_updated_at.isoformat() if max_updated_at else "none",
             SITE_CONTENT_FRESHNESS_WINDOW_S // 3600,
         )
+        try:
+            await _raise_site_content_stale_alert(conn, populator, written, max_updated_at)
+        except Exception as e:  # noqa: BLE001 — the alert is best-effort; never crash the loop
+            log.error("site_content_refresh: could not record site_content_stale alert: %s", e)
 
 
 async def shelly_sync(pool: asyncpg.Pool) -> None:

--- a/scripts/populate-site-content.py
+++ b/scripts/populate-site-content.py
@@ -8,7 +8,8 @@ but was empty, and the planner playbook lived only on disk (so embed-corpora.py
 had nothing to chunk). This script:
 
   - Walks docs/**/*.md (excluding agent-internal/meta docs) → site_content
-  - Walks /mnt/iris/verdify-vault/website/**/*.md → site_content
+  - Walks $VERDIFY_SITE_WEBSITE_ROOT/**/*.md → site_content (optional; only
+    when the env var points at a mounted public website corpus)
   - Walks docs/planner/*.md and the agent-host skills mirror → playbook_content
   - Chunks long files by markdown headings, then ~512-token blocks
   - Idempotent: content_hash skips unchanged rows
@@ -23,6 +24,7 @@ import argparse
 import asyncio
 import hashlib
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -30,7 +32,13 @@ from pathlib import Path
 import asyncpg
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-WEBSITE_ROOT = Path("/mnt/iris/verdify-vault/website")
+# Optional extra corpus root for the public lab-site vault snapshot. The legacy
+# hardcoded default (the decommissioned iris-VM vault mount) never exists in
+# the k3s ingestor pod, so the website corpus silently dropped out of the RAG
+# snapshot while the daily refresh kept "running" (#43/#400). There is no dead
+# default anymore: the env var is the only way to add a website root, so a
+# future in-cluster vault snapshot can be repointed without a code change.
+WEBSITE_ROOT_ENV = "VERDIFY_SITE_WEBSITE_ROOT"
 sys.path.insert(0, str(REPO_ROOT / "ingestor"))
 from config import DB_DSN  # noqa: E402
 
@@ -51,10 +59,18 @@ SITE_DOC_EXCLUDE_PATTERNS = (
     "showcase-",
 )
 
+# (root, rel_root) pairs; page_path = md_path.relative_to(rel_root). The repo
+# docs tree is the always-live corpus source — it exists in the checkout AND in
+# the ingestor image (Dockerfile COPYs docs/), so the daily site_content
+# refresh can advance the RAG watermark post-VM-decommission (#43/#400).
 SITE_DOC_ROOTS = [
     (REPO_ROOT / "docs", REPO_ROOT),
-    (WEBSITE_ROOT, WEBSITE_ROOT.parent),
 ]
+_website_root = os.environ.get(WEBSITE_ROOT_ENV, "")
+if _website_root:
+    # rel_root = parent keeps the legacy "website/..." page_path keys when the
+    # mounted snapshot directory is named `website`.
+    SITE_DOC_ROOTS.append((Path(_website_root), Path(_website_root).parent))
 PLAYBOOK_ROOTS = [
     REPO_ROOT / "docs" / "planner",
 ]

--- a/tests/test_12_fidelity.py
+++ b/tests/test_12_fidelity.py
@@ -2043,11 +2043,14 @@ def test_firmware_misters_have_no_standalone_zone_stress_path():
     assert "&& (humidity_demand || any_zone_stressed)" not in controls
 
 
-def test_site_content_populator_indexes_public_website_markdown():
+def test_site_content_populator_corpus_roots_are_post_vm_decommission():
+    """#43/#400: the RAG corpus source of truth must never point at the dead
+    iris-VM vault mount again. The always-live root is the in-repo docs tree
+    (packaged into the ingestor image); a website corpus is opt-in via env."""
     script = Path("scripts/populate-site-content.py").read_text()
-    assert 'WEBSITE_ROOT = Path("/mnt/iris/verdify-vault/website")' in script
-    assert "(WEBSITE_ROOT, WEBSITE_ROOT.parent)" in script
-    assert "Walks /mnt/iris/verdify-vault/website/**/*.md" in script
+    assert "/mnt/iris" not in script  # grep proof, per the #400 acceptance
+    assert '(REPO_ROOT / "docs", REPO_ROOT),' in script
+    assert 'WEBSITE_ROOT_ENV = "VERDIFY_SITE_WEBSITE_ROOT"' in script
 
 
 def test_embedding_chunker_hard_splits_oversized_blocks():

--- a/tests/test_site_content_refresh.py
+++ b/tests/test_site_content_refresh.py
@@ -1,10 +1,15 @@
 """Unit tests for the daily site_content RAG-refresh task (issue #43).
 
 Covers:
-  - the corpus walk selects/upserts in-scope vault pages and advances
-    max(updated_at) (the "selects/refreshes" half), and
+  - the corpus walk selects/upserts in-scope corpus pages and advances
+    max(updated_at) (the "selects/refreshes" half),
   - the freshness assertion that max(updated_at) stays inside the cadence
-    window after a refresh (the "freshness assertion (fixture)" half).
+    window after a refresh (the "freshness assertion (fixture)" half),
+  - the #400 stale-after-refresh path: a forced-stale corpus produces a
+    warning-severity site_content_stale alert_log row (not just a log line),
+    deduped on the open row, and
+  - the #400 source-of-truth contract: SITE_DOC_ROOTS points at the live
+    in-repo docs tree, never the decommissioned /mnt/iris vault mount.
 
 Read/embed side only — no device, no live DB. A FakePool models site_content
 as an in-memory dict so the upsert path runs end-to-end with deterministic
@@ -38,9 +43,11 @@ class _FakeConn:
     max(updated_at) advances on refresh.
     """
 
-    def __init__(self, store, stamp: datetime):
+    def __init__(self, store, stamp: datetime, alerts: list | None = None):
         self._store = store
         self._stamp = stamp
+        # alert_log rows as dicts (the #400 stale-alert path writes here).
+        self.alerts = alerts if alerts is not None else []
 
     async def fetchval(self, query, *args):
         q = " ".join(query.split())
@@ -50,6 +57,11 @@ class _FakeConn:
             if not self._store:
                 return None
             return max(ua for _, ua in self._store.values())
+        if q.startswith("SELECT id FROM alert_log WHERE alert_type = 'site_content_stale'"):
+            for i, row in enumerate(self.alerts):
+                if row["alert_type"] == "site_content_stale" and row["disposition"] == "open":
+                    return i + 1
+            return None
         raise AssertionError(f"unexpected fetchval: {q!r}")
 
     async def execute(self, query, *args):
@@ -61,6 +73,33 @@ class _FakeConn:
         if q.startswith("INSERT INTO site_content"):
             page_path, content = args[0], args[1]
             self._store[page_path] = (content, self._stamp)
+            return "INSERT 0 1"
+        if q.startswith("INSERT INTO alert_log"):
+            (
+                alert_type,
+                severity,
+                category,
+                sensor_id,
+                message,
+                details,
+                metric_value,
+                threshold_value,
+                greenhouse_id,
+            ) = args
+            self.alerts.append(
+                {
+                    "alert_type": alert_type,
+                    "severity": severity,
+                    "category": category,
+                    "sensor_id": sensor_id,
+                    "message": message,
+                    "details": details,
+                    "metric_value": metric_value,
+                    "threshold_value": threshold_value,
+                    "greenhouse_id": greenhouse_id,
+                    "disposition": "open",
+                }
+            )
             return "INSERT 0 1"
         raise AssertionError(f"unexpected execute: {q!r}")
 
@@ -78,10 +117,10 @@ class _FakeAcquire:
 
 class _FakePool:
     def __init__(self, store, stamp: datetime):
-        self._conn = _FakeConn(store, stamp)
+        self.conn = _FakeConn(store, stamp)
 
     def acquire(self):
-        return _FakeAcquire(self._conn)
+        return _FakeAcquire(self.conn)
 
 
 @pytest.fixture
@@ -186,3 +225,108 @@ def test_task_loop_registers_site_content_refresh():
     src = (INGESTOR_ROOT / "ingestor.py").read_text()
     assert '("site_content_refresh", 86400, site_content_refresh)' in src
     assert "site_content_refresh," in src  # imported from tasks
+
+
+# ── #400: stale-after-refresh must raise an alert row, not just a log line ──
+def _point_populator_at_missing_root(populator, root: Path) -> None:
+    """Corpus roots that do not exist — the post-VM-decommission failure mode."""
+    populator.REPO_ROOT = root
+    populator.SITE_DOC_ROOTS = [(root / "vanished-corpus", root)]
+
+
+@pytest.mark.asyncio
+async def test_stale_after_refresh_inserts_site_content_stale_alert(tmp_path, monkeypatch):
+    import json
+
+    stamp = datetime.now(UTC)
+    stale = stamp - timedelta(days=8)
+    store: dict[str, tuple[str, datetime]] = {"docs/overview.md": ("old content", stale)}
+    pool = _FakePool(store, stamp)
+
+    populator = tasks._load_site_content_populator()
+    _point_populator_at_missing_root(populator, tmp_path)
+    monkeypatch.setattr(tasks.ha, "_load_site_content_populator", lambda: populator)
+
+    await tasks.site_content_refresh(pool)
+
+    # The watermark could not advance (roots missing) → one alert_log ROW.
+    assert len(pool.conn.alerts) == 1
+    row = pool.conn.alerts[0]
+    assert row["alert_type"] == "site_content_stale"
+    assert row["severity"] == "warning"  # never critical: must not gate firmware deploys
+    assert row["category"] == "system"
+    assert row["sensor_id"] == "site_content"
+    assert row["disposition"] == "open"
+    details = json.loads(row["details"])
+    assert details["rows_refreshed"] == 0
+    assert details["window_s"] == tasks.SITE_CONTENT_FRESHNESS_WINDOW_S
+    assert details["age_s"] >= 7 * 86400
+    assert details["corpus_roots"] == [str(tmp_path / "vanished-corpus")]
+    assert row["metric_value"] == pytest.approx(float(details["age_s"]))
+    assert row["threshold_value"] == float(tasks.SITE_CONTENT_FRESHNESS_WINDOW_S)
+
+
+@pytest.mark.asyncio
+async def test_stale_alert_dedupes_on_open_row(tmp_path, monkeypatch):
+    stamp = datetime.now(UTC)
+    stale = stamp - timedelta(days=8)
+    store: dict[str, tuple[str, datetime]] = {"docs/overview.md": ("old content", stale)}
+    pool = _FakePool(store, stamp)
+
+    populator = tasks._load_site_content_populator()
+    _point_populator_at_missing_root(populator, tmp_path)
+    monkeypatch.setattr(tasks.ha, "_load_site_content_populator", lambda: populator)
+
+    await tasks.site_content_refresh(pool)
+    await tasks.site_content_refresh(pool)
+
+    # A corpus outage holds ONE open alert; daily passes don't stack rows.
+    assert len(pool.conn.alerts) == 1
+
+
+@pytest.mark.asyncio
+async def test_fresh_refresh_inserts_no_alert(fixture_corpus, monkeypatch):
+    stamp = datetime.now(UTC)
+    store: dict[str, tuple[str, datetime]] = {}
+    pool = _FakePool(store, stamp)
+
+    populator = tasks._load_site_content_populator()
+    _point_populator_at(populator, fixture_corpus)
+    monkeypatch.setattr(tasks.ha, "_load_site_content_populator", lambda: populator)
+
+    await tasks.site_content_refresh(pool)
+
+    assert store  # corpus indexed
+    assert pool.conn.alerts == []
+
+
+# ── #400: the corpus source of truth must be live post-VM-decommission ──────
+def test_live_populator_corpus_roots_exist_in_repo(monkeypatch):
+    monkeypatch.delenv("VERDIFY_SITE_WEBSITE_ROOT", raising=False)
+    populator = tasks._load_site_content_populator()
+    roots = [root for root, _ in populator.SITE_DOC_ROOTS]
+    # Never the decommissioned iris-VM vault mount again.
+    assert all(not str(root).startswith("/mnt/iris") for root in roots)
+    # The default corpus root is the in-repo docs tree, and it exists.
+    assert roots == [REPO_ROOT / "docs"]
+    assert all(root.is_dir() for root in roots)
+    # Grep proof (the #400 acceptance): no /mnt/iris path remains in the script.
+    assert "/mnt/iris" not in (REPO_ROOT / "scripts" / "populate-site-content.py").read_text()
+
+
+def test_env_override_adds_website_corpus_root(tmp_path, monkeypatch):
+    website = tmp_path / "website"
+    website.mkdir()
+    monkeypatch.setenv("VERDIFY_SITE_WEBSITE_ROOT", str(website))
+    populator = tasks._load_site_content_populator()
+    # rel_root = parent keeps the legacy "website/..." page_path keys.
+    assert (website, tmp_path) in populator.SITE_DOC_ROOTS
+
+
+def test_ingestor_image_packages_the_docs_corpus():
+    """The in-repo docs tree only counts as a LIVE source if it exists in the
+    ingestor image — the walk runs in the pod, not the checkout (#43/#400)."""
+    dockerfile = (REPO_ROOT / "ingestor" / "Dockerfile").read_text()
+    assert "COPY docs/ /app/docs/" in dockerfile
+    dockerignore = (REPO_ROOT / ".dockerignore").read_text()
+    assert "!docs/**" in dockerignore

--- a/verdify_schemas/alerts.py
+++ b/verdify_schemas/alerts.py
@@ -50,6 +50,7 @@ AlertType = Literal[
     "safety_invalid",
     "sensor_offline",
     "setpoint_unconfirmed",
+    "site_content_stale",
     "soil_dryout",
     "soil_sensor_offline",
     "temp_safety",
@@ -97,6 +98,7 @@ ALERT_TYPES: tuple[str, ...] = (
     "safety_invalid",
     "sensor_offline",
     "setpoint_unconfirmed",
+    "site_content_stale",
     "soil_dryout",
     "soil_sensor_offline",
     "temp_safety",
@@ -201,6 +203,19 @@ class ClimateActionProofStaleDetails(_DetailsBase):
     age_s: int | None = Field(default=None, ge=0)
     latest_ts: AwareDatetime | None = None
     proof_missing: str | None = None
+
+
+class SiteContentStaleDetails(_DetailsBase):
+    # site_content RAG snapshot watermark did not advance back inside the
+    # cadence window after a refresh pass (#43/#400): the corpus roots were
+    # unavailable in the runtime environment (docs tree missing from the
+    # image, website snapshot unmounted), so Iris keeps serving a stale
+    # corpus. age_s/max_updated_at None == empty table (nothing to serve).
+    age_s: int | None = Field(default=None, ge=0)
+    max_updated_at: AwareDatetime | None = None
+    rows_refreshed: int = Field(..., ge=0)
+    window_s: int = Field(..., gt=0)
+    corpus_roots: list[str] = Field(default_factory=list)
 
 
 class ESP32RebootDetails(_DetailsBase):
@@ -558,6 +573,11 @@ class ClimateActionProofStaleAlert(_AlertBase):
     details: ClimateActionProofStaleDetails
 
 
+class SiteContentStaleAlert(_AlertBase):
+    alert_type: Literal["site_content_stale"]
+    details: SiteContentStaleDetails
+
+
 class ESP32RebootAlert(_AlertBase):
     alert_type: Literal["esp32_reboot"]
     details: ESP32RebootDetails
@@ -801,6 +821,7 @@ AlertEnvelopeUnion = Annotated[
     | SafetyInvalidAlert
     | SensorOfflineAlert
     | SetpointUnconfirmedAlert
+    | SiteContentStaleAlert
     | SoilDryoutAlert
     | SoilSensorOfflineAlert
     | TempSafetyAlert

--- a/verdify_schemas/tests/test_alert_envelope.py
+++ b/verdify_schemas/tests/test_alert_envelope.py
@@ -46,6 +46,7 @@ from verdify_schemas.alerts import (
     SafetyInvalidAlert,
     SensorOfflineAlert,
     SetpointUnconfirmedAlert,
+    SiteContentStaleAlert,
     SoilDryoutAlert,
     SoilSensorOfflineAlert,
     TelemetryStallAlert,
@@ -106,6 +107,16 @@ CASES = {
     "climate_action_proof_stale": (
         ClimateActionProofStaleAlert,
         {"age_s": 360, "latest_ts": NOW, "proof_missing": "relay_truth"},
+    ),
+    "site_content_stale": (
+        SiteContentStaleAlert,
+        {
+            "age_s": 2592000,
+            "max_updated_at": NOW,
+            "rows_refreshed": 0,
+            "window_s": 108000,
+            "corpus_roots": ["/app/docs"],
+        },
     ),
     "esp32_push_failed": (
         ESP32PushFailedAlert,


### PR DESCRIPTION
Closes #400 (implementation child of #43).

## Problem

The daily `site_content_refresh` ingestor task (#43 → PR #160) was wired and running, but the corpus source of truth was dead: `scripts/populate-site-content.py` `SITE_DOC_ROOTS` hardcoded `/mnt/iris/verdify-vault/website` (the decommissioned iris-VM vault mount, never present in the k3s pod), and the ingestor image only packaged `docs/planner/greenhouse-playbook.md` (which the walk explicitly skips). Every daily pass walked **0 pages**, `log.warning()`'d into the void, and Iris RAG kept serving a month-stale corpus — the exact "task wired (done) vs corpus source valid (broken)" drift this issue owns.

## What changed

**Repoint (live source — the backlog's "pick the in-repo source first" option):**
- `scripts/populate-site-content.py`: `SITE_DOC_ROOTS` defaults to the in-repo `docs/` tree only. The dead `WEBSITE_ROOT` constant is gone — **no `/mnt/iris` path remains in the script** (grep proof pinned by tests). An optional `VERDIFY_SITE_WEBSITE_ROOT` env var re-adds a mounted website corpus without a code change (`rel_root = parent` keeps the legacy `website/...` page_path keys).
- `ingestor/Dockerfile` + `.dockerignore`: `COPY docs/ /app/docs/` so the corpus exists **where the task runs** (~2 MB of Markdown). The `.dockerignore` re-include uses the kaniko-safe `!docs` + `!docs/**` dance after the repo-wide `*.md` exclusion — the previous bare `!docs/planner/greenhouse-playbook.md` under an excluded `docs` directory is exactly the kaniko empty-COPY quirk documented at the `db/` block, so this also hardens the existing playbook packaging (#339/#210).
- Corpus scope note: `site/docs/` was deliberately **not** added as a root — it is upstream Quartz framework documentation (plugins, hosting, "migrating from Quartz 3"), not Verdify content; indexing it would pollute Iris retrieval.

**Alert (staleness observable, not buried in a log line):**
- `verdify_schemas/alerts.py`: new `site_content_stale` alert type (`SiteContentStaleDetails` + `SiteContentStaleAlert`, added to `AlertType`/`ALERT_TYPES`/the envelope union) with `age_s`, `max_updated_at`, `rows_refreshed`, `window_s`, `corpus_roots` details.
- `ingestor/tasks/ha.py`: when `site_content_is_fresh()` is still False after a refresh pass, insert a **warning**-severity `site_content_stale` row into `alert_log` via `AlertEnvelope`, deduped on the open row (the dispatcher `band_anchor_db_read_failed` pattern — one open alert per outage, not one per daily pass). Best-effort and never raises: RAG maintenance must never block greenhouse ops.

**Alert mechanism choice** (per the issue's How): the existing app-level alerts insert path, severity from the existing `chk_alert_severity` domain (`info`/`warning`/`critical` — there is no `'low'`/`'high'`, so `'warning'` is reused; never `'critical'`, which would trip the firmware-deploy alert gate for a non-safety RAG issue). **No PrometheusRule**: this repo ships none — per `COORDINATION_REQUESTS.md` PrometheusRules belong to `monitoring-stack`. No cross-repo ask is needed here because the failure mode this alert covers (task runs, corpus roots dead) is observable from inside the ingestor; a dead ingestor itself is already the monitoring-stack writer-absent ask (#343 row).

## Acceptance mapping (#400)

- [x] Same as #43 acceptance — repoint + self-alerting staleness landed; `tests/test_site_content_refresh.py` covers the new source root and the alert-on-stale path (forced-stale fixture produces an **alerts-table row**, not just a log line; open-row dedup; no-alert-when-fresh).
- [x] **No new tunable introduced** — the alert is an `alert_log` row, not a tunable; no `cfg_*` readback required (confirmed: no `firmware/greenhouse/tunables.yaml` or registry touch).
- [x] service-restart-drift-guard: restart documentation below; guard passes structurally (see verification).
- [ ] Runtime half (post-deploy, needs image roll + gated sync): after the rebuilt ingestor image is promoted and `verdify-ingestor` bounces, probe `bash scripts/verdify-db.sh prod -c "SELECT max(updated_at) FROM site_content"` lands inside the 30h window after the next daily pass, re-probed +60 min per the durability gate. Cannot be closed from this PR — it is the same residual runtime confirmation #43 tracks.

## Post-merge restart (rule 7)

**Post-merge restart: verdify-ingestor, verdify-mcp.**
- `verdify-ingestor` — must bounce onto the rebuilt image to pick up the new corpus root (`/app/docs`), the packaged docs tree, and the stale-alert path.
- `verdify-mcp` — imports `verdify_schemas`; bounce for the new `site_content_stale` alert type (2026-04-21 MCP staleness incident class).

## Verification

- `tests/test_site_content_refresh.py` — 11 passed (5 existing + 6 new: stale-alert row, dedup, no-alert-when-fresh, live corpus roots + grep proof, env-override root, image-packaging guard).
- `verdify_schemas/tests/test_alert_envelope.py` — passed with the new `site_content_stale` CASES entry (dispatch, legacy API, extra-field rejection, write-path scan).
- `tests/test_12_fidelity.py` populator test repinned from the dead-mount contract to the post-VM contract.
- `make lint` — green.
- `CI_BASE_REF=origin/main bash scripts/ci-local.sh` — **ALL GATES GREEN** (ruff lint+format, schema suites incl. drift guards, device write gate, pure-logic/contract suites, migration rollback safety, grafana CM check, solar SSOT guard, twin g++ compile, prod overlay render, no-new-fire-and-forget, service-restart drift guard, replay-diff trigger: no firmware-logic diff).
- Full `pytest tests/` compared against an origin/main baseline in a clean worktree: **zero delta** — 139 FAILED + 4 ERROR on this branch, byte-identical `FAILED`/`ERROR` list on origin/main (`diff` of sorted failure sets is empty). All are the documented pre-existing environment set (#322 class: live-stack asserts against `test_01_infrastructure`/`test_02_database` localhost:5432, live api/website/cron/observability checks). None touch the changed surfaces.

## Known limitation (documented, out of scope)

Legacy `website/...` rows from the vault era remain in `site_content` (present but stale). The freshness watermark is `max(updated_at)`, so they don't mask staleness of the live corpus; pruning/retiring vault-era rows is a separate data-hygiene decision. When a public website snapshot lands in-cluster, mount it and set `VERDIFY_SITE_WEBSITE_ROOT` on the ingestor Deployment — no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu
