### PR TITLE
gitops(stage): pin Verdify Lab runtime images sha256:556b8e4d76e76876c4e492342cbf85c1369228f88250b97c4a69cb64494ba2b2 for 6ecb5a8f8aea6ebc1f0a74b177a548b33da3416a

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -19,10 +19,10 @@ images:
   # replicas; digest presence alone is not rollout authority.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
-    digest: sha256:3ae9f1f2cec8ee3d6748a37bf2ce8d9a780230d1ad5ef69ebdd35ce1d7f3fac9
+    digest: sha256:984eb3c514c297d8c45d5915fdcecc2da27502e48e1607108fba2bbfafc5736d
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
-    digest: sha256:004320c7ba9b4d038509f86d8929f5d60dd68dc4455251b2cb068e6f769074ee
+    digest: sha256:bfe7a20ddc67fd16e37c81827312772e19df121bcdfe5219250731f520fcc275
 
 patches:
   - path: lab-release-runtime-dormant.patch.yaml


### PR DESCRIPTION
Stage-only digest pin for the dormant release-agent/nginx pair (jvallery/agents#2930). Source revision: 6ecb5a8f8aea6ebc1f0a74b177a548b33da3416a. The serving static Astro digest is unchanged; the release runtime remains replicas=0 and unrouted. Review and merge do not authorize runtime activation, production cutover, or production APPLY.