### PR TITLE
fix(lab): isolate release site build target

### DIFF
--- a/site-astro/Dockerfile.release-runtime
+++ b/site-astro/Dockerfile.release-runtime
@@ -45,6 +45,24 @@ USER 101:101
 ENTRYPOINT ["/app/release-runtime/entrypoint.sh"]
 CMD ["reconcile"]
 
+FROM nginxinc/nginx-unprivileged:1.29.3-alpine@sha256:f7d0d0f2ebc0486dc110278672b9073f7fd641e58376b112b0c8865cf36d2e36 AS site
+
+LABEL org.opencontainers.image.title="Verdify Lab atomic release server" \
+      org.opencontainers.image.description="Nginx serving a verified per-pod atomic Lab release cache" \
+      ai.verdify.release-authority="none" \
+      ai.verdify.device-authority="none"
+
+COPY release-runtime/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx/security-headers.inc /etc/nginx/conf.d/security-headers.inc
+
+USER 101:101
+EXPOSE 8080
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]
+
+# Keep this independent target after `site`: Kaniko evaluates every preceding
+# stage even when --target is set, so exporter-only required build arguments
+# must never be traversed by the site-image build.
 FROM dependencies AS occurrence-exporter
 
 ARG LAB_EXPORTER_BUILDER_COMMIT
@@ -69,18 +87,3 @@ RUN printf '%s' "${LAB_EXPORTER_BUILDER_COMMIT}" | grep -Eq '^[0-9a-f]{40}([0-9a
 
 USER 101:101
 CMD ["node", "/app/scripts/verify-occurrence-exporter-image.mjs"]
-
-FROM nginxinc/nginx-unprivileged:1.29.3-alpine@sha256:f7d0d0f2ebc0486dc110278672b9073f7fd641e58376b112b0c8865cf36d2e36 AS site
-
-LABEL org.opencontainers.image.title="Verdify Lab atomic release server" \
-      org.opencontainers.image.description="Nginx serving a verified per-pod atomic Lab release cache" \
-      ai.verdify.release-authority="none" \
-      ai.verdify.device-authority="none"
-
-COPY release-runtime/nginx.conf /etc/nginx/conf.d/default.conf
-COPY nginx/security-headers.inc /etc/nginx/conf.d/security-headers.inc
-
-USER 101:101
-EXPOSE 8080
-STOPSIGNAL SIGQUIT
-CMD ["nginx", "-g", "daemon off;"]

--- a/site-astro/tests/manifests.test.mjs
+++ b/site-astro/tests/manifests.test.mjs
@@ -286,16 +286,21 @@ test("release runtime images bake a real digest-bound fallback and serve only th
   assert.equal(Object.isFrozen(config.cliEnvironment), true);
 });
 
-test("occurrence exporter image is packaged offline before the unchanged default site target", async () => {
+test("site target precedes the independent occurrence exporter target for Kaniko", async () => {
   const dockerfile = await readFile(path.join(SITE_ROOT, "Dockerfile.release-runtime"), "utf8");
   const stages = [...dockerfile.matchAll(/^FROM\s+\S+(?:\s+AS\s+(\S+))?\s*$/gmi)]
     .map((match) => match[1] ?? "");
-  assert.deepEqual(stages, ["dependencies", "build", "agent", "occurrence-exporter", "site"]);
-  assert.equal(stages.at(-1), "site", "the final implicit release-runtime target must remain the site server");
+  assert.deepEqual(stages, ["dependencies", "build", "agent", "site", "occurrence-exporter"]);
+  for (const target of ["agent", "site", "occurrence-exporter"]) {
+    assert.equal(stages.filter((stage) => stage === target).length, 1, `${target} must be declared exactly once`);
+  }
+  assert.ok(
+    stages.indexOf("agent") < stages.indexOf("site") && stages.indexOf("site") < stages.indexOf("occurrence-exporter"),
+    "--target site must stop before exporter-only required build arguments",
+  );
 
   const exporterStart = dockerfile.indexOf("FROM dependencies AS occurrence-exporter");
-  const exporterEnd = dockerfile.indexOf("FROM nginxinc/nginx-unprivileged", exporterStart);
-  const exporter = dockerfile.slice(exporterStart, exporterEnd);
+  const exporter = dockerfile.slice(exporterStart);
   assert.match(exporter, /ai\.verdify\.release-authority="none"/u);
   assert.match(exporter, /ai\.verdify\.device-authority="none"/u);
   assert.match(exporter, /ai\.verdify\.live-authority="none"/u);


### PR DESCRIPTION
## What
Move the independent `occurrence-exporter` stage after the nginx `site` stage in `site-astro/Dockerfile.release-runtime`, and lock the stage order in the manifest suite.

## Why
The exact-source in-cluster build reached `build-lab-release-site` and Kaniko evaluated the earlier exporter stage while targeting `site`. That invocation intentionally has no `LAB_EXPORTER_*` arguments, so the exporter metadata guard failed before the nginx image could be produced.

## How
Keep the explicit `agent`, `site`, and `occurrence-exporter` targets, but order `site` before exporter. The regression test asserts each target occurs once and `agent < site < occurrence-exporter`, so the site target cannot traverse exporter-only required arguments.

## Test
- `cd site-astro && node --test tests/manifests.test.mjs` — 10/10 passed
- `git diff --check` — passed

## Success
The exact-main workflow builds the release agent, release site, and occurrence exporter independently, then opens a reviewed four-image Lab-stage pin without weakening exporter provenance validation.

Stage-only source fix. No production sync, DNS, Quartz, device/VLAN, credential, or runtime activation change.
