### PR TITLE
gitops(stage): roll Lab Astro source 1963141

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -13,7 +13,7 @@ images:
   # release; changing it requires its own reviewed exact-source pin.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:814eafff19c748c7a87e2b617d9eff8738dd13814a24c193f8768b63ebf12fff
+    digest: sha256:878c522740a44df44369dae1154b162b485a29d4b4b45d9ad48e20a44f22d56b
   # These exact-source runtime images remain dormant under the replicas-zero
   # patch. A separate reviewed activation must add the store contract and raise
   # replicas; digest presence alone is not rollout authority.


### PR DESCRIPTION
## What
Pin `lab-stage` static Astro to `verdify-lab-astro@sha256:878c522740a44df44369dae1154b162b485a29d4b4b45d9ad48e20a44f22d56b`.

## Why
Jason directed an immediate stage rollout. The serving image is still the `814eafff` scroll-fix build and predates the merged freshness/LKG, occurrence, and S3 wiring source.

## How
This digest was produced by the retained exact-source workflow `verdify-platform-ci-exporter-20260714` from reviewed main source `196314126ccb74cd9ff8cda51163b8fc4b2e5cca`. Its full validate and `build-lab-astro` nodes succeeded. Only the separate release nginx target failed later; that target-order fix is #529 and does not invalidate the already-completed static image.

## Test
- exact-source workflow `validate`: succeeded
- exact-source workflow `build-lab-astro`: succeeded, emitted this digest and source revision
- `kubectl kustomize deploy/k8s/overlays/lab-stage`: renders 2 replicas with exactly this digest
- `git diff --check`: passed

## Success
After PR CI and merge, sync only `verdify-platform-lab-stage`, wait for 2/2 rollout, and pass T0 plus T+10 live acceptance while the route stays on static.

Stage-only pin. No production sync, DNS, Quartz, device/VLAN, credential, or route-switch change.
