### PR TITLE
feat(lab): add stage-profiled occurrence publisher

### DIFF
--- a/docs/agents/web.md
+++ b/docs/agents/web.md
@@ -122,6 +122,19 @@ presence is not a deployment or activation claim: no Lab workload invokes it,
 and no endpoint, credential, environment binding, route, or replica is supplied
 by the source adapter.
 
+The separate built-site consumer command is
+`site-astro/scripts/execute-occurrence-site-publish.mjs`. It accepts only the
+literal `execute` command, canonical event/producer/policy/manifest documents,
+and disjoint canonical candidate/workspace roots. It checks the exact document
+identities and closed Jason approval record before asking a construction-only
+runtime resolver. The returned build and verifier operations must both bind the
+same digest-identified `https://lab-stage.verdify.ai` global-noindex profile;
+the selected build record and verifier result must attest that profile before a
+site release can publish. The command deliberately has no default runtime,
+store, endpoint, credential, or network client, so this source slice cannot
+publish or activate anything by itself. Explicit object-store/runtime binding
+remains the next gated Phase 4b slice.
+
 `scripts/rebuild-site.sh` builds Quartz into a staged `public.*` directory,
 verifies the staged `index.html`, then rsyncs the complete staged output into
 the live public tree with delayed deletes. In k3s, nginx reload is skipped

--- a/docs/site-publishing-pipeline.md
+++ b/docs/site-publishing-pipeline.md
@@ -251,7 +251,7 @@ source does not alter the live cluster; even an operator sync cannot schedule th
 zero-replica workload.
 
 This storage foundation and source-only operation adapter do not change the
-credential-free local CLI or deploy anything. The built-site CLI/publisher factory,
+credential-free local CLI or deploy anything. The built-site runtime factory,
 bounded cache hydration from object bytes, distributed lease, bounded retention
 and GC, event agent, resource accounting, endpoint configuration, actual
 resource/value binding (the #501 readiness slice fixes names only), and real-endpoint
@@ -260,6 +260,30 @@ the compatible store preserves the tested conditional semantics before any write
 activated. Activation additionally requires reviewed store/egress wiring, an explicit
 replicas change, and live cache/freshness/alert proof. Those are deployment and data
 authority concerns, not hidden claims of either backend.
+
+The source tree now includes the built-site event consumer command:
+
+```bash
+cd site-astro
+npm run occurrence:site:execute -- execute \
+  --event /path/to/event.json \
+  --producer-result /path/to/producer-result.json \
+  --policy /path/to/policy.json \
+  --manifest /path/to/static-occurrence-manifest.json \
+  --candidate-root /absolute/candidates \
+  --workspace-root /absolute/workspace
+```
+
+It validates canonical file identities, disjoint canonical roots, and Jason's
+closed approval record before requesting a construction-only runtime resolver.
+The returned build and verifier operations must share digest-identified profile
+bindings for the fixed `https://lab-stage.verdify.ai` target with global
+noindex. The processor independently requires the selected build record and
+verifier result to attest that profile before publication. The shipped command
+supplies no runtime factory, store, endpoint, credential, environment reader,
+or network client; therefore the command intentionally stops without taking
+live action. The following S3 injection slice must supply those capabilities
+explicitly and remains separate from activation.
 
 ### Astro occurrence-store binding names (source-only)
 

--- a/site-astro/package.json
+++ b/site-astro/package.json
@@ -21,6 +21,7 @@
     "occurrence:media:rollback": "node scripts/manage-occurrence-release.mjs rollback-media",
     "occurrence:export": "node scripts/prepare-occurrence-export.mjs",
     "occurrence:execute": "node scripts/execute-occurrence-export.mjs",
+    "occurrence:site:execute": "node scripts/execute-occurrence-site-publish.mjs",
     "camera:export": "node scripts/export-camera-occurrence.mjs capture",
     "object-store:binding-readiness": "node scripts/check-object-store-binding-readiness.mjs",
     "site-release:prepare": "node scripts/manage-site-release.mjs prepare",

--- a/site-astro/scripts/execute-occurrence-site-publish.mjs
+++ b/site-astro/scripts/execute-occurrence-site-publish.mjs
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { readCanonicalExportDocument } from "./lib/occurrence-export-contract.mjs";
+import { runOccurrenceSitePublisherDelivery } from "./lib/occurrence-site-publisher-runner.mjs";
+
+function usage() {
+    return [
+        "Usage:",
+        "  node scripts/execute-occurrence-site-publish.mjs execute --event EVENT --producer-result PRODUCER_RESULT --policy POLICY --manifest MANIFEST --candidate-root CANDIDATE_ROOT --workspace-root WORKSPACE_ROOT",
+        "",
+        "The execute command is mutation-capable and requires a canonical Jason-approved policy.",
+        "The source-only executable has no default runtime, store, endpoint, credential, or network client.",
+    ].join("\n");
+}
+
+function options(argv) {
+    const result = { command: argv[0] ?? "", values: new Map() };
+    for (let index = 1; index < argv.length; index += 2) {
+        const key = argv[index];
+        const value = argv[index + 1];
+        if (
+            !key?.startsWith("--") ||
+            value === undefined ||
+            result.values.has(key)
+        ) {
+            throw new Error("invalid command arguments");
+        }
+        result.values.set(key, value);
+    }
+    return result;
+}
+
+function exactOptions(values) {
+    const names = [
+        "--event",
+        "--producer-result",
+        "--policy",
+        "--manifest",
+        "--candidate-root",
+        "--workspace-root",
+    ];
+    if (
+        values.size !== names.length ||
+        names.some((name) => !values.has(name))
+    ) {
+        throw new Error(usage());
+    }
+}
+
+function canonical(value) {
+    return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export async function runOccurrenceSitePublishCli(
+    argv,
+    {
+        readDocument = readCanonicalExportDocument,
+        createRuntime = null,
+        runDelivery = runOccurrenceSitePublisherDelivery,
+        processEvent,
+    } = {},
+) {
+    const { command, values } = options(argv);
+    if (command !== "execute") throw new Error(usage());
+    exactOptions(values);
+
+    const [event, producerResult, policy, manifest] = await Promise.all([
+        readDocument(values.get("--event"), "occurrence site event"),
+        readDocument(
+            values.get("--producer-result"),
+            "occurrence producer result",
+        ),
+        readDocument(values.get("--policy"), "occurrence export policy"),
+        readDocument(values.get("--manifest"), "static occurrence manifest"),
+    ]);
+    return runDelivery(
+        {
+            event,
+            producerResult,
+            policy,
+            manifest,
+            candidateRoot: path.resolve(values.get("--candidate-root")),
+            workspaceRoot: path.resolve(values.get("--workspace-root")),
+        },
+        { createRuntime, processEvent },
+    );
+}
+
+async function main() {
+    const result = await runOccurrenceSitePublishCli(process.argv.slice(2));
+    process.stdout.write(canonical(result));
+}
+
+const invokedAs = process.argv[1]
+    ? pathToFileURL(path.resolve(process.argv[1])).href
+    : null;
+if (invokedAs === import.meta.url) {
+    main().catch((error) => {
+        process.stderr.write(
+            `execute-occurrence-site-publish: ${error.message}\n`,
+        );
+        process.exitCode = 1;
+    });
+}

--- a/site-astro/scripts/lib/occurrence-site-publisher-runner.mjs
+++ b/site-astro/scripts/lib/occurrence-site-publisher-runner.mjs
@@ -1,0 +1,362 @@
+import { createHash } from "node:crypto";
+import { lstat, realpath } from "node:fs/promises";
+import path from "node:path";
+
+import {
+    occurrenceExportPolicySha256,
+    validateOccurrenceExportPolicy,
+    validatePolicyManifestBinding,
+} from "./occurrence-export-contract.mjs";
+import { validateOccurrenceProducerResult } from "./occurrence-producer-result-contract.mjs";
+import {
+    occurrenceSiteOperationSha256,
+    occurrenceSitePublicationProfiles,
+    processOccurrenceSitePublishEvent,
+    validateOccurrenceSitePublishEvent,
+} from "./occurrence-site-publisher.mjs";
+
+const SHA256_RE = /^[0-9a-f]{64}$/u;
+const STAGE_ORIGIN = "https://lab-stage.verdify.ai";
+const STAGE_PROFILE = occurrenceSitePublicationProfiles.stage;
+
+const RUNTIME_KEYS = [
+    "contract",
+    "schemaVersion",
+    "siteOrigin",
+    "stageGlobalNoindex",
+    "occurrenceStore",
+    "buildOperation",
+    "verificationOperation",
+    "checkpointOperations",
+    "publicationOperation",
+];
+
+const PUBLICATION_RESULT_KEYS = [
+    "contract",
+    "schemaVersion",
+    "status",
+    "eventId",
+    "eventSha256",
+    "producerResultSha256",
+    "occurrenceCallResultSha256",
+    "occurrenceSelectionSha256",
+    "occurrenceManifestSha256",
+    "occurrencePolicySha256",
+    "occurrenceStoreIdentitySha256",
+    "buildOperationSha256",
+    "verificationOperationSha256",
+    "buildContentIdentitySha256",
+    "siteStoreIdentitySha256",
+    "siteEventSha256",
+    "releaseSha256",
+    "siteSelectionSha256",
+];
+
+function canonicalBytes(value) {
+    return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(value) {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function exactKeys(value, keys) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        Object.getPrototypeOf(value) === Object.prototype &&
+        Object.keys(value).join(",") === keys.join(",")
+    );
+}
+
+function canonicalValue(value, label) {
+    if (
+        !exactKeys(value, ["document", "bytes", "sha256"]) ||
+        value.document === null ||
+        typeof value.document !== "object" ||
+        Array.isArray(value.document) ||
+        !Buffer.isBuffer(value.bytes) ||
+        !SHA256_RE.test(value.sha256)
+    ) {
+        throw new Error(`${label} is not a canonical document value`);
+    }
+    const bytes = canonicalBytes(value.document);
+    if (!bytes.equals(value.bytes) || sha256(bytes) !== value.sha256) {
+        throw new Error(`${label} canonical identity mismatch`);
+    }
+    return value;
+}
+
+async function canonicalRoot(value, label) {
+    if (
+        typeof value !== "string" ||
+        value.length === 0 ||
+        value.length > 4096 ||
+        /[\u0000-\u001f\u007f]/u.test(value) ||
+        !path.isAbsolute(value) ||
+        path.normalize(value) !== value
+    ) {
+        throw new Error(`${label} must be one canonical absolute path`);
+    }
+    const metadata = await lstat(value, { bigint: true });
+    if (
+        !metadata.isDirectory() ||
+        metadata.isSymbolicLink() ||
+        (await realpath(value)) !== value
+    ) {
+        throw new Error(`${label} must be one canonical directory`);
+    }
+    return value;
+}
+
+function rootsOverlap(first, second) {
+    const relative = path.relative(first, second);
+    return (
+        relative === "" ||
+        (relative !== ".." &&
+            !relative.startsWith(`..${path.sep}`) &&
+            !path.isAbsolute(relative))
+    );
+}
+
+function operationProfileMatches(operation, kind, eventSha256) {
+    const functionName = kind === "build" ? "build" : "verify";
+    const contract =
+        kind === "build"
+            ? "verdify.lab-selected-astro-build-operation"
+            : "verdify.lab-site-output-verification-operation";
+    const keys = [
+        "contract",
+        "schemaVersion",
+        "operationSha256",
+        "publicationProfile",
+        functionName,
+    ];
+    return (
+        exactKeys(operation, keys) &&
+        operation.contract === contract &&
+        operation.schemaVersion === 2 &&
+        typeof operation[functionName] === "function" &&
+        canonicalBytes(operation.publicationProfile).equals(
+            canonicalBytes(STAGE_PROFILE),
+        ) &&
+        operation.operationSha256 ===
+            occurrenceSiteOperationSha256(kind, STAGE_PROFILE) &&
+        operation.operationSha256 === eventSha256
+    );
+}
+
+function validateApprovedPolicy(policy) {
+    validateOccurrenceExportPolicy(policy);
+    if (
+        policy.activation.state !== "approved" ||
+        policy.activation.approvedBy !== "jason" ||
+        !policy.activation.approvedAt
+    ) {
+        throw new Error(
+            "occurrence site publication is disabled by the supplied policy",
+        );
+    }
+    return policy;
+}
+
+function validateRuntime(runtime, event) {
+    if (
+        !exactKeys(runtime, RUNTIME_KEYS) ||
+        runtime.contract !== "verdify.lab-stage-occurrence-site-runtime" ||
+        runtime.schemaVersion !== 1 ||
+        runtime.siteOrigin !== STAGE_ORIGIN ||
+        runtime.stageGlobalNoindex !== true ||
+        runtime.occurrenceStore?.identity?.sha256 !==
+            event.occurrenceStoreIdentitySha256 ||
+        !operationProfileMatches(
+            runtime.buildOperation,
+            "build",
+            event.buildOperationSha256,
+        ) ||
+        !operationProfileMatches(
+            runtime.verificationOperation,
+            "verification",
+            event.verificationOperationSha256,
+        )
+    ) {
+        throw new Error(
+            "occurrence site runtime does not preserve the closed noindex Lab stage contract",
+        );
+    }
+    return runtime;
+}
+
+function validatePublicationResult(result, event) {
+    const eventSha256 = sha256(canonicalBytes(event));
+    if (
+        !exactKeys(result, PUBLICATION_RESULT_KEYS) ||
+        result.contract !== "verdify.lab-occurrence-site-publish-result" ||
+        result.schemaVersion !== 1 ||
+        !["published", "idempotent"].includes(result.status) ||
+        result.eventId !== event.eventId ||
+        result.eventSha256 !== eventSha256 ||
+        result.producerResultSha256 !== event.producerResultSha256 ||
+        result.occurrencePolicySha256 !== event.occurrencePolicySha256 ||
+        result.occurrenceStoreIdentitySha256 !==
+            event.occurrenceStoreIdentitySha256 ||
+        result.buildOperationSha256 !== event.buildOperationSha256 ||
+        result.verificationOperationSha256 !==
+            event.verificationOperationSha256 ||
+        result.siteStoreIdentitySha256 !== event.siteStoreIdentitySha256 ||
+        PUBLICATION_RESULT_KEYS.slice(4).some(
+            (key) => !SHA256_RE.test(result[key]),
+        )
+    ) {
+        throw new Error(
+            "occurrence site processor did not return the exact event-bound result",
+        );
+    }
+    return result;
+}
+
+/**
+ * Consume one canonical, file-transported occurrence publication delivery.
+ * The caller must inject every I/O-capable runtime dependency. Policy approval
+ * and event identity are checked before the construction-only runtime resolver
+ * is requested. That resolver must perform no external I/O; its returned
+ * stage-profiled operations are validated before any operation is invoked.
+ */
+export async function runOccurrenceSitePublisherDelivery(
+    {
+        event: rawEvent,
+        producerResult: rawProducerResult,
+        policy: rawPolicy,
+        manifest: rawManifest,
+        candidateRoot: rawCandidateRoot,
+        workspaceRoot: rawWorkspaceRoot,
+    },
+    {
+        createRuntime = null,
+        processEvent = processOccurrenceSitePublishEvent,
+    } = {},
+) {
+    const eventValue = canonicalValue(rawEvent, "occurrence site event");
+    const producerResultValue = canonicalValue(
+        rawProducerResult,
+        "occurrence producer result",
+    );
+    const policyValue = canonicalValue(rawPolicy, "occurrence export policy");
+    const manifestValue = canonicalValue(
+        rawManifest,
+        "static occurrence manifest",
+    );
+    const event = structuredClone(eventValue.document);
+    const producerResult = structuredClone(producerResultValue.document);
+    const policy = structuredClone(policyValue.document);
+    const manifest = structuredClone(manifestValue.document);
+    const candidateRoot = await canonicalRoot(
+        rawCandidateRoot,
+        "occurrence candidate root",
+    );
+    const workspaceRoot = await canonicalRoot(
+        rawWorkspaceRoot,
+        "occurrence publisher workspace root",
+    );
+    if (
+        rootsOverlap(candidateRoot, workspaceRoot) ||
+        rootsOverlap(workspaceRoot, candidateRoot)
+    ) {
+        throw new Error(
+            "occurrence candidate and publisher workspace roots must be disjoint",
+        );
+    }
+
+    validateOccurrenceSitePublishEvent(event);
+    validateApprovedPolicy(policy);
+    const policySha256 = occurrenceExportPolicySha256(policy);
+    if (
+        policyValue.sha256 !== policySha256 ||
+        event.occurrencePolicySha256 !== policySha256 ||
+        event.sourceOccurrenceManifestSha256 !== manifestValue.sha256 ||
+        event.sourceSnapshotManifestSha256 !==
+            policy.sourceSnapshotManifestSha256 ||
+        producerResultValue.sha256 !== event.producerResultSha256
+    ) {
+        throw new Error(
+            "occurrence site event does not bind the exact canonical input documents",
+        );
+    }
+    validatePolicyManifestBinding(policy, manifest, manifestValue.sha256);
+    validateOccurrenceProducerResult(producerResult, {
+        policySha256,
+        sourceOccurrenceManifestSha256: manifestValue.sha256,
+        sourceId: event.sourceId,
+        sourceWatermark: event.sourceWatermark,
+        sourceWatermarkAt: event.occurredAt,
+    });
+
+    if (typeof createRuntime !== "function") {
+        throw new Error(
+            "occurrence site publisher runtime is not configured; no default live action is available",
+        );
+    }
+    if (typeof processEvent !== "function") {
+        throw new Error("occurrence site event processor is invalid");
+    }
+    const runtime = validateRuntime(
+        await createRuntime({
+            contract: "verdify.lab-stage-occurrence-site-runtime-request",
+            schemaVersion: 1,
+            siteOrigin: STAGE_ORIGIN,
+            stageGlobalNoindex: true,
+            publicationProfile: structuredClone(STAGE_PROFILE),
+            event: structuredClone(event),
+            producerResult: structuredClone(producerResult),
+            policy: structuredClone(policy),
+            manifest: structuredClone(manifest),
+            manifestSha256: manifestValue.sha256,
+            candidateRoot,
+            workspaceRoot,
+        }),
+        event,
+    );
+    const publication = validatePublicationResult(
+        await processEvent({
+            event,
+            producerResult,
+            policy,
+            manifest,
+            manifestSha256: manifestValue.sha256,
+            occurrenceStore: runtime.occurrenceStore,
+            candidateRoot,
+            workspaceRoot,
+            buildOperation: runtime.buildOperation,
+            verificationOperation: runtime.verificationOperation,
+            checkpointOperations: runtime.checkpointOperations,
+            publicationOperation: runtime.publicationOperation,
+        }),
+        event,
+    );
+    return {
+        contract: "verdify.lab-stage-occurrence-site-execution-result",
+        schemaVersion: 1,
+        siteOrigin: STAGE_ORIGIN,
+        stageGlobalNoindex: true,
+        publicationProfile: STAGE_PROFILE,
+        publication,
+    };
+}
+
+export const occurrenceSitePublisherRunnerContract = Object.freeze({
+    runtime: Object.freeze({
+        contract: "verdify.lab-stage-occurrence-site-runtime",
+        schemaVersion: 1,
+        siteOrigin: STAGE_ORIGIN,
+        stageGlobalNoindex: true,
+    }),
+    result: Object.freeze({
+        contract: "verdify.lab-stage-occurrence-site-execution-result",
+        schemaVersion: 1,
+        publicationProfile: STAGE_PROFILE,
+    }),
+    defaults: Object.freeze({
+        createRuntime: null,
+    }),
+});

--- a/site-astro/scripts/lib/occurrence-site-publisher.mjs
+++ b/site-astro/scripts/lib/occurrence-site-publisher.mjs
@@ -36,6 +36,22 @@ const RELEASE_EVENT_ID_RE = /^evt_[A-Za-z0-9_-]{8,128}$/u;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u;
 const COMMIT_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const PROVENANCE_PATH = "occurrence-publish-provenance.json";
+const PUBLICATION_PROFILE_KEYS = [
+    "siteOrigin",
+    "stageGlobalNoindex",
+    "policyVersion",
+];
+
+const PRODUCTION_PUBLICATION_PROFILE = Object.freeze({
+    siteOrigin: "https://lab.verdify.ai",
+    stageGlobalNoindex: false,
+    policyVersion: "occurrence-selected-production-v1",
+});
+const STAGE_PUBLICATION_PROFILE = Object.freeze({
+    siteOrigin: "https://lab-stage.verdify.ai",
+    stageGlobalNoindex: true,
+    policyVersion: "occurrence-selected-stage-v1",
+});
 
 const EVENT_KEYS = [
     "contract",
@@ -112,6 +128,42 @@ function exactKeys(value, keys) {
         Object.keys(value).join(",") === keys.join(",")
     );
 }
+
+function validatePublicationProfile(value) {
+    if (!exactKeys(value, PUBLICATION_PROFILE_KEYS)) {
+        throw new Error(
+            "site publication profile does not use the closed v1 shape",
+        );
+    }
+    const canonical = canonicalBytes(value);
+    if (
+        !canonical.equals(canonicalBytes(PRODUCTION_PUBLICATION_PROFILE)) &&
+        !canonical.equals(canonicalBytes(STAGE_PUBLICATION_PROFILE))
+    ) {
+        throw new Error("site publication profile is not an approved target");
+    }
+    return structuredClone(value);
+}
+
+export function occurrenceSiteOperationSha256(kind, rawProfile) {
+    if (!["build", "verification"].includes(kind)) {
+        throw new Error("occurrence site operation kind is invalid");
+    }
+    const publicationProfile = validatePublicationProfile(rawProfile);
+    return sha256(
+        canonicalBytes({
+            contract: "verdify.lab-occurrence-site-operation-identity",
+            schemaVersion: 1,
+            kind,
+            publicationProfile,
+        }),
+    );
+}
+
+export const occurrenceSitePublicationProfiles = Object.freeze({
+    production: PRODUCTION_PUBLICATION_PROFILE,
+    stage: STAGE_PUBLICATION_PROFILE,
+});
 
 function safeText(value, label, maximum = 512) {
     if (
@@ -303,44 +355,90 @@ function validateProducerResult(
 }
 
 function validateBuildOperation(operation, event) {
-    if (
-        !exactKeys(operation, [
+    const legacy =
+        exactKeys(operation, [
             "contract",
             "schemaVersion",
             "operationSha256",
             "build",
-        ]) ||
+        ]) && operation.schemaVersion === 1;
+    const profiled =
+        exactKeys(operation, [
+            "contract",
+            "schemaVersion",
+            "operationSha256",
+            "publicationProfile",
+            "build",
+        ]) && operation.schemaVersion === 2;
+    if (
+        (!legacy && !profiled) ||
         operation.contract !== "verdify.lab-selected-astro-build-operation" ||
-        operation.schemaVersion !== 1 ||
         operation.operationSha256 !== event.buildOperationSha256 ||
         !SHA256_RE.test(operation.operationSha256) ||
         typeof operation.build !== "function"
-    )
+    ) {
         throw new Error(
             "Astro build operation does not use the bound v1 contract",
         );
-    return operation;
+    }
+    const publicationProfile = profiled
+        ? validatePublicationProfile(operation.publicationProfile)
+        : structuredClone(PRODUCTION_PUBLICATION_PROFILE);
+    if (
+        profiled &&
+        occurrenceSiteOperationSha256("build", publicationProfile) !==
+            operation.operationSha256
+    ) {
+        throw new Error(
+            "Astro build operation identity does not bind its publication profile",
+        );
+    }
+    return { operation, publicationProfile, targetAttested: profiled };
 }
 
 function validateVerificationOperation(operation, event) {
-    if (
-        !exactKeys(operation, [
+    const legacy =
+        exactKeys(operation, [
             "contract",
             "schemaVersion",
             "operationSha256",
             "verify",
-        ]) ||
-        operation.contract !==
-            "verdify.lab-production-output-verification-operation" ||
-        operation.schemaVersion !== 1 ||
+        ]) &&
+        operation.contract ===
+            "verdify.lab-production-output-verification-operation" &&
+        operation.schemaVersion === 1;
+    const profiled =
+        exactKeys(operation, [
+            "contract",
+            "schemaVersion",
+            "operationSha256",
+            "publicationProfile",
+            "verify",
+        ]) &&
+        operation.contract ===
+            "verdify.lab-site-output-verification-operation" &&
+        operation.schemaVersion === 2;
+    if (
+        (!legacy && !profiled) ||
         operation.operationSha256 !== event.verificationOperationSha256 ||
         !SHA256_RE.test(operation.operationSha256) ||
         typeof operation.verify !== "function"
-    )
+    ) {
+        throw new Error("site output verifier does not use a bound contract");
+    }
+    const publicationProfile = profiled
+        ? validatePublicationProfile(operation.publicationProfile)
+        : structuredClone(PRODUCTION_PUBLICATION_PROFILE);
+    if (
+        profiled &&
+        occurrenceSiteOperationSha256("verification", publicationProfile) !==
+            operation.operationSha256
+    ) {
         throw new Error(
-            "production output verifier does not use the bound v1 contract",
+            "site output verifier identity does not bind its publication profile",
         );
-    return operation;
+    }
+    return { operation, publicationProfile, targetAttested: profiled };
 }
 
 function validateCheckpointOperations(operation, event) {
@@ -1005,6 +1103,8 @@ async function verifySelectedBuild({
     policy,
     selected,
     inventory,
+    publicationProfile,
+    targetAttested,
 }) {
     const [buildValue, occurrenceValue, provenanceValue] = await Promise.all([
         readCanonicalJson(
@@ -1022,6 +1122,15 @@ async function verifySelectedBuild({
     ]);
     const build = buildValue.document;
     const occurrenceManifest = occurrenceValue.document;
+    if (
+        targetAttested &&
+        (build.siteOrigin !== publicationProfile.siteOrigin ||
+            build.stageGlobalNoindex !== publicationProfile.stageGlobalNoindex)
+    ) {
+        throw new Error(
+            "Astro build does not attest the bound site publication target",
+        );
+    }
     for (const [relative, value] of [
         ["static-build.json", buildValue],
         ["occurrence-manifest.json", occurrenceValue],
@@ -1101,24 +1210,41 @@ async function verifySelectedBuild({
     };
 }
 
-function validateVerificationResult(value, expected) {
-    if (
-        !exactKeys(value, [
+function validateVerificationResult(value, expected, targetAttested) {
+    const identityKeys = [
+        "buildInventorySha256",
+        "buildContentIdentitySha256",
+        "staticBuildSha256",
+        "occurrenceOutputManifestSha256",
+        "occurrenceSelectionSha256",
+        "occurrenceManifestSha256",
+        "provenanceSha256",
+        "siteEventSha256",
+        "sitePayloadSha256",
+    ];
+    const legacy =
+        !targetAttested &&
+        exactKeys(value, ["contract", "schemaVersion", ...identityKeys]) &&
+        value.contract ===
+            "verdify.lab-production-output-verification-result" &&
+        value.schemaVersion === 1;
+    const profiled =
+        targetAttested &&
+        exactKeys(value, [
             "contract",
             "schemaVersion",
-            "buildInventorySha256",
-            "buildContentIdentitySha256",
-            "staticBuildSha256",
-            "occurrenceOutputManifestSha256",
-            "occurrenceSelectionSha256",
-            "occurrenceManifestSha256",
-            "provenanceSha256",
-            "siteEventSha256",
-            "sitePayloadSha256",
-        ]) ||
-        value.contract !==
-            "verdify.lab-production-output-verification-result" ||
-        value.schemaVersion !== 1 ||
+            "siteOrigin",
+            "stageGlobalNoindex",
+            "policyVersion",
+            ...identityKeys,
+        ]) &&
+        value.contract === "verdify.lab-site-output-verification-result" &&
+        value.schemaVersion === 2 &&
+        value.siteOrigin === expected.siteOrigin &&
+        value.stageGlobalNoindex === expected.stageGlobalNoindex &&
+        value.policyVersion === expected.policyVersion;
+    if (
+        (!legacy && !profiled) ||
         value.buildInventorySha256 !== expected.buildInventorySha256 ||
         value.buildContentIdentitySha256 !==
             expected.buildContentIdentitySha256 ||
@@ -1133,12 +1259,12 @@ function validateVerificationResult(value, expected) {
         value.sitePayloadSha256 !== expected.sitePayloadSha256
     )
         throw new Error(
-            "production output verifier did not attest the exact selected build",
+            "site output verifier did not attest the exact selected build and target",
         );
     return value;
 }
 
-function siteEvent(event, contentIdentitySha256) {
+function siteEvent(event, contentIdentitySha256, policyVersion) {
     return {
         contract: "verdify.lab-release-trigger",
         schemaVersion: 1,
@@ -1149,7 +1275,7 @@ function siteEvent(event, contentIdentitySha256) {
         occurredAt: event.occurredAt,
         payloadSha256: siteReleasePayloadSha256({
             sourceSnapshotManifestSha256: event.sourceSnapshotManifestSha256,
-            policyVersion: "occurrence-selected-production-v1",
+            policyVersion,
             builderCommit: event.builderCommit,
             contentIdentitySha256,
         }),
@@ -1262,7 +1388,12 @@ function assertEventOrder(event, current) {
     }
 }
 
-async function publishedEventState(publication, event, checkpoint) {
+async function publishedEventState(
+    publication,
+    event,
+    checkpoint,
+    publicationProfile,
+) {
     const intent = await publication.readEventIntent(event.eventId);
     if (intent === null) return null;
     if (
@@ -1304,7 +1435,8 @@ async function publishedEventState(publication, event, checkpoint) {
         manifest.event.occurredAt !== event.occurredAt ||
         manifest.sourceSnapshotManifestSha256 !==
             event.sourceSnapshotManifestSha256 ||
-        manifest.builderCommit !== event.builderCommit
+        manifest.builderCommit !== event.builderCommit ||
+        manifest.policyVersion !== publicationProfile.policyVersion
     )
         throw new Error(
             "published site release does not match the exact event envelope",
@@ -1381,7 +1513,7 @@ function publicResult({
 
 /**
  * Join one already-produced occurrence result to the selected occurrence store,
- * a single-use Astro workspace, production verification, and full-site release.
+ * a single-use Astro workspace, target-profiled verification, and full-site release.
  * Every I/O-capable dependency is explicit; this module constructs no client,
  * transport, command, environment binding, route, workload, or activation.
  */
@@ -1427,11 +1559,25 @@ export async function processOccurrenceSitePublishEvent({
         manifestSha256,
         manifest,
     );
-    const buildOperation = validateBuildOperation(rawBuildOperation, event);
-    const verificationOperation = validateVerificationOperation(
+    const buildBinding = validateBuildOperation(rawBuildOperation, event);
+    const verificationBinding = validateVerificationOperation(
         rawVerificationOperation,
         event,
     );
+    if (
+        buildBinding.targetAttested !== verificationBinding.targetAttested ||
+        !canonicalBytes(buildBinding.publicationProfile).equals(
+            canonicalBytes(verificationBinding.publicationProfile),
+        )
+    ) {
+        throw new Error(
+            "Astro build and verification operations target different publication profiles",
+        );
+    }
+    const buildOperation = buildBinding.operation;
+    const verificationOperation = verificationBinding.operation;
+    const publicationProfile = buildBinding.publicationProfile;
+    const targetAttested = buildBinding.targetAttested;
     const checkpointOperations = validateCheckpointOperations(
         rawCheckpointOperations,
         event,
@@ -1520,6 +1666,7 @@ export async function processOccurrenceSitePublishEvent({
         publication,
         event,
         checkpoint,
+        publicationProfile,
     );
     if (alreadyPublished?.state === "selected") {
         return publicResult({
@@ -1533,8 +1680,13 @@ export async function processOccurrenceSitePublishEvent({
 
     const workspace = await canonicalEmptyWorkspace(workspaceRoot);
     const buildResult = await buildOperation.build({
-        contract: "verdify.lab-selected-astro-build-request",
-        schemaVersion: 1,
+        contract: targetAttested
+            ? "verdify.lab-profiled-selected-astro-build-request"
+            : "verdify.lab-selected-astro-build-request",
+        schemaVersion: targetAttested ? 2 : 1,
+        ...(targetAttested
+            ? { publicationProfile: structuredClone(publicationProfile) }
+            : {}),
         event: structuredClone(event),
         checkpoint: structuredClone(checkpoint),
         workspaceRoot: workspace,
@@ -1554,6 +1706,8 @@ export async function processOccurrenceSitePublishEvent({
         policy,
         selected,
         inventory: beforeSemanticReads,
+        publicationProfile,
+        targetAttested,
     });
     const afterSemanticReads = await inventoryBuiltSite(buildRoot);
     if (
@@ -1566,12 +1720,19 @@ export async function processOccurrenceSitePublishEvent({
     const files = publicInventory(beforeVerification);
     const contentIdentitySha256 = siteContentIdentitySha256({
         sourceSnapshotManifestSha256: event.sourceSnapshotManifestSha256,
-        policyVersion: "occurrence-selected-production-v1",
+        policyVersion: publicationProfile.policyVersion,
         builderCommit: event.builderCommit,
         files,
     });
-    const releaseEvent = siteEvent(event, contentIdentitySha256);
+    const releaseEvent = siteEvent(
+        event,
+        contentIdentitySha256,
+        publicationProfile.policyVersion,
+    );
     const verificationExpected = {
+        siteOrigin: publicationProfile.siteOrigin,
+        stageGlobalNoindex: publicationProfile.stageGlobalNoindex,
+        policyVersion: publicationProfile.policyVersion,
         buildInventorySha256: inventoryIdentity(beforeVerification),
         buildContentIdentitySha256: contentIdentitySha256,
         staticBuildSha256: buildEvidence.buildSha256,
@@ -1585,8 +1746,17 @@ export async function processOccurrenceSitePublishEvent({
     };
     validateVerificationResult(
         await verificationOperation.verify({
-            contract: "verdify.lab-production-output-verification-request",
-            schemaVersion: 1,
+            contract: targetAttested
+                ? "verdify.lab-site-output-verification-request"
+                : "verdify.lab-production-output-verification-request",
+            schemaVersion: targetAttested ? 2 : 1,
+            ...(targetAttested
+                ? {
+                      siteOrigin: publicationProfile.siteOrigin,
+                      stageGlobalNoindex: publicationProfile.stageGlobalNoindex,
+                      policyVersion: publicationProfile.policyVersion,
+                  }
+                : {}),
             event: structuredClone(event),
             buildRoot,
             buildContentIdentitySha256: contentIdentitySha256,
@@ -1601,13 +1771,14 @@ export async function processOccurrenceSitePublishEvent({
             sitePayloadSha256: verificationExpected.sitePayloadSha256,
         }),
         verificationExpected,
+        targetAttested,
     );
     const afterVerification = await inventoryBuiltSite(buildRoot);
     if (
         inventoryIdentity(beforeVerification) !==
         inventoryIdentity(afterVerification)
     ) {
-        throw new Error("Astro build changed during production verification");
+        throw new Error("Astro build changed during site output verification");
     }
     await validateSelectedOccurrence(occurrenceOperations, checkpoint, policy);
 
@@ -1617,7 +1788,7 @@ export async function processOccurrenceSitePublishEvent({
             buildRoot,
             event: releaseEvent,
             sourceSnapshotManifestSha256: event.sourceSnapshotManifestSha256,
-            policyVersion: "occurrence-selected-production-v1",
+            policyVersion: publicationProfile.policyVersion,
             builderCommit: event.builderCommit,
             releasedAt: event.releasedAt,
             expectedSelectionSha256: event.expectedSiteSelectionSha256,
@@ -1627,7 +1798,12 @@ export async function processOccurrenceSitePublishEvent({
     }
     let published;
     try {
-        published = await publishedEventState(publication, event, checkpoint);
+        published = await publishedEventState(
+            publication,
+            event,
+            checkpoint,
+            publicationProfile,
+        );
     } catch (readError) {
         if (publicationError !== null) throw publicationError;
         throw readError;

--- a/site-astro/tests/occurrence-site-publisher.test.mjs
+++ b/site-astro/tests/occurrence-site-publisher.test.mjs
@@ -20,9 +20,16 @@ import { deflateSync } from "node:zlib";
 
 import {
     createOccurrenceSitePublishEvent,
+    occurrenceSiteOperationSha256,
+    occurrenceSitePublicationProfiles,
     occurrenceSitePublisherContract,
     processOccurrenceSitePublishEvent,
 } from "../scripts/lib/occurrence-site-publisher.mjs";
+import {
+    occurrenceSitePublisherRunnerContract,
+    runOccurrenceSitePublisherDelivery,
+} from "../scripts/lib/occurrence-site-publisher-runner.mjs";
+import { runOccurrenceSitePublishCli } from "../scripts/execute-occurrence-site-publish.mjs";
 import {
     draftBlockedOccurrenceExportPolicy,
     occurrenceExportPolicySha256,
@@ -127,6 +134,15 @@ function canonicalBytes(value) {
 
 function sha256(value) {
     return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalDocument(document) {
+    const bytes = canonicalBytes(document);
+    return {
+        document: structuredClone(document),
+        bytes,
+        sha256: sha256(bytes),
+    };
 }
 
 function missing() {
@@ -613,11 +629,20 @@ function publicationOperation(
     };
 }
 
-function buildOperation() {
+function buildOperation(
+    publicationProfile = null,
+    { targetOverride = null } = {},
+) {
+    const profiled = publicationProfile !== null;
     return {
         contract: "verdify.lab-selected-astro-build-operation",
-        schemaVersion: 1,
-        operationSha256: BUILD_OPERATION_SHA256,
+        schemaVersion: profiled ? 2 : 1,
+        operationSha256: profiled
+            ? occurrenceSiteOperationSha256("build", publicationProfile)
+            : BUILD_OPERATION_SHA256,
+        ...(profiled
+            ? { publicationProfile: structuredClone(publicationProfile) }
+            : {}),
         build: async (request) => {
             const buildRoot = path.join(
                 request.workspaceRoot,
@@ -644,7 +669,9 @@ function buildOperation() {
             await Promise.all([
                 writeFile(
                     path.join(buildRoot, "index.html"),
-                    "<!doctype html><title>Selected Astro proof</title>\n",
+                    profiled
+                        ? '<!doctype html><meta name="robots" content="noindex,follow"><title>Selected Astro stage proof</title>\n'
+                        : "<!doctype html><title>Selected Astro proof</title>\n",
                 ),
                 writeFile(
                     path.join(buildRoot, "occurrence-manifest.json"),
@@ -653,6 +680,18 @@ function buildOperation() {
                 writeFile(
                     path.join(buildRoot, "static-build.json"),
                     canonicalBytes({
+                        ...(profiled
+                            ? {
+                                  contract: "verdify.lab-astro-stage-build",
+                                  schemaVersion: 1,
+                                  siteOrigin:
+                                      targetOverride?.siteOrigin ??
+                                      publicationProfile.siteOrigin,
+                                  stageGlobalNoindex:
+                                      targetOverride?.stageGlobalNoindex ??
+                                      publicationProfile.stageGlobalNoindex,
+                              }
+                            : {}),
                         snapshotManifestDigest: `sha256:${request.event.sourceSnapshotManifestSha256}`,
                         selectedOccurrenceManifestSha256: `sha256:${selected.selection.current.manifestSha256}`,
                         grafanaOccurrenceCount:
@@ -871,11 +910,22 @@ function realCompilerBuildOperation(value, calls) {
     };
 }
 
-function verificationOperation() {
+function verificationOperation(
+    publicationProfile = null,
+    { resultOverride = null } = {},
+) {
+    const profiled = publicationProfile !== null;
     return {
-        contract: "verdify.lab-production-output-verification-operation",
-        schemaVersion: 1,
-        operationSha256: VERIFICATION_OPERATION_SHA256,
+        contract: profiled
+            ? "verdify.lab-site-output-verification-operation"
+            : "verdify.lab-production-output-verification-operation",
+        schemaVersion: profiled ? 2 : 1,
+        operationSha256: profiled
+            ? occurrenceSiteOperationSha256("verification", publicationProfile)
+            : VERIFICATION_OPERATION_SHA256,
+        ...(profiled
+            ? { publicationProfile: structuredClone(publicationProfile) }
+            : {}),
         verify: async (request) => {
             const build = JSON.parse(
                 await readFile(
@@ -890,9 +940,45 @@ function verificationOperation() {
                 ),
             );
             verifySelectedEvidence(build, occurrenceManifest);
+            if (
+                profiled &&
+                (request.siteOrigin !== publicationProfile.siteOrigin ||
+                    request.stageGlobalNoindex !==
+                        publicationProfile.stageGlobalNoindex ||
+                    request.policyVersion !==
+                        publicationProfile.policyVersion ||
+                    build.siteOrigin !== publicationProfile.siteOrigin ||
+                    build.stageGlobalNoindex !==
+                        publicationProfile.stageGlobalNoindex ||
+                    !(
+                        await readFile(
+                            path.join(request.buildRoot, "index.html"),
+                            "utf8",
+                        )
+                    ).includes('<meta name="robots" content="noindex,follow">'))
+            ) {
+                throw new Error(
+                    "stage verifier did not observe the bound origin and noindex output",
+                );
+            }
             return {
-                contract: "verdify.lab-production-output-verification-result",
-                schemaVersion: 1,
+                contract: profiled
+                    ? "verdify.lab-site-output-verification-result"
+                    : "verdify.lab-production-output-verification-result",
+                schemaVersion: profiled ? 2 : 1,
+                ...(profiled
+                    ? {
+                          siteOrigin:
+                              resultOverride?.siteOrigin ??
+                              publicationProfile.siteOrigin,
+                          stageGlobalNoindex:
+                              resultOverride?.stageGlobalNoindex ??
+                              publicationProfile.stageGlobalNoindex,
+                          policyVersion:
+                              resultOverride?.policyVersion ??
+                              publicationProfile.policyVersion,
+                      }
+                    : {}),
                 buildInventorySha256: request.buildInventorySha256,
                 buildContentIdentitySha256: request.buildContentIdentitySha256,
                 staticBuildSha256: request.staticBuildSha256,
@@ -996,6 +1082,10 @@ function eventFor(
     value,
     expectedSiteSelectionSha256,
     producerResult = value.producerResult,
+    operationIdentities = {
+        build: BUILD_OPERATION_SHA256,
+        verification: VERIFICATION_OPERATION_SHA256,
+    },
 ) {
     return createOccurrenceSitePublishEvent({
         sourceId: producerResult.exportBatch.reportingFeed.sourceId,
@@ -1009,8 +1099,8 @@ function eventFor(
         occurrenceStoreIdentitySha256: value.occurrenceStore.identity.sha256,
         producerResultSha256: sha256(canonicalBytes(producerResult)),
         builderCommit: BUILDER_COMMIT,
-        buildOperationSha256: BUILD_OPERATION_SHA256,
-        verificationOperationSha256: VERIFICATION_OPERATION_SHA256,
+        buildOperationSha256: operationIdentities.build,
+        verificationOperationSha256: operationIdentities.verification,
         siteStoreIdentitySha256: value.siteStore.identity.sha256,
         expectedSiteSelectionSha256,
     });
@@ -1574,5 +1664,244 @@ test("publisher has no default client, command, environment, or activation surfa
         verificationOperation: null,
         checkpointOperations: null,
         publicationOperation: null,
+    });
+});
+
+test("stage execution wrapper publishes one canonical delivery and rejects unbound execution", async (context) => {
+    const value = await fixture(context);
+    const profile = occurrenceSitePublicationProfiles.stage;
+    const stageBuild = buildOperation(profile);
+    const stageVerification = verificationOperation(profile);
+    const event = eventFor(value, null, value.producerResult, {
+        build: stageBuild.operationSha256,
+        verification: stageVerification.operationSha256,
+    });
+    const canonicalInputs = {
+        event: canonicalDocument(event),
+        producerResult: canonicalDocument(value.producerResult),
+        policy: canonicalDocument(value.policy),
+        manifest: canonicalDocument(value.manifest),
+        candidateRoot: value.candidateRoot,
+    };
+    const inputsFor = async (name) => {
+        const workspaceRoot = path.join(value.root, name);
+        await mkdir(workspaceRoot);
+        return { ...canonicalInputs, workspaceRoot };
+    };
+    const checkpoints = checkpointOperations(value.siteStore.identity.sha256);
+    const publication = publicationOperation(value.siteStore);
+    let runtimeCalls = 0;
+    const runtimeFactory =
+        ({
+            build = stageBuild,
+            verification = stageVerification,
+            siteOrigin = profile.siteOrigin,
+        } = {}) =>
+        async (request) => {
+            runtimeCalls += 1;
+            assert.equal(
+                request.contract,
+                "verdify.lab-stage-occurrence-site-runtime-request",
+            );
+            assert.deepEqual(request.publicationProfile, profile);
+            return {
+                contract: "verdify.lab-stage-occurrence-site-runtime",
+                schemaVersion: 1,
+                siteOrigin,
+                stageGlobalNoindex: true,
+                occurrenceStore: value.occurrenceStore,
+                buildOperation: build,
+                verificationOperation: verification,
+                checkpointOperations: checkpoints,
+                publicationOperation: publication,
+            };
+        };
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(await inputsFor("wrong-target"), {
+            createRuntime: runtimeFactory({
+                build: buildOperation(profile, {
+                    targetOverride: {
+                        siteOrigin: "https://lab.verdify.ai",
+                        stageGlobalNoindex: false,
+                    },
+                }),
+            }),
+        }),
+        /build does not attest the bound site publication target/,
+    );
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(await inputsFor("wrong-proof"), {
+            createRuntime: runtimeFactory({
+                verification: verificationOperation(profile, {
+                    resultOverride: {
+                        siteOrigin: "https://lab.verdify.ai",
+                    },
+                }),
+            }),
+        }),
+        /verifier did not attest the exact selected build and target/,
+    );
+
+    const inputs = await inputsFor("stage-execution-workspace");
+    const createRuntime = runtimeFactory();
+    const result = await runOccurrenceSitePublisherDelivery(inputs, {
+        createRuntime,
+    });
+    assert.equal(
+        result.contract,
+        occurrenceSitePublisherRunnerContract.result.contract,
+    );
+    assert.equal(result.siteOrigin, "https://lab-stage.verdify.ai");
+    assert.equal(result.stageGlobalNoindex, true);
+    assert.deepEqual(result.publicationProfile, profile);
+    assert.equal(result.publication.status, "published");
+    assert.equal(result.publication.eventSha256, inputs.event.sha256);
+    assert.equal(runtimeCalls, 3);
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(inputs),
+        /runtime is not configured; no default live action is available/,
+    );
+    assert.equal(runtimeCalls, 3);
+
+    const blockedPolicy = structuredClone(value.policy);
+    blockedPolicy.activation = {
+        ...blockedPolicy.activation,
+        state: "blocked",
+        approvedBy: null,
+        approvedAt: null,
+    };
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(
+            { ...inputs, policy: canonicalDocument(blockedPolicy) },
+            { createRuntime },
+        ),
+        /publication is disabled by the supplied policy/,
+    );
+    assert.equal(runtimeCalls, 3);
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(
+            { ...inputs, event: { ...inputs.event, sha256: "f".repeat(64) } },
+            { createRuntime },
+        ),
+        /canonical identity mismatch/,
+    );
+    assert.equal(runtimeCalls, 3);
+
+    const nestedWorkspace = path.join(value.candidateRoot, "nested-workspace");
+    await mkdir(nestedWorkspace);
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(
+            { ...canonicalInputs, workspaceRoot: nestedWorkspace },
+            { createRuntime },
+        ),
+        /roots must be disjoint/,
+    );
+    assert.equal(runtimeCalls, 3);
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(inputs, {
+            createRuntime: runtimeFactory({
+                siteOrigin: "https://lab.verdify.ai",
+            }),
+        }),
+        /does not preserve the closed noindex Lab stage contract/,
+    );
+
+    await assert.rejects(
+        runOccurrenceSitePublisherDelivery(inputs, {
+            createRuntime,
+            processEvent: async () => ({
+                ...result.publication,
+                eventSha256: "e".repeat(64),
+            }),
+        }),
+        /did not return the exact event-bound result/,
+    );
+});
+
+test("stage execution CLI keeps document reads and runtime creation explicit", async () => {
+    const paths = new Map([
+        ["event.json", { name: "event" }],
+        ["producer.json", { name: "producer" }],
+        ["policy.json", { name: "policy" }],
+        ["manifest.json", { name: "manifest" }],
+    ]);
+    const reads = [];
+    const runtime = async () => ({ configured: true });
+    let delivery;
+    const result = await runOccurrenceSitePublishCli(
+        [
+            "execute",
+            "--event",
+            "event.json",
+            "--producer-result",
+            "producer.json",
+            "--policy",
+            "policy.json",
+            "--manifest",
+            "manifest.json",
+            "--candidate-root",
+            "candidate",
+            "--workspace-root",
+            "workspace",
+        ],
+        {
+            readDocument: async (file, label) => {
+                reads.push([file, label]);
+                return paths.get(file);
+            },
+            createRuntime: runtime,
+            runDelivery: async (inputs, dependencies) => {
+                delivery = { inputs, dependencies };
+                return { status: "accepted" };
+            },
+        },
+    );
+    assert.deepEqual(result, { status: "accepted" });
+    assert.deepEqual(
+        reads.map(([file]) => file),
+        ["event.json", "producer.json", "policy.json", "manifest.json"],
+    );
+    assert.equal(delivery.inputs.event.name, "event");
+    assert.equal(delivery.inputs.producerResult.name, "producer");
+    assert.equal(delivery.dependencies.createRuntime, runtime);
+    assert.equal(delivery.dependencies.processEvent, undefined);
+    assert.equal(delivery.inputs.candidateRoot, path.resolve("candidate"));
+    assert.equal(delivery.inputs.workspaceRoot, path.resolve("workspace"));
+
+    await assert.rejects(runOccurrenceSitePublishCli(["status"]), /Usage:/);
+    await assert.rejects(
+        runOccurrenceSitePublishCli(["execute", "--event", "event.json"]),
+        /Usage:/,
+    );
+});
+
+test("stage execution source has no implicit live integration surface", async () => {
+    const source = await Promise.all([
+        readFile(
+            new URL(
+                "../scripts/lib/occurrence-site-publisher-runner.mjs",
+                import.meta.url,
+            ),
+            "utf8",
+        ),
+        readFile(
+            new URL(
+                "../scripts/execute-occurrence-site-publish.mjs",
+                import.meta.url,
+            ),
+            "utf8",
+        ),
+    ]);
+    assert.doesNotMatch(
+        source.join("\n"),
+        /process\.env|node:child_process|spawnSync|execFile|fetch\s*\(|@aws-sdk|kubectl|kubernetes|argocd|replicas?:/iu,
+    );
+    assert.deepEqual(occurrenceSitePublisherRunnerContract.defaults, {
+        createRuntime: null,
     });
 });


### PR DESCRIPTION
Phase 4c/4b source prerequisite for #476 and #480.

What:
- adds the canonical file-transported occurrence-to-site execute command
- binds build and verifier operations to one digest-identified Lab stage/noindex publication profile
- verifies exact input, event, build, verifier, release-policy, and retry identities
- rejects linked or overlapping candidate/workspace roots

Validation:
- independent review and re-review: no blockers
- focused profiled publisher proof: 3/3
- Astro unit: 194/194
- complete Astro test gate: green, including 31 parity and 13 browser-quality tests
- root lint: green
- full repo scripts/ci-local.sh: ALL GATES GREEN

Boundary: source-only. The command has no default runtime, endpoint, credential, environment reader, network client, workload, route, replica, or activation path. It does not provision or access object storage and does not sync stage or production. The real stage build/verifier and explicit S3 factories remain the next runtime-injection slice; Jason activation approval remains pending.