### PR TITLE
docs: fix stale live-firmware version strings in handoff/laptop-operator OTA sections (#416)

### DIFF
--- a/docs/handoff/k3s-agent-handoff.md
+++ b/docs/handoff/k3s-agent-handoff.md
@@ -116,14 +116,19 @@ device-VLAN + secrets). Until that's built (§5), the agent prepares the change 
 the evidence (replay-diff, invariants, unit-test delta) and an operator runs the
 flash. The procedure and its traps:
 
-- **Device:** ESP32 `192.168.10.111` (OTA `:3232`, native API `:6053`). It
-  currently runs **`2026.6.17.2042.dcc6078`** (the band-compliance firmware; pinch
-  wired, `band_track_fraction=0.25` live).
+- **Device:** ESP32 `192.168.10.111` (OTA `:3232`, native API `:6053`). As of
+  2026-07-13 it runs **`2026.7.10.1500.09ee886`** (the 2026-07-10 software-recovery
+  release; pinch machinery still wired, `band_track_fraction` **`0.0` live** — the
+  ADR-0004/#377 float, recorded in
+  `docs/handoff/software-recovery-deploy-2026-07-10.md`). Any version string
+  written in a doc rots — read the live value per the VERIFY bullet below before
+  trusting this one.
 - **Pinch resets on every flash (#413/#377, verified 2026-07-03):**
   `band_track_fraction` is `restore_value: no` in `firmware/greenhouse/globals.yaml`
   — an OTA/reboot **cold-starts it to the compiled `initial_value`, `0.0` on
-  current `main`** (the ADR-0004 float flip), silently dropping the live
-  planner-pushed 0.25. The `crop_band_anchors`→NVS reconcile does **NOT** cover it
+  current `main`** (the ADR-0004 float flip), silently dropping any live
+  planner-pushed nonzero value (this is how the pre-recovery live `0.25` was
+  dropped). The `crop_band_anchors`→NVS reconcile does **NOT** cover it
   (it only re-asserts `restore_value: yes` band globals —
   `docs/CONTROL-ARCHITECTURE.md` §7), and no dispatcher path re-pushes it: the
   registry pins its bounds to `[0.0, 0.0]`, so MCP `set_tunable` rejects a nonzero
@@ -132,7 +137,10 @@ flash. The procedure and its traps:
   registry-bounds change — vs accept float 0.0) per the checklist step in
   `docs/RELEASE-CHECKLIST.md` §B "Deploy + post".
 - **VERIFY the running firmware from telemetry — `diagnostics.firmware_version`
-  — NEVER from `firmware/artifacts/last-good.version`.** `last-good` is the
+  — NEVER from `firmware/artifacts/last-good.version`.** The authoritative read
+  (any kubectl host):
+  `scripts/verdify-db.sh prod -c "SELECT firmware_version, max(ts) FROM diagnostics WHERE firmware_version IS NOT NULL GROUP BY 1 ORDER BY 2 DESC LIMIT 1;"`
+  (live `band_track_fraction`: latest `setpoint_snapshot` row). `last-good` is the
   **rollback floor**, which deliberately lags the running binary through the 48 h
   bake. (Misreading it caused a wrong "device is on the old firmware" conclusion
   mid-2026-06-18; don't repeat it.)
@@ -226,10 +234,11 @@ and #322/#339 (retired-VM doc/test cleanup).
   especially `.sql`). Use `grep -rnE` or Python globs; cross-check any "zero hits."
 - **Verify device firmware from `diagnostics.firmware_version`,** not
   `firmware/artifacts/last-good.version` (rollback floor, lags during the bake).
-- **The pinched band IS the device's control band today** (device runs
-  band-compliance dcc6078, pinch wired @ 0.25). VPD sitting above the band with
-  actuators idle = cooling-priority arbitration, not a wider tolerance. ADR-0004
-  direction = float (`band_track_fraction → 0`, #377).
+- **The pinched band IS the device's control band** (pinch machinery wired since
+  band-compliance `dcc6078`; since the 2026-07-10 recovery OTA `09ee886` the live
+  `band_track_fraction` is `0.0` — the ADR-0004/#377 float — so the pinched band
+  currently equals the full band). VPD sitting above the band with actuators
+  idle = cooling-priority arbitration, not a wider tolerance.
 - **Never wrap a self-committing migration in an outer `BEGIN..ROLLBACK`** (the
   2026-05-30 live-commit incident). Use `make migration-rollback-safety` +
   `scripts/check_migration_rollback_safety.py`.

--- a/docs/runbooks/laptop-operator.md
+++ b/docs/runbooks/laptop-operator.md
@@ -90,10 +90,19 @@ by default; any prod apply requires an explicit operator gate.
 ## 3. Firmware OTA from the laptop
 
 Device: ESP32 at `192.168.10.111` (OTA :3232, native API :6053). **Running
-firmware `2026.6.17.2042.dcc6078`** (band-compliance; pinch wired, live
-`band_track_fraction=0.25`). **Verify the running version from
-`diagnostics.firmware_version`, NOT `firmware/artifacts/last-good.version`**
-(last-good is the rollback floor — it lags through the 48 h bake). The secrets
+firmware as of 2026-07-13: `2026.7.10.1500.09ee886`** (the 2026-07-10
+software-recovery release; pinch machinery wired, live
+`band_track_fraction=0.0` — the ADR-0004/#377 float). **Verify the running
+version from `diagnostics.firmware_version`, NOT
+`firmware/artifacts/last-good.version`** (last-good is the rollback floor — it
+lags through the 48 h bake); the authoritative read from any kubectl host:
+
+```bash
+scripts/verdify-db.sh prod -c "SELECT firmware_version, max(ts) FROM diagnostics
+  WHERE firmware_version IS NOT NULL GROUP BY 1 ORDER BY 2 DESC LIMIT 1;"
+```
+
+The secrets
 reconstruction (k3s sources) and the **false-rollback gotcha** (the post-OTA
 checks default to the wrong DB backend off-laptop and can auto-rollback a
 healthy OTA) are documented in
@@ -103,11 +112,12 @@ before flashing.
 **Pinch resets on every flash (#413/#377):** `band_track_fraction` is
 `restore_value: no` in `firmware/greenhouse/globals.yaml`, so an OTA/reboot
 cold-starts it to the compiled `initial_value` — **`0.0` on current `main`**
-(ADR-0004) — regardless of the live planner-pushed 0.25. The
+(ADR-0004) — regardless of any live planner-pushed value (this is how the
+pre-2026-07-10 live 0.25 was dropped). The
 `crop_band_anchors`→NVS reconcile does **NOT** re-assert it (that path only
 protects `restore_value: yes` band globals — `docs/CONTROL-ARCHITECTURE.md` §7),
 and the registry pins its bounds to `[0.0, 0.0]`, so no current push path can
-restore 0.25 without a registry-bounds change first. Post-flash, execute the
+restore a nonzero pinch without a registry-bounds change first. Post-flash, execute the
 g-377 pinch decision (re-pin vs accept float) and record `band_track_fraction` +
 `dehum_vent_hold_enabled` (#410) + the envelope config (door screen-window
 open/closed, #412) in the bake report — step-by-step in


### PR DESCRIPTION
Closes #416

## What was stale

`docs/handoff/k3s-agent-handoff.md` (§4 device bullet + §6 pinched-band gotcha) and `docs/runbooks/laptop-operator.md` (§3 OTA section) still claimed the device runs **`2026.6.17.2042.dcc6078`** with `band_track_fraction=0.25` live. Even the issue's own correction (`2026.6.23.0146.995c9b3`) has since been superseded by the 2026-07-10 software-recovery OTA.

## Current truth (verified against prod, 2026-07-13)

- Live firmware: **`2026.7.10.1500.09ee886`** — `diagnostics.firmware_version`, latest row 2026-07-13 18:59 UTC.
- Live `band_track_fraction`: **`0.0`** (latest `setpoint_snapshot` rows) — the ADR-0004/#377 float, recorded in `docs/handoff/software-recovery-deploy-2026-07-10.md`.

## Anti-rot wording

Per the issue's spirit, both docs now (a) date-stamp the quoted version, (b) carry the authoritative read inline so the value can be re-derived instead of trusted:

```
scripts/verdify-db.sh prod -c "SELECT firmware_version, max(ts) FROM diagnostics WHERE firmware_version IS NOT NULL GROUP BY 1 ORDER BY 2 DESC LIMIT 1;"
```

(Exact query was run against `verdify-db-0` before embedding; returned `2026.7.10.1500.09ee886`.)

The stale "silently dropping the live planner-pushed 0.25" phrasing in both pinch-reset bullets was adjusted to past tense (there is no live 0.25 anymore), resolving the tension the issue flagged; the g-377 post-flash decision procedure is unchanged.

## Deliberately NOT touched

- Dated point-in-time docs (`docs/reviews/*`, handoff §8 "State at the handoff (2026-06-18)") — historical records, left as-is.
- `docs/grafana-graph-authoring.md:125` carries the same class of stale live-claim (`dcc6078`, "live 0.25") but is outside the issue's named scope — flagging here for a follow-up if wanted.

## Verification

- `git diff --check` — clean (docs-only change, per CLAUDE.md verification order).
- Embedded query executed against prod read-only before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu