### PR TITLE
feat(lab): package dormant occurrence exporter contract image

### DIFF
--- a/docs/agents/web.md
+++ b/docs/agents/web.md
@@ -155,6 +155,21 @@ Kubernetes manifest or Secret values, endpoint probe, network call, replica,
 egress, route, sync, activation, distributed lease, retention/GC, or credential
 provisioning. Merging this source prerequisite does not activate it.
 
+`site-astro/Dockerfile.release-runtime` also carries a source-only
+`occurrence-exporter` target. It derives from the locked dependency stage and
+copies only two project-source files: an offline verifier and the shared
+contract module imported by the real graph, camera, and joint producers. Its
+default command reports `packaged` / `runtime-unbound`
+after checking the 143-graph, two-camera, and joint runner contracts. The target
+runs as `101:101`, grants no release/device/live authority, and bakes no policy,
+runtime configuration, object-store endpoint, credential, or reporting feed.
+Its required build revision and release instant are syntax-checked, recorded in
+OCI revision/created labels, and repeated in canonical metadata that the
+verifier validates and emits.
+It is not a runnable graph renderer: there is no runtime binding, workload,
+overlay image sentinel, built digest, pin, route, or activation for this target
+yet.
+
 `scripts/rebuild-site.sh` builds Quartz into a staged `public.*` directory,
 verifies the staged `index.html`, then rsyncs the complete staged output into
 the live public tree with delayed deletes. In k3s, nginx reload is skipped

--- a/docs/plans/lab-astro-migration.md
+++ b/docs/plans/lab-astro-migration.md
@@ -13,6 +13,9 @@ make no endpoint, value, credential, deployment, or activation claim.
 Phase 4b PR #525 carries strict runtime S3 dependency injection. It is a
 source-only prerequisite and does not change the live stage or satisfy a
 build, pin, rollout, or activation gate.
+The source tree also defines an offline-default `occurrence-exporter` image target;
+it has no renderer/runtime binding, workload, digest, or pin and is not part of
+the latest completed image chain.
 Owner: platform agent (Claude outer loop plans/verifies; Codex executes on
 xhigh). Human gate: Jason (prod sync, DNS/edge, Quartz retirement, credential
 work). Epic: #351 (L9, G3). This file is the single source of truth for the
@@ -25,7 +28,7 @@ changes state.
 |---|---|
 | `lab.verdify.ai` (prod) | Quartz. `verdify-lab` Deployment in `verdify-prod` (ghcr image — pre-ADR-0021 holdover), `verdify-lab-publisher` CronJob republished every 10 min (mutable, shared RWO PVC, both replicas node-pinned). Healthy and fresh; had a 5-job BackoffLimitExceeded streak before recovering. |
 | `lab-stage.verdify.ai` (canary) | Astro. `verdify-lab-astro-stage` in ns `verdify-platform`, 2/2 Ready with zero restarts on distinct nodes, exact image and pod image IDs `verdify-lab-astro@sha256:ee36941f20028fcfe06f12bf253e7139c00e3d5de1949eb8b12bb1d4ebe60b99` (pin PR #468), shell contract **1.1.0**, content frozen at the 2026-07-12 snapshot. Live T0/T+10 acceptance passed and the ArgoCD app returned to manual-sync. |
-| `main` | Astro source includes the accepted static implementation, dormant release/cache runtime, offline camera producer (#487), complete offline 143-graph producer (#492), inactive S3 conditional-store foundation (#496), typed occurrence store (#502), and the closed 143+2 caller (#507). The concrete store-operation adapter and execute CLI in this source tree require an explicit store plus canonical Jason-approved policy before initialization. Runtime pin #500 binds the dormant agent/nginx pair to the latest completed relevant source chain; later source changes are not automatically staged. The source-only name-readiness contract is carried by #501, not yet a deployed binding. The live stage remains the static image above; endpoint binding, event delivery, exact parity, and production cutover remain. |
+| `main` | Astro source includes the accepted static implementation, dormant release/cache runtime, offline camera producer (#487), complete offline 143-graph producer (#492), inactive S3 conditional-store foundation (#496), typed occurrence store (#502), and the closed 143+2 caller (#507). The concrete store-operation adapter and execute CLI in this source tree require an explicit store plus canonical Jason-approved policy before initialization. Runtime pin #500 binds the dormant agent/nginx pair to the latest completed relevant source chain; later source changes are not automatically staged. A fourth source-only `occurrence-exporter` Docker target packages the producer contracts behind an offline verifier, but has no renderer/runtime binding, workload, built digest, or pin. The source-only name-readiness contract is carried by #501, not yet a deployed binding. The live stage remains the static image above; endpoint binding, event delivery, exact parity, and production cutover remain. |
 | Phase 4b PR #525 | Strict source-only S3 injection fixes endpoint `https://s3-hdd.vallery.net` and region `garage`, enforces reader/writer roles, and adds explicit CLI/reconciler and construction-only stage-publisher bindings. It selects no workload and authorizes no activation. |
 | In-cluster CI | **Green for the latest completed Lab source/pin chain.** Workflow `verdify-platform-ci-crv96` completed 17/17 Lab Pod gates for `6729cc2...`: 12 browser quality tests, static/agent/nginx builds, metadata hydration, exact static probe, and paired runtime probe. Pin #500 passed exact-head PR CI/render/kubeconform and its digest-only follow-up workflow passed. Later exact-main workflows do not authorize stage sync or runtime activation. Earlier Playwright fixes #463/#464 and agents#2969/#2970 remain enforced without relaxing quality budgets. |
 
@@ -182,6 +185,16 @@ Phase 4 — **Feature completion (owner: codex, critical-path order below).**
    `verdify-platform-ci-crv96` and #500. This proves the packaged source pair
    only; no stage sync,
    reporting feed, producer request, route, or runtime activation occurred.
+   The source tree now also defines an `occurrence-exporter` target derived from
+   the locked dependencies image. It copies only two additional project-source
+   files: an offline verifier and the shared contract module consumed by the
+   real graph, camera, and joint producers. It runs as `101:101`, grants no
+   release/device/live authority, and defaults to
+   an offline contract verifier. This is packaging source only: no runnable
+   renderer, runtime binding, workload, overlay image sentinel, built digest,
+   pin, endpoint, credential, policy, reporting feed, or activation exists for
+   it yet. Required build revision/release-time arguments are validated and
+   bound into OCI labels plus canonical verifier-emitted image metadata.
 2. **4a Release runtime:** `d91737d` landed via #473 with init hydration,
    atomic runtime, readiness, metrics, and tests. The follow-through makes the
    candidate visible in the Lab stage GitOps source only as a truly disconnected

--- a/docs/site-publishing-pipeline.md
+++ b/docs/site-publishing-pipeline.md
@@ -159,6 +159,26 @@ source-only merge needs no service restart. Any stage rollout needs the
 normal stage acceptance and delayed durability probes; production sync, public
 cutover, and Quartz retirement remain human-gated.
 
+The release-runtime Dockerfile contains a source-only
+`occurrence-exporter` packaging target. It derives from the locked Node
+dependencies stage and copies only two project-source files into it: an
+offline verifier and the shared contract module consumed by the real graph,
+camera, and joint producers. It runs as `101:101`
+and defaults to `verify-occurrence-exporter-image.mjs`. That verifier imports
+and checks the existing graph, camera, and joint runner contracts, emits a
+deterministic `packaged` / `runtime-unbound` status, and invokes no network,
+store, capture, or render operation. The target grants no release, device, or
+live authority and contains no policy, runtime configuration, endpoint,
+credential, or reporting feed.
+The build requires a 40/64-hex source revision and canonical UTC release time,
+binds them to OCI revision/created labels, and writes the same values into a
+canonical metadata record that the default verifier validates and emits.
+
+This is not a deployable exporter runtime claim. No graph renderer or other
+runtime dependency is selected, no Kubernetes workload or overlay image
+sentinel references the target, and no build digest or pin exists for it yet.
+Those remain separate source, CI, GitOps, and Jason-gated activation steps.
+
 The specialist-occurrence fixture is separate from the complete built-tree release
 store below. It retains ten occurrence manifests and two selected media generations,
 but does not claim a deployed object-store adapter or distributed lease.

--- a/site-astro/Dockerfile.release-runtime
+++ b/site-astro/Dockerfile.release-runtime
@@ -45,6 +45,31 @@ USER 101:101
 ENTRYPOINT ["/app/release-runtime/entrypoint.sh"]
 CMD ["reconcile"]
 
+FROM dependencies AS occurrence-exporter
+
+ARG LAB_EXPORTER_BUILDER_COMMIT
+ARG LAB_EXPORTER_RELEASED_AT
+
+LABEL org.opencontainers.image.title="Verdify Lab occurrence exporter" \
+      org.opencontainers.image.description="Packaged offline producer contracts with no runtime binding" \
+      org.opencontainers.image.revision="${LAB_EXPORTER_BUILDER_COMMIT}" \
+      org.opencontainers.image.created="${LAB_EXPORTER_RELEASED_AT}" \
+      ai.verdify.release-authority="none" \
+      ai.verdify.device-authority="none" \
+      ai.verdify.live-authority="none"
+
+COPY scripts/verify-occurrence-exporter-image.mjs /app/scripts/verify-occurrence-exporter-image.mjs
+COPY scripts/lib/occurrence-producer-contracts.mjs /app/scripts/lib/occurrence-producer-contracts.mjs
+RUN printf '%s' "${LAB_EXPORTER_BUILDER_COMMIT}" | grep -Eq '^[0-9a-f]{40}([0-9a-f]{24})?$' \
+    && printf '%s' "${LAB_EXPORTER_RELEASED_AT}" | grep -Eq '^20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})?Z$' \
+    && printf '{\n  "contract": "verdify.lab-occurrence-exporter-image-metadata",\n  "schemaVersion": 1,\n  "builderCommit": "%s",\n  "releasedAt": "%s"\n}\n' \
+      "${LAB_EXPORTER_BUILDER_COMMIT}" "${LAB_EXPORTER_RELEASED_AT}" \
+      > /app/occurrence-exporter-image.json \
+    && node /app/scripts/verify-occurrence-exporter-image.mjs > /dev/null
+
+USER 101:101
+CMD ["node", "/app/scripts/verify-occurrence-exporter-image.mjs"]
+
 FROM nginxinc/nginx-unprivileged:1.29.3-alpine@sha256:f7d0d0f2ebc0486dc110278672b9073f7fd641e58376b112b0c8865cf36d2e36 AS site
 
 LABEL org.opencontainers.image.title="Verdify Lab atomic release server" \

--- a/site-astro/scripts/lib/camera-export-producer.mjs
+++ b/site-astro/scripts/lib/camera-export-producer.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import sharp from "sharp";
 
+import { cameraExportProducerContract } from "./occurrence-producer-contracts.mjs";
 import {
   occurrenceExportPolicySha256,
   validateOccurrenceExportPolicy,
@@ -16,18 +17,18 @@ import { decodePng, validatePngFile } from "./png-validation.mjs";
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
-const MAX_TIMEOUT_MS = 15_000;
-const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = cameraExportProducerContract.maxTimeoutMs;
+const DEFAULT_TIMEOUT_MS = cameraExportProducerContract.defaultTimeoutMs;
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
 
 // #483 deliberately approved exactly these two public, read-only requests. Keep
 // this producer closed if a later policy is broadened accidentally.
 const APPROVED_CAMERA_REQUESTS = new Map([
-  ["media_024bdac9f86794c7d1f36d48", {
+  [cameraExportProducerContract.approvedOccurrenceIds[0], {
     url: "https://api.verdify.ai/api/v1/public/cameras/greenhouse_2/latest.jpg?h=1080",
     requestProvenanceSha256: "34d53abda8ab745e106c0719534a554769a9b1017f22b7bb40e5895a6be74a34",
   }],
-  ["media_4e973f995789201d00aed8fd", {
+  [cameraExportProducerContract.approvedOccurrenceIds[1], {
     url: "https://api.verdify.ai/api/v1/public/cameras/greenhouse_1/latest.jpg?h=1080",
     requestProvenanceSha256: "0667d58e2f39c22e68bd906d3e4c754de1b41a845487eb55654aadba37c76fe0",
   }],
@@ -427,8 +428,4 @@ export async function captureCameraOccurrence({
   };
 }
 
-export const cameraExportProducerContract = {
-  approvedOccurrenceIds: [...APPROVED_CAMERA_REQUESTS.keys()],
-  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-  maxTimeoutMs: MAX_TIMEOUT_MS,
-};
+export { cameraExportProducerContract };

--- a/site-astro/scripts/lib/graph-export-producer.mjs
+++ b/site-astro/scripts/lib/graph-export-producer.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import sharp from "sharp";
 
+import { graphExportProducerContract } from "./occurrence-producer-contracts.mjs";
 import {
   occurrenceExportPolicySha256,
   reportingFeedEnvelopeSha256,
@@ -15,24 +16,18 @@ import {
 } from "./occurrence-candidate-store.mjs";
 import { decodePng } from "./png-validation.mjs";
 
-const EXPECTED_GRAPH_COUNT = 143;
-const MAX_CONCURRENCY = 4;
-const DEFAULT_CONCURRENCY = 4;
-const MAX_TIMEOUT_MS = 15_000;
-const DEFAULT_TIMEOUT_MS = 10_000;
-const MAX_SETTLEMENT_GRACE_MS = 250;
-const DEFAULT_SETTLEMENT_GRACE_MS = 50;
+const EXPECTED_GRAPH_COUNT = graphExportProducerContract.expectedGraphCount;
+const MAX_CONCURRENCY = graphExportProducerContract.maxConcurrency;
+const DEFAULT_CONCURRENCY = graphExportProducerContract.defaultConcurrency;
+const MAX_TIMEOUT_MS = graphExportProducerContract.maxTimeoutMs;
+const DEFAULT_TIMEOUT_MS = graphExportProducerContract.defaultTimeoutMs;
+const MAX_SETTLEMENT_GRACE_MS = graphExportProducerContract.maxSettlementGraceMs;
+const DEFAULT_SETTLEMENT_GRACE_MS = graphExportProducerContract.defaultSettlementGraceMs;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
 const WAIT_TIMEOUT = Symbol("wait-timeout");
-const LEGACY_DATASOURCE_DASHBOARD_UIDS = Object.freeze([
-  "greenhouse-equipment",
-  "greenhouse-hydroponics",
-  "greenhouse-lighting",
-  "greenhouse-soil",
-  "greenhouse-weather",
-]);
+const LEGACY_DATASOURCE_DASHBOARD_UIDS = graphExportProducerContract.legacyDatasourceDashboardUids;
 const LEGACY_DATASOURCE_DASHBOARD_UID_SET = new Set(LEGACY_DATASOURCE_DASHBOARD_UIDS);
 const FORBIDDEN_DATASOURCE_IDENTITIES = new Set([
   "P44368ADAD746BC27",
@@ -690,23 +685,4 @@ export async function produceGraphExportCandidates({
   };
 }
 
-export const graphExportProducerContract = Object.freeze({
-  expectedGraphCount: EXPECTED_GRAPH_COUNT,
-  defaultConcurrency: DEFAULT_CONCURRENCY,
-  maxConcurrency: MAX_CONCURRENCY,
-  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-  maxTimeoutMs: MAX_TIMEOUT_MS,
-  defaultSettlementGraceMs: DEFAULT_SETTLEMENT_GRACE_MS,
-  maxSettlementGraceMs: MAX_SETTLEMENT_GRACE_MS,
-  renderer: Object.freeze({
-    contract: "verdify.lab-graph-renderer",
-    schemaVersion: 3,
-    sourceClass: "operator-owned-reporting-tier",
-    anonymousAccess: false,
-    reportingFeedSha256: "required-exact-plan-digest",
-    reportingDatasourceIdentitySha256: "required-dedicated-identity-digest",
-    abortCooperation: "settle-within-grace-after-abort",
-  }),
-  legacyDatasourceDashboardUids: LEGACY_DATASOURCE_DASHBOARD_UIDS,
-  probeStatuses: Object.freeze(["success", "timeout", "http-error", "decode-error", "missing"]),
-});
+export { graphExportProducerContract };

--- a/site-astro/scripts/lib/occurrence-producer-contracts.mjs
+++ b/site-astro/scripts/lib/occurrence-producer-contracts.mjs
@@ -1,0 +1,60 @@
+export const graphExportProducerContract = Object.freeze({
+  expectedGraphCount: 143,
+  defaultConcurrency: 4,
+  maxConcurrency: 4,
+  defaultTimeoutMs: 10_000,
+  maxTimeoutMs: 15_000,
+  defaultSettlementGraceMs: 50,
+  maxSettlementGraceMs: 250,
+  renderer: Object.freeze({
+    contract: "verdify.lab-graph-renderer",
+    schemaVersion: 3,
+    sourceClass: "operator-owned-reporting-tier",
+    anonymousAccess: false,
+    reportingFeedSha256: "required-exact-plan-digest",
+    reportingDatasourceIdentitySha256: "required-dedicated-identity-digest",
+    abortCooperation: "settle-within-grace-after-abort",
+  }),
+  legacyDatasourceDashboardUids: Object.freeze([
+    "greenhouse-equipment",
+    "greenhouse-hydroponics",
+    "greenhouse-lighting",
+    "greenhouse-soil",
+    "greenhouse-weather",
+  ]),
+  probeStatuses: Object.freeze(["success", "timeout", "http-error", "decode-error", "missing"]),
+});
+
+export const cameraExportProducerContract = Object.freeze({
+  approvedOccurrenceIds: Object.freeze([
+    "media_024bdac9f86794c7d1f36d48",
+    "media_4e973f995789201d00aed8fd",
+  ]),
+  defaultTimeoutMs: 10_000,
+  maxTimeoutMs: 15_000,
+});
+
+export const occurrenceProducerRunnerContract = Object.freeze({
+  expectedGraphCount: 143,
+  expectedCurrentMediaCount: 2,
+  expectedLegacyOverrideCount: 40,
+  expectedReportingDefaultCount: 103,
+  defaultCameraConcurrency: 2,
+  maxCameraConcurrency: 2,
+  defaultCameraMaxAttempts: 2,
+  maxCameraMaxAttempts: 3,
+  retryableCameraStatuses: Object.freeze([
+    "timeout",
+    "http-error",
+    "decode-error",
+    "missing",
+  ]),
+  selectorReader: Object.freeze({
+    contract: "verdify.lab-occurrence-selector-precondition-reader",
+    schemaVersion: 1,
+  }),
+  result: Object.freeze({
+    contract: "verdify.lab-occurrence-producer-run",
+    schemaVersion: 1,
+  }),
+});

--- a/site-astro/scripts/lib/occurrence-producer-runner.mjs
+++ b/site-astro/scripts/lib/occurrence-producer-runner.mjs
@@ -19,24 +19,25 @@ import {
   captureCameraOccurrence,
   validateCameraExportRequest,
 } from "./camera-export-producer.mjs";
+import { occurrenceProducerRunnerContract } from "./occurrence-producer-contracts.mjs";
 import { validateOccurrenceProducerResult } from "./occurrence-producer-result-contract.mjs";
 
 const SHA256_RE = /^[0-9a-f]{64}$/u;
 const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u;
-const EXPECTED_GRAPH_COUNT = graphExportBatchContract.expectedGraphCount;
-const EXPECTED_CURRENT_MEDIA_COUNT = graphExportBatchContract.expectedCurrentMediaCount;
-const EXPECTED_LEGACY_OVERRIDE_COUNT = 40;
-const EXPECTED_REPORTING_DEFAULT_COUNT = 103;
-const DEFAULT_CAMERA_CONCURRENCY = 2;
-const MAX_CAMERA_CONCURRENCY = 2;
-const DEFAULT_CAMERA_MAX_ATTEMPTS = 2;
-const MAX_CAMERA_MAX_ATTEMPTS = 3;
-const RETRYABLE_CAMERA_STATUSES = Object.freeze([
-  "timeout",
-  "http-error",
-  "decode-error",
-  "missing",
-]);
+const EXPECTED_GRAPH_COUNT = occurrenceProducerRunnerContract.expectedGraphCount;
+const EXPECTED_CURRENT_MEDIA_COUNT = occurrenceProducerRunnerContract.expectedCurrentMediaCount;
+const EXPECTED_LEGACY_OVERRIDE_COUNT = occurrenceProducerRunnerContract.expectedLegacyOverrideCount;
+const EXPECTED_REPORTING_DEFAULT_COUNT = occurrenceProducerRunnerContract.expectedReportingDefaultCount;
+const DEFAULT_CAMERA_CONCURRENCY = occurrenceProducerRunnerContract.defaultCameraConcurrency;
+const MAX_CAMERA_CONCURRENCY = occurrenceProducerRunnerContract.maxCameraConcurrency;
+const DEFAULT_CAMERA_MAX_ATTEMPTS = occurrenceProducerRunnerContract.defaultCameraMaxAttempts;
+const MAX_CAMERA_MAX_ATTEMPTS = occurrenceProducerRunnerContract.maxCameraMaxAttempts;
+const RETRYABLE_CAMERA_STATUSES = occurrenceProducerRunnerContract.retryableCameraStatuses;
+
+if (
+  EXPECTED_GRAPH_COUNT !== graphExportBatchContract.expectedGraphCount
+  || EXPECTED_CURRENT_MEDIA_COUNT !== graphExportBatchContract.expectedCurrentMediaCount
+) throw new Error("occurrence producer runner and export batch contracts disagree");
 
 function canonicalBytes(value) {
   return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
@@ -523,22 +524,4 @@ export async function runOccurrenceProducer({
   return result;
 }
 
-export const occurrenceProducerRunnerContract = Object.freeze({
-  expectedGraphCount: EXPECTED_GRAPH_COUNT,
-  expectedCurrentMediaCount: EXPECTED_CURRENT_MEDIA_COUNT,
-  expectedLegacyOverrideCount: EXPECTED_LEGACY_OVERRIDE_COUNT,
-  expectedReportingDefaultCount: EXPECTED_REPORTING_DEFAULT_COUNT,
-  defaultCameraConcurrency: DEFAULT_CAMERA_CONCURRENCY,
-  maxCameraConcurrency: MAX_CAMERA_CONCURRENCY,
-  defaultCameraMaxAttempts: DEFAULT_CAMERA_MAX_ATTEMPTS,
-  maxCameraMaxAttempts: MAX_CAMERA_MAX_ATTEMPTS,
-  retryableCameraStatuses: RETRYABLE_CAMERA_STATUSES,
-  selectorReader: Object.freeze({
-    contract: "verdify.lab-occurrence-selector-precondition-reader",
-    schemaVersion: 1,
-  }),
-  result: Object.freeze({
-    contract: "verdify.lab-occurrence-producer-run",
-    schemaVersion: 1,
-  }),
-});
+export { occurrenceProducerRunnerContract };

--- a/site-astro/scripts/verify-occurrence-exporter-image.mjs
+++ b/site-astro/scripts/verify-occurrence-exporter-image.mjs
@@ -1,0 +1,123 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+import {
+  cameraExportProducerContract,
+  graphExportProducerContract,
+  occurrenceProducerRunnerContract,
+} from "./lib/occurrence-producer-contracts.mjs";
+
+function requireContract(condition, label) {
+  if (!condition) throw new Error(`packaged occurrence exporter ${label} contract is invalid`);
+}
+
+const METADATA_PATH = "/app/occurrence-exporter-image.json";
+const SOURCE_REVISION_RE = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
+const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u;
+
+function exactKeys(value, keys) {
+  return value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype
+    && Object.keys(value).join(",") === keys.join(",");
+}
+
+function validateMetadata(metadata) {
+  requireContract(
+    exactKeys(metadata, ["contract", "schemaVersion", "builderCommit", "releasedAt"])
+      && metadata.contract === "verdify.lab-occurrence-exporter-image-metadata"
+      && metadata.schemaVersion === 1
+      && SOURCE_REVISION_RE.test(metadata.builderCommit)
+      && ISO_INSTANT_RE.test(metadata.releasedAt),
+    "source metadata",
+  );
+  const parsed = Date.parse(metadata.releasedAt);
+  const normalized = Number.isFinite(parsed) ? new Date(parsed).toISOString() : "";
+  const expected = metadata.releasedAt.includes(".") ? normalized : normalized.replace(".000Z", "Z");
+  requireContract(metadata.releasedAt === expected, "source metadata time");
+  return metadata;
+}
+
+export function verifyOccurrenceExporterImage(metadata) {
+  validateMetadata(metadata);
+  requireContract(
+    graphExportProducerContract.expectedGraphCount === 143
+      && graphExportProducerContract.renderer.contract === "verdify.lab-graph-renderer"
+      && graphExportProducerContract.renderer.schemaVersion === 3
+      && graphExportProducerContract.renderer.sourceClass === "operator-owned-reporting-tier"
+      && graphExportProducerContract.renderer.anonymousAccess === false,
+    "graph producer",
+  );
+  requireContract(
+    cameraExportProducerContract.approvedOccurrenceIds.length === 2
+      && new Set(cameraExportProducerContract.approvedOccurrenceIds).size === 2
+      && cameraExportProducerContract.defaultTimeoutMs > 0
+      && cameraExportProducerContract.defaultTimeoutMs <= cameraExportProducerContract.maxTimeoutMs,
+    "camera producer",
+  );
+  requireContract(
+    occurrenceProducerRunnerContract.expectedGraphCount === 143
+      && occurrenceProducerRunnerContract.expectedCurrentMediaCount === 2
+      && occurrenceProducerRunnerContract.expectedLegacyOverrideCount
+        + occurrenceProducerRunnerContract.expectedReportingDefaultCount === 143
+      && occurrenceProducerRunnerContract.result.contract === "verdify.lab-occurrence-producer-run"
+      && occurrenceProducerRunnerContract.result.schemaVersion === 1,
+    "runner",
+  );
+
+  return Object.freeze({
+    contract: "verdify.lab-occurrence-exporter-image-status",
+    schemaVersion: 1,
+    status: "packaged",
+    runtime: "runtime-unbound",
+    source: Object.freeze({
+      builderCommit: metadata.builderCommit,
+      releasedAt: metadata.releasedAt,
+    }),
+    authorities: Object.freeze({
+      release: "none",
+      device: "none",
+      live: "none",
+    }),
+    operations: Object.freeze({
+      network: "not-invoked",
+      store: "not-invoked",
+      capture: "not-invoked",
+      render: "not-invoked",
+    }),
+    producerContracts: Object.freeze({
+      graphs: "verified-143",
+      cameras: "verified-2",
+      runner: "verified-143-plus-2",
+    }),
+  });
+}
+
+export async function verifyPackagedOccurrenceExporterImage(metadataPath = METADATA_PATH) {
+  const bytes = await readFile(metadataPath);
+  requireContract(bytes.length > 0 && bytes.length <= 1024, "source metadata bytes");
+  let metadata;
+  try {
+    metadata = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("packaged occurrence exporter source metadata is not JSON");
+  }
+  requireContract(
+    Buffer.from(`${JSON.stringify(metadata, null, 2)}\n`).compare(bytes) === 0,
+    "source metadata canonical bytes",
+  );
+  return verifyOccurrenceExporterImage(metadata);
+}
+
+async function main() {
+  process.stdout.write(`${JSON.stringify(await verifyPackagedOccurrenceExporterImage(), null, 2)}\n`);
+}
+
+const executablePath = process.argv[1];
+if (executablePath && import.meta.url === pathToFileURL(executablePath).href) {
+  main().catch((error) => {
+    process.stderr.write(`verify-occurrence-exporter-image: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/site-astro/tests/manifests.test.mjs
+++ b/site-astro/tests/manifests.test.mjs
@@ -17,6 +17,18 @@ import {
   siteContentIdentitySha256,
   siteReleasePayloadSha256,
 } from "../scripts/lib/site-release-store.mjs";
+import { cameraExportProducerContract as cameraImplementationContract } from "../scripts/lib/camera-export-producer.mjs";
+import { graphExportProducerContract as graphImplementationContract } from "../scripts/lib/graph-export-producer.mjs";
+import {
+  cameraExportProducerContract,
+  graphExportProducerContract,
+  occurrenceProducerRunnerContract,
+} from "../scripts/lib/occurrence-producer-contracts.mjs";
+import { occurrenceProducerRunnerContract as runnerImplementationContract } from "../scripts/lib/occurrence-producer-runner.mjs";
+import {
+  verifyOccurrenceExporterImage,
+  verifyPackagedOccurrenceExporterImage,
+} from "../scripts/verify-occurrence-exporter-image.mjs";
 
 const SITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const REPO_ROOT = path.resolve(SITE_ROOT, "..");
@@ -272,6 +284,93 @@ test("release runtime images bake a real digest-bound fallback and serve only th
     AWS_SECRET_ACCESS_KEY: "fixture-secret-key",
   });
   assert.equal(Object.isFrozen(config.cliEnvironment), true);
+});
+
+test("occurrence exporter image is packaged offline before the unchanged default site target", async () => {
+  const dockerfile = await readFile(path.join(SITE_ROOT, "Dockerfile.release-runtime"), "utf8");
+  const stages = [...dockerfile.matchAll(/^FROM\s+\S+(?:\s+AS\s+(\S+))?\s*$/gmi)]
+    .map((match) => match[1] ?? "");
+  assert.deepEqual(stages, ["dependencies", "build", "agent", "occurrence-exporter", "site"]);
+  assert.equal(stages.at(-1), "site", "the final implicit release-runtime target must remain the site server");
+
+  const exporterStart = dockerfile.indexOf("FROM dependencies AS occurrence-exporter");
+  const exporterEnd = dockerfile.indexOf("FROM nginxinc/nginx-unprivileged", exporterStart);
+  const exporter = dockerfile.slice(exporterStart, exporterEnd);
+  assert.match(exporter, /ai\.verdify\.release-authority="none"/u);
+  assert.match(exporter, /ai\.verdify\.device-authority="none"/u);
+  assert.match(exporter, /ai\.verdify\.live-authority="none"/u);
+  assert.match(exporter, /ARG LAB_EXPORTER_BUILDER_COMMIT/u);
+  assert.match(exporter, /ARG LAB_EXPORTER_RELEASED_AT/u);
+  assert.match(exporter, /org\.opencontainers\.image\.revision="\$\{LAB_EXPORTER_BUILDER_COMMIT\}"/u);
+  assert.match(exporter, /org\.opencontainers\.image\.created="\$\{LAB_EXPORTER_RELEASED_AT\}"/u);
+  assert.match(exporter, /verdify\.lab-occurrence-exporter-image-metadata/u);
+  assert.match(exporter, /\^\[0-9a-f\]\{40\}\(\[0-9a-f\]\{24\}\)\?\$/u);
+  assert.match(exporter, /USER 101:101/u);
+  assert.match(exporter, /CMD \["node", "\/app\/scripts\/verify-occurrence-exporter-image\.mjs"\]/u);
+  assert.doesNotMatch(exporter, /^ENV\s/mu);
+  assert.doesNotMatch(exporter, /COPY\s+\.\s|COPY[^\n]*(?:config|policy|credential|feed)|https?:\/\/|AWS_|LAB_S3_/u);
+
+  const copiedScripts = [...exporter.matchAll(/^COPY\s+(scripts\/[^\s]+)\s+\/app\/scripts\//gmu)]
+    .map((match) => match[1]);
+  assert.deepEqual(copiedScripts, [
+    "scripts/verify-occurrence-exporter-image.mjs",
+    "scripts/lib/occurrence-producer-contracts.mjs",
+  ]);
+  assert.strictEqual(graphImplementationContract, graphExportProducerContract);
+  assert.strictEqual(cameraImplementationContract, cameraExportProducerContract);
+  assert.strictEqual(runnerImplementationContract, occurrenceProducerRunnerContract);
+  const packagedSource = await Promise.all(copiedScripts.map((relative) => readFile(path.join(SITE_ROOT, relative), "utf8")));
+  assert.doesNotMatch(
+    packagedSource.join("\n"),
+    /https?:\/\/|AWS_|LAB_S3_|S3Client|process\.env|\bfetch\s*\(|\bsharp\b/u,
+  );
+
+  const metadata = {
+    contract: "verdify.lab-occurrence-exporter-image-metadata",
+    schemaVersion: 1,
+    builderCommit: "1".repeat(40),
+    releasedAt: "2026-07-14T01:02:03Z",
+  };
+  const expected = {
+    contract: "verdify.lab-occurrence-exporter-image-status",
+    schemaVersion: 1,
+    status: "packaged",
+    runtime: "runtime-unbound",
+    source: {
+      builderCommit: "1".repeat(40),
+      releasedAt: "2026-07-14T01:02:03Z",
+    },
+    authorities: { release: "none", device: "none", live: "none" },
+    operations: {
+      network: "not-invoked",
+      store: "not-invoked",
+      capture: "not-invoked",
+      render: "not-invoked",
+    },
+    producerContracts: {
+      graphs: "verified-143",
+      cameras: "verified-2",
+      runner: "verified-143-plus-2",
+    },
+  };
+  assert.deepEqual(verifyOccurrenceExporterImage(metadata), expected);
+  assert.throws(
+    () => verifyOccurrenceExporterImage({ ...metadata, builderCommit: "1".repeat(39) }),
+    /source metadata contract is invalid/u,
+  );
+  assert.throws(
+    () => verifyOccurrenceExporterImage({ ...metadata, releasedAt: "2026-02-30T01:02:03Z" }),
+    /source metadata time contract is invalid/u,
+  );
+
+  const metadataRoot = await mkdtemp(path.join(tmpdir(), "verdify-occurrence-exporter-image-"));
+  try {
+    const metadataPath = path.join(metadataRoot, "occurrence-exporter-image.json");
+    await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+    assert.deepEqual(await verifyPackagedOccurrenceExporterImage(metadataPath), expected);
+  } finally {
+    await rm(metadataRoot, { recursive: true, force: true });
+  }
 });
 
 test("release reconciler CLI forwards only the store-specific environment allowlist", async (context) => {


### PR DESCRIPTION
Closes one source-only prerequisite under #476 and #480; neither issue closes.

What:
- adds an explicit `occurrence-exporter` target before the unchanged final nginx target;
- extracts one shared contract module consumed by the real graph, camera, and joint producers;
- runs the image as 101:101 with an offline default verifier and no release/device/live authority;
- binds the exact source revision/release time into OCI labels and canonical verifier-emitted metadata;
- documents that this is packaged, runtime-unbound source with no renderer, workload, endpoint, credential, digest, pin, route, or activation.

Verification:
- focused producer/image tests: 33/33 passed after rebase onto `e10db4f`;
- full Astro unit suite: 207/207 passed;
- parity: 31/31 passed; manifests/output passed;
- browser quality: one local fixture route returned a transient 404 during the first full run, then the exact quality suite passed 13/13 on immediate rerun;
- production fixture/output: 4/4 passed;
- root lint and `git diff --check`: passed;
- independent review: YES after clarifying inherited dependency-layer wording.

The OCI build itself is intentionally left to the in-cluster Kaniko/PR-CI gate. This PR performs no cluster sync, runtime activation, network request, store mutation, credential work, or route change.
