### PR TITLE
ci(lab-stage): pin P0 scroll-fix static image

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -13,7 +13,7 @@ images:
   # release; changing it requires its own reviewed exact-source pin.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99
+    digest: sha256:814eafff19c748c7a87e2b617d9eff8738dd13814a24c193f8768b63ebf12fff
   # These exact-source runtime images remain dormant under the replicas-zero
   # patch. A separate reviewed activation must add the store contract and raise
   # replicas; digest presence alone is not rollout authority.


### PR DESCRIPTION
Stage-only serving-static pin for the merged Lab viewport-scroll P0.

Source revision: 65567fc0b58c17fbb1c29d8a144a3f78d311fa76 (#504)
Workflow: verdify-platform-ci-qmnlb
Built image: registry.vallery.net/verdifyconsultancy/verdify-lab-astro@sha256:814eafff19c748c7a87e2b617d9eff8738dd13814a24c193f8768b63ebf12fff

Exact-source gates:
- build-lab-astro: succeeded, with all 13 Playwright quality cases green
- verify-lab-stage-release: succeeded at 2026-07-13T17:13:40Z
- probe-lab-stage-image: succeeded at 2026-07-13T17:14:05Z
- exact PR-head workflow verdify-platform-pr-ci-vbddl: succeeded
- independent read-only pin and rendered-posture review: YES

This PR changes exactly one digest line. Both dormant release-runtime digests remain byte-for-byte unchanged; runtime replicas remain zero, unrouted, deny-all egress, and without endpoint or credential bindings. The paired runtime image probe is not a dependency for this static pin because this PR deliberately preserves the already-reviewed runtime pair.

Local checks:
- stage rendered verifier: 9 resources, pass
- kubeconform: 8 valid, 0 invalid, 1 expected IngressRoute schema skip
- targeted pre-commit and git diff check: pass

Merge does not authorize production, dynamic-runtime activation, credentials, DNS, Quartz, devices, or database changes. Stage rollout remains through the reviewed exact-revision GitOps actuator and T0/T+10 acceptance under jvallery/agents#2930.

Refs #351, #475, #481.