### PR TITLE
db(202)+mcp: single-day scorecard function — outcome_kpi's ~6min floor becomes seconds (#498)

### DIFF
--- a/db/migrations/202-climate-action-scorecard-date-pushdown.sql
+++ b/db/migrations/202-climate-action-scorecard-date-pushdown.sql
@@ -1,0 +1,342 @@
+-- 202-climate-action-scorecard-date-pushdown.sql
+--
+-- #498: outcome_kpi()'s action-scorecard read had a ~6-minute-per-call CPU
+-- floor. The issue hypothesized the `date = $1` predicate was applied above
+-- the aggregation (whole-window evaluation); a prod EXPLAIN ANALYZE
+-- (2026-07-13, day 2026-07-12, 1,947 action rows, 348.6 s total) shows the
+-- planner ALREADY pushes the date predicate to the climate_action_log scans
+-- as a row filter — the real cost is per-row function-call fan-out inside
+-- fn_climate_action_effectiveness:
+--
+--   duty LATERAL (16 samples x 8 fn_equip_at calls per action row) 293.8 s (84%)
+--   targetlist fn_setpoint_at (4 calls per action row)              ~51 s (15%)
+--   non-sargable date filter over the 14-day window's chunks         ~2 s
+--   c0/c1 climate LATERAL lookups                                   ~1.6 s
+--
+-- fn_equip_at / fn_setpoint_at are non-inlinable scalar SQL functions (ORDER
+-- BY + LIMIT bodies); each call re-executes a ChunkAppend over the whole
+-- hypertable (~1.2 ms and ~6.6 ms per call respectively). 1,947 rows/day x
+-- 132 calls/row is the floor. Chunk pruning alone would save ~2 s of 348 s.
+--
+-- Fix: fn_climate_action_daily_scorecard(target_date) — a single-day,
+-- set-based scorecard whose OUTPUT is byte-identical to
+-- `SELECT * FROM v_climate_action_daily_scorecard WHERE date = target_date`
+-- while touching only the target day's chunks:
+--
+--   * sargable bounds: ts >= GREATEST(local-midnight, now() - '14 days')
+--     AND ts < next-local-midnight — [local-midnight, next) is exactly the
+--     row set of `(ts AT TIME ZONE 'America/Denver')::date = target_date`
+--     (DST-safe: America/Denver transitions at 02:00, midnight always
+--     exists and is unambiguous), and the GREATEST reproduces the
+--     effectiveness function's rolling `ts >= now() - interval '14 days'`
+--     window so the truncated oldest day aggregates identically;
+--   * c0/c1 climate lookups and the after-setpoint resolution are the
+--     EXACT SELECT bodies of migration 142 / fn_setpoint_at, inlined as
+--     LATERAL subqueries (same index paths, same values, no per-call
+--     SQL-function machinery);
+--   * the duty computation is one set-based last-observation-carried-forward
+--     pass over equipment_state edges instead of 112 fn_equip_at calls per
+--     row. Tie fidelity: fn_equip_at's `ORDER BY ts DESC LIMIT 1` btree scan
+--     returns the smallest-ctid row among equal-ts duplicates (btree stores
+--     equal keys in TID order), so edges are deduplicated with
+--     DISTINCT ON (equipment, ts) ... ORDER BY equipment, ts, ctid — the
+--     same row a conflicting same-timestamp pair resolves to today.
+--     Per-sample duty averages are avg(int) -> numeric, i.e. exact rational
+--     arithmetic — no float-order sensitivity.
+--
+-- The v_climate_action_effectiveness_5m/15m views, the daily-scorecard view,
+-- and fn_climate_action_effectiveness(interval) are UNTOUCHED — the view
+-- stays the whole-window ad-hoc surface; this function is the single-day
+-- read path (outcome_kpi). Equivalence is pinned by
+-- db/migrations/tests/test-202-climate-action-scorecard-date-pushdown.sql
+-- (fn == view row-for-row on seeded fixtures, including a conflicting
+-- same-timestamp equipment_state pair, a NULL-greenhouse action row, a
+-- missing-after-sample row, local-midnight boundary rows, the 14-day cutoff,
+-- and an empty day) and by the PR's prod golden capture.
+--
+-- Non-self-transactional: CREATE OR REPLACE FUNCTION + COMMENT only — no
+-- top-level COMMIT, no commit-forcing statements. Safe for an outer
+-- BEGIN..ROLLBACK proof. Functional rollback: DROP FUNCTION
+-- public.fn_climate_action_daily_scorecard(date) and point consumers back at
+-- v_climate_action_daily_scorecard.
+
+CREATE OR REPLACE FUNCTION public.fn_climate_action_daily_scorecard(target_date date)
+RETURNS TABLE (
+    date date,
+    greenhouse_id text,
+    climate_action text,
+    decisions bigint,
+    avg_abs_temp_error_before_f numeric,
+    avg_abs_vpd_error_before_kpa numeric,
+    avg_temp_abs_error_delta_15m_f numeric,
+    avg_vpd_abs_error_delta_15m_kpa numeric,
+    avg_wet_relay_duty_pct numeric,
+    avg_vent_fan_duty_pct numeric,
+    mister_water_delta_gal numeric,
+    wet_blocked_decisions bigint,
+    fog_blocked_decisions bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+WITH bounds AS (
+    SELECT
+        GREATEST(
+            (target_date::timestamp AT TIME ZONE 'America/Denver'),
+            now() - interval '14 days'
+        ) AS start_ts,
+        ((target_date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
+),
+-- One row per climate_action_log decision on the target day, with the
+-- migration-142 c0 (last climate sample at or before the action) and c1
+-- (first climate sample in [ts+15m, ts+18m]) lookups inlined verbatim and
+-- the after-setpoints resolved with fn_setpoint_at's exact body.
+actions AS (
+    SELECT
+        row_number() OVER () AS rid,
+        l.ts,
+        l.greenhouse_id,
+        l.climate_action,
+        l.temp_band_error_f,
+        l.vpd_band_error_kpa,
+        l.wet_assist_block_reason,
+        l.fog_block_reason,
+        c0.mister_water_today AS before_mister_water_gal,
+        c1.ts AS after_climate_ts,
+        c1.temp_avg AS after_temp_f,
+        c1.vpd_avg AS after_vpd_kpa,
+        c1.mister_water_today AS after_mister_water_gal,
+        sp_tl.value AS after_temp_low,
+        sp_th.value AS after_temp_high,
+        sp_vl.value AS after_vpd_low,
+        sp_vh.value AS after_vpd_high
+    FROM public.climate_action_log l
+    LEFT JOIN LATERAL (
+        SELECT c.*
+        FROM public.climate c
+        WHERE COALESCE(c.greenhouse_id, 'vallery') = COALESCE(l.greenhouse_id, 'vallery')
+          AND c.temp_avg IS NOT NULL
+          AND c.vpd_avg IS NOT NULL
+          AND c.ts <= l.ts
+        ORDER BY c.ts DESC
+        LIMIT 1
+    ) c0 ON true
+    LEFT JOIN LATERAL (
+        SELECT c.*
+        FROM public.climate c
+        WHERE COALESCE(c.greenhouse_id, 'vallery') = COALESCE(l.greenhouse_id, 'vallery')
+          AND c.temp_avg IS NOT NULL
+          AND c.vpd_avg IS NOT NULL
+          AND c.ts >= l.ts + interval '15 minutes'
+          AND c.ts <= l.ts + interval '15 minutes' + interval '3 minutes'
+        ORDER BY c.ts ASC
+        LIMIT 1
+    ) c1 ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'temp_low'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_tl ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'temp_high'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_th ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'vpd_low'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_vl ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'vpd_high'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_vh ON true
+    -- scalar-subquery bounds (InitPlan params) so TimescaleDB excludes
+    -- non-target chunks at executor startup; a CROSS JOIN would make these
+    -- join quals and merely index-descend every chunk
+    WHERE l.ts >= (SELECT start_ts FROM bounds)
+      AND l.ts < (SELECT end_ts FROM bounds)
+),
+-- The seven relay channels the scorecard's duty percentages read
+-- (migration 142's wet OR: fog + three misters; vent OR: vent + two fans).
+duty_channels AS (
+    SELECT unnest(ARRAY[
+        'fog', 'mister_south', 'mister_west', 'mister_center',
+        'vent', 'fan1', 'fan2'
+    ]) AS equipment
+),
+-- Last-known state per channel at the window start (fn_equip_at's exact
+-- body evaluated once per channel instead of once per sample).
+-- MATERIALIZED: referenced once, so without it the planner inlines the
+-- scalar subquery into the duty join and re-executes it per grp=0
+-- sample-channel row (measured 46k executions / 11.5 s on prod for a day
+-- where one fan never transitioned).
+carry AS MATERIALIZED (
+    SELECT
+        dc.equipment,
+        (
+            SELECT es.state
+            FROM public.equipment_state es
+            WHERE es.equipment = dc.equipment
+              AND es.ts <= b.start_ts
+            ORDER BY es.ts DESC
+            LIMIT 1
+        ) AS state
+    FROM duty_channels dc
+    CROSS JOIN bounds b
+),
+-- In-window transitions, one row per (equipment, ts). Among equal-ts
+-- duplicates fn_equip_at's index scan returns the smallest-ctid row, so the
+-- dedup keeps exactly that row.
+edges AS (
+    SELECT DISTINCT ON (es.equipment, es.ts)
+        es.equipment,
+        es.ts,
+        es.state
+    FROM public.equipment_state es
+    WHERE es.equipment IN (
+            'fog', 'mister_south', 'mister_west', 'mister_center',
+            'vent', 'fan1', 'fan2'
+          )
+      AND es.ts > (SELECT start_ts FROM bounds)
+      AND es.ts <= (SELECT end_ts FROM bounds) + interval '15 minutes'
+    ORDER BY es.equipment, es.ts, es.ctid
+),
+-- The migration-142 sample grid: minute instants anchored at each action's
+-- own timestamp, inclusive of both ends (16 instants per row).
+samples AS (
+    SELECT
+        a.rid,
+        s.sample_ts
+    FROM actions a
+    CROSS JOIN LATERAL generate_series(
+        a.ts, a.ts + interval '15 minutes', interval '1 minute'
+    ) AS s(sample_ts)
+),
+-- One LOCF pass: interleave edges (kind 0) and sample instants (kind 1) per
+-- channel; grp counts edges at or before each row (an edge applies at its
+-- own instant, matching fn_equip_at's ts <= sample), and edge_state carries
+-- the grp-leader edge's state to every sample in the group.
+events AS (
+    SELECT e.equipment, e.ts AS ts_point, 0 AS kind,
+           NULL::bigint AS rid, NULL::timestamptz AS sample_ts, e.state AS state_val
+    FROM edges e
+    UNION ALL
+    SELECT dc.equipment, s.sample_ts, 1,
+           s.rid, s.sample_ts, NULL::boolean
+    FROM samples s
+    CROSS JOIN duty_channels dc
+),
+resolved AS (
+    SELECT
+        ev.*,
+        count(CASE WHEN ev.kind = 0 THEN 1 END)
+            OVER (PARTITION BY ev.equipment ORDER BY ev.ts_point, ev.kind) AS grp
+    FROM events ev
+),
+states AS (
+    SELECT
+        r.*,
+        bool_or(CASE WHEN r.kind = 0 THEN r.state_val END)
+            OVER (PARTITION BY r.equipment, r.grp) AS edge_state
+    FROM resolved r
+),
+-- Per sample instant: the wet-relay OR and vent/fan OR of migration 142,
+-- with fn_equip_at's NULL -> false coalescing applied per channel.
+sample_flags AS (
+    SELECT
+        st.rid,
+        st.sample_ts,
+        bool_or(COALESCE(CASE WHEN st.grp > 0 THEN st.edge_state ELSE ci.state END, false))
+            FILTER (WHERE st.equipment IN ('fog', 'mister_south', 'mister_west', 'mister_center'))
+            AS wet_on,
+        bool_or(COALESCE(CASE WHEN st.grp > 0 THEN st.edge_state ELSE ci.state END, false))
+            FILTER (WHERE st.equipment IN ('vent', 'fan1', 'fan2'))
+            AS vent_on
+    FROM states st
+    JOIN carry ci ON ci.equipment = st.equipment
+    WHERE st.kind = 1
+    GROUP BY st.rid, st.sample_ts
+),
+duty AS (
+    SELECT
+        sf.rid,
+        round((avg(sf.wet_on::int) * 100.0)::numeric, 2)::double precision AS wet_relay_duty_pct,
+        round((avg(sf.vent_on::int) * 100.0)::numeric, 2)::double precision AS vent_fan_duty_pct
+    FROM sample_flags sf
+    GROUP BY sf.rid
+),
+-- Migration 142's scored/after expressions, verbatim.
+enriched AS (
+    SELECT
+        a.*,
+        CASE
+            WHEN a.after_temp_f IS NULL OR a.after_temp_low IS NULL OR a.after_temp_high IS NULL THEN NULL
+            WHEN a.after_temp_f < a.after_temp_low THEN a.after_temp_f - a.after_temp_low
+            WHEN a.after_temp_f > a.after_temp_high THEN a.after_temp_f - a.after_temp_high
+            ELSE 0.0
+        END AS after_temp_band_error,
+        CASE
+            WHEN a.after_vpd_kpa IS NULL OR a.after_vpd_low IS NULL OR a.after_vpd_high IS NULL THEN NULL
+            WHEN a.after_vpd_kpa < a.after_vpd_low THEN a.after_vpd_kpa - a.after_vpd_low
+            WHEN a.after_vpd_kpa > a.after_vpd_high THEN a.after_vpd_kpa - a.after_vpd_high
+            ELSE 0.0
+        END AS after_vpd_band_error,
+        CASE
+            WHEN a.before_mister_water_gal IS NULL OR a.after_mister_water_gal IS NULL THEN NULL
+            ELSE greatest(0.0, a.after_mister_water_gal - a.before_mister_water_gal)
+        END AS mister_water_delta_gal
+    FROM actions a
+)
+SELECT
+    (e.ts AT TIME ZONE 'America/Denver')::date AS date,
+    e.greenhouse_id,
+    e.climate_action,
+    count(*) AS decisions,
+    round(avg(abs(e.temp_band_error_f))::numeric, 2) AS avg_abs_temp_error_before_f,
+    round(avg(abs(e.vpd_band_error_kpa))::numeric, 3) AS avg_abs_vpd_error_before_kpa,
+    round(avg(
+        CASE
+            WHEN e.after_temp_band_error IS NULL OR e.temp_band_error_f IS NULL THEN NULL
+            ELSE abs(e.after_temp_band_error) - abs(e.temp_band_error_f)
+        END
+    )::numeric, 2) AS avg_temp_abs_error_delta_15m_f,
+    round(avg(
+        CASE
+            WHEN e.after_vpd_band_error IS NULL OR e.vpd_band_error_kpa IS NULL THEN NULL
+            ELSE abs(e.after_vpd_band_error) - abs(e.vpd_band_error_kpa)
+        END
+    )::numeric, 3) AS avg_vpd_abs_error_delta_15m_kpa,
+    round(avg(d.wet_relay_duty_pct)::numeric, 2) AS avg_wet_relay_duty_pct,
+    round(avg(d.vent_fan_duty_pct)::numeric, 2) AS avg_vent_fan_duty_pct,
+    round(sum(coalesce(e.mister_water_delta_gal, 0.0))::numeric, 3) AS mister_water_delta_gal,
+    count(*) FILTER (WHERE e.wet_assist_block_reason IS NOT NULL) AS wet_blocked_decisions,
+    count(*) FILTER (WHERE e.fog_block_reason IS NOT NULL AND e.fog_block_reason <> 'none') AS fog_blocked_decisions
+FROM enriched e
+JOIN duty d ON d.rid = e.rid
+GROUP BY 1, 2, 3;
+$$;
+
+COMMENT ON FUNCTION public.fn_climate_action_daily_scorecard(date) IS
+    'Single-day climate-action scorecard, byte-identical to v_climate_action_daily_scorecard filtered to the target Denver-local date, with sargable time bounds (chunk pruning) and set-based duty resolution (#498).';

--- a/db/migrations/tests/test-202-climate-action-scorecard-date-pushdown.sql
+++ b/db/migrations/tests/test-202-climate-action-scorecard-date-pushdown.sql
@@ -1,0 +1,407 @@
+-- Equivalence contract for the #498 single-day scorecard function.
+--
+-- Proves fn_climate_action_daily_scorecard(d) is row-identical to
+-- `SELECT * FROM v_climate_action_daily_scorecard WHERE date = d` for EVERY
+-- date the view emits, on fixtures that exercise the shapes where the two
+-- implementations could diverge:
+--
+--   1. a conflicting same-timestamp equipment_state pair (fn_equip_at's
+--      index scan returns the smallest-ctid duplicate; the function's
+--      DISTINCT ON ... ctid dedup must pick the same row — the hand-computed
+--      37.50% wet duty below is wrong (62.50%) if the tie resolves the other
+--      way);
+--   2. carry-in relay state from before the day (vent ON across midnight);
+--   3. a relay pulse crossing local midnight (both adjacent days read it);
+--   4. an expired setpoint row (expiry boundary falls between two actions'
+--      after-lookup instants);
+--   5. a NULL-greenhouse_id action row (NULL group key; setpoints resolve
+--      NULL through greenhouse_id = NULL, exactly like fn_setpoint_at);
+--   6. an action with no after-window climate sample (NULL deltas averaged
+--      with non-NULL siblings in the same group);
+--   7. the rolling 14-day cutoff: two actions share a local date but only
+--      the one inside now() - 14 days may aggregate (the GREATEST bound);
+--   8. an empty day and an out-of-window historical day (zero rows).
+--
+-- Fixture days are now()-relative because fn_climate_action_effectiveness
+-- bounds its scan to a rolling 14-day window; fixed dates would age out.
+--
+-- enable_seqscan is disabled inside the transaction so fn_equip_at /
+-- fn_setpoint_at resolve through the same composite-index scans they use in
+-- prod (on a table this small the planner would otherwise seqscan+sort,
+-- which does not pin the equal-timestamp tie order this test asserts).
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+SET LOCAL enable_seqscan = off;
+
+CREATE TABLE public.greenhouses (id text PRIMARY KEY);
+INSERT INTO public.greenhouses(id) VALUES ('vallery');
+
+CREATE TABLE public.climate (
+    ts timestamptz NOT NULL,
+    greenhouse_id text DEFAULT 'vallery',
+    temp_avg double precision,
+    vpd_avg double precision,
+    mister_water_today double precision,
+    outdoor_temp_f double precision,
+    outdoor_rh_pct double precision,
+    dew_point double precision,
+    solar_irradiance_w_m2 double precision
+);
+CREATE INDEX ON public.climate (ts);
+
+CREATE TABLE public.setpoint_changes (
+    ts timestamptz NOT NULL,
+    greenhouse_id text NOT NULL DEFAULT 'vallery',
+    parameter text NOT NULL,
+    value double precision,
+    expired_at timestamptz
+);
+CREATE INDEX ON public.setpoint_changes (greenhouse_id, parameter, ts DESC);
+
+CREATE TABLE public.equipment_state (
+    ts timestamptz NOT NULL,
+    equipment text NOT NULL,
+    state boolean NOT NULL,
+    greenhouse_id text DEFAULT 'vallery'
+);
+CREATE INDEX ON public.equipment_state (equipment, ts DESC);
+
+-- Prod bodies (db/schema.sql) — the exact functions migration 142 binds to.
+CREATE FUNCTION public.fn_setpoint_at(p_greenhouse_id text, p_param text, p_ts timestamp with time zone)
+RETURNS double precision
+LANGUAGE sql STABLE
+AS $function$
+    SELECT value
+      FROM setpoint_changes
+     WHERE greenhouse_id = p_greenhouse_id
+       AND parameter = p_param
+       AND ts <= p_ts
+       AND (expired_at IS NULL OR expired_at > p_ts)
+     ORDER BY ts DESC
+     LIMIT 1;
+$function$;
+
+CREATE FUNCTION public.fn_equip_at(p_equip text, p_ts timestamp with time zone)
+RETURNS boolean
+LANGUAGE sql STABLE
+AS $function$
+    SELECT state FROM equipment_state
+    WHERE equipment = p_equip AND ts <= p_ts
+    ORDER BY ts DESC LIMIT 1;
+$function$;
+
+\i db/migrations/142-climate-action-log.sql
+\i db/migrations/202-climate-action-scorecard-date-pushdown.sql
+
+-- ── Fixtures ────────────────────────────────────────────────────────────────
+-- day1 = two local days ago, day2 = yesterday. All instants are built as
+-- Denver-local wall clock, matching the view's date bucketing.
+
+CREATE TEMP TABLE fx AS
+SELECT (now() AT TIME ZONE 'America/Denver')::date - 2 AS day1,
+       (now() AT TIME ZONE 'America/Denver')::date - 1 AS day2;
+
+-- Denver-local instant helper.
+CREATE FUNCTION pg_temp.at_local(d date, hms interval) RETURNS timestamptz
+LANGUAGE sql STABLE
+AS $$ SELECT (d::timestamp + hms) AT TIME ZONE 'America/Denver' $$;
+
+-- Setpoints: base bands ten days before day1; one expired temp_high override
+-- active only during (day1 06:00, day1 06:30]; one mid-day2 temp_low change.
+INSERT INTO public.setpoint_changes (ts, parameter, value, expired_at)
+SELECT pg_temp.at_local(day1 - 10, interval '0'), p.parameter, p.value, NULL
+FROM fx, (VALUES
+    ('temp_low', 65.0), ('temp_high', 85.0),
+    ('vpd_low', 0.4), ('vpd_high', 1.4)
+) AS p(parameter, value);
+INSERT INTO public.setpoint_changes (ts, parameter, value, expired_at)
+SELECT pg_temp.at_local(day1, interval '6 hours'), 'temp_high', 99.0,
+       pg_temp.at_local(day1, interval '6 hours 30 minutes')
+FROM fx;
+INSERT INTO public.setpoint_changes (ts, parameter, value, expired_at)
+SELECT pg_temp.at_local(day2, interval '12 hours'), 'temp_low', 60.0, NULL
+FROM fx;
+
+-- Climate: one row every 5 minutes across day1 00:00 .. day2 24:00 local.
+-- mister_water_today accumulates 0.05 gal per row within each local day.
+INSERT INTO public.climate (ts, temp_avg, vpd_avg, mister_water_today)
+SELECT pg_temp.at_local(d.day, make_interval(mins => 5 * g)),
+       70.0, 0.8, 0.05 * g
+FROM fx, LATERAL (VALUES (fx.day1), (fx.day2)) AS d(day),
+     generate_series(0, 287) AS g;
+-- NULL-sensor rows are skipped by the c0/c1 temp/vpd IS NOT NULL filters.
+UPDATE public.climate c
+SET temp_avg = NULL
+FROM fx
+WHERE c.ts = pg_temp.at_local(fx.day1, interval '9 hours');
+
+-- Relay timeline.
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day1, interval '-6 hours'), e, false
+FROM fx, unnest(ARRAY[
+    'fog', 'mister_south', 'mister_west', 'mister_center',
+    'vent', 'fan1', 'fan2'
+]) AS e;
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day1, t), e, s FROM fx, (VALUES
+    -- carry-in: vent ON from before midnight, OFF at 00:20 (shape 2)
+    (interval '-1 hour',              'vent',          true),
+    (interval '20 minutes',           'vent',          false),
+    -- fog pulse 08:03:30 -> 08:07:30 (samples 08:04..08:07 of the 08:00 action)
+    (interval '8 hours 3 minutes 30 seconds', 'fog',   true),
+    (interval '8 hours 7 minutes 30 seconds', 'fog',   false),
+    -- mister_center pulse 08:09 -> 08:11 (samples 08:09, 08:10)
+    (interval '8 hours 9 minutes',    'mister_center', true),
+    (interval '8 hours 11 minutes',   'mister_center', false),
+    -- mister_south pulse crossing local midnight (shapes 2+3)
+    (interval '23 hours 55 minutes',  'mister_south',  true),
+    (interval '24 hours 5 minutes',   'mister_south',  false)
+) AS v(t, e, s);
+-- Shape 1: conflicting duplicate-timestamp pair at day1 08:02:00. The row
+-- inserted FIRST (state=false) has the smaller ctid, so fn_equip_at's
+-- (equipment, ts DESC) index scan — equal keys are TID-ordered — returns
+-- FALSE. If either implementation resolved the tie the other way,
+-- mister_center would read ON for samples 08:02..08:08 and the 08:00
+-- action's wet duty would be 62.50, not the asserted 37.50.
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day1, interval '8 hours 2 minutes'), 'mister_center', false FROM fx;
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day1, interval '8 hours 2 minutes'), 'mister_center', true FROM fx;
+-- day2: fan1 ON 10:00 -> 10:30 (the 10:05 action sees 100% vent duty).
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day2, interval '10 hours'), 'fan1', true FROM fx;
+INSERT INTO public.equipment_state (ts, equipment, state)
+SELECT pg_temp.at_local(day2, interval '10 hours 30 minutes'), 'fan1', false FROM fx;
+
+-- Actions.
+INSERT INTO public.climate_action_log
+    (ts, greenhouse_id, climate_action, priority_axis,
+     temp_band_error_f, vpd_band_error_kpa,
+     wet_assist_block_reason, fog_block_reason)
+SELECT pg_temp.at_local(day1, t), 'vallery', action, axis, terr, verr, wet_block, fog_block
+FROM fx, (VALUES
+    -- local-midnight boundary row; carry-in vent gives 100% vent duty
+    (interval '0',                    'IDLE',        'temp', 0.5,  0.02, NULL,        'none'),
+    -- after-lookup lands inside the expired-setpoint window (temp_high 99)
+    (interval '5 hours 50 minutes',   'HEAT',        'temp', -1.5, -0.05, NULL,       NULL),
+    -- after-lookup past the expiry instant (temp_high back to 85)
+    (interval '7 hours',              'SAFETY_HEAT', 'safety', -2.5, 0.0, NULL,       NULL),
+    -- the hand-checked duty row (fog pulse + tie pair + mister pulse)
+    (interval '8 hours',              'VENT_COOL',   'temp', 3.0,  0.30, 'dew_margin', NULL),
+    -- no climate row in [21:46, 21:49] -> NULL deltas inside the IDLE group
+    (interval '21 hours 31 minutes',  'IDLE',        'vpd',  1.0,  0.10, 'dew_margin', 'occupancy'),
+    -- last-of-day row whose sample grid crosses midnight (mister_south ON)
+    (interval '23 hours 59 minutes 30 seconds', 'SEALED_FOG', 'vpd', 0.0, 0.15, NULL, 'none')
+) AS v(t, action, axis, terr, verr, wet_block, fog_block);
+INSERT INTO public.climate_action_log
+    (ts, greenhouse_id, climate_action, priority_axis,
+     temp_band_error_f, vpd_band_error_kpa,
+     wet_assist_block_reason, fog_block_reason)
+SELECT pg_temp.at_local(day2, t), gh, action, axis, terr, verr, NULL, fog_block
+FROM fx, (VALUES
+    -- midnight sibling of the crossing pulse (ON for samples 00:00..00:04,
+    -- OFF at the 00:05 edge which applies at its own instant)
+    (interval '0',                   'vallery'::text, 'SEALED_FOG',  'vpd',  0.0, 0.12, 'none'),
+    -- NULL greenhouse_id row: NULL group key, NULL setpoints (shape 5)
+    (interval '9 hours',             NULL,            'DEHUM_VENT',  'vpd',  0.2, 0.25, NULL),
+    -- fan1 pulse fully covers the sample grid: 100.00 vent duty
+    (interval '10 hours 5 minutes',  'vallery',       'SAFETY_COOL', 'safety', 4.0, 0.0, NULL),
+    -- resolves the mid-day temp_low change (60, not 65)
+    (interval '13 hours',            'vallery',       'VENT_COOL_MIST_ASSIST', 'temp', -6.0, 0.1, 'wet_cutoff')
+) AS v(t, gh, action, axis, terr, verr, fog_block);
+-- Shape 7: same local date, split by the rolling now()-14d cutoff. Only the
+-- newer row may aggregate; a day-start lower bound (instead of GREATEST)
+-- would include both and fail the per-date comparison below.
+INSERT INTO public.climate_action_log
+    (ts, greenhouse_id, climate_action, priority_axis, temp_band_error_f, vpd_band_error_kpa)
+VALUES
+    (now() - interval '14 days' + interval '5 minutes',
+     'vallery', 'VENT_COOL_FOG_ASSIST', 'temp', 1.0, 0.0),
+    (now() - interval '14 days' - interval '5 minutes',
+     'vallery', 'VENT_COOL_FOG_ASSIST', 'temp', 1.0, 0.0);
+-- Shape 8: far outside the window — invisible to both paths.
+INSERT INTO public.climate_action_log
+    (ts, greenhouse_id, climate_action, priority_axis, temp_band_error_f, vpd_band_error_kpa)
+SELECT pg_temp.at_local(day1 - 18, interval '12 hours'), 'vallery', 'IDLE', 'temp', 1.0, 0.0
+FROM fx;
+
+-- Guard against fixture rot: the two rows must straddle now() - 14 days.
+-- (They share a Denver-local date except when the test runs within five
+-- minutes of that local midnight; the conditional hand-check below and the
+-- per-date comparison handle both layouts.)
+DO $$
+BEGIN
+    IF now() - interval '14 days' - interval '5 minutes' >= now() - interval '14 days'
+       OR now() - interval '14 days' + interval '5 minutes' <= now() - interval '14 days' THEN
+        RAISE EXCEPTION 'cutoff fixtures do not straddle now()-14d';
+    END IF;
+END $$;
+
+-- ── 1. Per-date row equivalence: fn(d) == view slice, both directions, for
+--       every date the view emits. ────────────────────────────────────────
+DO $$
+DECLARE
+    d date;
+    n_dates int := 0;
+    fn_count bigint;
+    view_count bigint;
+    diff_count bigint;
+BEGIN
+    FOR d IN SELECT DISTINCT date FROM public.v_climate_action_daily_scorecard ORDER BY 1
+    LOOP
+        n_dates := n_dates + 1;
+        SELECT count(*) INTO fn_count FROM public.fn_climate_action_daily_scorecard(d);
+        SELECT count(*) INTO view_count
+          FROM public.v_climate_action_daily_scorecard v WHERE v.date = d;
+        IF fn_count <> view_count THEN
+            RAISE EXCEPTION 'row-count mismatch on %: fn %, view %', d, fn_count, view_count;
+        END IF;
+        SELECT count(*) INTO diff_count FROM (
+            (SELECT * FROM public.fn_climate_action_daily_scorecard(d)
+             EXCEPT
+             SELECT * FROM public.v_climate_action_daily_scorecard v WHERE v.date = d)
+            UNION ALL
+            (SELECT * FROM public.v_climate_action_daily_scorecard v WHERE v.date = d
+             EXCEPT
+             SELECT * FROM public.fn_climate_action_daily_scorecard(d))
+        ) diffs;
+        IF diff_count <> 0 THEN
+            RAISE EXCEPTION 'fn/view divergence on % (% rows differ)', d, diff_count;
+        END IF;
+    END LOOP;
+    -- day1, day2, and the cutoff-straddling date must all have been compared.
+    IF n_dates < 3 THEN
+        RAISE EXCEPTION 'expected >= 3 scorecard dates, saw %', n_dates;
+    END IF;
+END $$;
+
+-- ── 2. Hand-computed cells (fixture-rot guard: these fail if the fixtures
+--       stop exercising the shapes, even while fn == view). ───────────────
+DO $$
+DECLARE
+    r record;
+    fx_day1 date;
+    fx_day2 date;
+BEGIN
+    SELECT day1, day2 INTO fx_day1, fx_day2 FROM fx;
+
+    -- Tie pair + fog/mister pulses: 6 of 16 samples wet => 37.50.
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day1)
+     WHERE climate_action = 'VENT_COOL';
+    IF r.avg_wet_relay_duty_pct <> 37.50 THEN
+        RAISE EXCEPTION 'VENT_COOL wet duty % (expected 37.50 — same-ts tie must resolve to the first-inserted row)',
+            r.avg_wet_relay_duty_pct;
+    END IF;
+
+    -- IDLE group: NULL-delta averaging, carry-in vent duty, water sum,
+    -- blocked counters.
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day1)
+     WHERE climate_action = 'IDLE';
+    IF r.decisions <> 2
+       OR r.avg_abs_temp_error_before_f <> 0.75
+       OR r.avg_abs_vpd_error_before_kpa <> 0.060
+       OR r.avg_temp_abs_error_delta_15m_f <> -0.50
+       OR r.avg_vpd_abs_error_delta_15m_kpa <> -0.020
+       OR r.avg_wet_relay_duty_pct <> 0.00
+       OR r.avg_vent_fan_duty_pct <> 50.00
+       OR r.mister_water_delta_gal <> 0.150
+       OR r.wet_blocked_decisions <> 1
+       OR r.fog_blocked_decisions <> 1 THEN
+        RAISE EXCEPTION 'IDLE group contract mismatch: %', row_to_json(r);
+    END IF;
+
+    -- Expired setpoint: HEAT after-lookup at 06:05 sees the 99 override
+    -- (delta -1.50); SAFETY_HEAT at 07:15 sees it expired (85 band, temp 70
+    -- inside => delta -2.50).
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day1)
+     WHERE climate_action = 'HEAT';
+    IF r.avg_temp_abs_error_delta_15m_f <> -1.50 THEN
+        RAISE EXCEPTION 'HEAT expired-setpoint delta % (expected -1.50)',
+            r.avg_temp_abs_error_delta_15m_f;
+    END IF;
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day1)
+     WHERE climate_action = 'SAFETY_HEAT';
+    IF r.avg_temp_abs_error_delta_15m_f <> -2.50 THEN
+        RAISE EXCEPTION 'SAFETY_HEAT post-expiry delta % (expected -2.50)',
+            r.avg_temp_abs_error_delta_15m_f;
+    END IF;
+
+    -- Midnight-crossing pulse: day1 tail 6/16, day2 head 5/16 (the OFF edge
+    -- applies at its own 00:05:00 instant).
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day1)
+     WHERE climate_action = 'SEALED_FOG';
+    IF r.avg_wet_relay_duty_pct <> 37.50 THEN
+        RAISE EXCEPTION 'day1 SEALED_FOG wet duty % (expected 37.50)', r.avg_wet_relay_duty_pct;
+    END IF;
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day2)
+     WHERE climate_action = 'SEALED_FOG';
+    IF r.avg_wet_relay_duty_pct <> 31.25 THEN
+        RAISE EXCEPTION 'day2 SEALED_FOG wet duty % (expected 31.25)', r.avg_wet_relay_duty_pct;
+    END IF;
+
+    -- Full-coverage fan pulse.
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day2)
+     WHERE climate_action = 'SAFETY_COOL';
+    IF r.avg_vent_fan_duty_pct <> 100.00 THEN
+        RAISE EXCEPTION 'SAFETY_COOL vent duty % (expected 100.00)', r.avg_vent_fan_duty_pct;
+    END IF;
+
+    -- NULL greenhouse_id group survives with NULL setpoint-driven deltas.
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day2)
+     WHERE climate_action = 'DEHUM_VENT';
+    IF r.greenhouse_id IS NOT NULL OR r.decisions <> 1
+       OR r.avg_temp_abs_error_delta_15m_f IS NOT NULL THEN
+        RAISE EXCEPTION 'NULL-greenhouse group mismatch: %', row_to_json(r);
+    END IF;
+
+    -- Mid-day setpoint change: temp 70 vs [60, 85] => after error 0,
+    -- delta -6.00.
+    SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(fx_day2)
+     WHERE climate_action = 'VENT_COOL_MIST_ASSIST';
+    IF r.avg_temp_abs_error_delta_15m_f <> -6.00 THEN
+        RAISE EXCEPTION 'VENT_COOL_MIST_ASSIST delta % (expected -6.00)',
+            r.avg_temp_abs_error_delta_15m_f;
+    END IF;
+
+    -- Rolling-cutoff date: only the row inside now()-14d aggregates. A
+    -- day-start lower bound instead of GREATEST(day-start, now()-14d) would
+    -- report 2 decisions here.
+    IF ((now() - interval '14 days' - interval '5 minutes') AT TIME ZONE 'America/Denver')::date
+       = ((now() - interval '14 days' + interval '5 minutes') AT TIME ZONE 'America/Denver')::date
+    THEN
+        SELECT * INTO r FROM public.fn_climate_action_daily_scorecard(
+            ((now() - interval '14 days' + interval '5 minutes') AT TIME ZONE 'America/Denver')::date)
+         WHERE climate_action = 'VENT_COOL_FOG_ASSIST';
+        IF r.decisions <> 1 THEN
+            RAISE EXCEPTION 'cutoff date decisions % (expected 1: GREATEST(now()-14d) bound)',
+                r.decisions;
+        END IF;
+    END IF;
+END $$;
+
+-- ── 3. Empty shapes: no rows for a future day or an aged-out day. ─────────
+DO $$
+DECLARE
+    fx_day1 date;
+    n bigint;
+BEGIN
+    SELECT day1 INTO fx_day1 FROM fx;
+    SELECT count(*) INTO n FROM public.fn_climate_action_daily_scorecard(fx_day1 + 30);
+    IF n <> 0 THEN
+        RAISE EXCEPTION 'future day returned % rows', n;
+    END IF;
+    SELECT count(*) INTO n FROM public.fn_climate_action_daily_scorecard(fx_day1 - 18);
+    IF n <> 0 THEN
+        RAISE EXCEPTION 'aged-out day returned % rows (14-day window not enforced)', n;
+    END IF;
+END $$;
+
+SELECT date, greenhouse_id, climate_action, decisions,
+       avg_wet_relay_duty_pct, avg_vent_fan_duty_pct
+FROM fx, LATERAL public.fn_climate_action_daily_scorecard(fx.day1)
+ORDER BY climate_action;
+
+ROLLBACK;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1133,6 +1133,282 @@ $$;
 ALTER FUNCTION public.fn_center_band_setpoints(target_ts timestamp with time zone) OWNER TO verdify;
 
 --
