### PR TITLE
fix(#447): fence the docker-less /setpoints backend + advance the stale setpoint-server pin

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -210,18 +210,30 @@ images:
   - name: ghcr.io/verdifyconsultancy/verdify-planner
     newName: registry.vallery.net/verdifyconsultancy/verdify-planner
     digest: sha256:77209866f6680c168f99d11ba26dfefc1dad449208bab49b46f5339154cb8608
-  # verdify-setpoint-server (#118): real GHCR digest of the grow-light writer +
-  # setpoint-diagnostics image built from scripts/Dockerfile.setpoint-server. The
-  # `branch-live-platform-main` build is published + repo-linked to
-  # VerdifyConsultancy/verdify-platform and verified pullable 2026-06-04 (GHCR
-  # manifest HEAD -> 200) — REPLACES the prior all-zeros placeholder pin.
-  # setpoint-server is a PROD-ONLY device-affecting Component, so it is excluded
-  # from prod-promote and remains hand-pinned. A rebuild alone does not advance it.
+  # verdify-setpoint-server (#118): grow-light writer + setpoint-diagnostics image
+  # built from scripts/Dockerfile.setpoint-server. setpoint-server is a PROD-ONLY
+  # device-affecting Component, so it is excluded from prod-promote and remains
+  # hand-pinned. A rebuild alone does not advance it.
+  #
+  # #447 HAND-PIN ADVANCE (2026-07-13): f5ac817 is the zot-origin build carrying
+  # commit 7e0d8c0 — /setpoints queries through the asyncpg pool (_db_text_safe);
+  # the VM-era _resolve_psql_prefix docker/psql shell-out is GONE. It REPLACES
+  # the stale 2026-06-04 f49868cb pin, whose /setpoints path resolved
+  # `docker exec` and returned HTTP 500 in the k3s pod (no docker binary).
+  # f5ac817 is what verdify-prod has been RUNNING since 2026-07-11 (hand-rolled
+  # with the #447 fix); repinning here makes the gated ArgoCD sync a NO-OP for
+  # this workload instead of a ROLLBACK to the broken image. Verified live
+  # 2026-07-13 (read-only, in-pod): GET /setpoints -> HTTP 200, 205 params;
+  # GET /health -> 200; image script has _db_text_safe, no _resolve_psql_prefix,
+  # no subprocess import. Rollback = revert this digest line (restores the
+  # previous rendered shape; the live pod is only touched by a gated sync).
+  # Regression fence: tests/test_setpoint_server_db_backend.py refuses the
+  # pre-fix digest.
   # hermes-agent is deliberately ABSENT from this transformer — its upstream
   # @sha256 is preserved inline in the component (NOT transformer-pinned).
   - name: ghcr.io/verdifyconsultancy/verdify-setpoint-server
     newName: registry.vallery.net/verdifyconsultancy/verdify-setpoint-server
-    digest: sha256:f49868cb9887c7e1dc18dc32f289fb873ee97dd1c5bd80bb961474a5f4976948
+    digest: sha256:f5ac817f42f9a0f306692e1fb0434eb1b600c2ba5fa35da0dccdc618bbb3690a
   # verdify-lab (#124): real GHCR digest of the Quartz research-site image built
   # from the verdify-site-legacy repo's Dockerfile.k3s (Quartz `npx quartz build`
   # -> static public/ -> nginx-unprivileged on :8080). Published + repo-linked by

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -70,6 +70,7 @@ $PY -m pytest -q \
   tests/test_public_output_remediation.py \
   tests/test_public_zone_renderer.py \
   tests/test_service_restart_drift_guard.py \
+  tests/test_setpoint_server_db_backend.py \
   tests/test_site_content_refresh.py \
   tests/test_slack_config.py \
   tests/test_slack_ops.py \

--- a/tests/test_setpoint_server_db_backend.py
+++ b/tests/test_setpoint_server_db_backend.py
@@ -1,0 +1,385 @@
+"""Setpoint-server /setpoints DB backend — Docker-socket-less contract (#447).
+
+On 2026-07-10 the live k3s verdify-setpoint-server pod was Ready, its asyncpg
+pool healthy, and a direct SELECT 1 passed — yet GET /setpoints returned HTTP
+500 with `[Errno 2] No such file or directory: 'docker'`: the endpoint's
+diagnostic query path still shelled out through the VM-era
+`_resolve_psql_prefix()` / lib/psql-verdify.sh docker-exec default, and the
+k3s image ships neither `docker` nor `psql`.
+
+The fix (commit 7e0d8c0) removed the subprocess split-brain entirely: every
+/setpoints query now runs through the already-healthy asyncpg pool via
+`_db_text_safe()` (run_coroutine_threadsafe onto the main loop), preserving
+the psql `-t -A -F'='` text shape the parsers expect. These tests are the
+regression fence around that guarantee — they need NO database and NO docker
+socket, and they prove:
+
+  1. scripts/setpoint-server.py cannot choose (or even reach) a docker/psql
+     subprocess: `_resolve_psql_prefix` is gone and the module imports no
+     subprocess machinery at all.
+  2. `_db_text_safe()` keeps the prior per-query failure semantics: "" (not an
+     exception) when the pool is unavailable or a query fails, and psql-shaped
+     '='-joined text on success.
+  3. GET /setpoints returns HTTP 200 with a non-empty key=value payload off
+     the async pool alone, and still fails closed to the HTTP 500 JSON error
+     shape when the query layer raises.
+  4. The rendered prod workload selects the in-cluster backend: the
+     setpoint-server pod inherits VERDIFY_DB_BACKEND=dsn from verdify-config
+     (the #211 overlay patch), mounts no docker socket, and keeps the
+     unchanged credential-injection / single-writer posture.
+  5. The overlays/prod image pin can never regress to the known-broken
+     pre-#447 build.
+
+The lib-side half of the contract (VERDIFY_DB_BACKEND=dsn resolves a bare
+`psql`, never `docker`) is already fenced by tests/test_psql_verdify_backend.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import runpy
+import sys
+import threading
+import urllib.request
+from http.server import HTTPServer
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "setpoint-server.py"
+COMPONENT = REPO_ROOT / "deploy" / "k8s" / "components" / "setpoint-server" / "setpoint-server.yaml"
+PROD_OVERLAY = REPO_ROOT / "deploy" / "k8s" / "overlays" / "prod"
+
+# The 2026-06-04 pre-#447 build: its /setpoints path still resolved
+# `docker exec ... psql` and 500'd in the k3s pod. The overlays/prod hand-pin
+# must never point back at it.
+PRE_FIX_BROKEN_DIGEST = "sha256:f49868cb9887c7e1dc18dc32f289fb873ee97dd1c5bd80bb961474a5f4976948"
+
+
+def _stub_asyncpg_if_missing() -> None:
+    """setpoint-server.py imports asyncpg at module level; the tests only need
+    the name to resolve (they inject fake pools). Same pattern as
+    tests/test_public_zone_renderer.py."""
+    if "asyncpg" not in sys.modules and importlib.util.find_spec("asyncpg") is None:
+        stub = ModuleType("asyncpg")
+
+        async def _unavailable(*_a, **_k):  # pragma: no cover - never awaited here
+            raise RuntimeError("asyncpg stub: no real DB in this test")
+
+        stub.create_pool = _unavailable
+        sys.modules["asyncpg"] = stub
+
+
+@pytest.fixture(scope="module")
+def setpoint_module() -> dict:
+    """Load scripts/setpoint-server.py once (main() stays un-run: run_name
+    differs from __main__)."""
+    _stub_asyncpg_if_missing()
+    return runpy.run_path(str(SCRIPT), run_name="_test_setpoint_server_backend")
+
+
+@pytest.fixture(scope="module")
+def module_globals(setpoint_module) -> dict:
+    """The REAL shared globals dict of the module's functions.
+
+    runpy.run_path returns a copy, so mutating its return value cannot reach
+    the functions; patch through __globals__ instead.
+    """
+    return setpoint_module["get_setpoint_text_sync"].__globals__
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    """Duck-typed asyncpg pool: `async with pool.acquire() as conn` + fetch."""
+
+    def __init__(self, fetch):
+        self._fetch = fetch
+
+    def acquire(self):
+        outer = self
+
+        class _Conn:
+            async def fetch(self, sql):
+                return outer._fetch(sql)
+
+            async def execute(self, *a, **k):
+                return None
+
+        return _FakeAcquire(_Conn())
+
+
+@pytest.fixture()
+def loop_thread():
+    """A real running event loop on a background thread, standing in for the
+    service's _main_loop (queries hop threads via run_coroutine_threadsafe)."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+# ── 1. no docker / subprocess escape hatch exists at all ─────────────────────
+
+
+def _executable_code_dump(src: str) -> str:
+    """AST dump of the script with docstrings blanked: comments and docstrings
+    (which legitimately narrate the #447 docker history) are excluded, while
+    every identifier and runtime string constant remains visible."""
+    import ast
+
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            body = getattr(node, "body", [])
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                body[0].value.value = ""
+    return ast.dump(tree)
+
+
+def test_script_has_no_subprocess_docker_or_psql_prefix_resolution(setpoint_module):
+    """#447 acceptance: a docker-socket-less runtime cannot end up invoking
+    `docker` because no code path resolves a psql prefix anymore."""
+    src = SCRIPT.read_text()
+    assert "_resolve_psql_prefix" not in src
+    assert "psql-verdify" not in src
+    assert "import subprocess" not in src
+    code = _executable_code_dump(src)
+    assert "docker" not in code.lower()
+    assert "subprocess" not in code
+    # The replacement seam is the async pool, bridged from the HTTP thread.
+    assert "_db_text_safe" in src
+    assert "asyncio.run_coroutine_threadsafe" in src
+    # And the loaded module namespace confirms it (not just source text).
+    assert "subprocess" not in setpoint_module
+    assert "_resolve_psql_prefix" not in setpoint_module
+    assert callable(setpoint_module["_db_text_safe"])
+
+
+def test_all_setpoint_queries_route_through_db_text_safe():
+    """Adversarial-audit item on #447: ALL query sites inherit the corrected
+    backend, not just the first. get_setpoint_text_sync may only query through
+    _db_text_safe."""
+    src = SCRIPT.read_text()
+    body = src.split("def get_setpoint_text_sync", 1)[1].split("\nclass ", 1)[0]
+    assert body.count("_db_text_safe(") >= 6
+    for token in ("subprocess", "Popen", "check_output", "os.system", "docker", "psql "):
+        assert token not in body, f"forbidden query transport {token!r} in get_setpoint_text_sync"
+
+
+# ── 2. _db_text_safe failure semantics match the prior subprocess contract ───
+
+
+def test_db_text_safe_returns_empty_string_when_pool_not_ready(module_globals):
+    saved = (module_globals["_main_loop"], module_globals["_db_pool"])
+    try:
+        module_globals["_main_loop"] = None
+        module_globals["_db_pool"] = None
+        assert module_globals["_db_text_safe"]("SELECT 1") == ""
+    finally:
+        module_globals["_main_loop"], module_globals["_db_pool"] = saved
+
+
+def test_db_text_safe_formats_rows_as_psql_text(module_globals, loop_thread):
+    """Rows come back '='-joined per row, newline-separated — the exact
+    `psql -t -A -F'='` shape every parser in get_setpoint_text_sync splits on."""
+    rows = [
+        {"parameter": "day_temp", "value": "75"},
+        {"parameter": "vent_open", "value": None},
+    ]
+    saved = (module_globals["_main_loop"], module_globals["_db_pool"])
+    try:
+        module_globals["_main_loop"] = loop_thread
+        module_globals["_db_pool"] = _FakePool(lambda sql: rows)
+        assert module_globals["_db_text_safe"]("SELECT ...") == "day_temp=75\nvent_open="
+        module_globals["_db_pool"] = _FakePool(lambda sql: [])
+        assert module_globals["_db_text_safe"]("SELECT ...") == ""
+    finally:
+        module_globals["_main_loop"], module_globals["_db_pool"] = saved
+
+
+def test_db_text_safe_fails_closed_to_empty_string_on_query_error(module_globals, loop_thread):
+    def _boom(sql):
+        raise RuntimeError("synthetic query failure")
+
+    saved = (module_globals["_main_loop"], module_globals["_db_pool"])
+    try:
+        module_globals["_main_loop"] = loop_thread
+        module_globals["_db_pool"] = _FakePool(_boom)
+        assert module_globals["_db_text_safe"]("SELECT 1") == ""
+    finally:
+        module_globals["_main_loop"], module_globals["_db_pool"] = saved
+
+
+# ── 3. endpoint behavior over a real HTTP round-trip ─────────────────────────
+
+
+def _fetch_rows(sql: str) -> list[dict]:
+    """Minimal DB world for one full get_setpoint_text_sync pass."""
+    if "FROM setpoint_changes" in sql:
+        return [{"parameter": "day_temp", "value": "75"}]
+    if "system_state" in sql:
+        return [{"value": "occupied"}]
+    if "FROM climate" in sql:
+        return [{"col": "68.2|41.0"}]
+    return []
+
+
+def _serve(module_globals, setpoint_module):
+    server = HTTPServer(("127.0.0.1", 0), setpoint_module["LutronHandler"])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_setpoints_endpoint_returns_200_nonempty_payload_off_async_pool(module_globals, setpoint_module, loop_thread):
+    saved = (module_globals["_main_loop"], module_globals["_db_pool"])
+    server = None
+    try:
+        module_globals["_main_loop"] = loop_thread
+        module_globals["_db_pool"] = _FakePool(_fetch_rows)
+        server, _ = _serve(module_globals, setpoint_module)
+        port = server.server_address[1]
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/setpoints", timeout=10) as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/plain"
+            body = resp.read().decode()
+        lines = [ln for ln in body.splitlines() if ln.strip()]
+        assert lines, "payload must be non-empty (#447 desired outcome)"
+        params = dict(ln.split("=", 1) for ln in lines)
+        # Forced-on controller switch is always present -> non-empty even on a
+        # sparse DB; occupancy + outdoor conditions came through the fake pool.
+        assert params["sw_fsm_controller_enabled"] == "1"
+        assert params["occupancy"] == "1"
+        assert params["outdoor_temp"] == "68.2"
+        assert params["outdoor_rh"] == "41.0"
+        assert body.endswith("\n")
+        assert lines == sorted(lines)
+    finally:
+        if server is not None:
+            server.shutdown()
+        module_globals["_main_loop"], module_globals["_db_pool"] = saved
+
+
+def test_setpoints_endpoint_fails_closed_to_500_json_when_query_layer_raises(module_globals, setpoint_module):
+    def _raise():
+        raise RuntimeError("synthetic setpoint failure")
+
+    saved = module_globals["get_setpoint_text_sync"]
+    server = None
+    try:
+        module_globals["get_setpoint_text_sync"] = _raise
+        server, _ = _serve(module_globals, setpoint_module)
+        port = server.server_address[1]
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/setpoints", timeout=10)
+        assert excinfo.value.code == 500
+        payload = json.loads(excinfo.value.read().decode())
+        assert "error" in payload
+    finally:
+        if server is not None:
+            server.shutdown()
+        module_globals["get_setpoint_text_sync"] = saved
+
+
+def test_health_endpoint_unchanged(module_globals, setpoint_module):
+    server = None
+    try:
+        server, _ = _serve(module_globals, setpoint_module)
+        port = server.server_address[1]
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=10) as resp:
+            assert resp.status == 200
+            payload = json.loads(resp.read().decode())
+        assert payload["status"] == "ok"
+        assert set(payload["lights"]) == {"main", "grow"}
+    finally:
+        if server is not None:
+            server.shutdown()
+
+
+# ── 4. rendered prod workload contract ───────────────────────────────────────
+
+
+def _component_docs() -> list[dict]:
+    return [d for d in yaml.safe_load_all(COMPONENT.read_text()) if d]
+
+
+def _setpoint_deployment() -> dict:
+    (dep,) = [d for d in _component_docs() if d["kind"] == "Deployment"]
+    return dep
+
+
+def test_prod_workload_selects_dsn_backend_via_verdify_config():
+    """The k3s runtime contract (#24/#447): the pod inherits
+    VERDIFY_DB_BACKEND=dsn from verdify-config, so nothing that ever consumes
+    the lib/psql-verdify.sh seam inside this pod can resolve `docker`."""
+    dep = _setpoint_deployment()
+    container = dep["spec"]["template"]["spec"]["containers"][0]
+    env_from = [ref.get("configMapRef", {}).get("name") for ref in container.get("envFrom", [])]
+    assert "verdify-config" in env_from
+
+    # The overlay patch that adds the key to verdify-config (#211) must stay
+    # wired into overlays/prod.
+    patch = yaml.safe_load((PROD_OVERLAY / "gather-script-env-configmap.yaml").read_text())
+    assert patch["metadata"]["name"] == "verdify-config"
+    assert patch["data"]["VERDIFY_DB_BACKEND"] == "dsn"
+    kustomization = yaml.safe_load((PROD_OVERLAY / "kustomization.yaml").read_text())
+    patch_paths = [p.get("path") for p in kustomization.get("patches", [])]
+    assert "gather-script-env-configmap.yaml" in patch_paths
+    assert "../../components/setpoint-server" in kustomization.get("components", [])
+
+
+def test_pod_mounts_no_docker_socket_and_keeps_credential_injection():
+    dep = _setpoint_deployment()
+    pod = dep["spec"]["template"]["spec"]
+    for vol in pod.get("volumes", []):
+        host_path = (vol.get("hostPath") or {}).get("path", "")
+        assert "docker" not in host_path, f"docker socket mount is forbidden (#447 non-goal): {vol}"
+
+    container = pod["containers"][0]
+    (pw_env,) = [e for e in container.get("env", []) if e["name"] == "POSTGRES_PASSWORD"]
+    ref = pw_env["valueFrom"]["secretKeyRef"]
+    assert ref["name"] == "verdify-app-secrets"
+    assert ref["key"] == "POSTGRES_PASSWORD"
+
+
+def test_single_writer_posture_unchanged():
+    dep = _setpoint_deployment()
+    assert dep["spec"]["replicas"] == 1
+    assert dep["spec"]["strategy"]["type"] == "Recreate"
+
+
+def test_prod_pin_never_regresses_to_pre_fix_build():
+    """The overlays/prod hand-pin must stay AT OR PAST the #447 fix. The
+    2026-06-04 f49868cb build predates commit 7e0d8c0: syncing it would bring
+    the docker-exec /setpoints path back to the only production environment."""
+    kustomization = yaml.safe_load((PROD_OVERLAY / "kustomization.yaml").read_text())
+    (pin,) = [img for img in kustomization["images"] if img["name"].endswith("/verdify-setpoint-server")]
+    assert pin["digest"] != PRE_FIX_BROKEN_DIGEST
+    assert pin["digest"].startswith("sha256:")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #447 — "Setpoint-server /setpoints uses Docker psql backend inside k3s" (P2, bug, area:ingestor).

## Defect

`GET /setpoints` on the live k3s `verdify-setpoint-server` returned HTTP 500 (`[Errno 2] No such file or directory: 'docker'`) while `/health` and a direct injected-credential `SELECT 1` passed: the endpoint's query path still resolved the VM-era `_resolve_psql_prefix()` / `lib/psql-verdify.sh` docker-exec default inside an image that ships neither `docker` nor `psql`.

## State when this PR was cut

The code fix already landed on main in 7e0d8c0 (2026-07-11): all 7 `/setpoints` query sites route through the existing asyncpg pool via `_db_text_safe()` (`run_coroutine_threadsafe`), preserving the psql `-t -A -F'='` text shape; `_resolve_psql_prefix` is gone. A post-fix image (`sha256:f5ac817f…`) was hand-rolled to prod the same day and is the live pod.

Two regression paths remained open in the repo — this PR closes them:

1. **Stale hand-pin (sync == rollback):** `overlays/prod/kustomization.yaml` still pinned the 2026-06-04 pre-fix build `sha256:f49868cb…`. The next gated `argocd app sync verdify-prod-dark` would have rolled the fixed live pod back to the broken image. The pin now advances to `sha256:f5ac817f…` — the exact digest the live pod's `imageID` reports (pulled from the zot origin) — making the gated sync a NO-OP for this workload. Rollback = revert the digest line.
2. **No regression fence:** new `tests/test_setpoint_server_db_backend.py` (12 tests, wired into `scripts/ci-local.sh`), all DB-less and docker-socket-less:
   - no subprocess/docker/psql-prefix escape hatch exists in the script's executable code (AST-level, and all query sites go through `_db_text_safe`) — the #447 acceptance replacement for the removed `_resolve_psql_prefix()`;
   - `_db_text_safe` failure semantics match the prior subprocess contract: `""` on pool-not-ready and on query error (fail-safe), `'='`-joined psql text on success;
   - real HTTP round-trip: `GET /setpoints` → 200 `text/plain` non-empty sorted `key=value` payload off the async pool alone; fails closed to the 500 JSON error shape when the query layer raises; `/health` unchanged;
   - rendered-workload contract: pod inherits `VERDIFY_DB_BACKEND=dsn` from `verdify-config` (#211 overlay patch — so nothing consuming the #24 `psql-verdify.sh` seam in this pod can ever resolve `docker`), no docker-socket mount, unchanged `verdify-app-secrets` credential injection, `replicas:1` + `Recreate` single-writer posture;
   - the prod pin can never regress to the pre-fix `f49868cb` digest.

The lib-side half (`VERDIFY_DB_BACKEND=dsn` ⇒ bare `psql`, never `docker`) was already fenced by `tests/test_psql_verdify_backend.py`.

## Acceptance intent → status

- [x] Rendered prod workload selects the in-cluster backend / endpoint uses the healthy async pool — both hold; now fenced by tests (`kustomize build deploy/k8s/overlays/prod` renders `verdify-config` with `VERDIFY_DB_BACKEND=dsn`; the setpoint-server container `envFrom`s it).
- [x] Docker-socket-less test proves the setpoint path cannot choose `docker` under the k3s runtime contract.
- [x] Deployed `GET /setpoints` returns HTTP 200 with a non-empty payload — live read-only probe 2026-07-13 (see evidence).
- [x] `/health`, grow-light control, credential injection, exactly-one device-writer unchanged (no product-code change in this PR; posture asserted by tests).
- [x] Deployment/restart + rollback evidence recorded (pin comment + below).

## Live evidence (read-only, 2026-07-13, `verdify-prod`; no secrets, no mutation)

```text
GET http://127.0.0.1:8200/health    -> 200
GET http://127.0.0.1:8200/setpoints -> 200, 205 non-empty key=value lines
in-pod script: has _db_text_safe=True, _resolve_psql_prefix=False, subprocess import=False
pod env: VERDIFY_DB_BACKEND=dsn (via envFrom verdify-config)
pod imageID: registry.vallery.net/verdifyconsultancy/verdify-setpoint-server@sha256:f5ac817f42f9a0f306692e1fb0434eb1b600c2ba5fa35da0dccdc618bbb3690a
```

## Verification

- `make lint` — All checks passed.
- `CI_BASE_REF=origin/main bash scripts/ci-local.sh` — **ALL GATES GREEN** (includes the new test file, migration classification, prod overlay render with the new pin, firmware replay-trigger check: no firmware-logic diff).
- New suite: `pytest tests/test_setpoint_server_db_backend.py` — 12 passed.
- Full `make test` vs pristine origin/main baseline on this host: baseline `139 failed, 1076 passed, 20 skipped, 4 errors` → with changes `139 failed, 1088 passed, 20 skipped, 4 errors`; failure-set diff **empty in both directions** (the 139+4 are pre-existing live-stack/environment failures on this runner; the +12 passes are the new suite).

## Restart / rollout

Restart: none — the fixed code is already the live pod. The pin advance takes effect only at the next **human-gated** ArgoCD sync and is a no-op for this workload (repo now == live). No prod mutation was performed by this work.

## Non-goals honored

No setpoint values, planner policy, firmware, device-write authority, credentials, or schema changed. No Docker-in-Docker / socket mount added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu