### PR TITLE
feat(lab): add S3 occurrence release adapter

### DIFF
--- a/docs/plans/lab-astro-migration.md
+++ b/docs/plans/lab-astro-migration.md
@@ -202,10 +202,11 @@ fallbacks at T0 and T+10, with no pending/invalid occurrences and with LKG and
 freshness recovery proven. No reporting-tier activation, credential work,
 production sync, DNS, or Quartz change occurs without its recorded human gate.
 
-Phase 5 — **Production cutover (Jason-gated).** Land canary scaffold
-(`da26d54`) on main once Phase 2 is green, build/pin/deploy the dark canary,
-full acceptance vs prod, then Jason APPLY: route cutover, Quartz retirement,
-publisher decommission, ghcr image retirement (ADR-0021 cleanup).
+Phase 5 — **Production cutover (Jason-gated).** The canary scaffold landed via
+#471 but remains unbuilt, unpinned, undeployed, and unrouted. Build/pin/deploy
+the dark canary only after its gates, run full acceptance vs prod, then Jason
+APPLY: route cutover, Quartz retirement, publisher decommission, ghcr image
+retirement (ADR-0021 cleanup).
 GATE: Jason explicit approval; rollback = route flip back to Quartz (kept
 warm until sign-off).
 
@@ -249,7 +250,8 @@ CLOSED REVIEW VEHICLE:
   validate (`verdify-platform-pr-ci-dgmff`), merged at head 6ff5b19 + branch
   deleted. MEDIUM/LOW review findings remain tracked as PR comments. The two
   subsumed branches (`web/public-output-guard`,
-  `web/site-unification-integration`) are now safe to delete. Residue: two
+  `web/site-unification-integration`) are confirmed absent locally and on
+  `origin`. Residue: two
   inert debug Workflows (`…debug458`, `…debug458b`) in agent-fleet-ci need a
   delete-rights cleanup.
 
@@ -264,9 +266,8 @@ DELETE — verified superseded (content demonstrably on main via #461/#462):
   `coordinator/lab-s3-release` (local-filesystem release/CAS content already on main; canary
   superseded), and `coordinator/lab-goal-completion` after PR #470 preserved its
   doc patch. These are the nine authorized deletions.
-- **Deferred:** `web/public-output-guard` +
-  `web/site-unification-integration` are subsumed by PR #458 but stay until that
-  PR is green and merged.
+- **Confirmed absent:** `web/public-output-guard` +
+  `web/site-unification-integration`, subsumed by merged PR #458.
 - Local `main` in the shared root checkout: do NOT push, reset, rewrite, or
   otherwise disturb it; its extra commit is canary-v2 content and may coexist
   with unrelated operator state. Continue all program work from fresh

--- a/docs/plans/lab-astro-migration.md
+++ b/docs/plans/lab-astro-migration.md
@@ -1,21 +1,22 @@
 # Lab Astro Migration — Consolidated Program Tracker
 
-Last updated: 2026-07-13 (Phase 4c offline producer build/probe/pin gate passed;
-Phase 4b S3 foundation merged; occurrence adapter ready for review).
+Last updated: 2026-07-13 (Phase 4c offline producer and current dormant-runtime
+build/probe/pin gates passed; Phase 4b S3 foundation merged; occurrence
+adapter is carried by #502).
 Owner: platform agent (Claude outer loop plans/verifies; Codex executes on
 xhigh). Human gate: Jason (prod sync, DNS/edge, Quartz retirement, credential
 work). Epic: #351 (L9, G3). This file is the single source of truth for the
 Quartz→Astro migration of lab.verdify.ai; update it whenever a phase gate
 changes state.
 
-## Ground truth (verified live 2026-07-13 ~07:04 UTC)
+## Ground truth (stage verified live ~07:04 UTC; repo/CI refreshed ~16:15 UTC)
 
 | Surface | State |
 |---|---|
 | `lab.verdify.ai` (prod) | Quartz. `verdify-lab` Deployment in `verdify-prod` (ghcr image — pre-ADR-0021 holdover), `verdify-lab-publisher` CronJob republished every 10 min (mutable, shared RWO PVC, both replicas node-pinned). Healthy and fresh; had a 5-job BackoffLimitExceeded streak before recovering. |
 | `lab-stage.verdify.ai` (canary) | Astro. `verdify-lab-astro-stage` in ns `verdify-platform`, 2/2 Ready with zero restarts on distinct nodes, exact image and pod image IDs `verdify-lab-astro@sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99` (pin PR #468), shell contract **1.1.0**, content frozen at the 2026-07-12 snapshot. Live T0/T+10 acceptance passed and the ArgoCD app returned to manual-sync. |
-| `main` | Astro source now includes the accepted static implementation, dormant release/cache runtime, offline camera producer (#487), and complete offline 143-graph producer (#492). Runtime pin #495 binds the dormant agent/nginx pair to the exact graph-containing source; the live stage remains the static image above. Occurrence-store/event wiring, exact parity, and production cutover remain. |
-| In-cluster CI | **Green for lab-astro.** Current-source workflow `verdify-platform-ci-d9bqw` completed 17/17 Lab Pod gates for `64dda4d...`: 12 browser quality tests, static/agent/nginx builds, metadata hydration, exact static probe, and paired runtime probe. Pin #495 passed exact-head PR CI/render/kubeconform; its digest-only follow-up workflow also passed. Earlier Playwright fixes #463/#464 and agents#2969/#2970 remain enforced without relaxing quality budgets. |
+| `main` | Astro source includes the accepted static implementation, dormant release/cache runtime, offline camera producer (#487), complete offline 143-graph producer (#492), and inactive S3 conditional-store foundation (#496). Runtime pin #500 binds the dormant agent/nginx pair to the latest completed relevant source chain; later #499 changes are outside the Lab source. The live stage remains the static image above. Occurrence caller/event wiring, exact parity, and production cutover remain. |
+| In-cluster CI | **Green for the latest completed Lab source/pin chain.** Workflow `verdify-platform-ci-crv96` completed 17/17 Lab Pod gates for `6729cc2...`: 12 browser quality tests, static/agent/nginx builds, metadata hydration, exact static probe, and paired runtime probe. Pin #500 passed exact-head PR CI/render/kubeconform and its digest-only follow-up workflow passed. Later exact-main workflows do not authorize stage sync or runtime activation. Earlier Playwright fixes #463/#464 and agents#2969/#2970 remain enforced without relaxing quality budgets. |
 
 ## Completed (do not re-plan)
 
@@ -49,9 +50,9 @@ Child issues (persisted 2026-07-13 post-consensus): 1→#474, 2→#475, 3→#476
 | 4 | Media & lightbox | Responsive images, intrinsic sizing, and lightbox accepted on stage | Production remains Quartz until Phase 5 |
 | 5 | Planner/evidence templates | Accepted on stage against the full frozen snapshot | Event-driven content refresh remains Phase 4b |
 | 6 | Semantic parity | Routes/aliases complete; comparator improved | Exact same-snapshot parity not green: ~240 false findings from SVG-`<title>` parser bug (fix exists uncommitted on a dead worktree — must be recreated), 9 unavailable historical refs (5 daily-plan routes, 4 images), and Quartz-vs-Astro must build from the SAME immutable snapshot |
-| 7 | Immutable publishing | Local-filesystem CAS/release/cache engine and inactive S3 conditional-store foundation (#496) merged; 4a runtime is source-visible with exact source-bound images as a disconnected `replicas: 0` workload | Occurrence adapter, CLI/caller, endpoint/credential-name probe, distributed coordination, retention/GC, and event producer remain; no runtime pod is scheduled or routed |
+| 7 | Immutable publishing | Local-filesystem CAS/release/cache engine and inactive S3 conditional-store foundation (#496) merged; typed occurrence adapter is carried by #502; 4a runtime is source-visible with exact source-bound images as a disconnected `replicas: 0` workload | CLI/caller, endpoint/credential-name probe, distributed coordination, retention/GC, and event producer remain; no runtime pod is scheduled or routed |
 | 8 | Quality gates | Strict real-content gates green; exact tested build passed live T0 and T+10 acceptance | Keep the same budgets for every Phase 4 rollout; no production acceptance yet |
-| 9 | Production cutover | Fail-closed canary scaffold is preserved in open PR #471 | Not on main/built/pinned/deployed; Quartz remains authoritative; Jason APPLY required |
+| 9 | Production cutover | Fail-closed canary scaffold merged via #471 | Not built/pinned/deployed; Quartz remains authoritative; Jason APPLY required |
 
 ## Execution phases and gates
 
@@ -166,8 +167,9 @@ Phase 4 — **Feature completion (owner: codex, critical-path order below).**
    implementation may proceed, but live reporting or occurrence activation
    remains separately Jason-gated.
    Their exact-source static/agent/nginx build, metadata, static-image, paired
-   runtime, and dormant digest-pin chain passed via `verdify-platform-ci-d9bqw`
-   and #495. This proves the packaged source pair only; no stage sync,
+   runtime, and latest completed dormant digest-pin chain passed via
+   `verdify-platform-ci-crv96` and #500. This proves the packaged source pair
+   only; no stage sync,
    reporting feed, producer request, route, or runtime activation occurred.
 2. **4a Release runtime:** `d91737d` landed via #473 with init hydration,
    atomic runtime, readiness, metrics, and tests. The follow-through makes the
@@ -186,8 +188,8 @@ Phase 4 — **Feature completion (owner: codex, critical-path order below).**
    occurrence wiring and S7 closure are hard-gated on the 4c producer contract.
    The inactive full-site S3 conditional-store foundation merged through #496;
    it is not selected by a CLI or workload and carries no endpoint, credential,
-   route, or activation. The next reviewed slice adds the distinct typed
-   occurrence adapter while keeping S3 mutation caller-disabled.
+   route, or activation. #502 carries the distinct typed occurrence adapter
+   while keeping S3 mutation caller-disabled.
 4. **4d Exact parity:** recreate the SVG-title comparator fix (+8 tests),
    rebuild Quartz+Astro from the same immutable snapshot, burn down real
    findings, and disposition the nine unavailable historical references. Its
@@ -209,31 +211,31 @@ warm until sign-off).
 
 ## Branch dispositions (2026-07-13, per-branch triage vs origin/main)
 
-KEEP — real unmerged work:
+LANDED — salvaged work:
 
 - `coordinator/lab-production-canary-v2` (da26d54) — the fail-closed Astro
-  production canary scaffold, salvaged onto current main as PR #471 (head
-  27822e1; in-cluster PR CI green). Phase 5 input; leave open/unmerged until its
-  gates. It supersedes the unpushed local-main
+  production canary scaffold, merged onto main via PR #471 as `0285196` after
+  in-cluster PR CI. It remains dormant Phase 5 input and is not built, pinned,
+  deployed, or routed. It supersedes the unpushed local-main
   commit 03cff94 (verified patch-identical) and the canary copies buried in
   `web/lab-production-candidate`, `coordinator/lab-s3-release`, and
   `coordinator/lab-goal-completion`.
 - `coordinator/lab-release-runtime` — ONLY home of d91737d, the immutable
   release-cache runtime (2-pod read-only cache candidate, init hydration +
   sidecar reconciliation, atomic nginx current/tree, readiness/metrics, 61
-  unit tests). Only d91737d was cherry-picked onto current main as PR #473
-  (head 29edeb9; in-cluster PR CI green); the five superseded sibling commits
-  were omitted.
+  unit tests). Only d91737d was cherry-picked onto main via PR #473 as
+  `71530e1` after in-cluster PR CI; the five superseded sibling commits were
+  omitted.
 - `security/grafana-supported-images` — unrelated to lab but valuable:
   upgrades EOL grafana-oss 11.6.0 / renderer 3.12.6 to supported digest-pinned
-  releases + Secret-sourced renderer token. Salvaged as PR #472 (head 38536ec;
-  in-cluster PR CI green); prod Grafana Secret delivery and sync stay gated.
+  releases + Secret-sourced renderer token. Merged via PR #472 as `37561db`
+  after in-cluster PR CI; prod Grafana Secret delivery and sync stay gated.
 - `coordinator/lab-goal-completion` — one salvage beyond the canary: PR #462's
   merge dropped a release-store section from
-  `docs/site-publishing-pipeline.md`; the exact section is restored in PR #470
-  (head 8846b00; in-cluster PR CI green), and the source branch is deleted.
+  `docs/site-publishing-pipeline.md`; the exact section was restored via PR
+  #470 as `e34cf1d` after in-cluster PR CI, and the source branch is deleted.
 
-OPEN PR — already the vehicle:
+CLOSED REVIEW VEHICLE:
 
 - `web/public-output-hls-ts` = PR #458 — **MERGED 2026-07-13 ~11:15Z** after
   outer-loop (Claude) review, verdict MERGE-AFTER-FIXES: HIGH fixes applied

--- a/docs/plans/lab-astro-migration.md
+++ b/docs/plans/lab-astro-migration.md
@@ -1,7 +1,7 @@
 # Lab Astro Migration — Consolidated Program Tracker
 
 Last updated: 2026-07-13 (Phase 4c offline producer build/probe/pin gate passed;
-Phase 4b S3 foundation ready for review).
+Phase 4b S3 foundation merged; occurrence adapter ready for review).
 Owner: platform agent (Claude outer loop plans/verifies; Codex executes on
 xhigh). Human gate: Jason (prod sync, DNS/edge, Quartz retirement, credential
 work). Epic: #351 (L9, G3). This file is the single source of truth for the
@@ -49,7 +49,7 @@ Child issues (persisted 2026-07-13 post-consensus): 1→#474, 2→#475, 3→#476
 | 4 | Media & lightbox | Responsive images, intrinsic sizing, and lightbox accepted on stage | Production remains Quartz until Phase 5 |
 | 5 | Planner/evidence templates | Accepted on stage against the full frozen snapshot | Event-driven content refresh remains Phase 4b |
 | 6 | Semantic parity | Routes/aliases complete; comparator improved | Exact same-snapshot parity not green: ~240 false findings from SVG-`<title>` parser bug (fix exists uncommitted on a dead worktree — must be recreated), 9 unavailable historical refs (5 daily-plan routes, 4 images), and Quartz-vs-Astro must build from the SAME immutable snapshot |
-| 7 | Immutable publishing | Local-filesystem CAS/release/cache engine merged; 4a runtime is source-visible with exact source-bound images as a disconnected `replicas: 0` workload | S3 conditional-store foundation is not yet on main; CLI/caller, occurrence adapter, endpoint/credential-name probe, distributed coordination, retention/GC, and event producer remain; no runtime pod is scheduled or routed |
+| 7 | Immutable publishing | Local-filesystem CAS/release/cache engine and inactive S3 conditional-store foundation (#496) merged; 4a runtime is source-visible with exact source-bound images as a disconnected `replicas: 0` workload | Occurrence adapter, CLI/caller, endpoint/credential-name probe, distributed coordination, retention/GC, and event producer remain; no runtime pod is scheduled or routed |
 | 8 | Quality gates | Strict real-content gates green; exact tested build passed live T0 and T+10 acceptance | Keep the same budgets for every Phase 4 rollout; no production acceptance yet |
 | 9 | Production cutover | Fail-closed canary scaffold is preserved in open PR #471 | Not on main/built/pinned/deployed; Quartz remains authoritative; Jason APPLY required |
 
@@ -184,6 +184,10 @@ Phase 4 — **Feature completion (owner: codex, critical-path order below).**
    writes and a distributed lease (credential presence by name only),
    event-driven publishing, bounded retention/GC, and resource metrics. S3
    occurrence wiring and S7 closure are hard-gated on the 4c producer contract.
+   The inactive full-site S3 conditional-store foundation merged through #496;
+   it is not selected by a CLI or workload and carries no endpoint, credential,
+   route, or activation. The next reviewed slice adds the distinct typed
+   occurrence adapter while keeping S3 mutation caller-disabled.
 4. **4d Exact parity:** recreate the SVG-title comparator fix (+8 tests),
    rebuild Quartz+Astro from the same immutable snapshot, burn down real
    findings, and disposition the nine unavailable historical references. Its
@@ -276,6 +280,11 @@ triage live on the (now-deleted) local branches' history and were never
 merged. Phase 4b therefore includes IMPLEMENTING the S3 backend and its
 conditional-write contract before any CLI/event wiring; endpoint and
 credential checks stay name-only and activation-gated.
+
+RESOLUTION (2026-07-13 ~14:56Z): #496 merged the inactive S3 full-site
+conditional-store foundation and exact SDK dependency. Occurrence persistence,
+CLI/caller selection, distributed coordination, retention/GC, endpoint proof,
+credentials, and activation remain open and separately gated.
 
 ## Operating cadence
 

--- a/docs/site-publishing-pipeline.md
+++ b/docs/site-publishing-pipeline.md
@@ -197,6 +197,17 @@ preceding read for the object-store compare-and-swap. Reads are byte-bounded and
 release listings consume bounded continuation pages. The AWS client is injected in
 offline tests; the exact SDK is locked in `site-astro/package-lock.json`.
 
+`OccurrenceReleaseStore` is a distinct source-only adapter for specialist evidence.
+`LocalOccurrenceReleaseStore` preserves the current aggregate and per-camera object
+layout. `S3OccurrenceReleaseStore` appends the typed `occurrence-releases/v1`
+namespace to a strict base URI so built-site and occurrence identities cannot overlap.
+It provides absent-only manifests, media generations, event intents, and validated PNG
+blobs; canonical store-identity binding on every event intent; immediate-read
+entity-tag CAS plus exact post-write verification for both selector families; and
+bounded PNG reads and exact materialization. High-level read/materialization accepts
+an explicitly injected adapter, but the credential-free occurrence CLI deliberately
+refuses implicit S3 access and its publication path remains local-only.
+
 The complete local filesystem primitive is present, and its candidate manifest is
 included by the Lab stage overlay only at `replicas: 0`. The overlay deliberately
 uses exact source-bound zot digests for the release agent and nginx site images. The
@@ -208,10 +219,11 @@ source does not alter the live cluster; even an operator sync cannot schedule th
 zero-replica workload.
 
 This storage foundation does not change the credential-free local CLI or deploy
-anything. The CLI/publisher factory, bounded cache hydration from object bytes,
-occurrence persistence caller, distributed lease, bounded retention/GC, event agent,
-resource accounting, endpoint configuration, credential-name wiring, and real-endpoint
-conditional-write proof remain separate Phase 4b work. The endpoint proof must confirm
+anything. The built-site CLI/publisher factory, bounded cache hydration from object
+bytes, occurrence producer/caller transaction, distributed lease, bounded retention
+and GC, event agent, resource accounting, endpoint configuration, credential-name
+wiring, and real-endpoint conditional-write proof remain separate Phase 4b work. The
+endpoint proof must confirm
 the compatible store preserves the tested conditional semantics before any writer is
 activated. Activation additionally requires reviewed store/egress wiring, an explicit
 replicas change, and live cache/freshness/alert proof. Those are deployment and data

--- a/site-astro/README.md
+++ b/site-astro/README.md
@@ -252,6 +252,15 @@ must carry the adapter's canonical store-identity digest. Bounded blob reads can
 materialize exact bytes for a compiler, but the occurrence CLI still accepts local
 stores only and no event producer is wired to mutate S3.
 
+Occurrence blob materialization is monotonic and delete-free at its public destination.
+Every selected blob is first written, synced, closed, and fully PNG/digest/size validated
+inside one private same-filesystem staging directory; no destination is committed until
+all source blobs pass. Commit uses an absent-only hard link. An existing destination is
+accepted only when bounded validation proves the exact expected content, while a conflict
+is left untouched. A later commit or directory-sync failure may therefore leave only exact
+content-addressed outputs; retry converges by accepting those outputs and completing the
+remainder. Cleanup removes private staging only and never rollback-deletes a destination.
+
 The runtime candidate is present in Lab stage GitOps source only as a dormant
 `replicas: 0` workload. Its paired agent/site images are pinned to exact zot digests
 after their source-bound container probe, but it still has no route, object-store/AWS

--- a/site-astro/README.md
+++ b/site-astro/README.md
@@ -242,6 +242,16 @@ immutable objects, entity-tag compare-and-swap for the selector, bounded streame
 reads, and bounded paginated listing. Its client is dependency-injected and covered by
 offline fakes; no endpoint or credential is configured or contacted by the tests.
 
+Specialist evidence has a separate inactive `OccurrenceReleaseStore` surface. Its
+local adapter preserves the existing aggregate/per-camera layout, while the injected
+S3 adapter binds every key beneath the typed `occurrence-releases/v1` namespace. Both
+selector families keep caller SHA-256 preconditions; S3 compare-and-swap uses the
+entity tag from the immediately preceding read. Manifests, media generations, event
+intents, and validated PNG blobs are absent-only and collision checked; event intents
+must carry the adapter's canonical store-identity digest. Bounded blob reads can
+materialize exact bytes for a compiler, but the occurrence CLI still accepts local
+stores only and no event producer is wired to mutate S3.
+
 The runtime candidate is present in Lab stage GitOps source only as a dormant
 `replicas: 0` workload. Its paired agent/site images are pinned to exact zot digests
 after their source-bound container probe, but it still has no route, object-store/AWS
@@ -250,11 +260,12 @@ environment, application/object-store credential, or egress. Its standard zot re
 merging source is not an operator sync, and even a sync cannot schedule this
 zero-replica candidate.
 
-The CLI and cache hydrator remain local-only. Object-store CLI wiring and bounded cache
-materialization, occurrence persistence, the event agent, distributed coordination,
-retention/GC, resource accounting, real-endpoint conditional-write proof, store/egress
-wiring, and alert routing are still required before activation. No endpoint or
-credential is configured here, and this change does not deploy or alter production.
+The CLI and cache hydrator remain local-only. Object-store CLI wiring and bounded site
+cache materialization, the occurrence producer/caller transaction, the event agent,
+distributed coordination, retention/GC, resource accounting, real-endpoint
+conditional-write proof, store/egress wiring, and alert routing are still required
+before activation. No endpoint or credential is configured here, and this change does
+not deploy or alter production.
 
 The stage vendors the reviewed offline parity comparator at
 `scripts/site-build-parity.py` (SHA-256

--- a/site-astro/package.json
+++ b/site-astro/package.json
@@ -32,7 +32,7 @@
     "build:fixture": "LAB_SNAPSHOT=tests/fixtures/snapshot ALLOW_SYNTHETIC_FIXTURE=true SITE_ORIGIN=https://lab-stage.verdify.ai npm run build",
     "build:production": "node scripts/build-production.mjs",
     "build:production:fixture": "node scripts/build-production.mjs --fixture",
-    "test:unit": "node --test tests/build-lock.test.mjs tests/camera-export-producer.test.mjs tests/compiler.test.mjs tests/graph-export-producer.test.mjs tests/manifests.test.mjs tests/occurrence-export.test.mjs tests/occurrence-release.test.mjs tests/site-release.test.mjs tests/site-release-s3.test.mjs tests/snapshot-hydrator.test.mjs",
+    "test:unit": "node --test tests/build-lock.test.mjs tests/camera-export-producer.test.mjs tests/compiler.test.mjs tests/graph-export-producer.test.mjs tests/manifests.test.mjs tests/occurrence-export.test.mjs tests/occurrence-release.test.mjs tests/occurrence-release-s3.test.mjs tests/site-release.test.mjs tests/site-release-s3.test.mjs tests/snapshot-hydrator.test.mjs",
     "test:parity": "python3 -m unittest discover -s tests -p 'test_site_build_parity_limits.py'",
     "test:manifests:stage": "kubectl kustomize ../deploy/k8s/overlays/lab-stage | node scripts/verify-rendered-stage.mjs",
     "test:manifests:production": "kubectl kustomize ../deploy/k8s/candidates/lab-astro-production | node scripts/verify-rendered-production-candidate.mjs",

--- a/site-astro/scripts/lib/occurrence-release-store.mjs
+++ b/site-astro/scripts/lib/occurrence-release-store.mjs
@@ -351,65 +351,134 @@ function blobValue(bytes, expectedSha256) {
   };
 }
 
-function materializedFileIdentity(metadata) {
-  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1n) {
+function materializedFileIdentity(metadata, { maximumLinks = 1n } = {}) {
+  if (
+    !metadata.isFile()
+    || metadata.isSymbolicLink()
+    || metadata.nlink < 1n
+    || metadata.nlink > maximumLinks
+  ) {
     throw new Error("materialized occurrence target is invalid");
   }
   return Object.freeze({
     dev: metadata.dev,
     ino: metadata.ino,
-    birthtimeNs: metadata.birthtimeNs,
-    ctimeNs: metadata.ctimeNs,
-    mtimeNs: metadata.mtimeNs,
-    size: metadata.size,
+    nlink: metadata.nlink,
   });
+}
+
+function materializedOwnership(destination, proofPath, identity) {
+  const absoluteDestination = path.resolve(destination);
+  const absoluteProof = path.resolve(proofPath);
+  if (
+    path.dirname(absoluteProof) !== path.dirname(absoluteDestination)
+    || !/^\.occurrence-materialize-[0-9a-f-]{36}$/u.test(path.basename(absoluteProof))
+  ) {
+    throw new Error("materialized occurrence ownership proof is invalid");
+  }
+  return Object.freeze({
+    destination: absoluteDestination,
+    proofPath: absoluteProof,
+    dev: identity.dev,
+    ino: identity.ino,
+  });
+}
+
+function validateMaterializedOwnership(destination, ownership) {
+  if (
+    ownership === null
+    || typeof ownership !== "object"
+    || ownership.destination !== path.resolve(destination)
+    || typeof ownership.proofPath !== "string"
+    || path.dirname(ownership.proofPath) !== path.dirname(ownership.destination)
+    || !/^\.occurrence-materialize-[0-9a-f-]{36}$/u.test(path.basename(ownership.proofPath))
+    || typeof ownership.dev !== "bigint"
+    || typeof ownership.ino !== "bigint"
+  ) {
+    throw new Error("materialized occurrence ownership proof is invalid");
+  }
+  return ownership;
+}
+
+async function ownedMaterializedProof(destination, ownership, lstatFile) {
+  validateMaterializedOwnership(destination, ownership);
+  let proof;
+  try {
+    proof = await lstatFile(ownership.proofPath, { bigint: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+  if (
+    !proof.isFile()
+    || proof.isSymbolicLink()
+    || proof.nlink < 1n
+    || proof.dev !== ownership.dev
+    || proof.ino !== ownership.ino
+  ) {
+    return null;
+  }
+  return proof;
 }
 
 export async function removeMaterializedOccurrenceTarget(
   destination,
-  identity,
+  ownership,
   { lstatFile = lstat, unlinkFile = unlink } = {},
 ) {
-  if (
-    identity === null
-    || typeof identity !== "object"
-    || typeof identity.dev !== "bigint"
-    || typeof identity.ino !== "bigint"
-    || typeof identity.birthtimeNs !== "bigint"
-    || typeof identity.ctimeNs !== "bigint"
-    || typeof identity.mtimeNs !== "bigint"
-    || typeof identity.size !== "bigint"
-  ) {
-    throw new Error("materialized occurrence target identity is invalid");
-  }
+  const proof = await ownedMaterializedProof(destination, ownership, lstatFile);
+  if (proof === null) return false;
   let selected;
   try {
     selected = await lstatFile(destination, { bigint: true });
   } catch (error) {
-    if (error.code === "ENOENT") return false;
+    if (error.code === "ENOENT") {
+      await unlinkFile(ownership.proofPath);
+      return false;
+    }
     throw error;
   }
   if (
     !selected.isFile()
     || selected.isSymbolicLink()
-    || selected.dev !== identity.dev
-    || selected.ino !== identity.ino
-    || selected.birthtimeNs !== identity.birthtimeNs
-    || selected.ctimeNs !== identity.ctimeNs
-    || selected.mtimeNs !== identity.mtimeNs
-    || selected.size !== identity.size
+    || selected.dev !== proof.dev
+    || selected.ino !== proof.ino
   ) {
+    await unlinkFile(ownership.proofPath);
     return false;
   }
   await unlinkFile(destination);
+  await unlinkFile(ownership.proofPath);
   return true;
+}
+
+export async function releaseMaterializedOccurrenceOwnership(
+  destination,
+  ownership,
+  { lstatFile = lstat, unlinkFile = unlink } = {},
+) {
+  const proof = await ownedMaterializedProof(destination, ownership, lstatFile);
+  if (proof === null) return false;
+  let selected;
+  try {
+    selected = await lstatFile(destination, { bigint: true });
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  const owned = selected !== undefined
+    && selected.isFile()
+    && !selected.isSymbolicLink()
+    && selected.dev === proof.dev
+    && selected.ino === proof.ino;
+  await unlinkFile(ownership.proofPath);
+  return owned;
 }
 
 async function materializeBytes(
   bytes,
   expectedSha256,
   destination,
-  { fileOperations = {} } = {},
+  { fileOperations = {}, retainOwnership = false } = {},
 ) {
   if (
     fileOperations === null
@@ -418,7 +487,11 @@ async function materializeBytes(
   ) {
     throw new Error("occurrence materialization file operations are invalid");
   }
+  if (typeof retainOwnership !== "boolean") {
+    throw new Error("occurrence materialization ownership option is invalid");
+  }
   const openFile = fileOperations.open ?? open;
+  const linkFile = fileOperations.link ?? link;
   const validateFile = fileOperations.validatePngFile ?? validatePngFile;
   const syncTargetDirectory = fileOperations.syncDirectory ?? syncDirectory;
   const cleanupOperations = {
@@ -426,39 +499,56 @@ async function materializeBytes(
     unlinkFile: fileOperations.unlink ?? unlink,
   };
   const directory = path.dirname(destination);
-  const relative = path.basename(destination);
+  const proofPath = path.join(directory, `.occurrence-materialize-${randomUUID()}`);
+  const relativeProof = path.basename(proofPath);
   let handle = null;
-  let identity = null;
-  let created = false;
+  let ownership = null;
   try {
-    handle = await openFile(destination, "wx", 0o644);
-    created = true;
-    materializedFileIdentity(await handle.stat({ bigint: true }));
+    handle = await openFile(proofPath, "wx", 0o644);
+    const identity = materializedFileIdentity(await handle.stat({ bigint: true }));
+    ownership = materializedOwnership(destination, proofPath, identity);
     await handle.writeFile(bytes);
     await handle.sync();
-    identity = materializedFileIdentity(await handle.stat({ bigint: true }));
+    materializedFileIdentity(await handle.stat({ bigint: true }));
     await handle.close();
     handle = null;
-    const verified = await validateFile(directory, relative);
+    const verified = await validateFile(directory, relativeProof);
     if (verified.sha256 !== expectedSha256) {
       throw new Error("materialized occurrence blob digest mismatch");
     }
+    await linkFile(proofPath, destination);
+    const linked = materializedFileIdentity(
+      await cleanupOperations.lstatFile(proofPath, { bigint: true }),
+      { maximumLinks: 2n },
+    );
+    if (linked.dev !== ownership.dev || linked.ino !== ownership.ino || linked.nlink !== 2n) {
+      throw new Error("materialized occurrence ownership proof changed");
+    }
     await syncTargetDirectory(directory);
-    return { ...verified, materializedIdentity: identity };
-  } catch (error) {
-    if (created && handle !== null) {
-      try {
-        identity = materializedFileIdentity(await handle.stat({ bigint: true }));
-      } catch {
-        // Without a descriptor identity, deleting by path could remove a replacement.
+    const result = {
+      ...verified,
+      sourcePath: path.resolve(destination),
+      materializedOwnership: retainOwnership ? ownership : null,
+    };
+    if (!retainOwnership) {
+      const released = await releaseMaterializedOccurrenceOwnership(
+        destination,
+        ownership,
+        cleanupOperations,
+      );
+      ownership = null;
+      if (!released) {
+        throw new Error("materialized occurrence target changed before completion");
       }
     }
+    return result;
+  } catch (error) {
     await handle?.close().catch(() => {});
-    if (created && identity !== null) {
+    if (ownership !== null) {
       try {
         await removeMaterializedOccurrenceTarget(
           destination,
-          identity,
+          ownership,
           cleanupOperations,
         );
       } catch (cleanupError) {
@@ -539,9 +629,12 @@ export class OccurrenceReleaseStore {
   }
 
   async materializePngBlob(digestValue, destination, options = {}) {
-    const { fileOperations, ...readOptions } = options;
+    const { fileOperations, retainOwnership, ...readOptions } = options;
     const value = await this.readPngBlob(digestValue, readOptions);
-    return materializeBytes(value.body, digestValue, destination, { fileOperations });
+    return materializeBytes(value.body, digestValue, destination, {
+      fileOperations,
+      retainOwnership,
+    });
   }
 }
 

--- a/site-astro/scripts/lib/occurrence-release-store.mjs
+++ b/site-astro/scripts/lib/occurrence-release-store.mjs
@@ -1,0 +1,981 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  lstat,
+  link,
+  mkdir,
+  open,
+  realpath,
+  rename,
+  unlink,
+} from "node:fs/promises";
+import path from "node:path";
+
+import { decodePng, limits as pngLimits, validatePngFile } from "./png-validation.mjs";
+import { S3ObjectStore, parseSiteReleaseStoreLocation } from "./s3-object-store.mjs";
+
+const SHA256_RE = /^[0-9a-f]{64}$/u;
+const EVENT_ID_RE = /^evt_[A-Za-z0-9_-]{8,128}$/u;
+const MEDIA_OCCURRENCE_ID_RE = /^media_[0-9a-f]{24}$/u;
+const TYPE_NAMESPACE = "occurrence-releases/v1";
+const MAX_SELECTION_BYTES = 64 * 1024;
+const MAX_MANIFEST_BYTES = 8 * 1024 * 1024;
+const MAX_GENERATION_BYTES = 128 * 1024;
+const MAX_EVENT_BYTES = 32 * 1024;
+const MAX_S3_KEY_BYTES = 1024;
+const MAX_RELATIVE_OBJECT_KEY_BYTES = 160;
+
+function canonicalBytes(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function digest(value, label) {
+  if (typeof value !== "string" || !SHA256_RE.test(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function eventId(value) {
+  if (typeof value !== "string" || !EVENT_ID_RE.test(value)) {
+    throw new Error("occurrence release event ID is invalid");
+  }
+  return value;
+}
+
+function mediaOccurrenceId(value) {
+  if (typeof value !== "string" || !MEDIA_OCCURRENCE_ID_RE.test(value)) {
+    throw new Error("current media occurrence identity is invalid");
+  }
+  return value;
+}
+
+function validateExpectedSelection(value) {
+  if (value !== null) digest(value, "occurrence selection precondition");
+  return value;
+}
+
+function parseCanonicalJson(bytes, label) {
+  let document;
+  try {
+    document = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`${label} is not valid JSON`);
+  }
+  if (canonicalBytes(document).compare(bytes) !== 0) {
+    throw new Error(`${label} is not canonical JSON`);
+  }
+  return document;
+}
+
+function storeIdentity(location) {
+  const document = location.kind === "local"
+    ? {
+        contract: "verdify.lab-occurrence-release-store-identity",
+        schemaVersion: 1,
+        namespace: TYPE_NAMESPACE,
+        backend: "local",
+        root: location.root,
+      }
+    : {
+        contract: "verdify.lab-occurrence-release-store-identity",
+        schemaVersion: 1,
+        namespace: TYPE_NAMESPACE,
+        backend: "s3",
+        bucket: location.bucket,
+        prefix: location.prefix,
+      };
+  return Object.freeze({
+    document: Object.freeze(document),
+    sha256: sha256(canonicalBytes(document)),
+  });
+}
+
+export function parseOccurrenceReleaseStoreLocation(value) {
+  let parsed;
+  try {
+    parsed = parseSiteReleaseStoreLocation(value);
+  } catch {
+    throw new Error("occurrence release store location is invalid");
+  }
+  if (parsed.kind === "local") return parsed;
+  const prefix = `${parsed.prefix}/${TYPE_NAMESPACE}`;
+  if (
+    Buffer.byteLength(prefix) + 1 + MAX_RELATIVE_OBJECT_KEY_BYTES
+    > MAX_S3_KEY_BYTES
+  ) {
+    throw new Error("occurrence release store location is invalid");
+  }
+  return Object.freeze({
+    kind: "s3",
+    bucket: parsed.bucket,
+    prefix,
+  });
+}
+
+async function canonicalRoot(root) {
+  const absolute = path.resolve(root);
+  const metadata = await lstat(absolute, { bigint: true });
+  if (
+    !metadata.isDirectory()
+    || metadata.isSymbolicLink()
+    || (await realpath(absolute)) !== absolute
+  ) {
+    throw new Error("occurrence store root is invalid");
+  }
+  return absolute;
+}
+
+async function secureDirectory(root, relative, { create = false, leafMode = 0o755 } = {}) {
+  let current = root;
+  const segments = relative.split("/");
+  for (let index = 0; index < segments.length; index += 1) {
+    current = path.join(current, segments[index]);
+    if (create) {
+      try {
+        await mkdir(current, {
+          mode: index === segments.length - 1 ? leafMode : 0o755,
+        });
+      } catch (error) {
+        if (error.code !== "EEXIST") throw error;
+      }
+    }
+    const metadata = await lstat(current, { bigint: true });
+    if (
+      !metadata.isDirectory()
+      || metadata.isSymbolicLink()
+      || (await realpath(current)) !== current
+    ) {
+      throw new Error("occurrence store layout is invalid");
+    }
+  }
+  return current;
+}
+
+async function syncDirectory(directory) {
+  const handle = await open(directory, fsConstants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readBoundedSingleLink(file, maximumBytes, label, { missing = false } = {}) {
+  let handle;
+  try {
+    handle = await open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (error) {
+    if (missing && error.code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const metadata = await handle.stat({ bigint: true });
+    if (
+      !metadata.isFile()
+      || metadata.nlink !== 1n
+      || metadata.size < 1n
+      || metadata.size > BigInt(maximumBytes)
+    ) {
+      throw new Error(`${label} file is invalid`);
+    }
+    const bytes = await handle.readFile();
+    const after = await handle.stat({ bigint: true });
+    if (
+      bytes.length !== Number(metadata.size)
+      || after.dev !== metadata.dev
+      || after.ino !== metadata.ino
+      || after.size !== metadata.size
+      || after.nlink !== 1n
+    ) {
+      throw new Error(`${label} changed while being read`);
+    }
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function atomicWrite(destination, bytes) {
+  const directory = path.dirname(destination);
+  const candidate = path.join(directory, `.candidate-${randomUUID()}`);
+  const handle = await open(candidate, "wx", 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(candidate, destination);
+    await syncDirectory(directory);
+  } finally {
+    await unlink(candidate).catch(() => {});
+  }
+}
+
+async function withLocalSelectorLock(selectionFile, callback) {
+  const lockFile = `${selectionFile}.cas.lock`;
+  let handle;
+  try {
+    handle = await open(lockFile, "wx", 0o600);
+  } catch (error) {
+    if (error.code === "EEXIST") {
+      throw new Error("another cooperating occurrence selector writer is active");
+    }
+    throw error;
+  }
+  const identity = await handle.stat({ bigint: true });
+  try {
+    return await callback();
+  } finally {
+    await handle.close().catch(() => {});
+    try {
+      const selected = await lstat(lockFile, { bigint: true });
+      if (
+        selected.isFile()
+        && selected.dev === identity.dev
+        && selected.ino === identity.ino
+      ) {
+        await unlink(lockFile);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function publishAbsent(destination, bytes, maximumBytes, collisionMessage) {
+  if (!Buffer.isBuffer(bytes) || bytes.length < 1 || bytes.length > maximumBytes) {
+    throw new Error("immutable occurrence release object is outside its byte limit");
+  }
+  const directory = path.dirname(destination);
+  const candidate = path.join(directory, `.candidate-${randomUUID()}`);
+  const handle = await open(candidate, "wx", 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    try {
+      await link(candidate, destination);
+      await syncDirectory(directory);
+      return { written: true, recovered: false };
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      const existing = await readBoundedSingleLink(
+        destination,
+        maximumBytes,
+        "immutable occurrence release object",
+      );
+      if (!existing.equals(bytes)) throw new Error(collisionMessage);
+      return { written: false, recovered: false };
+    }
+  } finally {
+    await unlink(candidate).catch(() => {});
+  }
+}
+
+function jsonValue(value, maximumBytes, label) {
+  const bytes = canonicalBytes(value);
+  if (bytes.length < 1 || bytes.length > maximumBytes) {
+    throw new Error(`${label} exceeds its byte limit`);
+  }
+  return bytes;
+}
+
+function boundEventIntent(value, storeIdentitySha256, expectedEventId) {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || Object.getPrototypeOf(value) !== Object.prototype
+    || value.storeIdentitySha256 !== storeIdentitySha256
+    || value.eventId !== expectedEventId
+  ) {
+    throw new Error("occurrence event intent does not match its canonical store identity");
+  }
+  return value;
+}
+
+function boundCurrentMediaDocument(value, expectedOccurrenceId, label) {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || Object.getPrototypeOf(value) !== Object.prototype
+    || value.occurrenceId !== expectedOccurrenceId
+  ) {
+    throw new Error(`${label} does not match its occurrence identity`);
+  }
+  return value;
+}
+
+function blobValue(bytes, expectedSha256) {
+  if (!Buffer.isBuffer(bytes) || bytes.length < 1 || bytes.length > pngLimits.maxFileBytes) {
+    throw new Error("occurrence PNG blob is outside its byte limit");
+  }
+  digest(expectedSha256, "occurrence PNG blob digest");
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("occurrence PNG blob digest mismatch");
+  }
+  const decoded = decodePng(bytes);
+  return {
+    body: bytes,
+    bytes: bytes.length,
+    sha256: expectedSha256,
+    decodedSha256: decoded.decodedSha256,
+    decodedBytes: decoded.decodedBytes,
+    width: decoded.width,
+    height: decoded.height,
+    mediaType: decoded.mediaType,
+  };
+}
+
+async function materializeBytes(bytes, expectedSha256, destination) {
+  const directory = path.dirname(destination);
+  const relative = path.basename(destination);
+  const handle = await open(destination, "wx", 0o644);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await unlink(destination).catch(() => {});
+    throw error;
+  }
+  await handle.close();
+  try {
+    const verified = await validatePngFile(directory, relative);
+    if (verified.sha256 !== expectedSha256) {
+      throw new Error("materialized occurrence blob digest mismatch");
+    }
+    await syncDirectory(directory);
+    return verified;
+  } catch (error) {
+    await unlink(destination).catch(() => {});
+    throw error;
+  }
+}
+
+export class OccurrenceReleaseStore {
+  constructor(location) {
+    this.location = location;
+    this.identity = storeIdentity(location);
+  }
+
+  async initialize(_options = {}) {
+    throw new Error("occurrence release store initialize is not implemented");
+  }
+
+  async readAggregateSelection() {
+    throw new Error("aggregate occurrence selection read is not implemented");
+  }
+
+  async writeAggregateSelection(_selection, _expectedSelectionSha256) {
+    throw new Error("aggregate occurrence selection write is not implemented");
+  }
+
+  async publishAggregateManifest(_manifest) {
+    throw new Error("aggregate occurrence manifest publication is not implemented");
+  }
+
+  async readAggregateManifest(_digest) {
+    throw new Error("aggregate occurrence manifest read is not implemented");
+  }
+
+  async publishAggregateEventIntent(_eventId, _intent) {
+    throw new Error("aggregate occurrence event publication is not implemented");
+  }
+
+  async readAggregateEventIntent(_eventId) {
+    throw new Error("aggregate occurrence event read is not implemented");
+  }
+
+  async readCurrentMediaSelection(_occurrenceId) {
+    throw new Error("current media selection read is not implemented");
+  }
+
+  async writeCurrentMediaSelection(_occurrenceId, _selection, _expectedSelectionSha256) {
+    throw new Error("current media selection write is not implemented");
+  }
+
+  async publishCurrentMediaGeneration(_occurrenceId, _generation) {
+    throw new Error("current media generation publication is not implemented");
+  }
+
+  async readCurrentMediaGeneration(_occurrenceId, _digest) {
+    throw new Error("current media generation read is not implemented");
+  }
+
+  async publishCurrentMediaEventIntent(_occurrenceId, _eventId, _intent) {
+    throw new Error("current media event publication is not implemented");
+  }
+
+  async readCurrentMediaEventIntent(_occurrenceId, _eventId) {
+    throw new Error("current media event read is not implemented");
+  }
+
+  async publishPngBlob(_bytes, _expectedSha256) {
+    throw new Error("occurrence PNG blob publication is not implemented");
+  }
+
+  async readPngBlob(_digest, _options = {}) {
+    throw new Error("occurrence PNG blob read is not implemented");
+  }
+
+  async materializePngBlob(digestValue, destination, options = {}) {
+    const value = await this.readPngBlob(digestValue, options);
+    return materializeBytes(value.body, digestValue, destination);
+  }
+}
+
+export class LocalOccurrenceReleaseStore extends OccurrenceReleaseStore {
+  constructor(root) {
+    const location = Object.freeze({ kind: "local", root: path.resolve(root) });
+    super(location);
+    this.root = location.root;
+  }
+
+  async initialize({ create = false } = {}) {
+    this.root = await canonicalRoot(this.root);
+    this.location = Object.freeze({ kind: "local", root: this.root });
+    this.identity = storeIdentity(this.location);
+    for (const relative of ["blobs/sha256", "manifests/sha256", "events/sha256"]) {
+      await secureDirectory(this.root, relative, { create });
+    }
+    await secureDirectory(this.root, ".quarantine", { create, leafMode: 0o700 });
+    return this;
+  }
+
+  async mediaDirectory(occurrenceIdValue, { create = false } = {}) {
+    mediaOccurrenceId(occurrenceIdValue);
+    const relative = `occurrences/${occurrenceIdValue}`;
+    await secureDirectory(this.root, `${relative}/generations/sha256`, { create });
+    await secureDirectory(this.root, `${relative}/events/sha256`, { create });
+    return path.join(this.root, ...relative.split("/"));
+  }
+
+  async readJson(file, maximumBytes, label, { missing = false } = {}) {
+    const bytes = await readBoundedSingleLink(file, maximumBytes, label, { missing });
+    if (bytes === null) return null;
+    return {
+      document: parseCanonicalJson(bytes, label),
+      bytes,
+      sha256: sha256(bytes),
+      etag: null,
+      storeIdentitySha256: this.identity.sha256,
+    };
+  }
+
+  async writeSelection(file, selection, expectedSelectionSha256, reader) {
+    validateExpectedSelection(expectedSelectionSha256);
+    const bytes = jsonValue(selection, MAX_SELECTION_BYTES, "occurrence selection");
+    return withLocalSelectorLock(file, async () => {
+      const current = await reader();
+      if ((current?.sha256 ?? null) !== expectedSelectionSha256) {
+        throw new Error("occurrence selection precondition failed");
+      }
+      await atomicWrite(file, bytes);
+      const committed = await reader();
+      if (committed === null || !committed.bytes.equals(bytes)) {
+        throw new Error("occurrence selection changed after conditional write");
+      }
+      return sha256(bytes);
+    });
+  }
+
+  async publishJson(file, document, maximumBytes, collisionMessage) {
+    const bytes = jsonValue(document, maximumBytes, "immutable occurrence release JSON");
+    await publishAbsent(file, bytes, maximumBytes, collisionMessage);
+    return sha256(bytes);
+  }
+
+  async readAggregateSelection() {
+    return this.readJson(
+      path.join(this.root, "selection.json"),
+      MAX_SELECTION_BYTES,
+      "occurrence selection",
+      { missing: true },
+    );
+  }
+
+  async writeAggregateSelection(selection, expectedSelectionSha256) {
+    return this.writeSelection(
+      path.join(this.root, "selection.json"),
+      selection,
+      expectedSelectionSha256,
+      () => this.readAggregateSelection(),
+    );
+  }
+
+  async publishAggregateManifest(manifest) {
+    const bytes = jsonValue(manifest, MAX_MANIFEST_BYTES, "occurrence manifest");
+    const valueSha256 = sha256(bytes);
+    await publishAbsent(
+      path.join(this.root, "manifests", "sha256", `${valueSha256}.json`),
+      bytes,
+      MAX_MANIFEST_BYTES,
+      "content-addressed occurrence manifest collision",
+    );
+    return valueSha256;
+  }
+
+  async readAggregateManifest(digestValue) {
+    digest(digestValue, "occurrence manifest digest");
+    const value = await this.readJson(
+      path.join(this.root, "manifests", "sha256", `${digestValue}.json`),
+      MAX_MANIFEST_BYTES,
+      "occurrence manifest",
+    );
+    if (value.sha256 !== digestValue) throw new Error("occurrence manifest digest mismatch");
+    return value;
+  }
+
+  aggregateEventPath(eventIdValue) {
+    eventId(eventIdValue);
+    return path.join(this.root, "events", "sha256", `${sha256(Buffer.from(eventIdValue))}.json`);
+  }
+
+  async publishAggregateEventIntent(eventIdValue, intent) {
+    boundEventIntent(intent, this.identity.sha256, eventIdValue);
+    return this.publishJson(
+      this.aggregateEventPath(eventIdValue),
+      intent,
+      MAX_EVENT_BYTES,
+      "content-addressed occurrence event collision",
+    );
+  }
+
+  async readAggregateEventIntent(eventIdValue) {
+    const value = await this.readJson(
+      this.aggregateEventPath(eventIdValue),
+      MAX_EVENT_BYTES,
+      "occurrence event intent",
+      { missing: true },
+    );
+    if (value !== null) boundEventIntent(value.document, this.identity.sha256, eventIdValue);
+    return value;
+  }
+
+  async readCurrentMediaSelection(occurrenceIdValue) {
+    let directory;
+    try {
+      directory = await this.mediaDirectory(occurrenceIdValue);
+    } catch (error) {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    }
+    const value = await this.readJson(
+      path.join(directory, "selection.json"),
+      MAX_SELECTION_BYTES,
+      "current media selection",
+      { missing: true },
+    );
+    if (value !== null) {
+      boundCurrentMediaDocument(value.document, occurrenceIdValue, "current media selection");
+    }
+    return value;
+  }
+
+  async writeCurrentMediaSelection(occurrenceIdValue, selection, expectedSelectionSha256) {
+    boundCurrentMediaDocument(selection, occurrenceIdValue, "current media selection");
+    const directory = await this.mediaDirectory(occurrenceIdValue, { create: true });
+    return this.writeSelection(
+      path.join(directory, "selection.json"),
+      selection,
+      expectedSelectionSha256,
+      () => this.readCurrentMediaSelection(occurrenceIdValue),
+    );
+  }
+
+  async publishCurrentMediaGeneration(occurrenceIdValue, generation) {
+    boundCurrentMediaDocument(generation, occurrenceIdValue, "current media generation");
+    const directory = await this.mediaDirectory(occurrenceIdValue, { create: true });
+    const bytes = jsonValue(generation, MAX_GENERATION_BYTES, "current media generation");
+    const valueSha256 = sha256(bytes);
+    await publishAbsent(
+      path.join(directory, "generations", "sha256", `${valueSha256}.json`),
+      bytes,
+      MAX_GENERATION_BYTES,
+      "content-addressed current media generation collision",
+    );
+    return valueSha256;
+  }
+
+  async readCurrentMediaGeneration(occurrenceIdValue, digestValue) {
+    digest(digestValue, "current media generation digest");
+    const directory = await this.mediaDirectory(occurrenceIdValue);
+    const value = await this.readJson(
+      path.join(directory, "generations", "sha256", `${digestValue}.json`),
+      MAX_GENERATION_BYTES,
+      "current media generation",
+    );
+    if (value.sha256 !== digestValue) throw new Error("current media generation digest mismatch");
+    boundCurrentMediaDocument(value.document, occurrenceIdValue, "current media generation");
+    return value;
+  }
+
+  async publishCurrentMediaEventIntent(occurrenceIdValue, eventIdValue, intent) {
+    const directory = await this.mediaDirectory(occurrenceIdValue, { create: true });
+    eventId(eventIdValue);
+    boundEventIntent(intent, this.identity.sha256, eventIdValue);
+    return this.publishJson(
+      path.join(directory, "events", "sha256", `${sha256(Buffer.from(eventIdValue))}.json`),
+      intent,
+      MAX_EVENT_BYTES,
+      "content-addressed current media event collision",
+    );
+  }
+
+  async readCurrentMediaEventIntent(occurrenceIdValue, eventIdValue) {
+    let directory;
+    try {
+      directory = await this.mediaDirectory(occurrenceIdValue);
+    } catch (error) {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    }
+    eventId(eventIdValue);
+    const value = await this.readJson(
+      path.join(directory, "events", "sha256", `${sha256(Buffer.from(eventIdValue))}.json`),
+      MAX_EVENT_BYTES,
+      "current media event intent",
+      { missing: true },
+    );
+    if (value !== null) boundEventIntent(value.document, this.identity.sha256, eventIdValue);
+    return value;
+  }
+
+  async publishPngBlob(bytes, expectedSha256) {
+    const value = blobValue(bytes, expectedSha256);
+    await publishAbsent(
+      path.join(this.root, "blobs", "sha256", `${expectedSha256}.png`),
+      bytes,
+      pngLimits.maxFileBytes,
+      "content-addressed occurrence PNG collision",
+    );
+    return value;
+  }
+
+  async readPngBlob(digestValue, { maximumBytes = pngLimits.maxFileBytes } = {}) {
+    digest(digestValue, "occurrence PNG blob digest");
+    if (
+      !Number.isSafeInteger(maximumBytes)
+      || maximumBytes < 1
+      || maximumBytes > pngLimits.maxFileBytes
+    ) {
+      throw new Error("occurrence PNG blob read limit is invalid");
+    }
+    const bytes = await readBoundedSingleLink(
+      path.join(this.root, "blobs", "sha256", `${digestValue}.png`),
+      maximumBytes,
+      "occurrence PNG blob",
+    );
+    return blobValue(bytes, digestValue);
+  }
+}
+
+export class S3OccurrenceReleaseStore extends OccurrenceReleaseStore {
+  constructor(location, options = {}) {
+    const parsed = typeof location === "string"
+      ? parseOccurrenceReleaseStoreLocation(location)
+      : location;
+    if (
+      parsed === null
+      || typeof parsed !== "object"
+      || parsed.kind !== "s3"
+      || typeof parsed.bucket !== "string"
+      || typeof parsed.prefix !== "string"
+      || !parsed.prefix.endsWith(`/${TYPE_NAMESPACE}`)
+    ) {
+      throw new Error("S3 occurrence release store location is invalid");
+    }
+    const normalized = Object.freeze({
+      kind: "s3",
+      bucket: parsed.bucket,
+      prefix: parsed.prefix,
+    });
+    super(normalized);
+    this.objects = new S3ObjectStore({
+      bucket: normalized.bucket,
+      prefix: normalized.prefix,
+      client: options.client ?? null,
+      clientConfig: options.clientConfig ?? {},
+      clientFactory: options.clientFactory,
+    });
+  }
+
+  async initialize(_options = {}) {
+    await this.objects.initialize();
+    return this;
+  }
+
+  async publishImmutable(key, bytes, maximumBytes, collisionMessage, contentType) {
+    if (!Buffer.isBuffer(bytes) || bytes.length < 1 || bytes.length > maximumBytes) {
+      throw new Error("immutable occurrence release object is outside its byte limit");
+    }
+    let published;
+    try {
+      published = await this.objects.putIfAbsent(key, bytes, { contentType });
+    } catch (error) {
+      let existing;
+      try {
+        existing = await this.objects.read(key, {
+          maximumBytes,
+          label: "immutable occurrence release object",
+          missing: true,
+        });
+      } catch {
+        throw error;
+      }
+      if (existing === null) throw error;
+      if (!existing.bytes.equals(bytes)) throw new Error(collisionMessage);
+      return { written: false, recovered: true };
+    }
+    if (published.written) return { written: true, recovered: false };
+    const existing = await this.objects.read(key, {
+      maximumBytes,
+      label: "immutable occurrence release object",
+    });
+    if (!existing.bytes.equals(bytes)) throw new Error(collisionMessage);
+    return { written: false, recovered: false };
+  }
+
+  async readJson(key, maximumBytes, label, { missing = false } = {}) {
+    const value = await this.objects.read(key, { maximumBytes, label, missing });
+    if (value === null) return null;
+    return {
+      document: parseCanonicalJson(value.bytes, label),
+      bytes: value.bytes,
+      sha256: sha256(value.bytes),
+      etag: value.etag,
+      storeIdentitySha256: this.identity.sha256,
+    };
+  }
+
+  async writeSelection(key, selection, expectedSelectionSha256, reader) {
+    validateExpectedSelection(expectedSelectionSha256);
+    const bytes = jsonValue(selection, MAX_SELECTION_BYTES, "occurrence selection");
+    const selected = await reader();
+    if ((selected?.sha256 ?? null) !== expectedSelectionSha256) {
+      throw new Error("occurrence selection precondition failed");
+    }
+    let result;
+    try {
+      result = selected === null
+        ? await this.objects.putIfAbsent(key, bytes, { contentType: "application/json" })
+        : await this.objects.putIfMatch(key, bytes, selected.etag, { contentType: "application/json" });
+    } catch (error) {
+      const recovered = await reader().catch(() => null);
+      if (recovered?.bytes.equals(bytes)) return sha256(bytes);
+      throw error;
+    }
+    if (!result.written) throw new Error("occurrence selection precondition failed");
+    const committed = await reader();
+    if (committed === null || !committed.bytes.equals(bytes)) {
+      throw new Error("occurrence selection changed after conditional write");
+    }
+    return sha256(bytes);
+  }
+
+  async publishJson(key, document, maximumBytes, collisionMessage) {
+    const bytes = jsonValue(document, maximumBytes, "immutable occurrence release JSON");
+    await this.publishImmutable(key, bytes, maximumBytes, collisionMessage, "application/json");
+    return sha256(bytes);
+  }
+
+  async readAggregateSelection() {
+    return this.readJson("selection.json", MAX_SELECTION_BYTES, "occurrence selection", { missing: true });
+  }
+
+  async writeAggregateSelection(selection, expectedSelectionSha256) {
+    return this.writeSelection(
+      "selection.json",
+      selection,
+      expectedSelectionSha256,
+      () => this.readAggregateSelection(),
+    );
+  }
+
+  async publishAggregateManifest(manifest) {
+    const bytes = jsonValue(manifest, MAX_MANIFEST_BYTES, "occurrence manifest");
+    const valueSha256 = sha256(bytes);
+    await this.publishImmutable(
+      `manifests/sha256/${valueSha256}.json`,
+      bytes,
+      MAX_MANIFEST_BYTES,
+      "content-addressed occurrence manifest collision",
+      "application/json",
+    );
+    return valueSha256;
+  }
+
+  async readAggregateManifest(digestValue) {
+    digest(digestValue, "occurrence manifest digest");
+    const value = await this.readJson(
+      `manifests/sha256/${digestValue}.json`,
+      MAX_MANIFEST_BYTES,
+      "occurrence manifest",
+    );
+    if (value.sha256 !== digestValue) throw new Error("occurrence manifest digest mismatch");
+    return value;
+  }
+
+  aggregateEventKey(eventIdValue) {
+    eventId(eventIdValue);
+    return `events/sha256/${sha256(Buffer.from(eventIdValue))}.json`;
+  }
+
+  async publishAggregateEventIntent(eventIdValue, intent) {
+    boundEventIntent(intent, this.identity.sha256, eventIdValue);
+    return this.publishJson(
+      this.aggregateEventKey(eventIdValue),
+      intent,
+      MAX_EVENT_BYTES,
+      "content-addressed occurrence event collision",
+    );
+  }
+
+  async readAggregateEventIntent(eventIdValue) {
+    const value = await this.readJson(
+      this.aggregateEventKey(eventIdValue),
+      MAX_EVENT_BYTES,
+      "occurrence event intent",
+      { missing: true },
+    );
+    if (value !== null) boundEventIntent(value.document, this.identity.sha256, eventIdValue);
+    return value;
+  }
+
+  mediaPrefix(occurrenceIdValue) {
+    mediaOccurrenceId(occurrenceIdValue);
+    return `occurrences/${occurrenceIdValue}`;
+  }
+
+  async readCurrentMediaSelection(occurrenceIdValue) {
+    const value = await this.readJson(
+      `${this.mediaPrefix(occurrenceIdValue)}/selection.json`,
+      MAX_SELECTION_BYTES,
+      "current media selection",
+      { missing: true },
+    );
+    if (value !== null) {
+      boundCurrentMediaDocument(value.document, occurrenceIdValue, "current media selection");
+    }
+    return value;
+  }
+
+  async writeCurrentMediaSelection(occurrenceIdValue, selection, expectedSelectionSha256) {
+    boundCurrentMediaDocument(selection, occurrenceIdValue, "current media selection");
+    const key = `${this.mediaPrefix(occurrenceIdValue)}/selection.json`;
+    return this.writeSelection(
+      key,
+      selection,
+      expectedSelectionSha256,
+      () => this.readCurrentMediaSelection(occurrenceIdValue),
+    );
+  }
+
+  async publishCurrentMediaGeneration(occurrenceIdValue, generation) {
+    boundCurrentMediaDocument(generation, occurrenceIdValue, "current media generation");
+    const bytes = jsonValue(generation, MAX_GENERATION_BYTES, "current media generation");
+    const valueSha256 = sha256(bytes);
+    await this.publishImmutable(
+      `${this.mediaPrefix(occurrenceIdValue)}/generations/sha256/${valueSha256}.json`,
+      bytes,
+      MAX_GENERATION_BYTES,
+      "content-addressed current media generation collision",
+      "application/json",
+    );
+    return valueSha256;
+  }
+
+  async readCurrentMediaGeneration(occurrenceIdValue, digestValue) {
+    digest(digestValue, "current media generation digest");
+    const value = await this.readJson(
+      `${this.mediaPrefix(occurrenceIdValue)}/generations/sha256/${digestValue}.json`,
+      MAX_GENERATION_BYTES,
+      "current media generation",
+    );
+    if (value.sha256 !== digestValue) throw new Error("current media generation digest mismatch");
+    boundCurrentMediaDocument(value.document, occurrenceIdValue, "current media generation");
+    return value;
+  }
+
+  mediaEventKey(occurrenceIdValue, eventIdValue) {
+    eventId(eventIdValue);
+    return `${this.mediaPrefix(occurrenceIdValue)}/events/sha256/${sha256(Buffer.from(eventIdValue))}.json`;
+  }
+
+  async publishCurrentMediaEventIntent(occurrenceIdValue, eventIdValue, intent) {
+    boundEventIntent(intent, this.identity.sha256, eventIdValue);
+    return this.publishJson(
+      this.mediaEventKey(occurrenceIdValue, eventIdValue),
+      intent,
+      MAX_EVENT_BYTES,
+      "content-addressed current media event collision",
+    );
+  }
+
+  async readCurrentMediaEventIntent(occurrenceIdValue, eventIdValue) {
+    const value = await this.readJson(
+      this.mediaEventKey(occurrenceIdValue, eventIdValue),
+      MAX_EVENT_BYTES,
+      "current media event intent",
+      { missing: true },
+    );
+    if (value !== null) boundEventIntent(value.document, this.identity.sha256, eventIdValue);
+    return value;
+  }
+
+  async publishPngBlob(bytes, expectedSha256) {
+    const value = blobValue(bytes, expectedSha256);
+    await this.publishImmutable(
+      `blobs/sha256/${expectedSha256}.png`,
+      bytes,
+      pngLimits.maxFileBytes,
+      "content-addressed occurrence PNG collision",
+      "image/png",
+    );
+    return value;
+  }
+
+  async readPngBlob(digestValue, { maximumBytes = pngLimits.maxFileBytes } = {}) {
+    digest(digestValue, "occurrence PNG blob digest");
+    if (
+      !Number.isSafeInteger(maximumBytes)
+      || maximumBytes < 1
+      || maximumBytes > pngLimits.maxFileBytes
+    ) {
+      throw new Error("occurrence PNG blob read limit is invalid");
+    }
+    const value = await this.objects.read(`blobs/sha256/${digestValue}.png`, {
+      maximumBytes,
+      label: "occurrence PNG blob",
+    });
+    return blobValue(value.bytes, digestValue);
+  }
+}
+
+export function createOccurrenceReleaseStore(location, options = {}) {
+  const parsed = parseOccurrenceReleaseStoreLocation(location);
+  return parsed.kind === "local"
+    ? new LocalOccurrenceReleaseStore(parsed.root)
+    : new S3OccurrenceReleaseStore(parsed, options);
+}
+
+export const occurrenceReleaseStoreContract = Object.freeze({
+  namespace: TYPE_NAMESPACE,
+  maximumSelectionBytes: MAX_SELECTION_BYTES,
+  maximumManifestBytes: MAX_MANIFEST_BYTES,
+  maximumGenerationBytes: MAX_GENERATION_BYTES,
+  maximumEventBytes: MAX_EVENT_BYTES,
+  maximumPngBytes: pngLimits.maxFileBytes,
+});

--- a/site-astro/scripts/lib/occurrence-release-store.mjs
+++ b/site-astro/scripts/lib/occurrence-release-store.mjs
@@ -95,6 +95,26 @@ function storeIdentity(location) {
   });
 }
 
+function validateS3OccurrenceLocation(value) {
+  if (
+    value === null
+    || typeof value !== "object"
+    || value.kind !== "s3"
+    || typeof value.bucket !== "string"
+    || typeof value.prefix !== "string"
+    || !value.prefix.endsWith(`/${TYPE_NAMESPACE}`)
+    || Buffer.byteLength(value.prefix) + 1 + MAX_RELATIVE_OBJECT_KEY_BYTES
+      > MAX_S3_KEY_BYTES
+  ) {
+    throw new Error("S3 occurrence release store location is invalid");
+  }
+  return Object.freeze({
+    kind: "s3",
+    bucket: value.bucket,
+    prefix: value.prefix,
+  });
+}
+
 export function parseOccurrenceReleaseStoreLocation(value) {
   let parsed;
   try {
@@ -103,17 +123,10 @@ export function parseOccurrenceReleaseStoreLocation(value) {
     throw new Error("occurrence release store location is invalid");
   }
   if (parsed.kind === "local") return parsed;
-  const prefix = `${parsed.prefix}/${TYPE_NAMESPACE}`;
-  if (
-    Buffer.byteLength(prefix) + 1 + MAX_RELATIVE_OBJECT_KEY_BYTES
-    > MAX_S3_KEY_BYTES
-  ) {
-    throw new Error("occurrence release store location is invalid");
-  }
-  return Object.freeze({
+  return validateS3OccurrenceLocation({
     kind: "s3",
     bucket: parsed.bucket,
-    prefix,
+    prefix: `${parsed.prefix}/${TYPE_NAMESPACE}`,
   });
 }
 
@@ -338,28 +351,123 @@ function blobValue(bytes, expectedSha256) {
   };
 }
 
-async function materializeBytes(bytes, expectedSha256, destination) {
-  const directory = path.dirname(destination);
-  const relative = path.basename(destination);
-  const handle = await open(destination, "wx", 0o644);
+function materializedFileIdentity(metadata) {
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1n) {
+    throw new Error("materialized occurrence target is invalid");
+  }
+  return Object.freeze({
+    dev: metadata.dev,
+    ino: metadata.ino,
+    birthtimeNs: metadata.birthtimeNs,
+    ctimeNs: metadata.ctimeNs,
+    mtimeNs: metadata.mtimeNs,
+    size: metadata.size,
+  });
+}
+
+export async function removeMaterializedOccurrenceTarget(
+  destination,
+  identity,
+  { lstatFile = lstat, unlinkFile = unlink } = {},
+) {
+  if (
+    identity === null
+    || typeof identity !== "object"
+    || typeof identity.dev !== "bigint"
+    || typeof identity.ino !== "bigint"
+    || typeof identity.birthtimeNs !== "bigint"
+    || typeof identity.ctimeNs !== "bigint"
+    || typeof identity.mtimeNs !== "bigint"
+    || typeof identity.size !== "bigint"
+  ) {
+    throw new Error("materialized occurrence target identity is invalid");
+  }
+  let selected;
   try {
-    await handle.writeFile(bytes);
-    await handle.sync();
+    selected = await lstatFile(destination, { bigint: true });
   } catch (error) {
-    await handle.close().catch(() => {});
-    await unlink(destination).catch(() => {});
+    if (error.code === "ENOENT") return false;
     throw error;
   }
-  await handle.close();
+  if (
+    !selected.isFile()
+    || selected.isSymbolicLink()
+    || selected.dev !== identity.dev
+    || selected.ino !== identity.ino
+    || selected.birthtimeNs !== identity.birthtimeNs
+    || selected.ctimeNs !== identity.ctimeNs
+    || selected.mtimeNs !== identity.mtimeNs
+    || selected.size !== identity.size
+  ) {
+    return false;
+  }
+  await unlinkFile(destination);
+  return true;
+}
+
+async function materializeBytes(
+  bytes,
+  expectedSha256,
+  destination,
+  { fileOperations = {} } = {},
+) {
+  if (
+    fileOperations === null
+    || typeof fileOperations !== "object"
+    || Array.isArray(fileOperations)
+  ) {
+    throw new Error("occurrence materialization file operations are invalid");
+  }
+  const openFile = fileOperations.open ?? open;
+  const validateFile = fileOperations.validatePngFile ?? validatePngFile;
+  const syncTargetDirectory = fileOperations.syncDirectory ?? syncDirectory;
+  const cleanupOperations = {
+    lstatFile: fileOperations.lstat ?? lstat,
+    unlinkFile: fileOperations.unlink ?? unlink,
+  };
+  const directory = path.dirname(destination);
+  const relative = path.basename(destination);
+  let handle = null;
+  let identity = null;
+  let created = false;
   try {
-    const verified = await validatePngFile(directory, relative);
+    handle = await openFile(destination, "wx", 0o644);
+    created = true;
+    materializedFileIdentity(await handle.stat({ bigint: true }));
+    await handle.writeFile(bytes);
+    await handle.sync();
+    identity = materializedFileIdentity(await handle.stat({ bigint: true }));
+    await handle.close();
+    handle = null;
+    const verified = await validateFile(directory, relative);
     if (verified.sha256 !== expectedSha256) {
       throw new Error("materialized occurrence blob digest mismatch");
     }
-    await syncDirectory(directory);
-    return verified;
+    await syncTargetDirectory(directory);
+    return { ...verified, materializedIdentity: identity };
   } catch (error) {
-    await unlink(destination).catch(() => {});
+    if (created && handle !== null) {
+      try {
+        identity = materializedFileIdentity(await handle.stat({ bigint: true }));
+      } catch {
+        // Without a descriptor identity, deleting by path could remove a replacement.
+      }
+    }
+    await handle?.close().catch(() => {});
+    if (created && identity !== null) {
+      try {
+        await removeMaterializedOccurrenceTarget(
+          destination,
+          identity,
+          cleanupOperations,
+        );
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "occurrence materialization failed and cleanup did not complete",
+        );
+      }
+    }
     throw error;
   }
 }
@@ -431,8 +539,9 @@ export class OccurrenceReleaseStore {
   }
 
   async materializePngBlob(digestValue, destination, options = {}) {
-    const value = await this.readPngBlob(digestValue, options);
-    return materializeBytes(value.body, digestValue, destination);
+    const { fileOperations, ...readOptions } = options;
+    const value = await this.readPngBlob(digestValue, readOptions);
+    return materializeBytes(value.body, digestValue, destination, { fileOperations });
   }
 }
 
@@ -687,21 +796,7 @@ export class S3OccurrenceReleaseStore extends OccurrenceReleaseStore {
     const parsed = typeof location === "string"
       ? parseOccurrenceReleaseStoreLocation(location)
       : location;
-    if (
-      parsed === null
-      || typeof parsed !== "object"
-      || parsed.kind !== "s3"
-      || typeof parsed.bucket !== "string"
-      || typeof parsed.prefix !== "string"
-      || !parsed.prefix.endsWith(`/${TYPE_NAMESPACE}`)
-    ) {
-      throw new Error("S3 occurrence release store location is invalid");
-    }
-    const normalized = Object.freeze({
-      kind: "s3",
-      bucket: parsed.bucket,
-      prefix: parsed.prefix,
-    });
+    const normalized = validateS3OccurrenceLocation(parsed);
     super(normalized);
     this.objects = new S3ObjectStore({
       bucket: normalized.bucket,

--- a/site-astro/scripts/lib/occurrence-release-store.mjs
+++ b/site-astro/scripts/lib/occurrence-release-store.mjs
@@ -4,9 +4,11 @@ import {
   lstat,
   link,
   mkdir,
+  mkdtemp,
   open,
   realpath,
   rename,
+  rm,
   unlink,
 } from "node:fs/promises";
 import path from "node:path";
@@ -24,6 +26,7 @@ const MAX_GENERATION_BYTES = 128 * 1024;
 const MAX_EVENT_BYTES = 32 * 1024;
 const MAX_S3_KEY_BYTES = 1024;
 const MAX_RELATIVE_OBJECT_KEY_BYTES = 160;
+const MATERIALIZATION_STAGE_PREFIX = ".occurrence-stage-";
 
 function canonicalBytes(value) {
   return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
@@ -351,135 +354,7 @@ function blobValue(bytes, expectedSha256) {
   };
 }
 
-function materializedFileIdentity(metadata, { maximumLinks = 1n } = {}) {
-  if (
-    !metadata.isFile()
-    || metadata.isSymbolicLink()
-    || metadata.nlink < 1n
-    || metadata.nlink > maximumLinks
-  ) {
-    throw new Error("materialized occurrence target is invalid");
-  }
-  return Object.freeze({
-    dev: metadata.dev,
-    ino: metadata.ino,
-    nlink: metadata.nlink,
-  });
-}
-
-function materializedOwnership(destination, proofPath, identity) {
-  const absoluteDestination = path.resolve(destination);
-  const absoluteProof = path.resolve(proofPath);
-  if (
-    path.dirname(absoluteProof) !== path.dirname(absoluteDestination)
-    || !/^\.occurrence-materialize-[0-9a-f-]{36}$/u.test(path.basename(absoluteProof))
-  ) {
-    throw new Error("materialized occurrence ownership proof is invalid");
-  }
-  return Object.freeze({
-    destination: absoluteDestination,
-    proofPath: absoluteProof,
-    dev: identity.dev,
-    ino: identity.ino,
-  });
-}
-
-function validateMaterializedOwnership(destination, ownership) {
-  if (
-    ownership === null
-    || typeof ownership !== "object"
-    || ownership.destination !== path.resolve(destination)
-    || typeof ownership.proofPath !== "string"
-    || path.dirname(ownership.proofPath) !== path.dirname(ownership.destination)
-    || !/^\.occurrence-materialize-[0-9a-f-]{36}$/u.test(path.basename(ownership.proofPath))
-    || typeof ownership.dev !== "bigint"
-    || typeof ownership.ino !== "bigint"
-  ) {
-    throw new Error("materialized occurrence ownership proof is invalid");
-  }
-  return ownership;
-}
-
-async function ownedMaterializedProof(destination, ownership, lstatFile) {
-  validateMaterializedOwnership(destination, ownership);
-  let proof;
-  try {
-    proof = await lstatFile(ownership.proofPath, { bigint: true });
-  } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  }
-  if (
-    !proof.isFile()
-    || proof.isSymbolicLink()
-    || proof.nlink < 1n
-    || proof.dev !== ownership.dev
-    || proof.ino !== ownership.ino
-  ) {
-    return null;
-  }
-  return proof;
-}
-
-export async function removeMaterializedOccurrenceTarget(
-  destination,
-  ownership,
-  { lstatFile = lstat, unlinkFile = unlink } = {},
-) {
-  const proof = await ownedMaterializedProof(destination, ownership, lstatFile);
-  if (proof === null) return false;
-  let selected;
-  try {
-    selected = await lstatFile(destination, { bigint: true });
-  } catch (error) {
-    if (error.code === "ENOENT") {
-      await unlinkFile(ownership.proofPath);
-      return false;
-    }
-    throw error;
-  }
-  if (
-    !selected.isFile()
-    || selected.isSymbolicLink()
-    || selected.dev !== proof.dev
-    || selected.ino !== proof.ino
-  ) {
-    await unlinkFile(ownership.proofPath);
-    return false;
-  }
-  await unlinkFile(destination);
-  await unlinkFile(ownership.proofPath);
-  return true;
-}
-
-export async function releaseMaterializedOccurrenceOwnership(
-  destination,
-  ownership,
-  { lstatFile = lstat, unlinkFile = unlink } = {},
-) {
-  const proof = await ownedMaterializedProof(destination, ownership, lstatFile);
-  if (proof === null) return false;
-  let selected;
-  try {
-    selected = await lstatFile(destination, { bigint: true });
-  } catch (error) {
-    if (error.code !== "ENOENT") throw error;
-  }
-  const owned = selected !== undefined
-    && selected.isFile()
-    && !selected.isSymbolicLink()
-    && selected.dev === proof.dev
-    && selected.ino === proof.ino;
-  await unlinkFile(ownership.proofPath);
-  return owned;
-}
-
-async function materializeBytes(
-  bytes,
-  expectedSha256,
-  destination,
-  { fileOperations = {}, retainOwnership = false } = {},
-) {
+function validateMaterializationFileOperations(fileOperations) {
   if (
     fileOperations === null
     || typeof fileOperations !== "object"
@@ -487,79 +362,211 @@ async function materializeBytes(
   ) {
     throw new Error("occurrence materialization file operations are invalid");
   }
-  if (typeof retainOwnership !== "boolean") {
-    throw new Error("occurrence materialization ownership option is invalid");
+  return fileOperations;
+}
+
+async function canonicalMaterializationDirectory(directory) {
+  const absolute = path.resolve(directory);
+  const metadata = await lstat(absolute, { bigint: true });
+  if (
+    !metadata.isDirectory()
+    || metadata.isSymbolicLink()
+    || (await realpath(absolute)) !== absolute
+  ) {
+    throw new Error("occurrence materialization directory is invalid");
   }
+  return absolute;
+}
+
+function validateMaterializationStage(stage) {
+  if (
+    stage === null
+    || typeof stage !== "object"
+    || typeof stage.directory !== "string"
+    || typeof stage.parent !== "string"
+    || path.dirname(stage.directory) !== stage.parent
+    || !path.basename(stage.directory).startsWith(MATERIALIZATION_STAGE_PREFIX)
+    || path.basename(stage.directory).length > MATERIALIZATION_STAGE_PREFIX.length + 64
+  ) {
+    throw new Error("occurrence materialization stage is invalid");
+  }
+  return stage;
+}
+
+async function createMaterializationStage(directory, { fileOperations = {} } = {}) {
+  validateMaterializationFileOperations(fileOperations);
+  const parent = await canonicalMaterializationDirectory(directory);
+  const createTemporaryDirectory = fileOperations.mkdtemp ?? mkdtemp;
+  const stagedDirectory = path.resolve(
+    await createTemporaryDirectory(path.join(parent, MATERIALIZATION_STAGE_PREFIX)),
+  );
+  const stage = Object.freeze({ directory: stagedDirectory, parent });
+  validateMaterializationStage(stage);
+  const metadata = await lstat(stagedDirectory, { bigint: true });
+  if (
+    !metadata.isDirectory()
+    || metadata.isSymbolicLink()
+    || (await realpath(stagedDirectory)) !== stagedDirectory
+  ) {
+    throw new Error("occurrence materialization stage is invalid");
+  }
+  return stage;
+}
+
+async function discardMaterializationStage(stage, { fileOperations = {} } = {}) {
+  validateMaterializationFileOperations(fileOperations);
+  validateMaterializationStage(stage);
+  const removeDirectory = fileOperations.rm ?? rm;
+  await removeDirectory(stage.directory, { recursive: true, force: true });
+}
+
+function sameMaterializedPng(left, right) {
+  return left.sha256 === right.sha256
+    && left.bytes === right.bytes
+    && left.decodedSha256 === right.decodedSha256
+    && left.decodedBytes === right.decodedBytes
+    && left.width === right.width
+    && left.height === right.height
+    && left.mediaType === right.mediaType;
+}
+
+async function stageMaterializationBytes(
+  bytes,
+  expectedSha256,
+  stage,
+  { fileOperations = {} } = {},
+) {
+  validateMaterializationFileOperations(fileOperations);
+  validateMaterializationStage(stage);
+  const expected = blobValue(bytes, expectedSha256);
   const openFile = fileOperations.open ?? open;
+  const validateFile = fileOperations.validatePngFile ?? validatePngFile;
+  const relative = `${expectedSha256}.png`;
+  const stagedPath = path.join(stage.directory, relative);
+  let handle = null;
+  try {
+    handle = await openFile(stagedPath, "wx", 0o644);
+    const identity = await handle.stat({ bigint: true });
+    if (!identity.isFile() || identity.nlink !== 1n || identity.size !== 0n) {
+      throw new Error("occurrence materialization staged file is invalid");
+    }
+    await handle.writeFile(bytes);
+    await handle.sync();
+    const completed = await handle.stat({ bigint: true });
+    if (
+      !completed.isFile()
+      || completed.dev !== identity.dev
+      || completed.ino !== identity.ino
+      || completed.nlink !== 1n
+      || completed.size !== BigInt(bytes.length)
+    ) {
+      throw new Error("occurrence materialization staged file changed while being written");
+    }
+    await handle.close();
+    handle = null;
+    const verified = await validateFile(stage.directory, relative);
+    if (!sameMaterializedPng(verified, expected)) {
+      throw new Error("staged occurrence materialization does not match its blob");
+    }
+    return Object.freeze({
+      ...verified,
+      sourcePath: stagedPath,
+      staging: Object.freeze({
+        stage,
+        stagedPath,
+        dev: completed.dev,
+        ino: completed.ino,
+      }),
+    });
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function validateStagedMaterialization(value) {
+  if (
+    value === null
+    || typeof value !== "object"
+    || value.staging === null
+    || typeof value.staging !== "object"
+    || typeof value.staging.stagedPath !== "string"
+    || typeof value.staging.dev !== "bigint"
+    || typeof value.staging.ino !== "bigint"
+  ) {
+    throw new Error("staged occurrence materialization is invalid");
+  }
+  const stage = validateMaterializationStage(value.staging.stage);
+  if (
+    path.dirname(value.staging.stagedPath) !== stage.directory
+    || path.basename(value.staging.stagedPath) !== `${value.sha256}.png`
+  ) {
+    throw new Error("staged occurrence materialization is invalid");
+  }
+  return value;
+}
+
+async function exactExistingMaterialization(destination, staged, validateFile) {
+  let verified;
+  try {
+    verified = await validateFile(path.dirname(destination), path.basename(destination));
+  } catch {
+    return null;
+  }
+  if (!sameMaterializedPng(verified, staged)) return null;
+  return {
+    ...verified,
+    sourcePath: destination,
+    created: false,
+  };
+}
+
+async function commitStagedMaterialization(
+  stagedValue,
+  destination,
+  { fileOperations = {} } = {},
+) {
+  validateMaterializationFileOperations(fileOperations);
+  const staged = validateStagedMaterialization(stagedValue);
+  const absoluteDestination = path.resolve(destination);
+  if (path.dirname(absoluteDestination) !== staged.staging.stage.parent) {
+    throw new Error("occurrence materialization destination is outside its stage");
+  }
+  const lstatFile = fileOperations.lstat ?? lstat;
   const linkFile = fileOperations.link ?? link;
   const validateFile = fileOperations.validatePngFile ?? validatePngFile;
   const syncTargetDirectory = fileOperations.syncDirectory ?? syncDirectory;
-  const cleanupOperations = {
-    lstatFile: fileOperations.lstat ?? lstat,
-    unlinkFile: fileOperations.unlink ?? unlink,
-  };
-  const directory = path.dirname(destination);
-  const proofPath = path.join(directory, `.occurrence-materialize-${randomUUID()}`);
-  const relativeProof = path.basename(proofPath);
-  let handle = null;
-  let ownership = null;
+  const metadata = await lstatFile(staged.staging.stagedPath, { bigint: true });
+  if (
+    !metadata.isFile()
+    || metadata.isSymbolicLink()
+    || metadata.dev !== staged.staging.dev
+    || metadata.ino !== staged.staging.ino
+    || metadata.nlink !== 1n
+    || metadata.size !== BigInt(staged.bytes)
+  ) {
+    throw new Error("staged occurrence materialization changed before commit");
+  }
   try {
-    handle = await openFile(proofPath, "wx", 0o644);
-    const identity = materializedFileIdentity(await handle.stat({ bigint: true }));
-    ownership = materializedOwnership(destination, proofPath, identity);
-    await handle.writeFile(bytes);
-    await handle.sync();
-    materializedFileIdentity(await handle.stat({ bigint: true }));
-    await handle.close();
-    handle = null;
-    const verified = await validateFile(directory, relativeProof);
-    if (verified.sha256 !== expectedSha256) {
-      throw new Error("materialized occurrence blob digest mismatch");
-    }
-    await linkFile(proofPath, destination);
-    const linked = materializedFileIdentity(
-      await cleanupOperations.lstatFile(proofPath, { bigint: true }),
-      { maximumLinks: 2n },
-    );
-    if (linked.dev !== ownership.dev || linked.ino !== ownership.ino || linked.nlink !== 2n) {
-      throw new Error("materialized occurrence ownership proof changed");
-    }
-    await syncTargetDirectory(directory);
-    const result = {
-      ...verified,
-      sourcePath: path.resolve(destination),
-      materializedOwnership: retainOwnership ? ownership : null,
-    };
-    if (!retainOwnership) {
-      const released = await releaseMaterializedOccurrenceOwnership(
-        destination,
-        ownership,
-        cleanupOperations,
-      );
-      ownership = null;
-      if (!released) {
-        throw new Error("materialized occurrence target changed before completion");
-      }
-    }
-    return result;
+    await linkFile(staged.staging.stagedPath, absoluteDestination);
   } catch (error) {
-    await handle?.close().catch(() => {});
-    if (ownership !== null) {
-      try {
-        await removeMaterializedOccurrenceTarget(
-          destination,
-          ownership,
-          cleanupOperations,
-        );
-      } catch (cleanupError) {
-        throw new AggregateError(
-          [error, cleanupError],
-          "occurrence materialization failed and cleanup did not complete",
-        );
-      }
+    const existing = await exactExistingMaterialization(
+      absoluteDestination,
+      staged,
+      validateFile,
+    );
+    if (existing !== null) return existing;
+    if (error.code === "EEXIST") {
+      throw new Error("existing occurrence materialization conflicts with staged blob");
     }
     throw error;
   }
+  await syncTargetDirectory(path.dirname(absoluteDestination));
+  const { staging: _staging, ...verified } = staged;
+  return {
+    ...verified,
+    sourcePath: absoluteDestination,
+    created: true,
+  };
 }
 
 export class OccurrenceReleaseStore {
@@ -628,13 +635,54 @@ export class OccurrenceReleaseStore {
     throw new Error("occurrence PNG blob read is not implemented");
   }
 
-  async materializePngBlob(digestValue, destination, options = {}) {
-    const { fileOperations, retainOwnership, ...readOptions } = options;
+  async createMaterializationStage(directory, options = {}) {
+    return createMaterializationStage(directory, options);
+  }
+
+  async discardMaterializationStage(stage, options = {}) {
+    return discardMaterializationStage(stage, options);
+  }
+
+  async stagePngBlob(digestValue, stage, options = {}) {
+    const { fileOperations, ...readOptions } = options;
     const value = await this.readPngBlob(digestValue, readOptions);
-    return materializeBytes(value.body, digestValue, destination, {
+    return stageMaterializationBytes(value.body, digestValue, stage, {
       fileOperations,
-      retainOwnership,
     });
+  }
+
+  async commitStagedPngBlob(staged, destination, options = {}) {
+    return commitStagedMaterialization(staged, destination, options);
+  }
+
+  async materializePngBlob(digestValue, destination, options = {}) {
+    const { fileOperations, ...readOptions } = options;
+    const stage = await this.createMaterializationStage(path.dirname(destination), {
+      fileOperations,
+    });
+    let operationError = null;
+    try {
+      const staged = await this.stagePngBlob(digestValue, stage, {
+        ...readOptions,
+        fileOperations,
+      });
+      return await this.commitStagedPngBlob(staged, destination, { fileOperations });
+    } catch (error) {
+      operationError = error;
+      throw error;
+    } finally {
+      try {
+        await this.discardMaterializationStage(stage, { fileOperations });
+      } catch (cleanupError) {
+        if (operationError !== null) {
+          throw new AggregateError(
+            [operationError, cleanupError],
+            "occurrence materialization failed and private staging cleanup did not complete",
+          );
+        }
+        throw cleanupError;
+      }
+    }
   }
 }
 

--- a/site-astro/scripts/lib/occurrence-release.mjs
+++ b/site-astro/scripts/lib/occurrence-release.mjs
@@ -2,6 +2,11 @@ import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, copyFile, link, lstat, mkdir, open, readdir, realpath, rename, unlink } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  LocalOccurrenceReleaseStore,
+  OccurrenceReleaseStore,
+  createOccurrenceReleaseStore,
+} from "./occurrence-release-store.mjs";
 import { validatePngFile } from "./png-validation.mjs";
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
@@ -27,6 +32,19 @@ const EVENT_FRESHNESS = {
 };
 
 class CandidateImageError extends Error {}
+
+async function occurrenceStore(value, { create = false } = {}) {
+  if (value instanceof OccurrenceReleaseStore) {
+    return value.initialize({ create });
+  }
+  const store = createOccurrenceReleaseStore(value);
+  if (!(store instanceof LocalOccurrenceReleaseStore)) {
+    throw new Error(
+      "S3 occurrence store access requires an explicitly constructed adapter; CLI S3 mutation is disabled",
+    );
+  }
+  return store.initialize({ create });
+}
 
 function canonicalBytes(value) {
   return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
@@ -375,15 +393,6 @@ export function summarizeOccurrenceFreshness(manifest, asOf) {
   };
 }
 
-async function canonicalStoreRoot(root) {
-  const absolute = path.resolve(root);
-  const metadata = await lstat(absolute, { bigint: true });
-  if (!metadata.isDirectory() || metadata.isSymbolicLink() || (await realpath(absolute)) !== absolute) {
-    throw new Error("occurrence store root is invalid");
-  }
-  return absolute;
-}
-
 async function secureDirectory(root, relative, { create = false, leafMode = 0o755 } = {}) {
   let current = root;
   const segments = relative.split("/");
@@ -402,23 +411,6 @@ async function secureDirectory(root, relative, { create = false, leafMode = 0o75
     }
   }
   return current;
-}
-
-async function ensureStore(root) {
-  const resolved = await canonicalStoreRoot(root);
-  for (const relative of ["blobs/sha256", "manifests/sha256", "events/sha256"]) {
-    await secureDirectory(resolved, relative, { create: true });
-  }
-  await secureDirectory(resolved, ".quarantine", { create: true, leafMode: 0o700 });
-  return resolved;
-}
-
-async function openStore(root) {
-  const resolved = await canonicalStoreRoot(root);
-  for (const relative of ["blobs/sha256", "manifests/sha256", "events/sha256", ".quarantine"]) {
-    await secureDirectory(resolved, relative);
-  }
-  return resolved;
 }
 
 async function syncDirectory(directory) {
@@ -657,29 +649,7 @@ function currentMediaDirectory(storeRoot, occurrenceIdValue) {
   return path.join(storeRoot, "occurrences", occurrenceIdValue);
 }
 
-async function readCurrentMediaSelectionFromRoot(storeRoot, occurrenceIdValue) {
-  const directory = currentMediaDirectory(storeRoot, occurrenceIdValue);
-  try {
-    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}`);
-    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/generations/sha256`);
-    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/events/sha256`);
-  } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  }
-  let bytes;
-  try {
-    bytes = await readBoundedSingleLink(path.join(directory, "selection.json"), 64 * 1024, "current media selection");
-  } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  }
-  let selection;
-  try {
-    selection = JSON.parse(bytes.toString("utf8"));
-  } catch {
-    throw new Error("current media selection is not valid JSON");
-  }
+function validateCurrentMediaSelection(selection, bytes, occurrenceIdValue) {
   if (
     !exactKeys(selection, [
       "contract",
@@ -707,25 +677,44 @@ async function readCurrentMediaSelectionFromRoot(storeRoot, occurrenceIdValue) {
     throw new Error("current media selection pointers are inconsistent");
   }
   requireInstant(selection.selectedAt, "current media selection time");
+  return selection;
+}
+
+async function readCurrentMediaSelectionFromRoot(storeRoot, occurrenceIdValue) {
+  const directory = currentMediaDirectory(storeRoot, occurrenceIdValue);
+  try {
+    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}`);
+    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/generations/sha256`);
+    await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/events/sha256`);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+  let bytes;
+  try {
+    bytes = await readBoundedSingleLink(path.join(directory, "selection.json"), 64 * 1024, "current media selection");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+  let selection;
+  try {
+    selection = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("current media selection is not valid JSON");
+  }
+  validateCurrentMediaSelection(selection, bytes, occurrenceIdValue);
   return { selection, selectionSha256: sha256(bytes), directory };
 }
 
-async function loadCurrentMediaGenerationFromRoot(storeRoot, occurrenceIdValue, digest) {
-  if (!SHA256_RE.test(digest)) throw new Error("current media generation digest is invalid");
-  const directory = currentMediaDirectory(storeRoot, occurrenceIdValue);
-  await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/generations/sha256`);
-  const bytes = await readBoundedSingleLink(
-    path.join(directory, "generations", "sha256", `${digest}.json`),
-    128 * 1024,
-    "current media generation",
-  );
+async function validateCurrentMediaGeneration(
+  generation,
+  bytes,
+  occurrenceIdValue,
+  digest,
+  storeRoot,
+) {
   if (sha256(bytes) !== digest) throw new Error("current media generation digest mismatch");
-  let generation;
-  try {
-    generation = JSON.parse(bytes.toString("utf8"));
-  } catch {
-    throw new Error("current media generation is not valid JSON");
-  }
   if (
     !exactKeys(generation, [
       "contract",
@@ -760,6 +749,24 @@ async function loadCurrentMediaGenerationFromRoot(storeRoot, occurrenceIdValue, 
   return generation;
 }
 
+async function loadCurrentMediaGenerationFromRoot(storeRoot, occurrenceIdValue, digest) {
+  if (!SHA256_RE.test(digest)) throw new Error("current media generation digest is invalid");
+  const directory = currentMediaDirectory(storeRoot, occurrenceIdValue);
+  await secureDirectory(storeRoot, `occurrences/${occurrenceIdValue}/generations/sha256`);
+  const bytes = await readBoundedSingleLink(
+    path.join(directory, "generations", "sha256", `${digest}.json`),
+    128 * 1024,
+    "current media generation",
+  );
+  let generation;
+  try {
+    generation = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("current media generation is not valid JSON");
+  }
+  return validateCurrentMediaGeneration(generation, bytes, occurrenceIdValue, digest, storeRoot);
+}
+
 async function selectedCurrentMediaPointer(storeRoot, occurrenceIdValue) {
   const selected = await readCurrentMediaSelectionFromRoot(storeRoot, occurrenceIdValue);
   if (selected === null) return null;
@@ -778,6 +785,56 @@ async function selectedCurrentMediaPointer(storeRoot, occurrenceIdValue) {
     throw new Error("current media selection does not match its generations");
   }
   return { ...selected, current, previous };
+}
+
+async function selectedCurrentMediaPointerFromStore(store, occurrenceIdValue) {
+  const selected = await store.readCurrentMediaSelection(occurrenceIdValue);
+  if (selected === null) return null;
+  const selection = validateCurrentMediaSelection(
+    selected.document,
+    selected.bytes,
+    occurrenceIdValue,
+  );
+  const currentValue = await store.readCurrentMediaGeneration(
+    occurrenceIdValue,
+    selection.current.generationSha256,
+  );
+  const current = await validateCurrentMediaGeneration(
+    currentValue.document,
+    currentValue.bytes,
+    occurrenceIdValue,
+    selection.current.generationSha256,
+    store,
+  );
+  let previous = null;
+  if (selection.previous !== null) {
+    const previousValue = await store.readCurrentMediaGeneration(
+      occurrenceIdValue,
+      selection.previous.generationSha256,
+    );
+    previous = await validateCurrentMediaGeneration(
+      previousValue.document,
+      previousValue.bytes,
+      occurrenceIdValue,
+      selection.previous.generationSha256,
+      store,
+    );
+  }
+  if (
+    current.fallback.sha256 !== selection.current.blobSha256
+    || (previous && previous.fallback.sha256 !== selection.previous.blobSha256)
+  ) {
+    throw new Error("current media selection does not match its generations");
+  }
+  return {
+    selection,
+    selectionSha256: selected.sha256,
+    directory: store.root
+      ? currentMediaDirectory(store.root, occurrenceIdValue)
+      : null,
+    current,
+    previous,
+  };
 }
 
 async function pruneCurrentMediaGenerations(directory, selection, priorSelection = null) {
@@ -957,20 +1014,7 @@ function publicCurrentMediaPointer(selected) {
   };
 }
 
-async function readSelection(storeRoot) {
-  let bytes;
-  try {
-    bytes = await readBoundedSingleLink(path.join(storeRoot, "selection.json"), 64 * 1024, "occurrence selection");
-  } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  }
-  let selection;
-  try {
-    selection = JSON.parse(bytes.toString("utf8"));
-  } catch {
-    throw new Error("occurrence selection is not valid JSON");
-  }
+function validateOccurrenceSelection(selection, bytes) {
   if (
     !exactKeys(selection, ["contract", "schemaVersion", "generation", "current", "previous", "selectedAt", "reason"])
     || selection.contract !== "verdify.lab-occurrence-selection"
@@ -990,6 +1034,23 @@ async function readSelection(storeRoot) {
   requireInstant(selection.selectedAt, "occurrence selection time");
   if (!["publish", "rollback"].includes(selection.reason)) throw new Error("occurrence selection reason is invalid");
   return selection;
+}
+
+async function readSelection(storeRoot) {
+  let bytes;
+  try {
+    bytes = await readBoundedSingleLink(path.join(storeRoot, "selection.json"), 64 * 1024, "occurrence selection");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+  let selection;
+  try {
+    selection = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("occurrence selection is not valid JSON");
+  }
+  return validateOccurrenceSelection(selection, bytes);
 }
 
 async function readIdempotencyRecord(file) {
@@ -1057,17 +1118,9 @@ async function pruneOccurrenceHistory(storeRoot, selection, retain = 10, priorSe
   await syncDirectory(directory);
 }
 
-async function loadManifest(storeRoot, digest) {
+function validateOccurrenceManifest(manifest, bytes, digest) {
   if (!SHA256_RE.test(digest)) throw new Error("occurrence manifest digest is invalid");
-  const file = path.join(storeRoot, "manifests", "sha256", `${digest}.json`);
-  const bytes = await readBoundedSingleLink(file, MAX_MANIFEST_BYTES, "occurrence manifest");
   if (sha256(bytes) !== digest) throw new Error("occurrence manifest digest mismatch");
-  let manifest;
-  try {
-    manifest = JSON.parse(bytes.toString("utf8"));
-  } catch {
-    throw new Error("occurrence manifest is not valid JSON");
-  }
   if (
     !exactKeys(manifest, [
       "contract",
@@ -1097,7 +1150,20 @@ async function loadManifest(storeRoot, digest) {
   return manifest;
 }
 
-async function verifyFallbackBlob(storeRoot, fallback) {
+async function loadManifest(storeRoot, digest) {
+  if (!SHA256_RE.test(digest)) throw new Error("occurrence manifest digest is invalid");
+  const file = path.join(storeRoot, "manifests", "sha256", `${digest}.json`);
+  const bytes = await readBoundedSingleLink(file, MAX_MANIFEST_BYTES, "occurrence manifest");
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("occurrence manifest is not valid JSON");
+  }
+  return validateOccurrenceManifest(manifest, bytes, digest);
+}
+
+function validateFallbackRecord(fallback) {
   if (fallback === null) return;
   const keys = [
     "publicPath",
@@ -1120,11 +1186,23 @@ async function verifyFallbackBlob(storeRoot, fallback) {
     || fallback.publicPath !== `/evidence/blobs/sha256/${fallback.sha256}.png`
     || !Number.isSafeInteger(fallback.decodedBytes)
     || fallback.decodedBytes <= 0
+    || !Number.isSafeInteger(fallback.bytes)
+    || fallback.bytes <= 0
+    || !Number.isSafeInteger(fallback.width)
+    || fallback.width <= 0
+    || !Number.isSafeInteger(fallback.height)
+    || fallback.height <= 0
   ) {
     throw new Error("occurrence fallback does not use the closed v1 shape");
   }
-  const relative = path.posix.join("blobs", "sha256", `${fallback.sha256}.png`);
-  const verified = await validatePngFile(storeRoot, relative);
+  requireInstant(fallback.capturedAt, "fallback capture time");
+  requireInstant(fallback.verifiedAt, "fallback verification time");
+  requireSafeText(fallback.policyVersion, "fallback policy version", 256);
+  return fallback;
+}
+
+function verifyFallbackMetadata(verified, fallback) {
+  validateFallbackRecord(fallback);
   if (
     verified.sha256 !== fallback.sha256
     || verified.decodedSha256 !== fallback.decodedSha256
@@ -1135,12 +1213,19 @@ async function verifyFallbackBlob(storeRoot, fallback) {
   ) {
     throw new Error("occurrence fallback metadata does not match decoded bytes");
   }
-  requireInstant(fallback.capturedAt, "fallback capture time");
-  requireInstant(fallback.verifiedAt, "fallback verification time");
-  requireSafeText(fallback.policyVersion, "fallback policy version", 256);
+  return verified;
 }
 
-async function verifyReleaseBlobs(storeRoot, manifest) {
+async function verifyFallbackBlob(storeRoot, fallback) {
+  validateFallbackRecord(fallback);
+  const relative = path.posix.join("blobs", "sha256", `${fallback.sha256}.png`);
+  const verified = storeRoot instanceof OccurrenceReleaseStore
+    ? await storeRoot.readPngBlob(fallback.sha256, { maximumBytes: fallback.bytes })
+    : await validatePngFile(storeRoot, relative);
+  return verifyFallbackMetadata(verified, fallback);
+}
+
+async function verifyReleaseBlobs(storeRoot, manifest, { verifyBlobBytes = true } = {}) {
   const occurrences = [...manifest.occurrences.graphs, ...manifest.occurrences.currentMedia];
   if (occurrences.length > 10_000) throw new Error("occurrence release exceeds its record limit");
   if (JSON.stringify(manifest.freshness) !== JSON.stringify(evaluateEventFreshness(manifest.event, manifest.publishedAt))) {
@@ -1276,28 +1361,62 @@ async function verifyReleaseBlobs(storeRoot, manifest) {
   let encodedBytes = 0;
   let decodedBytes = 0;
   for (const fallback of uniqueFallbacks.values()) {
+    validateFallbackRecord(fallback);
     encodedBytes += fallback.bytes;
     decodedBytes += fallback.decodedBytes;
     if (encodedBytes > MAX_RELEASE_ENCODED_BYTES || decodedBytes > MAX_RELEASE_DECODED_BYTES) {
       throw new Error("occurrence release exceeds its aggregate image byte budget");
     }
-    await verifyFallbackBlob(storeRoot, fallback);
+    if (verifyBlobBytes) await verifyFallbackBlob(storeRoot, fallback);
   }
 }
 
 export async function loadSelectedOccurrenceRelease(storeRoot) {
-  const root = await openStore(storeRoot);
-  const selection = await readSelection(root);
-  if (selection === null) return { root, selection: null, selectionSha256: null, current: null, previous: null };
-  const current = await loadManifest(root, selection.current.manifestSha256);
-  const previous = selection.previous ? await loadManifest(root, selection.previous.manifestSha256) : null;
-  await verifyReleaseBlobs(root, current);
-  if (previous) await verifyReleaseBlobs(root, previous);
-  return { root, selection, selectionSha256: sha256(canonicalBytes(selection)), current, previous };
+  const store = await occurrenceStore(storeRoot);
+  const selected = await store.readAggregateSelection();
+  const root = store.root ?? null;
+  if (selected === null) {
+    return {
+      root,
+      selection: null,
+      selectionSha256: null,
+      current: null,
+      previous: null,
+    };
+  }
+  const selection = validateOccurrenceSelection(selected.document, selected.bytes);
+  const currentValue = await store.readAggregateManifest(selection.current.manifestSha256);
+  const current = validateOccurrenceManifest(
+    currentValue.document,
+    currentValue.bytes,
+    selection.current.manifestSha256,
+  );
+  let previous = null;
+  if (selection.previous !== null) {
+    const previousValue = await store.readAggregateManifest(selection.previous.manifestSha256);
+    previous = validateOccurrenceManifest(
+      previousValue.document,
+      previousValue.bytes,
+      selection.previous.manifestSha256,
+    );
+  }
+  await verifyReleaseBlobs(store, current);
+  if (previous) await verifyReleaseBlobs(store, previous);
+  return {
+    root,
+    selection,
+    selectionSha256: selected.sha256,
+    current,
+    previous,
+  };
 }
 
 async function withStoreLock(storeRoot, callback) {
-  const root = await ensureStore(storeRoot);
+  const store = await occurrenceStore(storeRoot, { create: true });
+  if (!(store instanceof LocalOccurrenceReleaseStore)) {
+    throw new Error("S3 occurrence publication is not enabled by the local publisher");
+  }
+  const root = store.root;
   const lockPath = path.join(root, ".publish.lock");
   let handle;
   try {
@@ -1531,8 +1650,8 @@ export async function rollbackOccurrenceRelease({ storeRoot, expectedSelectionSh
 }
 
 export async function loadSelectedCurrentMediaGeneration(storeRoot, occurrenceIdValue) {
-  const root = await openStore(storeRoot);
-  return selectedCurrentMediaPointer(root, occurrenceIdValue);
+  const store = await occurrenceStore(storeRoot);
+  return selectedCurrentMediaPointerFromStore(store, occurrenceIdValue);
 }
 
 export async function rollbackCurrentMediaGeneration({
@@ -1568,19 +1687,23 @@ export async function rollbackCurrentMediaGeneration({
 }
 
 export async function materializeOccurrenceBlobs(storeRoot, manifest, destination) {
-  const root = await openStore(storeRoot);
-  await verifyReleaseBlobs(root, manifest);
+  const store = await occurrenceStore(storeRoot);
+  await verifyReleaseBlobs(store, manifest, { verifyBlobBytes: false });
   await mkdir(path.join(destination, "evidence", "blobs", "sha256"), { recursive: true, mode: 0o755 });
   const fallbacks = [...manifest.occurrences.graphs, ...manifest.occurrences.currentMedia]
     .map((occurrence) => occurrence.fallback)
     .filter(Boolean);
   const digests = [...new Set(fallbacks.map((fallback) => fallback.sha256))].sort();
   for (const digest of digests) {
-    const source = path.join(root, "blobs", "sha256", `${digest}.png`);
     const target = path.join(destination, "evidence", "blobs", "sha256", `${digest}.png`);
-    await copyFile(source, target, fsConstants.COPYFILE_EXCL);
-    const verified = await validatePngFile(path.dirname(target), path.basename(target));
-    if (verified.sha256 !== digest) throw new Error("materialized occurrence blob digest mismatch");
+    const fallback = fallbacks.find((value) => value.sha256 === digest);
+    const verified = await store.materializePngBlob(digest, target, { maximumBytes: fallback.bytes });
+    try {
+      verifyFallbackMetadata(verified, fallback);
+    } catch (error) {
+      await unlink(target).catch(() => {});
+      throw error;
+    }
   }
   return digests.length;
 }

--- a/site-astro/scripts/lib/occurrence-release.mjs
+++ b/site-astro/scripts/lib/occurrence-release.mjs
@@ -6,8 +6,6 @@ import {
   LocalOccurrenceReleaseStore,
   OccurrenceReleaseStore,
   createOccurrenceReleaseStore,
-  releaseMaterializedOccurrenceOwnership,
-  removeMaterializedOccurrenceTarget,
 } from "./occurrence-release-store.mjs";
 import { validatePngFile } from "./png-validation.mjs";
 
@@ -1691,57 +1689,47 @@ export async function rollbackCurrentMediaGeneration({
 export async function materializeOccurrenceBlobs(storeRoot, manifest, destination) {
   const store = await occurrenceStore(storeRoot);
   await verifyReleaseBlobs(store, manifest, { verifyBlobBytes: false });
-  await mkdir(path.join(destination, "evidence", "blobs", "sha256"), { recursive: true, mode: 0o755 });
+  const targetDirectory = path.join(destination, "evidence", "blobs", "sha256");
+  await mkdir(targetDirectory, { recursive: true, mode: 0o755 });
   const fallbacks = [...manifest.occurrences.graphs, ...manifest.occurrences.currentMedia]
     .map((occurrence) => occurrence.fallback)
     .filter(Boolean);
   const digests = [...new Set(fallbacks.map((fallback) => fallback.sha256))].sort();
-  const created = [];
+  const stage = await store.createMaterializationStage(targetDirectory);
+  let operationError = null;
   try {
+    const staged = [];
     for (const digest of digests) {
-      const target = path.join(destination, "evidence", "blobs", "sha256", `${digest}.png`);
       const fallback = fallbacks.find((value) => value.sha256 === digest);
-      const verified = await store.materializePngBlob(digest, target, {
+      const verified = await store.stagePngBlob(digest, stage, {
         maximumBytes: fallback.bytes,
-        retainOwnership: true,
       });
-      created.push({ target, ownership: verified.materializedOwnership });
       verifyFallbackMetadata(verified, fallback);
+      staged.push({
+        target: path.join(targetDirectory, `${digest}.png`),
+        verified,
+      });
     }
+    for (const item of staged) {
+      await store.commitStagedPngBlob(item.verified, item.target);
+    }
+    return digests.length;
   } catch (error) {
-    const cleanupErrors = [];
-    for (const item of created.reverse()) {
-      try {
-        await removeMaterializedOccurrenceTarget(item.target, item.ownership);
-      } catch (cleanupError) {
-        cleanupErrors.push(cleanupError);
-      }
-    }
-    if (cleanupErrors.length > 0) {
-      throw new AggregateError(
-        [error, ...cleanupErrors],
-        "occurrence materialization failed and cleanup did not complete",
-      );
-    }
+    operationError = error;
     throw error;
-  }
-  const releaseErrors = [];
-  for (const item of created) {
+  } finally {
     try {
-      if (!await releaseMaterializedOccurrenceOwnership(item.target, item.ownership)) {
-        throw new Error("materialized occurrence target changed before commit");
+      await store.discardMaterializationStage(stage);
+    } catch (cleanupError) {
+      if (operationError !== null) {
+        throw new AggregateError(
+          [operationError, cleanupError],
+          "occurrence materialization failed and private staging cleanup did not complete",
+        );
       }
-    } catch (error) {
-      releaseErrors.push(error);
+      throw cleanupError;
     }
   }
-  if (releaseErrors.length > 0) {
-    throw new AggregateError(
-      releaseErrors,
-      "occurrence materialization completed but ownership release did not complete",
-    );
-  }
-  return digests.length;
 }
 
 export function occurrenceStateIndex(manifest) {

--- a/site-astro/scripts/lib/occurrence-release.mjs
+++ b/site-astro/scripts/lib/occurrence-release.mjs
@@ -6,6 +6,7 @@ import {
   LocalOccurrenceReleaseStore,
   OccurrenceReleaseStore,
   createOccurrenceReleaseStore,
+  releaseMaterializedOccurrenceOwnership,
   removeMaterializedOccurrenceTarget,
 } from "./occurrence-release-store.mjs";
 import { validatePngFile } from "./png-validation.mjs";
@@ -1700,15 +1701,18 @@ export async function materializeOccurrenceBlobs(storeRoot, manifest, destinatio
     for (const digest of digests) {
       const target = path.join(destination, "evidence", "blobs", "sha256", `${digest}.png`);
       const fallback = fallbacks.find((value) => value.sha256 === digest);
-      const verified = await store.materializePngBlob(digest, target, { maximumBytes: fallback.bytes });
-      created.push({ target, identity: verified.materializedIdentity });
+      const verified = await store.materializePngBlob(digest, target, {
+        maximumBytes: fallback.bytes,
+        retainOwnership: true,
+      });
+      created.push({ target, ownership: verified.materializedOwnership });
       verifyFallbackMetadata(verified, fallback);
     }
   } catch (error) {
     const cleanupErrors = [];
     for (const item of created.reverse()) {
       try {
-        await removeMaterializedOccurrenceTarget(item.target, item.identity);
+        await removeMaterializedOccurrenceTarget(item.target, item.ownership);
       } catch (cleanupError) {
         cleanupErrors.push(cleanupError);
       }
@@ -1720,6 +1724,22 @@ export async function materializeOccurrenceBlobs(storeRoot, manifest, destinatio
       );
     }
     throw error;
+  }
+  const releaseErrors = [];
+  for (const item of created) {
+    try {
+      if (!await releaseMaterializedOccurrenceOwnership(item.target, item.ownership)) {
+        throw new Error("materialized occurrence target changed before commit");
+      }
+    } catch (error) {
+      releaseErrors.push(error);
+    }
+  }
+  if (releaseErrors.length > 0) {
+    throw new AggregateError(
+      releaseErrors,
+      "occurrence materialization completed but ownership release did not complete",
+    );
   }
   return digests.length;
 }

--- a/site-astro/scripts/lib/occurrence-release.mjs
+++ b/site-astro/scripts/lib/occurrence-release.mjs
@@ -6,6 +6,7 @@ import {
   LocalOccurrenceReleaseStore,
   OccurrenceReleaseStore,
   createOccurrenceReleaseStore,
+  removeMaterializedOccurrenceTarget,
 } from "./occurrence-release-store.mjs";
 import { validatePngFile } from "./png-validation.mjs";
 
@@ -1694,16 +1695,31 @@ export async function materializeOccurrenceBlobs(storeRoot, manifest, destinatio
     .map((occurrence) => occurrence.fallback)
     .filter(Boolean);
   const digests = [...new Set(fallbacks.map((fallback) => fallback.sha256))].sort();
-  for (const digest of digests) {
-    const target = path.join(destination, "evidence", "blobs", "sha256", `${digest}.png`);
-    const fallback = fallbacks.find((value) => value.sha256 === digest);
-    const verified = await store.materializePngBlob(digest, target, { maximumBytes: fallback.bytes });
-    try {
+  const created = [];
+  try {
+    for (const digest of digests) {
+      const target = path.join(destination, "evidence", "blobs", "sha256", `${digest}.png`);
+      const fallback = fallbacks.find((value) => value.sha256 === digest);
+      const verified = await store.materializePngBlob(digest, target, { maximumBytes: fallback.bytes });
+      created.push({ target, identity: verified.materializedIdentity });
       verifyFallbackMetadata(verified, fallback);
-    } catch (error) {
-      await unlink(target).catch(() => {});
-      throw error;
     }
+  } catch (error) {
+    const cleanupErrors = [];
+    for (const item of created.reverse()) {
+      try {
+        await removeMaterializedOccurrenceTarget(item.target, item.identity);
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupErrors],
+        "occurrence materialization failed and cleanup did not complete",
+      );
+    }
+    throw error;
   }
   return digests.length;
 }

--- a/site-astro/tests/occurrence-release-s3.test.mjs
+++ b/site-astro/tests/occurrence-release-s3.test.mjs
@@ -1,15 +1,12 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {
-  lstat,
   mkdir,
   mkdtemp,
   open,
   readFile,
   readdir,
   rm,
-  unlink,
-  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -32,7 +29,6 @@ import {
   createOccurrenceReleaseStore,
   occurrenceReleaseStoreContract,
   parseOccurrenceReleaseStoreLocation,
-  removeMaterializedOccurrenceTarget,
 } from "../scripts/lib/occurrence-release-store.mjs";
 
 const BUCKET = "verdify-lab-releases";
@@ -426,12 +422,16 @@ test("local adapter preserves aggregate, per-camera, event, and PNG layouts", as
   );
 
   const target = path.join(output, `${imageSha256}.png`);
-  await store.materializePngBlob(imageSha256, target, { maximumBytes: image.length });
-  assert.deepEqual(await readFile(target), image);
-  await assert.rejects(
-    store.materializePngBlob(imageSha256, target),
-    (error) => error.code === "EEXIST",
+  assert.equal(
+    (await store.materializePngBlob(imageSha256, target, { maximumBytes: image.length })).created,
+    true,
   );
+  assert.deepEqual(await readFile(target), image);
+  assert.equal(
+    (await store.materializePngBlob(imageSha256, target, { maximumBytes: image.length })).created,
+    false,
+  );
+  assert.deepEqual(await readdir(output), [`${imageSha256}.png`]);
 });
 
 test("materialization removes its wx target when the file-handle close fails", async (t) => {
@@ -473,73 +473,99 @@ test("materialization removes its wx target when the file-handle close fails", a
   assert.deepEqual(await readdir(output), []);
 });
 
-test("materialization cleanup preserves a same-content foreign replacement under ABA pressure", async (t) => {
-  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-replacement-"));
+test("staging and directory-sync failures clean private state and retry monotonically", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-sync-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const storeRoot = path.join(root, "store");
+  await mkdir(storeRoot);
+  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
+  const image = png(25, 50, 75);
+  const imageSha256 = sha256(image);
+  await store.publishPngBlob(image, imageSha256);
+
+  const stagedOutput = path.join(root, "staged-output");
+  await mkdir(stagedOutput);
+  const stagedTarget = path.join(stagedOutput, `${imageSha256}.png`);
+  await assert.rejects(
+    store.materializePngBlob(imageSha256, stagedTarget, {
+      maximumBytes: image.length,
+      fileOperations: {
+        open: async (...args) => {
+          const handle = await open(...args);
+          return {
+            stat: (...values) => handle.stat(...values),
+            writeFile: (...values) => handle.writeFile(...values),
+            sync: async () => {
+              throw new Error("injected staged file sync failure");
+            },
+            close: (...values) => handle.close(...values),
+          };
+        },
+      },
+    }),
+    /injected staged file sync failure/,
+  );
+  assert.deepEqual(await readdir(stagedOutput), []);
+  assert.equal(
+    (await store.materializePngBlob(imageSha256, stagedTarget, { maximumBytes: image.length })).created,
+    true,
+  );
+
+  const directorySyncOutput = path.join(root, "directory-sync-output");
+  await mkdir(directorySyncOutput);
+  const directorySyncTarget = path.join(directorySyncOutput, `${imageSha256}.png`);
+  await assert.rejects(
+    store.materializePngBlob(imageSha256, directorySyncTarget, {
+      maximumBytes: image.length,
+      fileOperations: {
+        syncDirectory: async () => {
+          throw new Error("injected destination directory sync failure");
+        },
+      },
+    }),
+    /injected destination directory sync failure/,
+  );
+  assert.deepEqual(await readFile(directorySyncTarget), image);
+  assert.deepEqual(await readdir(directorySyncOutput), [`${imageSha256}.png`]);
+  assert.equal(
+    (await store.materializePngBlob(
+      imageSha256,
+      directorySyncTarget,
+      { maximumBytes: image.length },
+    )).created,
+    false,
+  );
+});
+
+test("a conflicting target arriving at commit is never overwritten or deleted", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-conflict-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   const storeRoot = path.join(root, "store");
   const output = path.join(root, "output");
   await mkdir(storeRoot);
   await mkdir(output);
   const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
-  const image = png(25, 50, 75);
-  const imageSha256 = sha256(image);
-  await store.publishPngBlob(image, imageSha256);
-  const target = path.join(output, "target.png");
-  const verified = await store.materializePngBlob(imageSha256, target, {
-    maximumBytes: image.length,
-    retainOwnership: true,
-  });
-  const created = await lstat(target, { bigint: true });
-  const proof = await lstat(verified.materializedOwnership.proofPath, { bigint: true });
-  assert.equal(proof.dev, created.dev);
-  assert.equal(proof.ino, created.ino);
-  assert.equal(proof.nlink, 2n);
-  await unlink(target);
-  for (let attempt = 0; attempt < 64; attempt += 1) {
-    await writeFile(target, image);
-    const replacement = await lstat(target, { bigint: true });
-    assert.notEqual(`${replacement.dev}:${replacement.ino}`, `${created.dev}:${created.ino}`);
-    if (attempt < 63) await unlink(target);
-  }
-  await utimes(target, Number(created.atimeNs) / 1e9, Number(created.mtimeNs) / 1e9);
-  assert.equal(
-    await removeMaterializedOccurrenceTarget(target, verified.materializedOwnership),
-    false,
+  const expected = png(10, 20, 30);
+  const expectedSha256 = sha256(expected);
+  const foreign = png(90, 80, 70);
+  await store.publishPngBlob(expected, expectedSha256);
+  const target = path.join(output, `${expectedSha256}.png`);
+  await assert.rejects(
+    store.materializePngBlob(expectedSha256, target, {
+      maximumBytes: expected.length,
+      fileOperations: {
+        link: async (_source, destination) => {
+          await writeFile(destination, foreign, { flag: "wx" });
+          const error = new Error("injected destination arrival");
+          error.code = "EEXIST";
+          throw error;
+        },
+      },
+    }),
+    /conflicts with staged blob/,
   );
-  assert.deepEqual(await readFile(target), image);
-  assert.deepEqual(await readdir(output), ["target.png"]);
-});
-
-test("retained materialization ownership is isolated across parallel replacements", async (t) => {
-  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-parallel-replacement-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
-  const storeRoot = path.join(root, "store");
-  await mkdir(storeRoot);
-  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
-  const image = png(80, 40, 20);
-  const imageSha256 = sha256(image);
-  await store.publishPngBlob(image, imageSha256);
-
-  await Promise.all(Array.from({ length: 24 }, async (_, index) => {
-    const output = path.join(root, `output-${index}`);
-    await mkdir(output);
-    const target = path.join(output, "target.png");
-    const verified = await store.materializePngBlob(imageSha256, target, {
-      maximumBytes: image.length,
-      retainOwnership: true,
-    });
-    const created = await lstat(target, { bigint: true });
-    await unlink(target);
-    await writeFile(target, image);
-    const replacement = await lstat(target, { bigint: true });
-    assert.notEqual(`${replacement.dev}:${replacement.ino}`, `${created.dev}:${created.ino}`);
-    assert.equal(
-      await removeMaterializedOccurrenceTarget(target, verified.materializedOwnership),
-      false,
-    );
-    assert.deepEqual(await readFile(target), image);
-    assert.deepEqual(await readdir(output), ["target.png"]);
-  }));
+  assert.deepEqual(await readFile(target), foreign);
+  assert.deepEqual(await readdir(output), [`${expectedSha256}.png`]);
 });
 
 test("S3 adapter covers both selector families and immutable object families offline", async (t) => {
@@ -627,7 +653,7 @@ test("S3 adapter covers both selector families and immutable object families off
   assert.deepEqual(await readFile(target), image);
 });
 
-test("explicit S3 two-blob materialization removes partial output and retries cleanly", async (t) => {
+test("S3 two-blob materialization pre-stages sources and partial commit retries monotonically", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-s3-materialize-"));
   const output = path.join(root, "output");
   await mkdir(output);
@@ -654,6 +680,24 @@ test("explicit S3 two-blob materialization removes partial output and retries cl
   assert.deepEqual(await readdir(targetDirectory), []);
 
   client.seed(failedKey, failedBlob.body);
+  const commitStagedPngBlob = store.commitStagedPngBlob.bind(store);
+  let commitCalls = 0;
+  store.commitStagedPngBlob = async (...args) => {
+    commitCalls += 1;
+    if (commitCalls === 2) throw new Error("injected second destination commit failure");
+    return commitStagedPngBlob(...args);
+  };
+  await assert.rejects(
+    materializeOccurrenceBlobs(store, manifest, output),
+    /injected second destination commit failure/,
+  );
+  store.commitStagedPngBlob = commitStagedPngBlob;
+  assert.deepEqual(await readdir(targetDirectory), [`${ordered[0].sha256}.png`]);
+  assert.deepEqual(
+    await readFile(path.join(targetDirectory, `${ordered[0].sha256}.png`)),
+    ordered[0].body,
+  );
+
   assert.equal(await materializeOccurrenceBlobs(store, manifest, output), 2);
   assert.deepEqual(
     (await readdir(targetDirectory)).sort(),
@@ -665,10 +709,7 @@ test("explicit S3 two-blob materialization removes partial output and retries cl
       blob.body,
     );
   }
-  await assert.rejects(
-    materializeOccurrenceBlobs(store, manifest, output),
-    (error) => error.code === "EEXIST",
-  );
+  assert.equal(await materializeOccurrenceBlobs(store, manifest, output), 2);
   for (const blob of ordered) {
     assert.deepEqual(
       await readFile(path.join(targetDirectory, `${blob.sha256}.png`)),

--- a/site-astro/tests/occurrence-release-s3.test.mjs
+++ b/site-astro/tests/occurrence-release-s3.test.mjs
@@ -1,0 +1,563 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { deflateSync } from "node:zlib";
+
+import {
+  evaluateEventFreshness,
+  loadSelectedCurrentMediaGeneration,
+  loadSelectedOccurrenceRelease,
+  occurrenceReleasePayloadSha256,
+  publishOccurrenceRelease,
+} from "../scripts/lib/occurrence-release.mjs";
+import {
+  LocalOccurrenceReleaseStore,
+  S3OccurrenceReleaseStore,
+  createOccurrenceReleaseStore,
+  occurrenceReleaseStoreContract,
+  parseOccurrenceReleaseStoreLocation,
+} from "../scripts/lib/occurrence-release-store.mjs";
+
+const BUCKET = "verdify-lab-releases";
+const BASE_PREFIX = "lab-stage/releases";
+const TYPED_PREFIX = `${BASE_PREFIX}/occurrence-releases/v1`;
+const LOCATION = `s3://${BUCKET}/${BASE_PREFIX}`;
+const MEDIA_ID = `media_${"1".repeat(24)}`;
+
+function canonicalBytes(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function missing() {
+  const error = new Error("object is absent");
+  error.name = "NoSuchKey";
+  error.$metadata = { httpStatusCode: 404 };
+  return error;
+}
+
+function precondition() {
+  const error = new Error("conditional write did not match");
+  error.name = "PreconditionFailed";
+  error.$metadata = { httpStatusCode: 412 };
+  return error;
+}
+
+class FakeS3Client {
+  constructor() {
+    this.objects = new Map();
+    this.commands = [];
+    this.sequence = 0;
+    this.afterPutError = null;
+    this.beforePut = null;
+  }
+
+  identity(input) {
+    return `${input.Bucket}/${input.Key}`;
+  }
+
+  seed(key, bytes, etag = null) {
+    this.sequence += 1;
+    this.objects.set(`${BUCKET}/${key}`, {
+      bytes: Buffer.from(bytes),
+      etag: etag ?? `"fake-${this.sequence}"`,
+    });
+  }
+
+  async send(command) {
+    const name = command.constructor.name;
+    const input = command.input;
+    this.commands.push({
+      name,
+      input: {
+        ...input,
+        ...(Buffer.isBuffer(input.Body) ? { Body: Buffer.from(input.Body) } : {}),
+      },
+    });
+    if (name === "GetObjectCommand") {
+      const value = this.objects.get(this.identity(input));
+      if (value === undefined) throw missing();
+      return {
+        ETag: value.etag,
+        ContentLength: value.bytes.length,
+        Body: (async function* body() {
+          for (let offset = 0; offset < value.bytes.length; offset += 5) {
+            yield value.bytes.subarray(offset, offset + 5);
+          }
+        })(),
+      };
+    }
+    if (name === "PutObjectCommand") {
+      if (this.beforePut !== null) await this.beforePut(input, this);
+      const identity = this.identity(input);
+      const current = this.objects.get(identity);
+      if (input.IfNoneMatch === "*" && current !== undefined) throw precondition();
+      if (input.IfMatch !== undefined && current?.etag !== input.IfMatch) throw precondition();
+      const bytes = Buffer.from(input.Body);
+      assert.equal(input.ContentLength, bytes.length);
+      this.sequence += 1;
+      const etag = `"fake-${this.sequence}"`;
+      this.objects.set(identity, { bytes, etag });
+      if (this.afterPutError !== null) {
+        const error = this.afterPutError;
+        this.afterPutError = null;
+        throw error;
+      }
+      return { ETag: etag };
+    }
+    if (name === "ListObjectsV2Command") {
+      return { Contents: [], IsTruncated: false };
+    }
+    throw new Error(`unexpected command ${name}`);
+  }
+}
+
+const CRC_TABLE = Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit += 1) {
+    crc = (crc & 1) === 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+  }
+  return crc >>> 0;
+});
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type, data) {
+  const typeBytes = Buffer.from(type);
+  const result = Buffer.alloc(12 + data.length);
+  result.writeUInt32BE(data.length, 0);
+  typeBytes.copy(result, 4);
+  data.copy(result, 8);
+  result.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])), 8 + data.length);
+  return result;
+}
+
+function png(r, g, b) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(2, 0);
+  header.writeUInt32BE(1, 4);
+  header[8] = 8;
+  header[9] = 6;
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    chunk("IHDR", header),
+    chunk("IDAT", deflateSync(Buffer.from([0, r, g, b, 255, r, g, b, 255]))),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function aggregateSelection(manifestSha256, generation = 1, previous = null) {
+  return {
+    contract: "verdify.lab-occurrence-selection",
+    schemaVersion: 1,
+    generation,
+    current: {
+      manifestSha256,
+      eventId: `evt_aggregate_${String(generation).padStart(4, "0")}`,
+    },
+    previous,
+    selectedAt: `2026-07-12T12:${String(generation).padStart(2, "0")}:00Z`,
+    reason: "publish",
+  };
+}
+
+function mediaSelection(generationSha256, blobSha256, generation = 1, previous = null) {
+  return {
+    contract: "verdify.lab-current-media-selection",
+    schemaVersion: 1,
+    occurrenceId: MEDIA_ID,
+    generation,
+    current: { generationSha256, blobSha256 },
+    previous,
+    selectedAt: `2026-07-12T12:${String(generation).padStart(2, "0")}:00Z`,
+    reason: "publish",
+  };
+}
+
+function event(eventId, eventType = "reconciliation") {
+  return {
+    contract: "verdify.lab-release-trigger",
+    schemaVersion: 1,
+    eventId,
+    eventType,
+    sourceId: "offline-test-source",
+    sourceWatermark: "offline-test-watermark",
+    occurredAt: "2026-07-12T12:00:00Z",
+    payloadSha256: "a".repeat(64),
+  };
+}
+
+function storeEventIntent(store, contract, eventId) {
+  return {
+    contract,
+    eventId,
+    storeIdentitySha256: store.identity.sha256,
+  };
+}
+
+function aggregateManifest(eventId = "evt_aggregate_0001") {
+  const releaseEvent = event(eventId);
+  const publishedAt = "2026-07-12T12:01:00Z";
+  return {
+    contract: "verdify.lab-specialist-occurrence-release",
+    schemaVersion: 2,
+    event: releaseEvent,
+    policyVersion: "offline-policy-v1",
+    policySha256: "b".repeat(64),
+    sourceSnapshotManifestSha256: "c".repeat(64),
+    publishedAt,
+    freshness: evaluateEventFreshness(releaseEvent, publishedAt),
+    occurrences: { graphs: [], currentMedia: [] },
+  };
+}
+
+function mediaGeneration(blob) {
+  return {
+    contract: "verdify.lab-current-media-generation",
+    schemaVersion: 3,
+    occurrenceId: MEDIA_ID,
+    sourceProvenanceSha256: "d".repeat(64),
+    policySha256: "e".repeat(64),
+    requestProvenanceSha256: "f".repeat(64),
+    event: event("evt_media_adapter_0001", "current-media-updated"),
+    policyVersion: "offline-policy-v1",
+    publishedAt: "2026-07-12T12:01:00Z",
+    fallback: {
+      publicPath: `/evidence/blobs/sha256/${blob.sha256}.png`,
+      sha256: blob.sha256,
+      decodedSha256: blob.decodedSha256,
+      decodedBytes: blob.decodedBytes,
+      bytes: blob.bytes,
+      mediaType: "image/png",
+      width: blob.width,
+      height: blob.height,
+      capturedAt: "2026-07-12T12:00:00Z",
+      verifiedAt: "2026-07-12T12:00:30Z",
+      policyVersion: "offline-policy-v1",
+    },
+  };
+}
+
+test("occurrence store factory is strict and binds a distinct typed namespace", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-store-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  assert.deepEqual(parseOccurrenceReleaseStoreLocation(LOCATION), {
+    kind: "s3",
+    bucket: BUCKET,
+    prefix: TYPED_PREFIX,
+  });
+  assert.deepEqual(parseOccurrenceReleaseStoreLocation(root), {
+    kind: "local",
+    root,
+  });
+  for (const invalid of [
+    "s3://verdify-lab-releases",
+    "s3://Verdify/releases",
+    "s3://verdify-lab-releases/",
+    "s3://verdify-lab-releases/lab//occurrences",
+    "s3://verdify-lab-releases/lab/../occurrences",
+    "https://verdify.invalid/releases",
+    "file:///tmp/releases",
+    "//remote/releases",
+    "relative\\windows",
+    `s3://verdify-lab-releases/${Array.from({ length: 4 }, () => "a".repeat(220)).join("/")}`,
+  ]) {
+    assert.throws(() => parseOccurrenceReleaseStoreLocation(invalid), /invalid/);
+  }
+
+  const local = createOccurrenceReleaseStore(root);
+  const client = new FakeS3Client();
+  const s3 = createOccurrenceReleaseStore(LOCATION, { client });
+  assert.ok(local instanceof LocalOccurrenceReleaseStore);
+  assert.ok(s3 instanceof S3OccurrenceReleaseStore);
+  assert.notEqual(local.identity.sha256, s3.identity.sha256);
+  assert.equal(s3.identity.document.namespace, occurrenceReleaseStoreContract.namespace);
+  assert.equal(s3.identity.document.prefix, TYPED_PREFIX);
+  assert.equal(client.commands.length, 0, "construction performs no client operation");
+});
+
+test("local adapter preserves aggregate, per-camera, event, and PNG layouts", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-local-"));
+  const output = path.join(root, "output");
+  const storeRoot = path.join(root, "store");
+  await mkdir(storeRoot);
+  await mkdir(output);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
+
+  const manifest = aggregateManifest();
+  const manifestSha256 = await store.publishAggregateManifest(manifest);
+  await store.publishAggregateManifest(manifest);
+  const intent = storeEventIntent(store, "offline.aggregate.intent", manifest.event.eventId);
+  await store.publishAggregateEventIntent(manifest.event.eventId, intent);
+  const storedManifest = await store.readAggregateManifest(manifestSha256);
+  assert.deepEqual(storedManifest.document, manifest);
+  assert.equal(storedManifest.storeIdentitySha256, store.identity.sha256);
+  const storedIntent = await store.readAggregateEventIntent(manifest.event.eventId);
+  assert.deepEqual(storedIntent.document, intent);
+  assert.equal(storedIntent.storeIdentitySha256, store.identity.sha256);
+  const selected = aggregateSelection(manifestSha256);
+  const selectionSha256 = await store.writeAggregateSelection(selected, null);
+  assert.equal((await store.readAggregateSelection()).sha256, selectionSha256);
+  const concurrent = await Promise.allSettled([
+    store.writeAggregateSelection(
+      aggregateSelection("d".repeat(64), 2, selected.current),
+      selectionSha256,
+    ),
+    store.writeAggregateSelection(
+      aggregateSelection("e".repeat(64), 2, selected.current),
+      selectionSha256,
+    ),
+  ]);
+  assert.equal(concurrent.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(concurrent.filter((result) => result.status === "rejected").length, 1);
+
+  const image = png(20, 80, 40);
+  const imageSha256 = sha256(image);
+  const blob = await store.publishPngBlob(image, imageSha256);
+  await store.publishPngBlob(image, imageSha256);
+  const generation = mediaGeneration(blob);
+  const generationSha256 = await store.publishCurrentMediaGeneration(MEDIA_ID, generation);
+  const mediaIntent = storeEventIntent(store, "offline.media.intent", generation.event.eventId);
+  await store.publishCurrentMediaEventIntent(MEDIA_ID, generation.event.eventId, mediaIntent);
+  const mediaSelected = mediaSelection(generationSha256, imageSha256);
+  const mediaSelectionSha256 = await store.writeCurrentMediaSelection(MEDIA_ID, mediaSelected, null);
+  assert.equal((await store.readCurrentMediaSelection(MEDIA_ID)).sha256, mediaSelectionSha256);
+  const storedGeneration = await store.readCurrentMediaGeneration(MEDIA_ID, generationSha256);
+  assert.deepEqual(storedGeneration.document, generation);
+  assert.equal(storedGeneration.storeIdentitySha256, store.identity.sha256);
+  assert.deepEqual(
+    (await store.readCurrentMediaEventIntent(MEDIA_ID, generation.event.eventId)).document,
+    mediaIntent,
+  );
+
+  const target = path.join(output, `${imageSha256}.png`);
+  await store.materializePngBlob(imageSha256, target, { maximumBytes: image.length });
+  assert.deepEqual(await readFile(target), image);
+  await assert.rejects(
+    store.materializePngBlob(imageSha256, target),
+    (error) => error.code === "EEXIST",
+  );
+});
+
+test("S3 adapter covers both selector families and immutable object families offline", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-s3-"));
+  const output = path.join(root, "output");
+  await mkdir(output);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+
+  const image = png(90, 30, 10);
+  const imageSha256 = sha256(image);
+  const blob = await store.publishPngBlob(image, imageSha256);
+  await store.publishPngBlob(image, imageSha256);
+  const manifest = aggregateManifest();
+  const manifestSha256 = await store.publishAggregateManifest(manifest);
+  assert.equal(
+    (await store.readAggregateManifest(manifestSha256)).storeIdentitySha256,
+    store.identity.sha256,
+  );
+  await store.publishAggregateEventIntent(
+    manifest.event.eventId,
+    storeEventIntent(store, "offline.aggregate.intent", manifest.event.eventId),
+  );
+  const firstSelection = aggregateSelection(manifestSha256);
+  const firstSelectionSha256 = await store.writeAggregateSelection(firstSelection, null);
+
+  const secondManifest = aggregateManifest("evt_aggregate_0002");
+  const secondManifestSha256 = await store.publishAggregateManifest(secondManifest);
+  const secondSelection = aggregateSelection(
+    secondManifestSha256,
+    2,
+    firstSelection.current,
+  );
+  const immediatelyRead = await store.readAggregateSelection();
+  const secondSelectionSha256 = await store.writeAggregateSelection(
+    secondSelection,
+    firstSelectionSha256,
+  );
+  const aggregatePut = client.commands
+    .filter((command) => command.name === "PutObjectCommand" && command.input.Key.endsWith("selection.json"))
+    .at(-1);
+  assert.equal(aggregatePut.input.IfMatch, immediatelyRead.etag);
+  assert.equal((await store.readAggregateSelection()).sha256, secondSelectionSha256);
+
+  const generation = mediaGeneration(blob);
+  const generationSha256 = await store.publishCurrentMediaGeneration(MEDIA_ID, generation);
+  await store.publishCurrentMediaEventIntent(
+    MEDIA_ID,
+    generation.event.eventId,
+    storeEventIntent(store, "offline.media.intent", generation.event.eventId),
+  );
+  const firstMediaSelection = mediaSelection(generationSha256, imageSha256);
+  const firstMediaSelectionSha256 = await store.writeCurrentMediaSelection(
+    MEDIA_ID,
+    firstMediaSelection,
+    null,
+  );
+  assert.equal(
+    (await store.readCurrentMediaSelection(MEDIA_ID)).sha256,
+    firstMediaSelectionSha256,
+  );
+  assert.deepEqual(
+    (await store.readCurrentMediaGeneration(MEDIA_ID, generationSha256)).document,
+    generation,
+  );
+  assert.equal(
+    (await store.readCurrentMediaGeneration(MEDIA_ID, generationSha256)).storeIdentitySha256,
+    store.identity.sha256,
+  );
+  assert.equal(
+    (await store.readCurrentMediaEventIntent(MEDIA_ID, generation.event.eventId)).document.eventId,
+    generation.event.eventId,
+  );
+
+  const immutablePuts = client.commands.filter(
+    (command) => command.name === "PutObjectCommand" && !command.input.Key.endsWith("selection.json"),
+  );
+  assert.ok(immutablePuts.length >= 5);
+  assert.ok(immutablePuts.every((command) => command.input.IfNoneMatch === "*"));
+  assert.ok(immutablePuts.every((command) => command.input.Key.startsWith(`${TYPED_PREFIX}/`)));
+
+  const target = path.join(output, `${imageSha256}.png`);
+  await store.materializePngBlob(imageSha256, target, { maximumBytes: image.length });
+  assert.deepEqual(await readFile(target), image);
+});
+
+test("S3 immutable writes recover exact committed bytes and reject collisions and bounds", async () => {
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+  await assert.rejects(
+    store.publishAggregateEventIntent("evt_wrong_store_0001", {
+      contract: "offline.aggregate.intent",
+      eventId: "evt_wrong_store_0001",
+      storeIdentitySha256: "0".repeat(64),
+    }),
+    /canonical store identity/,
+  );
+  assert.equal(client.commands.length, 0);
+  await assert.rejects(
+    store.writeCurrentMediaSelection(MEDIA_ID, {
+      ...mediaSelection("1".repeat(64), "2".repeat(64)),
+      occurrenceId: `media_${"9".repeat(24)}`,
+    }, null),
+    /does not match its occurrence identity/,
+  );
+  assert.equal(client.commands.length, 0);
+  const intent = storeEventIntent(store, "offline.aggregate.intent", "evt_recovery_0001");
+  client.afterPutError = new Error("response was unavailable after commit");
+  await store.publishAggregateEventIntent(intent.eventId, intent);
+  assert.deepEqual((await store.readAggregateEventIntent(intent.eventId)).document, intent);
+
+  const manifest = aggregateManifest("evt_collision_0001");
+  const manifestBytes = canonicalBytes(manifest);
+  const manifestSha256 = sha256(manifestBytes);
+  client.seed(
+    `${TYPED_PREFIX}/manifests/sha256/${manifestSha256}.json`,
+    Buffer.from(`${"x".repeat(manifestBytes.length - 1)}\n`),
+  );
+  await assert.rejects(
+    store.publishAggregateManifest(manifest),
+    /content-addressed occurrence manifest collision/,
+  );
+
+  const image = png(10, 20, 30);
+  const imageSha256 = sha256(image);
+  client.seed(`${TYPED_PREFIX}/blobs/sha256/${imageSha256}.png`, image);
+  await assert.rejects(
+    store.readPngBlob(imageSha256, { maximumBytes: image.length - 1 }),
+    /exceeds its byte limit/,
+  );
+  const commandsBefore = client.commands.length;
+  await assert.rejects(
+    store.publishPngBlob(Buffer.alloc(0), imageSha256),
+    /byte limit/,
+  );
+  assert.equal(client.commands.length, commandsBefore);
+});
+
+test("S3 selectors reject stale and racing writers using the immediately read ETag", async () => {
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+  const first = aggregateSelection("1".repeat(64));
+  const firstSha256 = await store.writeAggregateSelection(first, null);
+  const second = aggregateSelection("2".repeat(64), 2, first.current);
+  await assert.rejects(
+    store.writeAggregateSelection(second, "f".repeat(64)),
+    /precondition failed/,
+  );
+  client.beforePut = async (input, fake) => {
+    if (input.IfMatch === undefined) return;
+    fake.beforePut = null;
+    const current = fake.objects.get(`${input.Bucket}/${input.Key}`);
+    fake.seed(input.Key, current.bytes, '"competing-writer"');
+  };
+  await assert.rejects(
+    store.writeAggregateSelection(second, firstSha256),
+    /precondition failed/,
+  );
+  assert.equal((await store.readAggregateSelection()).document.generation, 1);
+});
+
+test("high-level readers consume an explicitly injected S3 adapter without enabling CLI mutation", async () => {
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+  const manifest = aggregateManifest();
+  const manifestSha256 = await store.publishAggregateManifest(manifest);
+  await store.writeAggregateSelection(aggregateSelection(manifestSha256), null);
+  const selected = await loadSelectedOccurrenceRelease(store);
+  assert.equal(selected.current.event.eventId, manifest.event.eventId);
+  assert.match(store.identity.sha256, /^[0-9a-f]{64}$/u);
+
+  const image = png(80, 40, 20);
+  const blob = await store.publishPngBlob(image, sha256(image));
+  const generation = mediaGeneration(blob);
+  const generationSha256 = await store.publishCurrentMediaGeneration(MEDIA_ID, generation);
+  await store.writeCurrentMediaSelection(
+    MEDIA_ID,
+    mediaSelection(generationSha256, blob.sha256),
+    null,
+  );
+  const selectedMedia = await loadSelectedCurrentMediaGeneration(store, MEDIA_ID);
+  assert.equal(selectedMedia.current.fallback.sha256, blob.sha256);
+
+  assert.throws(
+    () => createOccurrenceReleaseStore("s3://verdify-lab-releases"),
+    /invalid/,
+  );
+  await assert.rejects(
+    loadSelectedOccurrenceRelease(LOCATION),
+    /explicitly constructed adapter; CLI S3 mutation is disabled/,
+  );
+  const request = {
+    storeRoot: LOCATION,
+    sourceRoot: "/offline/not-read",
+    event: null,
+    sourceSnapshotManifestSha256: "c".repeat(64),
+    policyVersion: "offline-policy-v1",
+    policySha256: "b".repeat(64),
+    publishedAt: "2026-07-12T12:01:00Z",
+    graphs: [],
+    currentMedia: [],
+    expectedSelectionSha256: null,
+  };
+  request.event = {
+    ...event("evt_cli_s3_disabled_0001"),
+    payloadSha256: occurrenceReleasePayloadSha256(request),
+  };
+  await assert.rejects(
+    publishOccurrenceRelease(request),
+    /explicitly constructed adapter; CLI S3 mutation is disabled/,
+  );
+});

--- a/site-astro/tests/occurrence-release-s3.test.mjs
+++ b/site-astro/tests/occurrence-release-s3.test.mjs
@@ -9,6 +9,7 @@ import {
   readdir,
   rm,
   unlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -469,27 +470,76 @@ test("materialization removes its wx target when the file-handle close fails", a
   );
   assert.ok(closeCalls >= 1);
   await assert.rejects(readFile(target), (error) => error.code === "ENOENT");
+  assert.deepEqual(await readdir(output), []);
 });
 
-test("materialization cleanup preserves a foreign replacement", async (t) => {
+test("materialization cleanup preserves a same-content foreign replacement under ABA pressure", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-replacement-"));
   t.after(() => rm(root, { recursive: true, force: true }));
-  const target = path.join(root, "target.png");
-  await writeFile(target, "created-by-this-invocation");
+  const storeRoot = path.join(root, "store");
+  const output = path.join(root, "output");
+  await mkdir(storeRoot);
+  await mkdir(output);
+  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
+  const image = png(25, 50, 75);
+  const imageSha256 = sha256(image);
+  await store.publishPngBlob(image, imageSha256);
+  const target = path.join(output, "target.png");
+  const verified = await store.materializePngBlob(imageSha256, target, {
+    maximumBytes: image.length,
+    retainOwnership: true,
+  });
   const created = await lstat(target, { bigint: true });
-  const identity = {
-    dev: created.dev,
-    ino: created.ino,
-    birthtimeNs: created.birthtimeNs,
-    ctimeNs: created.ctimeNs,
-    mtimeNs: created.mtimeNs,
-    size: created.size,
-  };
+  const proof = await lstat(verified.materializedOwnership.proofPath, { bigint: true });
+  assert.equal(proof.dev, created.dev);
+  assert.equal(proof.ino, created.ino);
+  assert.equal(proof.nlink, 2n);
   await unlink(target);
-  const replacement = Buffer.alloc(Number(created.size), 0x66);
-  await writeFile(target, replacement);
-  assert.equal(await removeMaterializedOccurrenceTarget(target, identity), false);
-  assert.deepEqual(await readFile(target), replacement);
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    await writeFile(target, image);
+    const replacement = await lstat(target, { bigint: true });
+    assert.notEqual(`${replacement.dev}:${replacement.ino}`, `${created.dev}:${created.ino}`);
+    if (attempt < 63) await unlink(target);
+  }
+  await utimes(target, Number(created.atimeNs) / 1e9, Number(created.mtimeNs) / 1e9);
+  assert.equal(
+    await removeMaterializedOccurrenceTarget(target, verified.materializedOwnership),
+    false,
+  );
+  assert.deepEqual(await readFile(target), image);
+  assert.deepEqual(await readdir(output), ["target.png"]);
+});
+
+test("retained materialization ownership is isolated across parallel replacements", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-parallel-replacement-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const storeRoot = path.join(root, "store");
+  await mkdir(storeRoot);
+  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
+  const image = png(80, 40, 20);
+  const imageSha256 = sha256(image);
+  await store.publishPngBlob(image, imageSha256);
+
+  await Promise.all(Array.from({ length: 24 }, async (_, index) => {
+    const output = path.join(root, `output-${index}`);
+    await mkdir(output);
+    const target = path.join(output, "target.png");
+    const verified = await store.materializePngBlob(imageSha256, target, {
+      maximumBytes: image.length,
+      retainOwnership: true,
+    });
+    const created = await lstat(target, { bigint: true });
+    await unlink(target);
+    await writeFile(target, image);
+    const replacement = await lstat(target, { bigint: true });
+    assert.notEqual(`${replacement.dev}:${replacement.ino}`, `${created.dev}:${created.ino}`);
+    assert.equal(
+      await removeMaterializedOccurrenceTarget(target, verified.materializedOwnership),
+      false,
+    );
+    assert.deepEqual(await readFile(target), image);
+    assert.deepEqual(await readdir(output), ["target.png"]);
+  }));
 });
 
 test("S3 adapter covers both selector families and immutable object families offline", async (t) => {

--- a/site-astro/tests/occurrence-release-s3.test.mjs
+++ b/site-astro/tests/occurrence-release-s3.test.mjs
@@ -1,15 +1,27 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { deflateSync } from "node:zlib";
 
 import {
+  discoverGraphOccurrence,
   evaluateEventFreshness,
   loadSelectedCurrentMediaGeneration,
   loadSelectedOccurrenceRelease,
+  materializeOccurrenceBlobs,
   occurrenceReleasePayloadSha256,
   publishOccurrenceRelease,
 } from "../scripts/lib/occurrence-release.mjs";
@@ -19,6 +31,7 @@ import {
   createOccurrenceReleaseStore,
   occurrenceReleaseStoreContract,
   parseOccurrenceReleaseStoreLocation,
+  removeMaterializedOccurrenceTarget,
 } from "../scripts/lib/occurrence-release-store.mjs";
 
 const BUCKET = "verdify-lab-releases";
@@ -248,6 +261,58 @@ function mediaGeneration(blob) {
   };
 }
 
+function fallbackRecord(blob) {
+  return {
+    publicPath: `/evidence/blobs/sha256/${blob.sha256}.png`,
+    sha256: blob.sha256,
+    decodedSha256: blob.decodedSha256,
+    decodedBytes: blob.decodedBytes,
+    bytes: blob.bytes,
+    mediaType: "image/png",
+    width: blob.width,
+    height: blob.height,
+    capturedAt: "2026-07-12T12:00:00Z",
+    verifiedAt: "2026-07-12T12:00:30Z",
+    policyVersion: "offline-policy-v1",
+  };
+}
+
+function graphOccurrence(ordinal, blob) {
+  const discovered = discoverGraphOccurrence({
+    route: `/evidence/materialize-${ordinal}`,
+    ordinal,
+    liveUrl: `https://graphs.verdify.ai/d-solo/site-home/public?panelId=${ordinal + 1}&from=now-24h&to=now`,
+    title: `Materialization graph ${ordinal}`,
+    renderCadenceSeconds: 600,
+  });
+  return {
+    ...discovered,
+    staleAfterSeconds: 1800,
+    probeStatus: "success",
+    state: "verified",
+    fallback: fallbackRecord(blob),
+  };
+}
+
+function twoGraphManifest(blobs) {
+  const releaseEvent = event("evt_materialize_s3_0001");
+  const publishedAt = "2026-07-12T12:01:00Z";
+  return {
+    contract: "verdify.lab-specialist-occurrence-release",
+    schemaVersion: 2,
+    event: releaseEvent,
+    policyVersion: "offline-policy-v1",
+    policySha256: "b".repeat(64),
+    sourceSnapshotManifestSha256: "c".repeat(64),
+    publishedAt,
+    freshness: evaluateEventFreshness(releaseEvent, publishedAt),
+    occurrences: {
+      graphs: blobs.map((blob, ordinal) => graphOccurrence(ordinal, blob)),
+      currentMedia: [],
+    },
+  };
+}
+
 test("occurrence store factory is strict and binds a distinct typed namespace", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-store-"));
   t.after(() => rm(root, { recursive: true, force: true }));
@@ -284,6 +349,24 @@ test("occurrence store factory is strict and binds a distinct typed namespace", 
   assert.equal(s3.identity.document.namespace, occurrenceReleaseStoreContract.namespace);
   assert.equal(s3.identity.document.prefix, TYPED_PREFIX);
   assert.equal(client.commands.length, 0, "construction performs no client operation");
+  let factoryCalls = 0;
+  const lazy = createOccurrenceReleaseStore(LOCATION, {
+    clientFactory: () => {
+      factoryCalls += 1;
+      return client;
+    },
+  });
+  assert.ok(lazy instanceof S3OccurrenceReleaseStore);
+  assert.equal(factoryCalls, 0, "the injected client factory stays lazy before initialize");
+  const oversizedTypedPrefix = `${Array.from({ length: 4 }, () => "a".repeat(220)).join("/")}/occurrence-releases/v1`;
+  assert.throws(
+    () => new S3OccurrenceReleaseStore({
+      kind: "s3",
+      bucket: BUCKET,
+      prefix: oversizedTypedPrefix,
+    }, { client }),
+    /location is invalid/,
+  );
 });
 
 test("local adapter preserves aggregate, per-camera, event, and PNG layouts", async (t) => {
@@ -348,6 +431,65 @@ test("local adapter preserves aggregate, per-camera, event, and PNG layouts", as
     store.materializePngBlob(imageSha256, target),
     (error) => error.code === "EEXIST",
   );
+});
+
+test("materialization removes its wx target when the file-handle close fails", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-close-"));
+  const storeRoot = path.join(root, "store");
+  const output = path.join(root, "output");
+  await mkdir(storeRoot);
+  await mkdir(output);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const store = await new LocalOccurrenceReleaseStore(storeRoot).initialize({ create: true });
+  const image = png(45, 60, 75);
+  const imageSha256 = sha256(image);
+  await store.publishPngBlob(image, imageSha256);
+  const target = path.join(output, `${imageSha256}.png`);
+  let closeCalls = 0;
+  await assert.rejects(
+    store.materializePngBlob(imageSha256, target, {
+      maximumBytes: image.length,
+      fileOperations: {
+        open: async (...args) => {
+          const handle = await open(...args);
+          return {
+            stat: (...values) => handle.stat(...values),
+            writeFile: (...values) => handle.writeFile(...values),
+            sync: (...values) => handle.sync(...values),
+            close: async () => {
+              closeCalls += 1;
+              await handle.close().catch(() => {});
+              throw new Error("injected materialization close failure");
+            },
+          };
+        },
+      },
+    }),
+    /injected materialization close failure/,
+  );
+  assert.ok(closeCalls >= 1);
+  await assert.rejects(readFile(target), (error) => error.code === "ENOENT");
+});
+
+test("materialization cleanup preserves a foreign replacement", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-replacement-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const target = path.join(root, "target.png");
+  await writeFile(target, "created-by-this-invocation");
+  const created = await lstat(target, { bigint: true });
+  const identity = {
+    dev: created.dev,
+    ino: created.ino,
+    birthtimeNs: created.birthtimeNs,
+    ctimeNs: created.ctimeNs,
+    mtimeNs: created.mtimeNs,
+    size: created.size,
+  };
+  await unlink(target);
+  const replacement = Buffer.alloc(Number(created.size), 0x66);
+  await writeFile(target, replacement);
+  assert.equal(await removeMaterializedOccurrenceTarget(target, identity), false);
+  assert.deepEqual(await readFile(target), replacement);
 });
 
 test("S3 adapter covers both selector families and immutable object families offline", async (t) => {
@@ -435,6 +577,56 @@ test("S3 adapter covers both selector families and immutable object families off
   assert.deepEqual(await readFile(target), image);
 });
 
+test("explicit S3 two-blob materialization removes partial output and retries cleanly", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-s3-materialize-"));
+  const output = path.join(root, "output");
+  await mkdir(output);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+  const firstBytes = png(15, 30, 45);
+  const secondBytes = png(90, 75, 60);
+  const blobs = [
+    await store.publishPngBlob(firstBytes, sha256(firstBytes)),
+    await store.publishPngBlob(secondBytes, sha256(secondBytes)),
+  ];
+  const manifest = twoGraphManifest(blobs);
+  const ordered = [...blobs].sort((left, right) => left.sha256.localeCompare(right.sha256));
+  const failedBlob = ordered[1];
+  const failedKey = `${TYPED_PREFIX}/blobs/sha256/${failedBlob.sha256}.png`;
+  client.seed(failedKey, Buffer.from("invalid PNG bytes"));
+
+  await assert.rejects(
+    materializeOccurrenceBlobs(store, manifest, output),
+    /digest mismatch|cannot be decoded|signature/,
+  );
+  const targetDirectory = path.join(output, "evidence", "blobs", "sha256");
+  assert.deepEqual(await readdir(targetDirectory), []);
+
+  client.seed(failedKey, failedBlob.body);
+  assert.equal(await materializeOccurrenceBlobs(store, manifest, output), 2);
+  assert.deepEqual(
+    (await readdir(targetDirectory)).sort(),
+    ordered.map((blob) => `${blob.sha256}.png`),
+  );
+  for (const blob of ordered) {
+    assert.deepEqual(
+      await readFile(path.join(targetDirectory, `${blob.sha256}.png`)),
+      blob.body,
+    );
+  }
+  await assert.rejects(
+    materializeOccurrenceBlobs(store, manifest, output),
+    (error) => error.code === "EEXIST",
+  );
+  for (const blob of ordered) {
+    assert.deepEqual(
+      await readFile(path.join(targetDirectory, `${blob.sha256}.png`)),
+      blob.body,
+    );
+  }
+});
+
 test("S3 immutable writes recover exact committed bytes and reject collisions and bounds", async () => {
   const client = new FakeS3Client();
   const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
@@ -508,6 +700,22 @@ test("S3 selectors reject stale and racing writers using the immediately read ET
     /precondition failed/,
   );
   assert.equal((await store.readAggregateSelection()).document.generation, 1);
+});
+
+test("S3 selector writes recover exact bytes after a committed response failure", async () => {
+  const client = new FakeS3Client();
+  const store = await new S3OccurrenceReleaseStore(LOCATION, { client }).initialize();
+  const first = aggregateSelection("1".repeat(64));
+  client.afterPutError = new Error("initial selector response was unavailable after commit");
+  const firstSha256 = await store.writeAggregateSelection(first, null);
+  assert.equal((await store.readAggregateSelection()).sha256, firstSha256);
+
+  const second = aggregateSelection("2".repeat(64), 2, first.current);
+  client.afterPutError = new Error("CAS selector response was unavailable after commit");
+  const secondSha256 = await store.writeAggregateSelection(second, firstSha256);
+  const selected = await store.readAggregateSelection();
+  assert.equal(selected.sha256, secondSha256);
+  assert.deepEqual(selected.document, second);
 });
 
 test("high-level readers consume an explicitly injected S3 adapter without enabling CLI mutation", async () => {


### PR DESCRIPTION
## Summary

- add the typed local/S3 occurrence release-store factory behind the existing occurrence interfaces
- preserve aggregate, per-camera, event, and PNG layouts with bounded reads and immutable absent-only writes
- use entity-tag compare-and-swap for selectors and exact-byte recovery for retryable committed responses
- pre-stage and validate complete materialization batches, then commit monotonically without destination overwrite or deletion

## Scope boundary

This is source-only Phase 4b/4c publishing infrastructure. S3 mutation remains unavailable from the CLI. The change adds no endpoint, environment binding, credential read, Secret, workload, route, egress, stage sync, runtime activation, reporting-feed request, or production action.

Refs #480 and #476; neither issue is closed by this slice.

## Verification

- focused occurrence adapter/release/export tests: 35/35
- site unit suite: 112/112
- targeted pre-commit checks: passed
- `git diff --check`: passed
- independent final review: running against exact PR head