+-- Name: fn_climate_action_daily_scorecard(date); Type: FUNCTION; Schema: public; Owner: verdify
+--
+
+CREATE FUNCTION public.fn_climate_action_daily_scorecard(target_date date) RETURNS TABLE(date date, greenhouse_id text, climate_action text, decisions bigint, avg_abs_temp_error_before_f numeric, avg_abs_vpd_error_before_kpa numeric, avg_temp_abs_error_delta_15m_f numeric, avg_vpd_abs_error_delta_15m_kpa numeric, avg_wet_relay_duty_pct numeric, avg_vent_fan_duty_pct numeric, mister_water_delta_gal numeric, wet_blocked_decisions bigint, fog_blocked_decisions bigint)
+    LANGUAGE sql STABLE
+    AS $$
+WITH bounds AS (
+    SELECT
+        GREATEST(
+            (target_date::timestamp AT TIME ZONE 'America/Denver'),
+            now() - interval '14 days'
+        ) AS start_ts,
+        ((target_date + 1)::timestamp AT TIME ZONE 'America/Denver') AS end_ts
+),
+-- One row per climate_action_log decision on the target day, with the
+-- migration-142 c0 (last climate sample at or before the action) and c1
+-- (first climate sample in [ts+15m, ts+18m]) lookups inlined verbatim and
+-- the after-setpoints resolved with fn_setpoint_at's exact body.
+actions AS (
+    SELECT
+        row_number() OVER () AS rid,
+        l.ts,
+        l.greenhouse_id,
+        l.climate_action,
+        l.temp_band_error_f,
+        l.vpd_band_error_kpa,
+        l.wet_assist_block_reason,
+        l.fog_block_reason,
+        c0.mister_water_today AS before_mister_water_gal,
+        c1.ts AS after_climate_ts,
+        c1.temp_avg AS after_temp_f,
+        c1.vpd_avg AS after_vpd_kpa,
+        c1.mister_water_today AS after_mister_water_gal,
+        sp_tl.value AS after_temp_low,
+        sp_th.value AS after_temp_high,
+        sp_vl.value AS after_vpd_low,
+        sp_vh.value AS after_vpd_high
+    FROM public.climate_action_log l
+    LEFT JOIN LATERAL (
+        SELECT c.*
+        FROM public.climate c
+        WHERE COALESCE(c.greenhouse_id, 'vallery') = COALESCE(l.greenhouse_id, 'vallery')
+          AND c.temp_avg IS NOT NULL
+          AND c.vpd_avg IS NOT NULL
+          AND c.ts <= l.ts
+        ORDER BY c.ts DESC
+        LIMIT 1
+    ) c0 ON true
+    LEFT JOIN LATERAL (
+        SELECT c.*
+        FROM public.climate c
+        WHERE COALESCE(c.greenhouse_id, 'vallery') = COALESCE(l.greenhouse_id, 'vallery')
+          AND c.temp_avg IS NOT NULL
+          AND c.vpd_avg IS NOT NULL
+          AND c.ts >= l.ts + interval '15 minutes'
+          AND c.ts <= l.ts + interval '15 minutes' + interval '3 minutes'
+        ORDER BY c.ts ASC
+        LIMIT 1
+    ) c1 ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'temp_low'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_tl ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'temp_high'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_th ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'vpd_low'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_vl ON true
+    LEFT JOIN LATERAL (
+        SELECT sc.value
+        FROM public.setpoint_changes sc
+        WHERE sc.greenhouse_id = l.greenhouse_id
+          AND sc.parameter = 'vpd_high'
+          AND sc.ts <= COALESCE(c1.ts, l.ts)
+          AND (sc.expired_at IS NULL OR sc.expired_at > COALESCE(c1.ts, l.ts))
+        ORDER BY sc.ts DESC
+        LIMIT 1
+    ) sp_vh ON true
+    -- scalar-subquery bounds (InitPlan params) so TimescaleDB excludes
+    -- non-target chunks at executor startup; a CROSS JOIN would make these
+    -- join quals and merely index-descend every chunk
+    WHERE l.ts >= (SELECT start_ts FROM bounds)
+      AND l.ts < (SELECT end_ts FROM bounds)
+),
+-- The seven relay channels the scorecard's duty percentages read
+-- (migration 142's wet OR: fog + three misters; vent OR: vent + two fans).
+duty_channels AS (
+    SELECT unnest(ARRAY[
+        'fog', 'mister_south', 'mister_west', 'mister_center',
+        'vent', 'fan1', 'fan2'
+    ]) AS equipment
+),
+-- Last-known state per channel at the window start (fn_equip_at's exact
+-- body evaluated once per channel instead of once per sample).
+-- MATERIALIZED: referenced once, so without it the planner inlines the
+-- scalar subquery into the duty join and re-executes it per grp=0
+-- sample-channel row (measured 46k executions / 11.5 s on prod for a day
+-- where one fan never transitioned).
+carry AS MATERIALIZED (
+    SELECT
+        dc.equipment,
+        (
+            SELECT es.state
+            FROM public.equipment_state es
+            WHERE es.equipment = dc.equipment
+              AND es.ts <= b.start_ts
+            ORDER BY es.ts DESC
+            LIMIT 1
+        ) AS state
+    FROM duty_channels dc
+    CROSS JOIN bounds b
+),
+-- In-window transitions, one row per (equipment, ts). Among equal-ts
+-- duplicates fn_equip_at's index scan returns the smallest-ctid row, so the
+-- dedup keeps exactly that row.
+edges AS (
+    SELECT DISTINCT ON (es.equipment, es.ts)
+        es.equipment,
+        es.ts,
+        es.state
+    FROM public.equipment_state es
+    WHERE es.equipment IN (
+            'fog', 'mister_south', 'mister_west', 'mister_center',
+            'vent', 'fan1', 'fan2'
+          )
+      AND es.ts > (SELECT start_ts FROM bounds)
+      AND es.ts <= (SELECT end_ts FROM bounds) + interval '15 minutes'
+    ORDER BY es.equipment, es.ts, es.ctid
+),
+-- The migration-142 sample grid: minute instants anchored at each action's
+-- own timestamp, inclusive of both ends (16 instants per row).
+samples AS (
+    SELECT
+        a.rid,
+        s.sample_ts
+    FROM actions a
+    CROSS JOIN LATERAL generate_series(
+        a.ts, a.ts + interval '15 minutes', interval '1 minute'
+    ) AS s(sample_ts)
+),
+-- One LOCF pass: interleave edges (kind 0) and sample instants (kind 1) per
+-- channel; grp counts edges at or before each row (an edge applies at its
+-- own instant, matching fn_equip_at's ts <= sample), and edge_state carries
+-- the grp-leader edge's state to every sample in the group.
+events AS (
+    SELECT e.equipment, e.ts AS ts_point, 0 AS kind,
+           NULL::bigint AS rid, NULL::timestamptz AS sample_ts, e.state AS state_val
+    FROM edges e
+    UNION ALL
+    SELECT dc.equipment, s.sample_ts, 1,
+           s.rid, s.sample_ts, NULL::boolean
+    FROM samples s
+    CROSS JOIN duty_channels dc
+),
+resolved AS (
+    SELECT
+        ev.*,
+        count(CASE WHEN ev.kind = 0 THEN 1 END)
+            OVER (PARTITION BY ev.equipment ORDER BY ev.ts_point, ev.kind) AS grp
+    FROM events ev
+),
+states AS (
+    SELECT
+        r.*,
+        bool_or(CASE WHEN r.kind = 0 THEN r.state_val END)
+            OVER (PARTITION BY r.equipment, r.grp) AS edge_state
+    FROM resolved r
+),
+-- Per sample instant: the wet-relay OR and vent/fan OR of migration 142,
+-- with fn_equip_at's NULL -> false coalescing applied per channel.
+sample_flags AS (
+    SELECT
+        st.rid,
+        st.sample_ts,
+        bool_or(COALESCE(CASE WHEN st.grp > 0 THEN st.edge_state ELSE ci.state END, false))
+            FILTER (WHERE st.equipment IN ('fog', 'mister_south', 'mister_west', 'mister_center'))
+            AS wet_on,
+        bool_or(COALESCE(CASE WHEN st.grp > 0 THEN st.edge_state ELSE ci.state END, false))
+            FILTER (WHERE st.equipment IN ('vent', 'fan1', 'fan2'))
+            AS vent_on
+    FROM states st
+    JOIN carry ci ON ci.equipment = st.equipment
+    WHERE st.kind = 1
+    GROUP BY st.rid, st.sample_ts
+),
+duty AS (
+    SELECT
+        sf.rid,
+        round((avg(sf.wet_on::int) * 100.0)::numeric, 2)::double precision AS wet_relay_duty_pct,
+        round((avg(sf.vent_on::int) * 100.0)::numeric, 2)::double precision AS vent_fan_duty_pct
+    FROM sample_flags sf
+    GROUP BY sf.rid
+),
+-- Migration 142's scored/after expressions, verbatim.
+enriched AS (
+    SELECT
+        a.*,
+        CASE
+            WHEN a.after_temp_f IS NULL OR a.after_temp_low IS NULL OR a.after_temp_high IS NULL THEN NULL
+            WHEN a.after_temp_f < a.after_temp_low THEN a.after_temp_f - a.after_temp_low
+            WHEN a.after_temp_f > a.after_temp_high THEN a.after_temp_f - a.after_temp_high
+            ELSE 0.0
+        END AS after_temp_band_error,
+        CASE
+            WHEN a.after_vpd_kpa IS NULL OR a.after_vpd_low IS NULL OR a.after_vpd_high IS NULL THEN NULL
+            WHEN a.after_vpd_kpa < a.after_vpd_low THEN a.after_vpd_kpa - a.after_vpd_low
+            WHEN a.after_vpd_kpa > a.after_vpd_high THEN a.after_vpd_kpa - a.after_vpd_high
+            ELSE 0.0
+        END AS after_vpd_band_error,
+        CASE
+            WHEN a.before_mister_water_gal IS NULL OR a.after_mister_water_gal IS NULL THEN NULL
+            ELSE greatest(0.0, a.after_mister_water_gal - a.before_mister_water_gal)
+        END AS mister_water_delta_gal
+    FROM actions a
+)
+SELECT
+    (e.ts AT TIME ZONE 'America/Denver')::date AS date,
+    e.greenhouse_id,
+    e.climate_action,
+    count(*) AS decisions,
+    round(avg(abs(e.temp_band_error_f))::numeric, 2) AS avg_abs_temp_error_before_f,
+    round(avg(abs(e.vpd_band_error_kpa))::numeric, 3) AS avg_abs_vpd_error_before_kpa,
+    round(avg(
+        CASE
+            WHEN e.after_temp_band_error IS NULL OR e.temp_band_error_f IS NULL THEN NULL
+            ELSE abs(e.after_temp_band_error) - abs(e.temp_band_error_f)
+        END
+    )::numeric, 2) AS avg_temp_abs_error_delta_15m_f,
+    round(avg(
+        CASE
+            WHEN e.after_vpd_band_error IS NULL OR e.vpd_band_error_kpa IS NULL THEN NULL
+            ELSE abs(e.after_vpd_band_error) - abs(e.vpd_band_error_kpa)
+        END
+    )::numeric, 3) AS avg_vpd_abs_error_delta_15m_kpa,
+    round(avg(d.wet_relay_duty_pct)::numeric, 2) AS avg_wet_relay_duty_pct,
+    round(avg(d.vent_fan_duty_pct)::numeric, 2) AS avg_vent_fan_duty_pct,
+    round(sum(coalesce(e.mister_water_delta_gal, 0.0))::numeric, 3) AS mister_water_delta_gal,
+    count(*) FILTER (WHERE e.wet_assist_block_reason IS NOT NULL) AS wet_blocked_decisions,
+    count(*) FILTER (WHERE e.fog_block_reason IS NOT NULL AND e.fog_block_reason <> 'none') AS fog_blocked_decisions
+FROM enriched e
+JOIN duty d ON d.rid = e.rid
+GROUP BY 1, 2, 3;
+$$;
+
+
+ALTER FUNCTION public.fn_climate_action_daily_scorecard(target_date date) OWNER TO verdify;
+
+--
+-- Name: FUNCTION fn_climate_action_daily_scorecard(target_date date); Type: COMMENT; Schema: public; Owner: verdify
+--
+
+COMMENT ON FUNCTION public.fn_climate_action_daily_scorecard(target_date date) IS 'Single-day climate-action scorecard, byte-identical to v_climate_action_daily_scorecard filtered to the target Denver-local date, with sargable time bounds (chunk pruning) and set-based duty resolution (#498).';
+
+
+--
 -- Name: fn_climate_action_effectiveness(interval); Type: FUNCTION; Schema: public; Owner: verdify
 --
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -854,6 +854,11 @@ async def outcome_kpi(target_date: str = "") -> str:
             FROM fn_realized_solar_night_dryout($1::date, $1::date, $2)
             ORDER BY episode_started_at
             """
+        # #498: the migration-202 single-day function, not the whole-window
+        # view — v_climate_action_daily_scorecard evaluates the effectiveness
+        # fan-out (fn_equip_at/fn_setpoint_at per action row) at ~6 min of DB
+        # CPU per call; the function is byte-identical for one Denver-local
+        # date and prunes to that day's chunks (~5 s measured in prod).
         actions_sql = """
             SELECT climate_action,
                    decisions,
@@ -866,8 +871,8 @@ async def outcome_kpi(target_date: str = "") -> str:
                    mister_water_delta_gal,
                    wet_blocked_decisions,
                    fog_blocked_decisions
-            FROM v_climate_action_daily_scorecard
-            WHERE date = $1::date AND greenhouse_id = $2
+            FROM fn_climate_action_daily_scorecard($1::date)
+            WHERE greenhouse_id = $2
             ORDER BY decisions DESC, climate_action
             """
         pinched_phase_sql = """
@@ -1927,7 +1932,7 @@ async def outcome_kpi(target_date: str = "") -> str:
                     "mv_equipment_runtime_daily",
                     "v_equipment_runtime_daily",
                     "fn_realized_solar_night_dryout",
-                    "v_climate_action_daily_scorecard",
+                    "fn_climate_action_daily_scorecard",
                     "v_water_attribution_daily",
                     "v_energy_estimate_reconciliation",
                     "v_resource_accounting_health",

--- a/tests/test_12_fidelity.py
+++ b/tests/test_12_fidelity.py
@@ -2283,6 +2283,56 @@ def test_climate_authority_action_log_contract_is_tracked():
     assert "ClimateActionLogRow(" in ingestor
 
 
+def test_climate_action_scorecard_single_day_pushdown_contract():
+    """#498: outcome_kpi's action scorecard reads the migration-202 single-day
+    function, not the whole-window view. The function must keep the sargable
+    day bounds intersected with the effectiveness 14-day window, the
+    fn_equip_at tie-order dedup, and the once-per-channel carry lookup; its
+    byte-equivalence to the view is pinned by the migration contract test."""
+    migration = (REPO_ROOT / "db" / "migrations" / "202-climate-action-scorecard-date-pushdown.sql").read_text()
+    contract_test = (
+        REPO_ROOT / "db" / "migrations" / "tests" / "test-202-climate-action-scorecard-date-pushdown.sql"
+    ).read_text()
+    schema = (REPO_ROOT / "db" / "schema.sql").read_text()
+    server = (REPO_ROOT / "mcp" / "server.py").read_text()
+
+    for token in (
+        "CREATE OR REPLACE FUNCTION public.fn_climate_action_daily_scorecard(target_date date)",
+        # day bounds must stay intersected with the rolling window (GREATEST),
+        # or a day at the window edge diverges from the view
+        "GREATEST(",
+        "now() - interval '14 days'",
+        "(target_date::timestamp AT TIME ZONE 'America/Denver')",
+        "((target_date + 1)::timestamp AT TIME ZONE 'America/Denver')",
+        # fn_equip_at returns the smallest-ctid duplicate at equal timestamps
+        "DISTINCT ON (es.equipment, es.ts)",
+        # once-per-channel carry: without MATERIALIZED the planner re-executes
+        # the lookup per grp=0 sample-channel row (measured 46k execs / 11.5 s)
+        "carry AS MATERIALIZED",
+    ):
+        assert token in migration
+
+    assert "CREATE FUNCTION public.fn_climate_action_daily_scorecard(target_date date)" in schema
+    assert "FROM fn_climate_action_daily_scorecard($1::date)" in server
+    assert "fn_climate_action_daily_scorecard" in server.split("source_tables=[")[1].split("]")[0]
+    assert "FROM v_climate_action_daily_scorecard" not in server
+
+    # the container contract test proves fn == view per date, both directions
+    assert "fn/view divergence" in contract_test
+    assert "EXCEPT" in contract_test
+
+    # schema.sql must carry the migration's function body VERBATIM (pg_dump
+    # prints prosrc as stored, so any drift here is drift from what prod
+    # would dump after the migration applies)
+    mig_body = migration.split("AS $$\n", 1)[1].split("\n$$;", 1)[0]
+    schema_fn = schema.split(
+        "CREATE FUNCTION public.fn_climate_action_daily_scorecard(target_date date) RETURNS TABLE",
+        1,
+    )[1]
+    schema_body = schema_fn.split("    AS $$\n", 1)[1].split("\n$$;", 1)[0]
+    assert schema_body == mig_body
+
+
 def test_health_checks_require_climate_action_log_freshness():
     api = (REPO_ROOT / "api" / "main.py").read_text()
     api_schema = (REPO_ROOT / "verdify_schemas" / "api.py").read_text()

--- a/tests/test_outcome_kpi_cycle_reconciliation.py
+++ b/tests/test_outcome_kpi_cycle_reconciliation.py
@@ -165,7 +165,7 @@ class _FakeConnection:
             return list(self.live_rows)
         for marker in (
             "fn_realized_solar_night_dryout",
-            "v_climate_action_daily_scorecard",
+            "fn_climate_action_daily_scorecard",
             "climate_moisture_exchange",
             "prev_action",  # vpd_policy_reason_sql
             "fn_band_setpoints",  # pinched/phase combined statement

--- a/verdify_schemas/mcp_responses.py
+++ b/verdify_schemas/mcp_responses.py
@@ -229,7 +229,11 @@ class OutcomeKpiCoverage(BaseModel):
 
 
 class OutcomeKpiActionRow(BaseModel):
-    """One action row from `v_climate_action_daily_scorecard`."""
+    """One action row from `fn_climate_action_daily_scorecard` (#498).
+
+    The migration-202 single-day function is byte-identical to a
+    `v_climate_action_daily_scorecard` slice for the same Denver-local date.
+    """
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
Closes #498

## Diagnosis first — the issue's mechanism was wrong, its measurement was right

#498 hypothesized the `date = $1` predicate is applied above the aggregation so every single-day call evaluates the effectiveness view across the whole 14-day window. A prod `EXPLAIN (ANALYZE, BUFFERS)` of the exact single-day query (2026-07-12, 1,947 action rows, **348.6 s** execution) shows the planner **already pushes the date predicate into the `climate_action_log` scans as a row filter**. The floor is per-row function-call fan-out inside `fn_climate_action_effectiveness`:

| node | cost |
|---|---|
| duty LATERAL — 16 samples × 8 non-inlinable `fn_equip_at` calls per action row (~1.2 ms/call: each re-executes a ChunkAppend over the 87-chunk `equipment_state` hypertable) | **293.8 s (84%)** |
| targetlist `fn_setpoint_at` — 4 calls/row at ~6.6 ms | **~51 s** |
| non-sargable date filter over the 3 in-window chunks (~55k rows scanned → 1,947 kept) | ~2 s |
| c0/c1 climate LATERAL lookups | ~1.6 s |

Chunk pruning alone would have saved ~2 s of 348 s. The fix has to make the per-day work set-based, not merely sargable — and the cost scales per row: 2026-07-06 has 5,857 action rows and took the old path **25m44.9s**.

## Design chosen

**Migration 202** (`db/migrations/202-climate-action-scorecard-date-pushdown.sql`) adds `fn_climate_action_daily_scorecard(target_date date)` — the issue's suggested date-parameterized function — as a **self-contained single-day scorecard** byte-identical to `SELECT * FROM v_climate_action_daily_scorecard WHERE date = target_date`:

- **Sargable bounds**: `ts >= GREATEST(Denver-local midnight, now() - interval '14 days') AND ts < next local midnight`, shipped as InitPlan params so TimescaleDB excludes non-target chunks at executor startup. `[local midnight, next)` is exactly the row set of `(ts AT TIME ZONE 'America/Denver')::date = target_date` (DST-safe — Denver transitions at 02:00), and `GREATEST` reproduces the effectiveness function's rolling `now() - '14 days'` cutoff so the truncated oldest day aggregates identically.
- **c0/c1 climate lookups and after-setpoint resolution** inline migration 142's / `fn_setpoint_at`'s *exact* SELECT bodies as LATERAL subqueries — same index paths, same values, no per-call SQL-function machinery.
- **Duty becomes one set-based LOCF pass** over `equipment_state` edges (~850 edges/day instead of ~250k `fn_equip_at` calls). Tie fidelity: `fn_equip_at`'s `ORDER BY ts DESC LIMIT 1` btree scan returns the smallest-ctid row among equal-timestamp duplicates (btree stores equal keys TID-ordered), so edges dedup via `DISTINCT ON (equipment, ts) ... ORDER BY equipment, ts, ctid` — prod has **9 conflicting same-timestamp groups** among the 7 duty channels in the current window, so this is load-bearing, and the contract test's 37.50-vs-62.50 duty assertion discriminates it. The per-channel carry-in lookup is `MATERIALIZED` (without it the planner re-executes it per grp=0 sample-channel row — measured 46k executions / 11.5 s on a day where one fan never transitioned).
- Per-sample duty averages are `avg(int) → numeric` — exact rational arithmetic, no float-order sensitivity.

**The view pair (`v_climate_action_effectiveness_5m/15m`, `v_climate_action_daily_scorecard`) and `fn_climate_action_effectiveness(interval)` are untouched** — the view stays the whole-window ad-hoc surface; rewriting it buys nothing (see diagnosis) and risks the effectiveness contract.

**`mcp/server.py`**: `outcome_kpi`'s `actions_sql` reads `FROM fn_climate_action_daily_scorecard($1::date) WHERE greenhouse_id = $2` (same column list and order); `source_tables` names the function (precedent: `fn_realized_solar_night_dryout`). This is the **only** consumer — `grep -rn v_climate_action_daily_scorecard` over api/, grafana/, site/, scripts/: zero hits; remaining references are the untouched migration-142/schema definitions and test fixtures.

## Byte-identity evidence (golden capture per PR #497's method, prod read-only)

Golden = ordered CSV (`COPY ... ORDER BY 1,2,3`) of the **view** slice on prod; new = the migration's function body executed as a raw inline query (identical text, literal date — the migration is **not** applied to prod, so this is the only read-only way to compare):

```
2026-07-12 (chunk _hyper_26_831, 1,947 rows): old path 6m04.5s wall
  view sha256 6cc0bcc71f235470a5231f95866e12aff3868f6aa12b2e0cf24e53ecca2abc81
  fn   sha256 6cc0bcc71f235470a5231f95866e12aff3868f6aa12b2e0cf24e53ecca2abc81  → BYTE-IDENTICAL
2026-07-06 (older chunk _hyper_26_814, 5,857 rows): old path 25m44.9s wall
  view sha256 4dafd12b6bb616e7711c405ccac0edf39bc1d61ef337df239e5e0fa5c36153c3
  fn   sha256 4dafd12b6bb616e7711c405ccac0edf39bc1d61ef337df239e5e0fa5c36153c3  → BYTE-IDENTICAL
2026-06-25 (outside the 14-day window): view 0 rows == fn 0 rows
```

Repeated fn runs are output-stable (`cmp` identical cold/warm). A full `outcome_kpi()` response capture on prod is impossible pre-application (the function does not exist there until the gated apply); the response-assembly delta is confined to `actions_sql`'s FROM/WHERE and one `source_tables` string ("v_climate_action_daily_scorecard" → "fn_climate_action_daily_scorecard"), and the real assembly is exercised green by `tests/test_outcome_kpi_cycle_reconciliation.py`.

## EXPLAIN — pruned scans + measured timing (issue acceptance)

New path, prod, literal 2026-07-12, `EXPLAIN (ANALYZE, BUFFERS)`:

```
Custom Scan (ChunkAppend) on climate_action_log l (actual time=0.205..11.527 rows=1947 loops=1)
  Chunks excluded during runtime: 7            -- 7 of 8 chunks "(never executed)"
  -> Index Scan using _hyper_26_831_chunk_climate_action_log_ts_idx on _hyper_26_831_chunk
       Index Cond: ((ts >= $1) AND (ts < $2))  -- sargable single-day bounds
...
Chunks excluded during runtime: 49             -- 50-chunk climate/setpoint scans pruned to 1
Chunks excluded during runtime: 86             -- 87-chunk equipment_state edges scan pruned to 1
Execution Time: 5599.563 ms
```

Old path, same day, same method: **348,610.7 ms**. Wall-clock via kubectl/psql: **364.5 s → 5.5–7.0 s (~62×)**; for 2026-07-06 (5,857 rows): 25m44.9s → 16.9s (~91×). `outcome_kpi()`'s scorecard read now completes in seconds, not minutes — the #365 looping caller stops stacking ~6-minute backends on the pool. The remaining ~5 s is the c0/c1 + setpoint per-row lateral resolution, which is exact-semantics-bound (each is `fn_setpoint_at`'s literal body).

## Migration safety

- `scripts/check_migration_rollback_safety.py --rollback-wrap db/migrations/202-...` → **`OK to wrap in BEGIN..ROLLBACK (non-self-transactional)`**; `--list` classifies 202 **safe-to-wrap**. `CREATE OR REPLACE FUNCTION` + `COMMENT` only — no `COMMIT`, no `CONCURRENTLY`, no new indexes (the composite indexes the inline lookups need already exist in prod).
- **Serialized**: zero open PRs touch `db/migrations/` (checked at branch time and again pre-push; the only open PR earlier, #513, was lab-docs and has since merged). Migration 201 exists on main **unapplied**; 202 is the next number and is independent of 201.
- **Not applied to prod** — application + the `verdify-mcp` bounce are gated operator work. Functional rollback: `DROP FUNCTION public.fn_climate_action_daily_scorecard(date)` and point `actions_sql` back at the view.

## Verification

- **Migration contract test** `db/migrations/tests/test-202-climate-action-scorecard-date-pushdown.sql` — green in a scratch `timescale/timescaledb:2.25.2-pg16` pod (same harness as #503): asserts `fn(d)` == view slice **per date, both directions, for every date the view emits** (row counts + two-way EXCEPT over all 13 columns), plus hand-computed cells that discriminate the risky shapes: the conflicting same-timestamp relay pair (wet duty must be 37.50, not 62.50 — tie order), carry-in state across midnight (50.00 group average), a midnight-crossing pulse (37.50/31.25 on adjacent days), an expired setpoint (−1.50 inside the expiry window, −2.50 after), a NULL-greenhouse_id group, a missing after-sample (NULL deltas averaged with non-NULL siblings), the rolling 14-day cutoff (GREATEST bound: two rows share a local date, exactly one aggregates), and empty/aged-out days.
- `CI_BASE_REF=origin/main bash scripts/ci-local.sh` on the rebased HEAD → **ALL GATES GREEN** (ruff lint+format, schema suites incl. drift guards, device write gate, pure-logic/contract suites, migration rollback safety, grafana CM check, solar SSOT guard, twin compile, prod overlay render, no-new-fire-and-forget, service-restart drift guard, replay trigger: no firmware diff).
- Full `pytest tests/` vs origin/main baseline on this pod: baseline 143 FAILED/ERROR (the pre-existing environment-dependent set), branch 143 + `test_01_infrastructure.py::test_esp32_reachable` — a single-ICMP-ping live-device test that passed 3/3 on immediate re-run (transient packet loss during the run; a db/mcp change cannot affect device ICMP). All other failure lines byte-identical (`diff` of sorted lists).
- New fidelity pin `tests/test_12_fidelity.py::test_climate_action_scorecard_single_day_pushdown_contract`: migration tokens (GREATEST cutoff, ctid dedup, MATERIALIZED carry), the mcp read path, **and schema.sql carrying the migration's function body verbatim** (pg_dump prints prosrc as stored).
- `tests/test_outcome_kpi_cycle_reconciliation.py` — the real response assembly against a faked connection, green with the function marker.
- The literal `actions_sql` (column list, `greenhouse_id` filter, ORDER BY) validated against the created function in the scratch pod.

## Prod impact accounting (all read-only)

Evidence gathering ran two view evaluations (6m/23m), one old-path and two new-path `EXPLAIN ANALYZE`s, and fast fn probes on `verdify-db-0`, serialized where heavy. Writer datapath stayed fresh throughout (climate age 17 s, action-log age 1 s checked post-run); the only non-Running pods in `verdify-prod` pre-date this session.

Post-merge restart: verdify-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RagqKvSVZnvRQeKVAmN7Wu
