### PR TITLE
fix(mcp+db): outcome_kpi cycle counts reconcile against raw on-edges; exclude partial/future days (#389)

### DIFF
--- a/db/migrations/201-snapshot-runtime-energy-model.sql
+++ b/db/migrations/201-snapshot-runtime-energy-model.sql
@@ -1,0 +1,162 @@
+-- 201-snapshot-runtime-energy-model.sql
+--
+-- #389 follow-through: outcome_kpi (the ADR-0004 deploy-gate outcome surface)
+-- died in prod with `canceling statement due to statement timeout` — measured
+-- 2026-07-13: a single-day read of v_energy_estimate_reconciliation costs
+-- 23.5 s because its `days` CTE and its modeled branch each evaluate
+-- v_runtime_energy_daily, which LEFT JOINs the LIVE v_equipment_runtime_daily
+-- transition derivation (11 s warm, 40+ s cold per the migration-199/200
+-- headers, O(transitions) and growing daily) — over the MCP's 15 s statement
+-- fence. Every consumer of the energy model (outcome_kpi, api, v_daily_kpi)
+-- pays that scan on every read.
+--
+-- Fix: the runtime evidence joins the migration-200 MATERIALIZED snapshot
+-- (mv_equipment_runtime_daily, refreshed every 10 minutes by the
+-- verdify-band-curve-refresh CronJob) instead of the live view. Energy
+-- modeling never needs sub-10-minute freshness: available_for_scoring already
+-- requires date < today, and the current local day is 'incomplete_runtime' by
+-- definition, so at worst a completed day reads as incomplete for the first
+-- <=10 minutes after local midnight and then converges. Same pattern as
+-- migration 200 (dashboards). Code paths that DO need current-day transition
+-- truth (ingestor daily rollups, firmware deploy preflight) keep reading the
+-- live view, unchanged.
+--
+-- View body is otherwise byte-identical to migration 194's definition; the
+-- snapshot has the full column set (SELECT * of the live view), and the
+-- output columns are unchanged, so dependents
+-- (v_energy_estimate_reconciliation, v_daily_kpi) are unaffected.
+--
+-- Non-self-transactional: CREATE OR REPLACE VIEW only. Safe for an outer
+-- rollback proof. Functional rollback: restore the migration-194 body
+-- (LEFT JOIN public.v_equipment_runtime_daily).
+
+CREATE OR REPLACE VIEW public.v_runtime_energy_daily AS
+WITH runtime AS (
+    SELECT
+        ds.date,
+        ds.greenhouse_id,
+        v.equipment,
+        rt.on_minutes::double precision AS on_minutes,
+        rt.is_complete_day,
+        rt.start_state_known,
+        rt.is_deploy_gate_eligible AS runtime_evidence_eligible,
+        rt.quality AS runtime_quality
+    FROM public.daily_summary ds
+    CROSS JOIN LATERAL (VALUES
+        ('heat1'::text),
+        ('fan1'),
+        ('fan2'),
+        ('fog'),
+        ('vent'),
+        ('grow_light_main'),
+        ('grow_light_grow')
+    ) AS v(equipment)
+    LEFT JOIN public.mv_equipment_runtime_daily rt
+      ON rt.day::date = ds.date
+     AND rt.greenhouse_id = ds.greenhouse_id
+     AND rt.equipment = v.equipment
+), evidence AS (
+    SELECT
+        r.*,
+        c.nominal_value AS coefficient_nominal,
+        c.lower_bound AS coefficient_low,
+        c.upper_bound AS coefficient_high,
+        c.coefficient_source,
+        c.revision AS coefficient_revision,
+        c.evidence_ref,
+        c.unit,
+        c.lower_bound <> c.upper_bound AS has_uncertainty
+    FROM runtime r
+    LEFT JOIN public.equipment e
+      ON e.greenhouse_id = r.greenhouse_id
+     AND e.slug = r.equipment
+     AND e.is_active
+    LEFT JOIN LATERAL (
+        SELECT rc.*
+        FROM public.resource_coefficients rc
+        WHERE rc.equipment_id = e.id
+          AND rc.resource_kind = 'electric_watts'
+          AND rc.valid_from <= (
+              r.date::timestamp AT TIME ZONE 'America/Denver'
+          )
+          AND (
+              rc.valid_to IS NULL
+              OR rc.valid_to > (r.date::timestamp AT TIME ZONE 'America/Denver')
+          )
+        ORDER BY rc.valid_from DESC, rc.id DESC
+        LIMIT 1
+    ) c ON true
+)
+SELECT
+    r.date,
+    r.greenhouse_id,
+    CASE WHEN bool_or(
+        r.on_minutes IS NULL
+        OR NOT COALESCE(r.runtime_evidence_eligible, false)
+        OR r.coefficient_nominal IS NULL
+    )
+      THEN NULL
+      ELSE round(sum((r.on_minutes / 60.0)
+        * r.coefficient_nominal / 1000.0)::numeric, 3)::double precision
+    END AS modeled_kwh,
+    CASE WHEN bool_or(
+        r.on_minutes IS NULL
+        OR NOT COALESCE(r.runtime_evidence_eligible, false)
+        OR r.coefficient_low IS NULL
+    )
+      THEN NULL
+      ELSE round(sum((r.on_minutes / 60.0)
+        * r.coefficient_low / 1000.0)::numeric, 3)::double precision
+    END AS modeled_kwh_low,
+    CASE WHEN bool_or(
+        r.on_minutes IS NULL
+        OR NOT COALESCE(r.runtime_evidence_eligible, false)
+        OR r.coefficient_high IS NULL
+    )
+      THEN NULL
+      ELSE round(sum((r.on_minutes / 60.0)
+        * r.coefficient_high / 1000.0)::numeric, 3)::double precision
+    END AS modeled_kwh_high,
+    round((100.0 * count(*) FILTER (
+            WHERE r.on_minutes IS NOT NULL AND r.coefficient_nominal IS NOT NULL
+              AND r.runtime_evidence_eligible
+        )
+        / NULLIF(count(*), 0))::numeric, 1)::double precision AS runtime_coverage_pct,
+    jsonb_agg(DISTINCT jsonb_build_object(
+        'equipment', r.equipment,
+        'revision', r.coefficient_revision,
+        'source', r.coefficient_source,
+        'low', r.coefficient_low,
+        'nominal', r.coefficient_nominal,
+        'high', r.coefficient_high,
+        'unit', r.unit,
+        'evidence_ref', r.evidence_ref
+    )) FILTER (WHERE r.coefficient_nominal IS NOT NULL) AS coefficient_revisions,
+    'whole_controlled_equipment_runtime'::text AS modeled_scope,
+    CASE
+        WHEN r.date >= (now() AT TIME ZONE 'America/Denver')::date THEN 'incomplete_runtime'
+        WHEN bool_or(r.coefficient_nominal IS NULL) THEN 'missing_coefficients'
+        WHEN bool_or(
+            r.on_minutes IS NULL
+            OR NOT COALESCE(r.runtime_evidence_eligible, false)
+        ) THEN 'incomplete_runtime_evidence'
+        WHEN bool_or(r.has_uncertainty) THEN 'uncertain_coefficients'
+        ELSE 'ok'
+    END AS model_quality,
+    r.date < (now() AT TIME ZONE 'America/Denver')::date
+      AND bool_and(r.on_minutes IS NOT NULL)
+      AND bool_and(COALESCE(r.runtime_evidence_eligible, false))
+      AND bool_and(r.coefficient_nominal IS NOT NULL)
+      AND NOT bool_or(COALESCE(r.has_uncertainty, true)) AS available_for_scoring,
+    jsonb_agg(jsonb_build_object(
+        'equipment', r.equipment,
+        'quality', COALESCE(r.runtime_quality, 'missing'),
+        'complete_day', COALESCE(r.is_complete_day, false),
+        'start_state_known', COALESCE(r.start_state_known, false),
+        'eligible', COALESCE(r.runtime_evidence_eligible, false)
+    ) ORDER BY r.equipment) AS runtime_evidence
+FROM evidence r
+GROUP BY r.date, r.greenhouse_id;
+
+COMMENT ON VIEW public.v_runtime_energy_daily IS
+'Whole controlled-equipment runtime model with low/nominal/high kWh, transition-derived runtime completeness, and the coefficient revision valid on that local day. Runtime evidence reads the migration-200 materialized snapshot (mv_equipment_runtime_daily, 10-minute refresh) — the live transition derivation exceeded consumer statement budgets (migration 201); scoring eligibility still requires a completed local day, so snapshot staleness can only delay, never fabricate, evidence. Populated daily_summary fields are never treated as runtime proof; missing/ineligible transitions or coefficients make the whole scalar NULL, and uncertain evidence is scoring-ineligible.';

--- a/db/migrations/tests/test-201-snapshot-runtime-energy-model.sql
+++ b/db/migrations/tests/test-201-snapshot-runtime-energy-model.sql
@@ -1,0 +1,256 @@
+-- Hand-counted contract for the #389 snapshot read path (migrations 199+200+201).
+--
+-- Proves, on a recent completed local day (inside the migration-199 45-day
+-- window):
+--   1. mv_equipment_runtime_daily starts equal an INDEPENDENT hand count of
+--      TRUE rising edges computed straight from equipment_state (mister_center);
+--   2. the materialized snapshot is row-identical to the live view for a
+--      completed day (the outcome_kpi fast path serves the same truth);
+--   3. current-local-day rows are partial/ineligible and future-dated rows do
+--      not exist in the snapshot;
+--   4. the migration-201 v_runtime_energy_daily (joined to the snapshot)
+--      reproduces a hand-computed modeled_kwh for the completed day and stays
+--      NULL / non-scorable for the current partial day.
+--
+-- Fixture days are now()-relative because migration 199 bounds the day series
+-- to a rolling 45-day window; fixed historical dates would fall outside it.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+CREATE TABLE public.equipment_state (
+    ts timestamptz NOT NULL,
+    equipment text NOT NULL,
+    state boolean NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+
+CREATE TABLE public.daily_summary (
+    date date NOT NULL,
+    greenhouse_id text NOT NULL DEFAULT 'vallery'
+);
+
+CREATE TABLE public.equipment (
+    id integer PRIMARY KEY,
+    greenhouse_id text NOT NULL DEFAULT 'vallery',
+    slug text NOT NULL,
+    is_active boolean NOT NULL DEFAULT true
+);
+
+CREATE TABLE public.resource_coefficients (
+    id integer PRIMARY KEY,
+    equipment_id integer NOT NULL,
+    resource_kind text NOT NULL,
+    nominal_value double precision NOT NULL,
+    lower_bound double precision NOT NULL,
+    upper_bound double precision NOT NULL,
+    coefficient_source text NOT NULL DEFAULT 'nameplate',
+    revision text NOT NULL DEFAULT 'test-r1',
+    evidence_ref text NOT NULL DEFAULT 'test-fixture',
+    unit text NOT NULL DEFAULT 'W',
+    valid_from timestamptz NOT NULL DEFAULT '2024-01-01 00:00:00+00',
+    valid_to timestamptz
+);
+
+\i db/migrations/199-bounded-equipment-runtime-view.sql
+\i db/migrations/200-materialized-equipment-runtime.sql
+\i db/migrations/201-snapshot-runtime-energy-model.sql
+
+-- day1 = two local days ago (completed, inside the 45-day window).
+-- Carry anchors the evening before give every circuit a known day-start state.
+INSERT INTO public.equipment_state(ts, equipment, state)
+SELECT (((now() AT TIME ZONE 'America/Denver')::date - 3)::timestamp
+            + interval '18 hours') AT TIME ZONE 'America/Denver',
+       e,
+       false
+FROM unnest(ARRAY[
+    'fan1', 'fan2', 'heat1', 'fog', 'vent',
+    'grow_light_main', 'grow_light_grow', 'mister_center'
+]) AS e;
+
+-- One clean pulse per energy circuit on day1 (offsets are seconds after local
+-- midnight), plus two mister_center pulses for the rising-edge hand count:
+--   fan1  08:00-09:00 (60 min)   fan2 09:00-09:30 (30 min)
+--   heat1 05:00-05:12 (12 min)   fog  10:00-10:06 (6 min)
+--   vent  11:00-12:00 (60 min)   glm  06:00-07:00 (60 min)
+--   glg   06:00-07:30 (90 min)
+--   mister_center 08:00-08:04 (4 min) and 09:00-09:00:30 (0.5 min)
+CREATE TEMP TABLE fixture_pulses (equipment text, start_s int, end_s int);
+INSERT INTO fixture_pulses VALUES
+    ('fan1', 28800, 32400),
+    ('fan2', 32400, 34200),
+    ('heat1', 18000, 18720),
+    ('fog', 36000, 36360),
+    ('vent', 39600, 43200),
+    ('grow_light_main', 21600, 25200),
+    ('grow_light_grow', 21600, 27000),
+    ('mister_center', 28800, 29040),
+    ('mister_center', 32400, 32430);
+
+INSERT INTO public.equipment_state(ts, equipment, state)
+SELECT (((now() AT TIME ZONE 'America/Denver')::date - 2)::timestamp
+            + make_interval(secs => start_s)) AT TIME ZONE 'America/Denver',
+       equipment, true
+FROM fixture_pulses
+UNION ALL
+SELECT (((now() AT TIME ZONE 'America/Denver')::date - 2)::timestamp
+            + make_interval(secs => end_s)) AT TIME ZONE 'America/Denver',
+       equipment, false
+FROM fixture_pulses;
+
+-- Current-day partial evidence and one future-dated row (must never surface
+-- as a comparison day).
+INSERT INTO public.equipment_state(ts, equipment, state) VALUES
+    (now() - interval '30 minutes', 'vent', true),
+    (now() + interval '2 days', 'vent', false);
+
+INSERT INTO public.daily_summary(date, greenhouse_id) VALUES
+    ((now() AT TIME ZONE 'America/Denver')::date - 2, 'vallery'),
+    ((now() AT TIME ZONE 'America/Denver')::date, 'vallery');
+
+INSERT INTO public.equipment(id, slug) VALUES
+    (1, 'fan1'), (2, 'fan2'), (3, 'heat1'), (4, 'fog'),
+    (5, 'vent'), (6, 'grow_light_main'), (7, 'grow_light_grow');
+
+-- Equal bounds => no uncertainty => scoring-eligible coefficients.
+INSERT INTO public.resource_coefficients
+    (id, equipment_id, resource_kind, nominal_value, lower_bound, upper_bound)
+VALUES
+    (1, 1, 'electric_watts', 200, 200, 200),
+    (2, 2, 'electric_watts', 200, 200, 200),
+    (3, 3, 'electric_watts', 100, 100, 100),
+    (4, 4, 'electric_watts', 50, 50, 50),
+    (5, 5, 'electric_watts', 40, 40, 40),
+    (6, 6, 'electric_watts', 600, 600, 600),
+    (7, 7, 'electric_watts', 600, 600, 600);
+
+-- The snapshot was created WITH DATA before the fixture rows existed; bring it
+-- current the same way the 10-minute refresh cron does.
+REFRESH MATERIALIZED VIEW public.mv_equipment_runtime_daily;
+
+-- 1. Snapshot starts == independent hand count of TRUE rising edges.
+DO $$
+DECLARE
+    day1 date := (now() AT TIME ZONE 'America/Denver')::date - 2;
+    snap record;
+    hand_edges bigint;
+BEGIN
+    SELECT * INTO snap
+      FROM public.mv_equipment_runtime_daily
+     WHERE day = day1 AND equipment = 'mister_center';
+
+    WITH collapsed AS (
+        SELECT ts, bool_or(state) AS state
+        FROM public.equipment_state
+        WHERE equipment = 'mister_center'
+        GROUP BY ts
+    ), lagged AS (
+        SELECT ts, state,
+               lag(state) OVER (ORDER BY ts) AS prev_state
+        FROM collapsed
+    )
+    SELECT count(*) INTO hand_edges
+      FROM lagged
+     WHERE state IS TRUE AND prev_state IS FALSE
+       AND (ts AT TIME ZONE 'America/Denver')::date = day1;
+
+    IF snap.starts IS DISTINCT FROM hand_edges OR hand_edges <> 2 THEN
+        RAISE EXCEPTION 'snapshot starts % != hand-counted rising edges % (expected 2)',
+            snap.starts, hand_edges;
+    END IF;
+    IF snap.on_minutes <> 4.5 OR NOT snap.is_deploy_gate_eligible
+       OR NOT snap.is_complete_day THEN
+        RAISE EXCEPTION 'mister_center snapshot contract mismatch: %',
+            row_to_json(snap);
+    END IF;
+END $$;
+
+-- 2. For the completed day the snapshot is row-identical to the live view.
+DO $$
+DECLARE
+    day1 date := (now() AT TIME ZONE 'America/Denver')::date - 2;
+    diff_count bigint;
+BEGIN
+    SELECT count(*) INTO diff_count FROM (
+        (SELECT equipment, on_minutes, starts, cycles, short_cycles_under_5m,
+                open_pulses_at_cutoff, is_complete_day, is_deploy_gate_eligible,
+                quality
+           FROM public.mv_equipment_runtime_daily WHERE day = day1
+         EXCEPT
+         SELECT equipment, on_minutes, starts, cycles, short_cycles_under_5m,
+                open_pulses_at_cutoff, is_complete_day, is_deploy_gate_eligible,
+                quality
+           FROM public.v_equipment_runtime_daily WHERE day = day1)
+        UNION ALL
+        (SELECT equipment, on_minutes, starts, cycles, short_cycles_under_5m,
+                open_pulses_at_cutoff, is_complete_day, is_deploy_gate_eligible,
+                quality
+           FROM public.v_equipment_runtime_daily WHERE day = day1
+         EXCEPT
+         SELECT equipment, on_minutes, starts, cycles, short_cycles_under_5m,
+                open_pulses_at_cutoff, is_complete_day, is_deploy_gate_eligible,
+                quality
+           FROM public.mv_equipment_runtime_daily WHERE day = day1)
+    ) diffs;
+    IF diff_count <> 0 THEN
+        RAISE EXCEPTION 'snapshot diverges from live view on completed day (% rows)',
+            diff_count;
+    END IF;
+END $$;
+
+-- 3. Partial current day is flagged/ineligible; future-dated rows are absent.
+DO $$
+DECLARE
+    current_day date := (now() AT TIME ZONE 'America/Denver')::date;
+    partial_ok int;
+    future_count int;
+BEGIN
+    SELECT count(*) INTO partial_ok
+      FROM public.mv_equipment_runtime_daily
+     WHERE equipment = 'vent' AND day = current_day
+       AND quality = 'partial_day'
+       AND NOT is_complete_day
+       AND NOT is_deploy_gate_eligible;
+    SELECT count(*) INTO future_count
+      FROM public.mv_equipment_runtime_daily
+     WHERE day > current_day;
+    IF partial_ok <> 1 OR future_count <> 0 THEN
+        RAISE EXCEPTION 'partial/future snapshot exclusion mismatch: partial %, future %',
+            partial_ok, future_count;
+    END IF;
+END $$;
+
+-- 4. Migration-201 energy model: hand-computed kWh on the completed day,
+--    NULL / non-scorable on the current partial day.
+--    60m*200W + 30m*200W + 12m*100W + 6m*50W + 60m*40W + 60m*600W + 90m*600W
+--    = 0.2 + 0.1 + 0.02 + 0.005 + 0.04 + 0.6 + 0.9 = 1.865 kWh
+DO $$
+DECLARE
+    day1 date := (now() AT TIME ZONE 'America/Denver')::date - 2;
+    current_day date := (now() AT TIME ZONE 'America/Denver')::date;
+    r record;
+BEGIN
+    SELECT * INTO r FROM public.v_runtime_energy_daily
+     WHERE date = day1 AND greenhouse_id = 'vallery';
+    IF r.modeled_kwh IS NULL OR abs(r.modeled_kwh - 1.865) > 1e-9
+       OR r.model_quality <> 'ok' OR NOT r.available_for_scoring THEN
+        RAISE EXCEPTION 'completed-day energy model mismatch: kwh %, quality %, scoring %',
+            r.modeled_kwh, r.model_quality, r.available_for_scoring;
+    END IF;
+
+    SELECT * INTO r FROM public.v_runtime_energy_daily
+     WHERE date = current_day AND greenhouse_id = 'vallery';
+    IF r.modeled_kwh IS NOT NULL OR r.model_quality <> 'incomplete_runtime'
+       OR r.available_for_scoring THEN
+        RAISE EXCEPTION 'partial-day energy model must be excluded: kwh %, quality %, scoring %',
+            r.modeled_kwh, r.model_quality, r.available_for_scoring;
+    END IF;
+END $$;
+
+SELECT day, equipment, on_minutes, starts, quality, is_deploy_gate_eligible
+FROM public.mv_equipment_runtime_daily
+WHERE day = (now() AT TIME ZONE 'America/Denver')::date - 2
+ORDER BY equipment;
+
+ROLLBACK;

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -611,6 +611,54 @@ async def scorecard(target_date: str = "") -> str:
         await conn.close()
 
 
+# #389: the transition-derived runtime contract lives in
+# v_equipment_runtime_daily, but its single-day evaluation costs 11-40+ s in
+# prod (O(days x transitions), migration-199/200 headers) — over the MCP
+# statement fence — so outcome_kpi reads the migration-200 materialized
+# snapshot (mv_equipment_runtime_daily, refreshed every 10 min) and reconciles:
+# a completed local day must be complete in the snapshot, otherwise the read
+# falls back to the live view so completed-day truth never silently degrades
+# to a stale snapshot. Rows for the snapshot window bound come from
+# migration 199.
+_EQUIPMENT_RUNTIME_SNAPSHOT_WINDOW_DAYS = 45
+
+
+def _cycle_day_status(target_day: date, today_local: date) -> str:
+    """Deploy-gate day classification for the cycle/runtime axis (#389).
+
+    Only completed local days are comparable across an OTA; the current local
+    day is mid-flight (its transition counts are honest but partial) and a
+    future-dated day has no evidence at all.
+    """
+    if target_day > today_local:
+        return "future_date_excluded"
+    if target_day == today_local:
+        return "partial_day_excluded"
+    return "complete"
+
+
+def _cycle_snapshot_is_stale(cycle_rows, target_day: date, today_local: date) -> bool:
+    """True when the materialized runtime snapshot cannot serve a completed day.
+
+    A completed local day inside the migration-199 window must exist in the
+    snapshot and be marked complete; a missing or still-partial row means the
+    10-minute refresh has not run since local midnight (or the snapshot never
+    covered the day), so the caller must re-read the live view instead of
+    serving mid-day counts as completed-day truth. Partial (current) and
+    future-dated targets never trigger the fallback — they are excluded from
+    deploy-gate comparison regardless of snapshot freshness — and neither do
+    days older than the operational window, where both surfaces are empty by
+    design.
+    """
+    if target_day >= today_local:
+        return False
+    if target_day < today_local - timedelta(days=_EQUIPMENT_RUNTIME_SNAPSHOT_WINDOW_DAYS):
+        return False
+    if not cycle_rows:
+        return True
+    return any(not row["is_complete_day"] for row in cycle_rows)
+
+
 @mcp.tool()
 async def outcome_kpi(target_date: str = "") -> str:
     """Get ADR-0004 outcome KPIs for a day.
@@ -637,6 +685,12 @@ async def outcome_kpi(target_date: str = "") -> str:
     Migration 187's v_moisture_estimator_telemetry view is the equivalent
     typed SQL surface.  Raw equipment transitions, not firmware daily counters,
     are the cycle/runtime authority; the counters remain diagnostic context.
+    Cycle/runtime rows are read from the migration-200 materialized snapshot
+    (mv_equipment_runtime_daily, refreshed every 10 minutes) with a live-view
+    fallback whenever the snapshot cannot serve a completed day; only
+    completed local days participate in deploy-gate cycle comparison —
+    the current (partial) day and future-dated targets are explicitly
+    excluded (vpd_policy.cycle_source.deploy_gate).
     Realized solar-night dry-out episodes distinguish effective, ineffective,
     blocked, and insufficient-evidence outcomes. Pass date as YYYY-MM-DD or
     omit for today.
@@ -652,13 +706,17 @@ async def outcome_kpi(target_date: str = "") -> str:
     greenhouse_id = "vallery"
     conn = await _db()
     try:
+        # today_local comes from the DB clock (the same clock that stamps
+        # equipment_state and the runtime views) so the #389 partial/future
+        # classification below can never disagree with the SQL surfaces.
+        today_local = await conn.fetchval("SELECT (now() AT TIME ZONE 'America/Denver')::date")
         if target_date:
             try:
                 d = datetime.strptime(target_date, "%Y-%m-%d").date()
             except ValueError:
                 return _json({"error": "target_date must be YYYY-MM-DD"})
         else:
-            d = await conn.fetchval("SELECT (now() AT TIME ZONE 'America/Denver')::date")
+            d = today_local
 
         summary_sql = """
             SELECT date, greenhouse_id,
@@ -747,7 +805,12 @@ async def outcome_kpi(target_date: str = "") -> str:
             FROM v_energy_estimate_reconciliation
             WHERE date = $1::date AND greenhouse_id = $2
             """
-        cycles_sql = """
+        # #389: one shared column list, two sources. The materialized snapshot
+        # (migration 200, refreshed every 10 min) is the fast path; the live
+        # view is the reconciliation fallback when the snapshot cannot serve a
+        # completed day (see _cycle_snapshot_is_stale). Both carry the
+        # identical migration-190/199 transition-derived contract.
+        cycles_columns = """
             SELECT equipment,
                    on_minutes::double precision AS on_minutes,
                    starts,
@@ -769,10 +832,23 @@ async def outcome_kpi(target_date: str = "") -> str:
                    same_timestamp_duplicate_rows,
                    redundant_state_rows,
                    conflicting_timestamp_count
+            """
+        cycles_snapshot_sql = (
+            cycles_columns
+            + """
+            FROM mv_equipment_runtime_daily
+            WHERE day = $1::date AND greenhouse_id = $2
+            ORDER BY equipment
+            """
+        )
+        cycles_live_sql = (
+            cycles_columns
+            + """
             FROM v_equipment_runtime_daily
             WHERE day = $1::date AND greenhouse_id = $2
             ORDER BY equipment
             """
+        )
         dryout_sql = """
             SELECT *
             FROM fn_realized_solar_night_dryout($1::date, $1::date, $2)
@@ -1461,9 +1537,18 @@ async def outcome_kpi(target_date: str = "") -> str:
             return summary_row, dli_evidence, water_resource_row, energy_resource_row
 
         async def _equipment_task(c: asyncpg.Connection):
-            cycle_rows = await c.fetch(cycles_sql, d, greenhouse_id)
+            cycle_rows = await c.fetch(cycles_snapshot_sql, d, greenhouse_id)
+            cycle_read_path = "mv_equipment_runtime_daily"
+            if _cycle_snapshot_is_stale(cycle_rows, d, today_local):
+                # Completed in-window day the snapshot cannot serve — re-read
+                # the live transition derivation rather than presenting stale
+                # partial counts as completed-day truth. Bounded by the
+                # statement fence: if the live view exceeds it, the tool fails
+                # loud instead of lying.
+                cycle_rows = await c.fetch(cycles_live_sql, d, greenhouse_id)
+                cycle_read_path = "v_equipment_runtime_daily_stale_snapshot_fallback"
             dryout_rows = await c.fetch(dryout_sql, d, greenhouse_id)
-            return cycle_rows, dryout_rows
+            return cycle_rows, cycle_read_path, dryout_rows
 
         async def _dif_task(c: asyncpg.Connection):
             return await c.fetchrow(dif_sql, d, greenhouse_id)
@@ -1499,7 +1584,7 @@ async def outcome_kpi(target_date: str = "") -> str:
         (
             (pinched, phase_rows),
             (summary_row, dli_evidence, water_resource_row, energy_resource_row),
-            (cycle_rows, dryout_rows),
+            (cycle_rows, cycle_read_path, dryout_rows),
             dif_row,
             (action_rows, moisture_rows, vpd_policy_row, vpd_policy_reason_rows),
         ) = results
@@ -1606,11 +1691,25 @@ async def outcome_kpi(target_date: str = "") -> str:
                 key.removeprefix("runtime_"): summary.get(key) for key in summary if key.startswith("runtime_")
             },
         }
+        cycle_day_status = _cycle_day_status(d, today_local)
         vpd_policy["cycle_source"] = {
             "authority": "v_equipment_runtime_daily",
+            "read_path": cycle_read_path,
             "semantics": "raw equipment_state transition derivation",
             "all_rows_deploy_gate_eligible": bool(cycle_rows)
             and all(row["is_deploy_gate_eligible"] for row in cycle_rows),
+            # #389: only completed local days participate in deploy-gate cycle
+            # comparison; the current (partial) day's transition counts stay
+            # readable — honest undercounts, never firmware-counter inflation —
+            # but are excluded from gates, and future-dated targets carry no
+            # evidence at all.
+            "deploy_gate": {
+                "eligible_days": "completed local days with is_deploy_gate_eligible rows only",
+                "target_day_status": cycle_day_status,
+                "excluded_from_deploy_gate": cycle_day_status != "complete"
+                or not cycle_rows
+                or not all(row["is_deploy_gate_eligible"] for row in cycle_rows),
+            },
             "equipment": cycle_quality,
         }
         vpd_policy["firmware_counter_diagnostics"] = firmware_counter_diagnostics
@@ -1650,7 +1749,16 @@ async def outcome_kpi(target_date: str = "") -> str:
         pending_metrics = []
         if not moisture_sample_count:
             pending_metrics.append("moisture_estimator: source path wired; waiting for OTA/deploy/live rows")
-        if not cycle_rows:
+        if cycle_day_status == "future_date_excluded":
+            pending_metrics.append(
+                "actuator_cycles_runtime: target date is future-dated; excluded from deploy-gate cycle comparison"
+            )
+        elif cycle_day_status == "partial_day_excluded":
+            pending_metrics.append(
+                "actuator_cycles_runtime: current local day is partial; counts are honest "
+                "mid-day undercounts and excluded from deploy-gate cycle comparison"
+            )
+        elif not cycle_rows:
             pending_metrics.append("actuator_cycles_runtime: no transition-derived rows for date")
         elif any(not row["is_deploy_gate_eligible"] for row in cycle_rows):
             pending_metrics.append(
@@ -1677,7 +1785,11 @@ async def outcome_kpi(target_date: str = "") -> str:
                     dli="unavailable",
                     actuator_cycles_runtime=(
                         "available"
-                        if cycle_rows and all(row["is_deploy_gate_eligible"] for row in cycle_rows)
+                        if cycle_day_status == "complete"
+                        and cycle_rows
+                        and all(row["is_deploy_gate_eligible"] for row in cycle_rows)
+                        else "unavailable"
+                        if cycle_day_status == "future_date_excluded"
                         else "pending"
                     ),
                     moisture_estimator="available" if moisture_sample_count else "pending",
@@ -1812,6 +1924,7 @@ async def outcome_kpi(target_date: str = "") -> str:
                 pending_metrics=pending_metrics,
                 source_tables=[
                     "daily_summary",
+                    "mv_equipment_runtime_daily",
                     "v_equipment_runtime_daily",
                     "fn_realized_solar_night_dryout",
                     "v_climate_action_daily_scorecard",

--- a/tests/test_04_planner.py
+++ b/tests/test_04_planner.py
@@ -364,6 +364,22 @@ class TestEvidencePipelineSources:
         cycle_mapping = source.split("actuator_cycles = {", 1)[1].split("actuator_runtime =", 1)[0]
         assert "summary.get" not in cycle_mapping
 
+    def test_outcome_kpi_cycle_reads_snapshot_and_excludes_partial_future_days(self):
+        # #389: the fast path is the migration-200 materialized snapshot; the
+        # live view remains only as the stale-snapshot reconciliation
+        # fallback, and partial/future-dated days are explicit deploy-gate
+        # exclusions, never silent numbers.
+        source = (REPO_ROOT / "mcp" / "server.py").read_text()
+        assert "FROM mv_equipment_runtime_daily" in source
+        assert "_cycle_snapshot_is_stale" in source
+        assert "_cycle_day_status" in source
+        assert '"read_path": cycle_read_path' in source
+        assert "v_equipment_runtime_daily_stale_snapshot_fallback" in source
+        assert '"target_day_status": cycle_day_status' in source
+        assert "partial_day_excluded" in source
+        assert "future_date_excluded" in source
+        assert "excluded from deploy-gate cycle comparison" in source
+
 
 class TestMCPToolAvailability:
     """The MCP server must expose all 17 planning tools."""

--- a/tests/test_outcome_kpi_cycle_reconciliation.py
+++ b/tests/test_outcome_kpi_cycle_reconciliation.py
@@ -1,0 +1,329 @@
+"""#389 — outcome_kpi cycle counts reconcile against raw equipment_state on-edges.
+
+The transition-derived contract (migrations 190/199) is served to outcome_kpi
+by the migration-200 materialized snapshot; these tests pin the read path:
+
+- completed days read mv_equipment_runtime_daily and are deploy-gate eligible;
+- a stale snapshot (completed day missing or still marked partial) falls back
+  to the live view instead of serving mid-day counts as completed-day truth;
+- the current (partial) local day and future-dated targets are excluded from
+  the deploy-gate cycle comparison, explicitly and visibly;
+- days older than the migration-199 window never trigger the live fallback.
+
+The DB is faked at the connection boundary — every SQL surface outcome_kpi
+touches is dispatched by substring — so the assertions exercise the real
+response assembly, not a re-implementation of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_MISSING_MODULE = object()
+_MCP_STUB_MODULES = ("mcp", "mcp.server", "mcp.server.fastmcp")
+
+
+def _install_fastmcp_test_stub() -> None:
+    """Registration-surface stub — same honest boundary as test_17."""
+
+    class _FastMCP:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._registered_tools: list[SimpleNamespace] = []
+
+        def tool(self, *_args, **_kwargs):
+            def decorator(func):
+                self._registered_tools.append(SimpleNamespace(name=func.__name__))
+                return func
+
+            return decorator
+
+        def custom_route(self, *_args, **_kwargs):
+            return lambda func: func
+
+        async def list_tools(self):
+            return list(self._registered_tools)
+
+        def run(self, *_args, **_kwargs) -> None:
+            pass
+
+    fastmcp_module = ModuleType("mcp.server.fastmcp")
+    fastmcp_module.FastMCP = _FastMCP
+    server_module = ModuleType("mcp.server")
+    server_module.__path__ = []
+    server_module.fastmcp = fastmcp_module
+    mcp_module = ModuleType("mcp")
+    mcp_module.__path__ = []
+    mcp_module.server = server_module
+    sys.modules["mcp"] = mcp_module
+    sys.modules["mcp.server"] = server_module
+    sys.modules["mcp.server.fastmcp"] = fastmcp_module
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    prior_modules = {name: sys.modules.get(name, _MISSING_MODULE) for name in _MCP_STUB_MODULES}
+    _install_fastmcp_test_stub()
+    try:
+        path = REPO_ROOT / "mcp" / "server.py"
+        spec = importlib.util.spec_from_file_location("verdify_mcp_server_cycle_test", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, previous in prior_modules.items():
+            if previous is _MISSING_MODULE:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+TODAY = date(2026, 7, 13)
+
+_DLI_VALIDITY_ROW = {
+    "value_mol_m2_day": None,
+    "availability": "unavailable",
+    "unavailable_reason": "validity_contract_missing",
+    "provenance": "unknown_unvalidated_source",
+    "validity_revision": "missing",
+    "valid_from": datetime(2024, 1, 1, tzinfo=UTC),
+    "valid_to": None,
+}
+
+
+def _cycle_row(equipment: str, *, starts: int = 3, complete: bool = True, eligible: bool = True):
+    return {
+        "equipment": equipment,
+        "on_minutes": 42.0,
+        "starts": starts,
+        "cycles_under_1m": 0,
+        "cycles_1m_to_5m": 1,
+        "short_cycles_under_5m": 1,
+        "cycles_5m_to_15m": 1,
+        "cycles_15m_plus": 1,
+        "open_pulses_at_cutoff": 0,
+        "peak_transitions_per_hour": 2,
+        "is_complete_day": complete,
+        "start_state_known": True,
+        "open_at_end": False,
+        "is_deploy_gate_eligible": eligible,
+        "quality": "complete" if complete else "partial_day",
+        "quality_flags": [] if complete else ["partial_day"],
+        "raw_event_rows": 6,
+        "normalized_transition_count": 6,
+        "same_timestamp_duplicate_rows": 0,
+        "redundant_state_rows": 0,
+        "conflicting_timestamp_count": 0,
+    }
+
+
+class _FakeConnection:
+    """Dispatches outcome_kpi's SQL by distinctive substrings."""
+
+    def __init__(self, *, snapshot_rows, live_rows):
+        self.snapshot_rows = snapshot_rows
+        self.live_rows = live_rows
+        self.live_cycles_queried = False
+        self.closed = False
+
+    async def fetchval(self, sql, *args):
+        assert "AT TIME ZONE 'America/Denver'" in sql
+        return TODAY
+
+    async def fetchrow(self, sql, *args):
+        if "fn_dli_validity" in sql:
+            return dict(_DLI_VALIDITY_ROW)
+        for marker in (
+            "FROM daily_summary",
+            "FROM v_dli_daily",
+            "v_water_attribution_daily",
+            "v_energy_estimate_reconciliation",
+            "climate_action",  # vpd_policy_sql
+            "solar_phase",  # dif_sql
+        ):
+            if marker in sql:
+                return None
+        raise AssertionError(f"unexpected fetchrow: {sql[:120]}")
+
+    async def fetch(self, sql, *args):
+        if "FROM mv_equipment_runtime_daily" in sql:
+            return list(self.snapshot_rows)
+        if "FROM v_equipment_runtime_daily" in sql:
+            self.live_cycles_queried = True
+            return list(self.live_rows)
+        for marker in (
+            "fn_realized_solar_night_dryout",
+            "v_climate_action_daily_scorecard",
+            "climate_moisture_exchange",
+            "prev_action",  # vpd_policy_reason_sql
+            "fn_band_setpoints",  # pinched/phase combined statement
+        ):
+            if marker in sql:
+                return []
+        raise AssertionError(f"unexpected fetch: {sql[:120]}")
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+def _run_outcome_kpi(mcp_server, monkeypatch, conn, target_date):
+    async def fake_db():
+        return conn
+
+    async def fake_pool_get():
+        return _FakePool(conn)
+
+    monkeypatch.setattr(mcp_server, "_db", fake_db)
+    monkeypatch.setattr(mcp_server, "_kpi_fanout_pool_get", fake_pool_get)
+    raw = asyncio.run(mcp_server.outcome_kpi(target_date))
+    return json.loads(raw)
+
+
+class TestDayStatusClassification:
+    def test_completed_partial_and_future_days(self, mcp_server):
+        assert mcp_server._cycle_day_status(date(2026, 7, 11), TODAY) == "complete"
+        assert mcp_server._cycle_day_status(TODAY, TODAY) == "partial_day_excluded"
+        assert mcp_server._cycle_day_status(date(2026, 7, 14), TODAY) == "future_date_excluded"
+
+
+class TestSnapshotStaleness:
+    def test_fresh_snapshot_of_completed_day_is_not_stale(self, mcp_server):
+        rows = [_cycle_row("fan1", complete=True)]
+        assert not mcp_server._cycle_snapshot_is_stale(rows, date(2026, 7, 11), TODAY)
+
+    def test_partial_row_for_completed_day_is_stale(self, mcp_server):
+        rows = [_cycle_row("fan1", complete=False)]
+        assert mcp_server._cycle_snapshot_is_stale(rows, date(2026, 7, 12), TODAY)
+
+    def test_missing_completed_day_inside_window_is_stale(self, mcp_server):
+        assert mcp_server._cycle_snapshot_is_stale([], date(2026, 7, 11), TODAY)
+
+    def test_current_and_future_days_never_fall_back(self, mcp_server):
+        assert not mcp_server._cycle_snapshot_is_stale([], TODAY, TODAY)
+        assert not mcp_server._cycle_snapshot_is_stale([], date(2026, 7, 20), TODAY)
+        assert not mcp_server._cycle_snapshot_is_stale([_cycle_row("fan1", complete=False)], TODAY, TODAY)
+
+    def test_days_older_than_snapshot_window_never_fall_back(self, mcp_server):
+        assert not mcp_server._cycle_snapshot_is_stale([], date(2026, 1, 1), TODAY)
+
+
+class TestOutcomeKpiCycleReadPath:
+    def test_completed_day_reads_snapshot_only(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(
+            snapshot_rows=[_cycle_row("fan1", starts=23), _cycle_row("mister_center", starts=79)],
+            live_rows=[],
+        )
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-07-12")
+        assert not conn.live_cycles_queried
+        assert data["actuator_cycles"]["fan1"] == 23
+        assert data["actuator_cycles"]["mister_center"] == 79
+        assert data["coverage"]["actuator_cycles_runtime"] == "available"
+        source = data["vpd_policy"]["cycle_source"]
+        assert source["read_path"] == "mv_equipment_runtime_daily"
+        assert source["deploy_gate"]["target_day_status"] == "complete"
+        assert source["deploy_gate"]["excluded_from_deploy_gate"] is False
+        assert "mv_equipment_runtime_daily" in data["source_tables"]
+
+    def test_stale_snapshot_falls_back_to_live_view(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(
+            snapshot_rows=[_cycle_row("fan1", starts=5, complete=False, eligible=False)],
+            live_rows=[_cycle_row("fan1", starts=23)],
+        )
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-07-12")
+        assert conn.live_cycles_queried
+        assert data["actuator_cycles"]["fan1"] == 23
+        assert data["coverage"]["actuator_cycles_runtime"] == "available"
+        source = data["vpd_policy"]["cycle_source"]
+        assert source["read_path"] == "v_equipment_runtime_daily_stale_snapshot_fallback"
+
+    def test_missing_completed_day_falls_back_to_live_view(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(snapshot_rows=[], live_rows=[_cycle_row("fog", starts=87)])
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-07-12")
+        assert conn.live_cycles_queried
+        assert data["actuator_cycles"]["fog"] == 87
+
+    def test_out_of_window_day_does_not_fall_back(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(snapshot_rows=[], live_rows=[])
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-01-01")
+        assert not conn.live_cycles_queried
+        assert any(
+            metric.startswith("actuator_cycles_runtime: no transition-derived rows")
+            for metric in data["pending_metrics"]
+        )
+
+
+class TestPartialAndFutureDayExclusion:
+    def test_partial_current_day_counts_stay_readable_but_excluded(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(
+            snapshot_rows=[_cycle_row("fan1", starts=7, complete=False, eligible=False)],
+            live_rows=[],
+        )
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, TODAY.isoformat())
+        assert not conn.live_cycles_queried
+        # Honest mid-day undercount remains readable (float-trial acceptance)…
+        assert data["actuator_cycles"]["fan1"] == 7
+        # …but the deploy gate excludes it, loudly.
+        assert data["coverage"]["actuator_cycles_runtime"] == "pending"
+        source = data["vpd_policy"]["cycle_source"]
+        assert source["deploy_gate"]["target_day_status"] == "partial_day_excluded"
+        assert source["deploy_gate"]["excluded_from_deploy_gate"] is True
+        assert any(
+            "current local day is partial" in metric and "excluded from deploy-gate" in metric
+            for metric in data["pending_metrics"]
+        )
+
+    def test_future_dated_target_is_excluded_and_unavailable(self, mcp_server, monkeypatch):
+        conn = _FakeConnection(snapshot_rows=[], live_rows=[])
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-07-20")
+        assert not conn.live_cycles_queried
+        assert all(count is None for count in data["actuator_cycles"].values())
+        assert data["coverage"]["actuator_cycles_runtime"] == "unavailable"
+        source = data["vpd_policy"]["cycle_source"]
+        assert source["deploy_gate"]["target_day_status"] == "future_date_excluded"
+        assert source["deploy_gate"]["excluded_from_deploy_gate"] is True
+        assert any(
+            "future-dated" in metric and "excluded from deploy-gate" in metric for metric in data["pending_metrics"]
+        )
+
+    def test_quarantined_evidence_on_completed_day_is_excluded(self, mcp_server, monkeypatch):
+        rows = [
+            _cycle_row("fan1", starts=23),
+            _cycle_row("mister_center", starts=49, eligible=False),
+        ]
+        conn = _FakeConnection(snapshot_rows=rows, live_rows=[])
+        data = _run_outcome_kpi(mcp_server, monkeypatch, conn, "2026-07-11")
+        assert data["coverage"]["actuator_cycles_runtime"] == "pending"
+        source = data["vpd_policy"]["cycle_source"]
+        assert source["deploy_gate"]["target_day_status"] == "complete"
+        assert source["deploy_gate"]["excluded_from_deploy_gate"] is True


### PR DESCRIPTION
Closes #389

## Discrepancy root cause (verified live, 2026-07-13)

`outcome_kpi()`'s cycle axis reads the **live** `v_equipment_runtime_daily` transition derivation, and `v_energy_estimate_reconciliation` evaluates the **same live scan again** via `v_runtime_energy_daily`. That derivation is O(days × transitions) and now costs 11 s warm / 40+ s cold for a *single day* (migration-199/200 headers) — over the MCP's 15 s statement fence. Measured in prod today:

| query (single day, `2026-07-11`) | time |
|---|---|
| `v_equipment_runtime_daily` (live) | **11,079 ms** (warm) |
| `v_energy_estimate_reconciliation` | **23,526 ms** |
| `v_water_attribution_daily` | 831 ms |
| `mv_equipment_runtime_daily` (migration-200 snapshot) | **1.3–7.4 ms** |

Invoking the deployed `outcome_kpi("2026-07-11")` in the prod MCP pod died with `asyncpg.exceptions.QueryCanceledError: canceling statement due to statement timeout` on the energy fetch — **cycle counts were unavailable to every deploy-gate consumer**, and the failure grows worse daily. Separately, the current (partial) local day's counts flowed into `actuator_cycles` with only advisory flags, and a future-dated target was indistinguishable from missing data.

The DB layer itself is correct: hand-counted TRUE rising edges from raw `equipment_state` match the view/snapshot **18/18 rows** across 2026-07-10..12 (see evidence below).

## Approach

- **`mcp/server.py`** (preserves the #497 bounded-pool fan-out structure):
  - cycles read `mv_equipment_runtime_daily` (10-min refresh, row-identical for completed days) — the same pattern migration 200 established for dashboards;
  - **reconciliation guard**: a completed in-window day the snapshot cannot serve (missing, or still marked partial ⇒ dead refresh cron) falls back to the live view — bounded by the statement fence, failing loud rather than serving stale mid-day counts as completed-day truth (`_cycle_snapshot_is_stale`);
  - **partial/future exclusion**: `vpd_policy.cycle_source.deploy_gate.target_day_status` ∈ {`complete`, `partial_day_excluded`, `future_date_excluded`} with `excluded_from_deploy_gate`; coverage and `pending_metrics` follow. The current day's counts stay readable (honest undercounts — the #377 float trial can still compare them against `daily_summary`), but never gate-eligible. `today_local` comes from the DB clock so classification cannot disagree with the SQL surfaces.
- **Migration 201** (`db/migrations/201-snapshot-runtime-energy-model.sql`): repoints `v_runtime_energy_daily`'s runtime evidence at the snapshot. Scoring eligibility already requires a completed local day (`available_for_scoring`, `model_quality='incomplete_runtime'` for today), so snapshot staleness can only *delay*, never fabricate, evidence. Output columns unchanged; dependents (`v_energy_estimate_reconciliation`, `v_daily_kpi`, api) unaffected. Ingestor rollups and the firmware deploy preflight keep the live view per migration 200's design.
- **No ingestor changes**; firmware daily counters remain diagnostics only (unchanged since #443).

## Migration safety

- `scripts/check_migration_rollback_safety.py`: **`safe-to-wrap: 201-snapshot-runtime-energy-model.sql`**; `--rollback-wrap` preflight: `OK to wrap in BEGIN..ROLLBACK (non-self-transactional)`. `CREATE OR REPLACE VIEW` only — no `COMMIT`, no `CONCURRENTLY`.
- Serialized: no other migration PR in flight (checked open PRs #501/#502 — docs-only, both merged before this branch was rebased).
- **Not applied to prod** — application + `verdify-mcp` restart is release-gated operator work.
- Functional rollback: restore the migration-194 view body (live-view join).

## Verification

- `CI_BASE_REF=origin/main bash scripts/ci-local.sh` → **exit 0** (lint, format, schema suites incl. drift guards, device write gate, contract tests, migration rollback safety, grafana CM check, solar SSOT, twin compile, prod overlay render, fire-and-forget, service-restart guard, replay trigger: "no firmware-logic diff").
- `make lint` clean; new/changed files ruff-formatted.
- Full `pytest tests/` vs origin/main baseline: **failure sets byte-identical** (139 FAILED + 4 ERROR on both, all pre-existing environment-dependent: docker-sock DB harness, live infra, cron files, lab-site artifacts). No new failures.
- New tests:
  - `tests/test_outcome_kpi_cycle_reconciliation.py` (13 tests) — exercises the **real response assembly** against a faked connection: snapshot fast path (live view never queried), stale-snapshot live fallback, missing-completed-day fallback, out-of-window no-fallback, partial-day counts readable-but-excluded, future-date exclusion, quarantined-evidence exclusion.
  - `db/migrations/tests/test-201-snapshot-runtime-energy-model.sql` — ran green in a scratch `timescale/timescaledb:2.25.2-pg16` pod: snapshot `starts` == **independent hand-counted TRUE rising edges** from `equipment_state` (mister_center, 2 starts / 4.5 min), snapshot == live view row-for-row on the completed day, partial current day flagged `partial_day`/ineligible, zero future rows, repointed energy model reproduces a hand-computed **1.865 kWh** and stays NULL/non-scorable on the partial day. Existing `test-190` re-run green (regression).
  - `tests/test_04_planner.py` — new source-contract test pinning the snapshot read, the fallback, and the exclusion strings.

## Prod read-only evidence (SELECT-only via `verdify-db-0`)

Hand-counted rising edges (independent LAG over collapsed `equipment_state`) vs the source outcome_kpi now reads — **all 18 rows equal** across 3 completed days:

| day | equipment | hand on-edges | snapshot starts |
|---|---|---|---|
| 07-10 | fan1 / fog / gl_grow / gl_main / mister_center / vent | 28 / 40 / 6 / 6 / 30 / 27 | 28 / 40 / 6 / 6 / 30 / 27 |
| 07-11 | fan1 / fog / gl_grow / gl_main / mister_center / vent | 28 / 49 / 5 / 5 / 49 / 18 | 28 / 49 / 5 / 5 / 49 / 18 |
| 07-12 | fan1 / fog / gl_grow / gl_main / mister_center / vent | 23 / 87 / 2 / 3 / 79 / 14 | 23 / 87 / 2 / 3 / 79 / 14 |

The literal new `cycles_snapshot_sql` runs in **7.4 ms** in prod (was 11 s), with quality/eligibility columns intact (e.g. 07-11 `mister_center` correctly quarantined as `conflicting_events`).

Migration-201 equivalence, executed read-only as an inline CTE against prod for 2026-07-11: repointed body vs current live view → **byte-identical** (`modeled_kwh` 12.661, low 10.922, high 14.388, coverage 100, `uncertain_coefficients`, scoring `f`).

Partial-day acceptance (today, 2026-07-13, mid-day): `daily_summary.cycles_mister_center` = 33, snapshot `starts` = 33, row flagged `is_complete_day=f`, `is_deploy_gate_eligible=f` → the new source never inflates and is explicitly excluded from gates.

## Post-merge

Post-merge restart: **verdify-mcp** (mcp/server.py query + response contract). Migration 201 application (`psql -f db/migrations/201-...`) + the restart are gated release work — after that, re-run the live `outcome_kpi` check that currently fails, which closes the last open acceptance on #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu
