### PR TITLE
schema(#388): ADR-0004 composite-outcome-score wire contract on ScorecardResponse + planner-io doc

### DIFF
--- a/docs/planner/planner-io-schema.md
+++ b/docs/planner/planner-io-schema.md
@@ -130,6 +130,47 @@ kubectl exec -n verdify-prod verdify-db-0 -c postgres -- psql -U verdify -d verd
           count(*) FILTER (WHERE anchor_score IS NOT NULL) FROM plan_journal"
 ```
 
+### 5.1 Composite outcome score — ADR-0004 wire contract (schema-first, #388)
+
+ADR-0004 §5 replaces target-distance grading with **outcome grading**:
+`time-in-corridor × DLI-achieved × DIF-delivered × wet/dry-completion −
+(energy + water + cycling)`. The wire property names for that composite are
+pinned in `verdify_schemas.mcp_responses.OUTCOME_COMPOSITE_METRICS` and
+modelled on `ScorecardResponse` (the MCP `scorecard()` tool and the public
+`/api/v1/scorecard` endpoint are pass-throughs of that model):
+
+| Property | Type | Semantics (ADR-0004 §5) |
+|---|---|---|
+| `outcome_score_composite` | `float \| null` | Headline composite outcome score for the day |
+| `outcome_time_in_band` | `float \| null` | Time-in-corridor component — how much of the day the served zone climate stayed inside the crop tolerance corridor |
+| `outcome_dli_grade` | `float \| null` | DLI-achieved component (broadband-solar proxy, ADR-0004 §4) |
+| `outcome_dif_grade` | `float \| null` | DIF-delivered component (day/night air-temp differential vs crop target) |
+| `outcome_wet_dry_completion` | `float \| null` | Wet→dry cycle completion component (mister duty + soil moisture) |
+| `outcome_cost_cycling_penalty` | `float \| null` | Subtracted resource penalty: energy + water + actuator cycling/wear |
+
+Contract status and sequencing (CLAUDE.md discipline #1 — schema first,
+consumers next):
+
+- **#388 (this): names + nullability only.** All six are `Optional`, default
+  `null`; no producer emits them yet. Present-but-null is the defined
+  transitional state, so `/api/v1/scorecard` cannot 500 (the migration-147
+  header pattern).
+- **#371 lands the DB side** — the outcome function / `daily_summary`
+  columns MUST use exactly these names. Exact normalization, weighting, and
+  units of each component are #371's to define; the schema pins only the
+  names and null-tolerance.
+- **#365 lands the planner consumer** — the reader binds to
+  `OUTCOME_COMPOSITE_METRICS`, and must treat `null` as "composite not yet
+  computed", never as a zero score.
+
+Drift guards (the wire protocol): `verdify_schemas/tests/test_mcp_responses.py::TestOutcomeCompositeContract`
+(static: model ↔ pinned names ↔ no-alias wire keys),
+`test_scorecard_metric_names_match_live_function` (live fn emits only
+modelled metrics), and `verdify_schemas/tests/test_drift_guards.py::test_outcome_composite_db_names_bound_to_pinned_contract`
+(any `outcome_*` column appearing on `daily_summary` must match the pinned
+set). A rename on any side fails loud instead of silently NULLing the
+planner reward.
+
 ## 6. Triggers (when the planner runs)
 
 `PLANNER_TRIGGER_MATRIX` (`ingestor/tasks/_common.py`), fired by the 60s planning

--- a/verdify_schemas/__init__.py
+++ b/verdify_schemas/__init__.py
@@ -114,6 +114,7 @@ from .lessons import (
     is_legal_lesson_transition,
 )
 from .mcp_responses import (
+    OUTCOME_COMPOSITE_METRICS,
     ClimateSnapshot,
     EquipmentStateRow,
     ForecastSummaryRow,
@@ -409,6 +410,7 @@ __all__ = [
     "ObservationWithCrop",
     "OpenMeteoForecastResponse",
     "OpenMeteoHourly",
+    "OUTCOME_COMPOSITE_METRICS",
     "OutcomeKpiActionRow",
     "OutcomeKpiCoverage",
     "OutcomeKpiResponse",

--- a/verdify_schemas/mcp_responses.py
+++ b/verdify_schemas/mcp_responses.py
@@ -49,6 +49,30 @@ class ClimateSnapshot(BaseModel):
     mode: str | None = None
 
 
+# ── ADR-0004 composite outcome score — shared wire contract (#388) ──────────
+# Canonical property names for the composite outcome score and its component
+# sub-scores (ADR-0004 §5: grade on outcomes — time-in-corridor × DLI-achieved
+# × DIF-delivered × wet/dry-completion − (energy + water + cycling) — not
+# target-distance). This frozenset is THE binding between:
+#   - the ScorecardResponse fields below (the MCP `scorecard()` emitter is a
+#     pass-through of this model, so these are also the wire keys),
+#   - the #371 DB function / daily_summary column names, and
+#   - the #365 planner reader.
+# Rename any side without the others and the drift guards fail loud
+# (tests/test_mcp_responses.py + tests/test_drift_guards.py) instead of the
+# planner reward silently going NULL.
+OUTCOME_COMPOSITE_METRICS: frozenset[str] = frozenset(
+    {
+        "outcome_score_composite",
+        "outcome_time_in_band",
+        "outcome_dli_grade",
+        "outcome_dif_grade",
+        "outcome_wet_dry_completion",
+        "outcome_cost_cycling_penalty",
+    }
+)
+
+
 def _scorecard_value_to_float(value: Any) -> float | None:
     """Normalize asyncpg Decimal / str / None into float | None for scorecard metrics."""
     if value is None:
@@ -96,6 +120,21 @@ class ScorecardResponse(BaseModel):
     compliance_v2_unachievable_frac: float | None = None
     graded_temp_compliance_pct: float | None = None
     graded_vpd_compliance_pct: float | None = None
+
+    # ── ADR-0004 composite outcome score (schema-first, #388) ────────────
+    # Grade on outcomes, not target-distance. Modelled BEFORE the #371 DB
+    # function emits them (the migration-147-header / G8 pattern) so the
+    # extra='forbid' contract cannot 500 the public /api/v1/scorecard or the
+    # MCP scorecard() tool when the metrics appear. All Optional — they read
+    # as null until #371 populates them; the #365 planner consumer must treat
+    # null as "composite not yet computed", never as a zero score. Names are
+    # pinned by OUTCOME_COMPOSITE_METRICS above (no wire aliases, ever).
+    outcome_score_composite: float | None = None
+    outcome_time_in_band: float | None = None
+    outcome_dli_grade: float | None = None
+    outcome_dif_grade: float | None = None
+    outcome_wet_dry_completion: float | None = None
+    outcome_cost_cycling_penalty: float | None = None
 
     # ── Stress hours (four independent categories; overlap allowed so
     #    total_stress_h can exceed 24h)

--- a/verdify_schemas/tests/test_drift_guards.py
+++ b/verdify_schemas/tests/test_drift_guards.py
@@ -35,6 +35,7 @@ from verdify_schemas.daily import (
 from verdify_schemas.forecast import ForecastHour
 from verdify_schemas.forecast_ops import ForecastActionLog, ForecastActionRule
 from verdify_schemas.lessons import PlannerLesson
+from verdify_schemas.mcp_responses import OUTCOME_COMPOSITE_METRICS, ScorecardResponse
 from verdify_schemas.media import ImageObservation
 from verdify_schemas.operations import (
     ConsumablesLog,
@@ -317,6 +318,40 @@ def test_operation_linkage_columns_declared_by_schema(model_class, table_name):
         f"on the {table_name!r} table: {missing_in_schema}. Declare them so "
         f"harvest/treatment records stay traceable to crop positions."
     )
+
+
+def test_outcome_composite_db_names_bound_to_pinned_contract():
+    """#388 — ADR-0004 composite outcome score, DB side of the wire contract.
+
+    OUTCOME_COMPOSITE_METRICS pins the property names shared by the
+    ScorecardResponse model / MCP scorecard() emitter (guarded statically in
+    test_mcp_responses.py::TestOutcomeCompositeContract), the #371 DB
+    function + daily_summary columns, and the #365 planner reader.
+
+    Schema lands FIRST (#388), so the DB legitimately has none of these yet —
+    absence passes. But the moment #371's migration adds ANY outcome_* column
+    to daily_summary (or fn_planner_scorecard emits an outcome_* metric, which
+    test_mcp_responses.py::test_scorecard_metric_names_match_live_function
+    already fails on when unmodeled), a name outside the pinned set fails HERE
+    instead of silently NULLing the planner reward — the L2-OBS rename hazard
+    (#371) this guard exists for.
+    """
+    db_cols = _table_columns("daily_summary")
+    if not db_cols:
+        pytest.skip("table 'daily_summary' not found (migration pending?)")
+    found = {c for c in db_cols if c.startswith("outcome_")}
+    unknown = sorted(found - OUTCOME_COMPOSITE_METRICS)
+    assert not unknown, (
+        f"daily_summary has outcome_* column(s) not in the pinned #388 contract: {unknown}. "
+        f"The composite-outcome wire names are OUTCOME_COMPOSITE_METRICS "
+        f"({sorted(OUTCOME_COMPOSITE_METRICS)}) — rename the column(s) to match, or "
+        f"update the contract + ScorecardResponse + the #365 reader TOGETHER."
+    )
+    # Every pinned name the DB does have must also be a modelled field —
+    # belt-and-suspenders with the static guard, using live column names.
+    modeled = set(ScorecardResponse.model_fields)
+    missing = sorted((found & OUTCOME_COMPOSITE_METRICS) - modeled)
+    assert not missing, f"pinned outcome column(s) present in DB but not on ScorecardResponse: {missing}"
 
 
 def test_ingestor_climate_route_targets_declared_by_schema_and_db():

--- a/verdify_schemas/tests/test_mcp_responses.py
+++ b/verdify_schemas/tests/test_mcp_responses.py
@@ -11,6 +11,7 @@ import pytest
 from pydantic import ValidationError
 
 from verdify_schemas.mcp_responses import (
+    OUTCOME_COMPOSITE_METRICS,
     ClimateSnapshot,
     EquipmentStateRow,
     ForecastSummaryRow,
@@ -122,9 +123,13 @@ class TestScorecard:
         migration-146/147 compliance rearchitecture (band-compliance §6-§7):
         compliance_v2_raw/attributable/unachievable_frac, graded temp/vpd, and
         4 graded_*_stress_h — accepted BEFORE fn_planner_scorecard emits them so
-        the extra='forbid' contract cannot 500 the public /api/v1/scorecard."""
+        the extra='forbid' contract cannot 500 the public /api/v1/scorecard.
+
+        Plus the 6 ADR-0004 composite outcome-score metrics (schema-first,
+        #388): outcome_score_composite + its component sub-scores — accepted
+        BEFORE the #371 DB function emits them, same 500-proofing pattern."""
         names = ScorecardResponse.metric_names()
-        assert len(names) == 27 + 9 + 2
+        assert len(names) == 27 + 9 + 2 + 6
         assert "planner_score" in names
         assert "7d_avg_score" in names
         assert "7d_avg_stress" in names  # CI-only until G15
@@ -134,6 +139,72 @@ class TestScorecard:
         # Graded compliance metrics (schema-first, migration 146/147).
         assert "compliance_v2_attributable_pct" in names
         assert "graded_vpd_high_stress_h" in names
+        # ADR-0004 composite outcome score (schema-first, #388).
+        assert OUTCOME_COMPOSITE_METRICS <= names
+
+
+class TestOutcomeCompositeContract:
+    """#388 — ADR-0004 composite outcome score, schema-first wire contract.
+
+    OUTCOME_COMPOSITE_METRICS is the single pinned name set that the
+    ScorecardResponse model (== MCP scorecard() wire keys, the emitter is a
+    pass-through), the #371 DB function / daily_summary columns, and the #365
+    planner reader all bind to. These guards run with NO DB so a rename fails
+    everywhere, immediately."""
+
+    def test_model_fields_exactly_match_pinned_contract(self):
+        """Every outcome_* field on the model must be in the pinned set and
+        vice versa — a rename on either side fails loud instead of silently
+        NULLing the planner reward (#365)."""
+        model_outcome_fields = {n for n in ScorecardResponse.model_fields if n.startswith("outcome_")}
+        assert model_outcome_fields == set(OUTCOME_COMPOSITE_METRICS), (
+            f"ScorecardResponse outcome_* fields {sorted(model_outcome_fields)} != "
+            f"pinned OUTCOME_COMPOSITE_METRICS {sorted(OUTCOME_COMPOSITE_METRICS)}. "
+            f"Update BOTH together (and #371's DB fn / #365's reader)."
+        )
+
+    def test_no_wire_alias_on_outcome_fields(self):
+        """The MCP emitter dumps by_alias — outcome fields must have NO alias
+        so the Python identifier, the wire key, and the DB metric/column name
+        are the identical string."""
+        for name in OUTCOME_COMPOSITE_METRICS:
+            field = ScorecardResponse.model_fields[name]
+            assert field.alias is None, f"{name} must not carry a wire alias"
+
+    def test_outcome_fields_optional_and_default_none(self):
+        """Transitional safety (migration-147-header pattern): all outcome
+        fields are Optional and default to None, so days before the #371 DB
+        fn populates them serve present-but-null instead of 500."""
+        s = ScorecardResponse()
+        for name in OUTCOME_COMPOSITE_METRICS:
+            assert getattr(s, name) is None
+
+    def test_outcome_metric_rows_roundtrip(self):
+        """Once #371's fn emits the composite rows, they parse as floats and
+        survive the by_alias wire dump under their pinned names."""
+        rows = [
+            ("outcome_score_composite", Decimal("61.4")),
+            ("outcome_time_in_band", Decimal("87.5")),
+            ("outcome_dli_grade", Decimal("72.0")),
+            ("outcome_dif_grade", Decimal("90.0")),
+            ("outcome_wet_dry_completion", Decimal("100")),
+            ("outcome_cost_cycling_penalty", Decimal("12.3")),
+        ]
+        s = ScorecardResponse.from_metric_rows(rows)
+        assert s.outcome_score_composite == 61.4
+        assert s.outcome_cost_cycling_penalty == 12.3
+        dumped = s.model_dump(by_alias=True)
+        for name, value in rows:
+            assert dumped[name] == float(value)
+
+    def test_outcome_null_rows_accepted(self):
+        """Present-but-null rows (fn emits the metric with NULL value on a
+        partial day) must not raise — the /api/v1/scorecard 500-proofing the
+        issue's acceptance calls out."""
+        rows = [(name, None) for name in sorted(OUTCOME_COMPOSITE_METRICS)]
+        s = ScorecardResponse.from_metric_rows(rows)
+        assert s.outcome_score_composite is None
+        assert s.outcome_time_in_band is None
 
 
 class TestOutcomeKpi:


### PR DESCRIPTION
Closes #388

## What

Schema-only (L3-S1, W0): pins the ADR-0004 §5 composite-outcome-score wire contract in `verdify_schemas` + the planner-io doc, **before** #371's DB function and #365's planner consumer bind to it (CLAUDE.md discipline #1: schema first, consumers next; drift guards are the wire protocol).

**Property shape** — six `float | None` fields on `ScorecardResponse`, names pinned by a new exported constant `verdify_schemas.mcp_responses.OUTCOME_COMPOSITE_METRICS`:

| Property | Semantics (ADR-0004 §5) |
|---|---|
| `outcome_score_composite` | headline composite outcome score |
| `outcome_time_in_band` | time-in-corridor component |
| `outcome_dli_grade` | DLI-achieved component (broadband-solar proxy) |
| `outcome_dif_grade` | DIF-delivered component |
| `outcome_wet_dry_completion` | wet→dry cycle completion component |
| `outcome_cost_cycling_penalty` | subtracted energy + water + cycling penalty |

All Optional / default-null, **no wire aliases** (Python identifier == MCP wire key == future DB metric/column name — the MCP `scorecard()` emitter is a pass-through of this model). Exact normalization/weighting/units are #371's to define; this PR pins only names + nullability. No score computation, no migration, no firmware.

## Drift guards (fail loud on any-side rename)

- **Static, no DB** (`test_mcp_responses.py::TestOutcomeCompositeContract`): model `outcome_*` fields == pinned set exactly; no aliases; default-null; null-row and populated-row round-trips; `metric_names()` count bumped 27+9+2 → +6.
- **DB-side** (`test_drift_guards.py::test_outcome_composite_db_names_bound_to_pinned_contract`): any `outcome_*` column appearing on `daily_summary` must be in the pinned set — absence passes pre-#371, a rename fails loud instead of silently NULLing the planner reward (the exact hazard #388 cites from PR #385 / migration-147's header).
- **Existing live-fn guard** (`test_scorecard_metric_names_match_live_function`) already fails on any `fn_planner_scorecard()` metric the model doesn't declare, covering the fn-side rename once #371 lands.
- **Doc contract**: `docs/planner/planner-io-schema.md` §5.1 — property table, sequencing (#388 names → #371 DB fn → #365 consumer, which must treat null as "not yet computed", never zero).

## Transitional safety (issue acceptance: no 500 present-but-null)

`extra='forbid'` on `ScorecardResponse` stays; the six fields are declared so present-but-null rows validate (proved by `test_outcome_null_rows_accepted` + `test_outcome_fields_optional_and_default_none`). `/api/v1/scorecard` additionally keeps its `metric_names()` belt-and-suspenders whitelist.

## Restart documentation (CLAUDE.md rule 7 — structural, not keyword)

**Post-merge restart: verdify-mcp, verdify-api.**
- `verdify-mcp` — `scorecard()` validates `fn_planner_scorecard` rows through this `extra='forbid'` model in-process; it must hold the new fields **before** #371's fn emits them (the 2026-04-21 staleness class).
- `verdify-api` — `response_model=ScorecardResponse` + the `metric_names()` whitelist on `/api/v1/scorecard`; a stale copy would silently drop the new keys.
- `verdify-ingestor` — verified: **does not import** `ScorecardResponse`/`mcp_responses` anywhere (`grep -rn "ScorecardResponse\|mcp_responses" ingestor/` → 0 hits); no behavioral dependency, no bounce required for this change. The issue's acceptance text listed it generically; documenting the checked reality instead of a keyword match.

## Verification

- `verdify_schemas` full suite: **555 passed, 169 skipped** (DB-backed guards skip without a DB backend, by design).
- `make lint` (ruff check): **All checks passed**; `ruff format --check`: clean.
- Full gate `CI_BASE_REF=origin/main bash scripts/ci-local.sh`: **ALL GATES GREEN** (exit 0) — incl. schema suites, migration rollback-safety classification, service-restart drift guard (`OK: restart documentation names a known bounceable service`, structural pass on the guarded `verdify_schemas/**` diff), no-new-fire-and-forget (no tunables diff), firmware replay gates not required (`no firmware-logic diff`).
- Read-only prod probes, 2026-07-13 UTC (evidence the pre-#371 state is clean, no name collisions): `information_schema.columns` shows **zero** `outcome_*` columns on `daily_summary`; `pg_get_functiondef('fn_planner_scorecard(date)')` contains **zero** `outcome` tokens (catalog read — the fn itself is too slow to execute casually in prod, per the migration-199/200 headers). The repo's canonical `db/schema.sql` fn body agrees: 27 metrics, none `outcome_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu
