### PR TITLE
fix(lab): isolate occurrence exporter Dockerfile

### DIFF
--- a/site-astro/Dockerfile.occurrence-exporter
+++ b/site-astro/Dockerfile.occurrence-exporter
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+FROM node:22.22.0-alpine3.22@sha256:7eb2c0c4b8cf6fd761f0e6a7fed8d3b8ad59186848f0eee59744e546f1b6a3e9 AS dependencies
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN test "$(node --version)" = "v22.22.0" \
+    && test "$(npm --version)" = "10.9.4" \
+    && npm ci --no-audit --no-fund
+
+FROM dependencies
+
+ARG LAB_EXPORTER_BUILDER_COMMIT
+ARG LAB_EXPORTER_RELEASED_AT
+
+LABEL org.opencontainers.image.title="Verdify Lab occurrence exporter" \
+      org.opencontainers.image.description="Packaged offline producer contracts with no runtime binding" \
+      org.opencontainers.image.revision="${LAB_EXPORTER_BUILDER_COMMIT}" \
+      org.opencontainers.image.created="${LAB_EXPORTER_RELEASED_AT}" \
+      ai.verdify.release-authority="none" \
+      ai.verdify.device-authority="none" \
+      ai.verdify.live-authority="none"
+
+COPY scripts/verify-occurrence-exporter-image.mjs /app/scripts/verify-occurrence-exporter-image.mjs
+COPY scripts/lib/occurrence-producer-contracts.mjs /app/scripts/lib/occurrence-producer-contracts.mjs
+RUN printf '%s' "${LAB_EXPORTER_BUILDER_COMMIT}" | grep -Eq '^[0-9a-f]{40}([0-9a-f]{24})?$' \
+    && printf '%s' "${LAB_EXPORTER_RELEASED_AT}" | grep -Eq '^20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})?Z$' \
+    && printf '{\n  "contract": "verdify.lab-occurrence-exporter-image-metadata",\n  "schemaVersion": 1,\n  "builderCommit": "%s",\n  "releasedAt": "%s"\n}\n' \
+      "${LAB_EXPORTER_BUILDER_COMMIT}" "${LAB_EXPORTER_RELEASED_AT}" \
+      > /app/occurrence-exporter-image.json \
+    && node /app/scripts/verify-occurrence-exporter-image.mjs > /dev/null
+
+USER 101:101
+CMD ["node", "/app/scripts/verify-occurrence-exporter-image.mjs"]

--- a/site-astro/Dockerfile.release-runtime
+++ b/site-astro/Dockerfile.release-runtime
@@ -59,31 +59,3 @@ USER 101:101
 EXPOSE 8080
 STOPSIGNAL SIGQUIT
 CMD ["nginx", "-g", "daemon off;"]
-
-# Keep this independent target after `site`: Kaniko evaluates every preceding
-# stage even when --target is set, so exporter-only required build arguments
-# must never be traversed by the site-image build.
-FROM dependencies AS occurrence-exporter
-
-ARG LAB_EXPORTER_BUILDER_COMMIT
-ARG LAB_EXPORTER_RELEASED_AT
-
-LABEL org.opencontainers.image.title="Verdify Lab occurrence exporter" \
-      org.opencontainers.image.description="Packaged offline producer contracts with no runtime binding" \
-      org.opencontainers.image.revision="${LAB_EXPORTER_BUILDER_COMMIT}" \
-      org.opencontainers.image.created="${LAB_EXPORTER_RELEASED_AT}" \
-      ai.verdify.release-authority="none" \
-      ai.verdify.device-authority="none" \
-      ai.verdify.live-authority="none"
-
-COPY scripts/verify-occurrence-exporter-image.mjs /app/scripts/verify-occurrence-exporter-image.mjs
-COPY scripts/lib/occurrence-producer-contracts.mjs /app/scripts/lib/occurrence-producer-contracts.mjs
-RUN printf '%s' "${LAB_EXPORTER_BUILDER_COMMIT}" | grep -Eq '^[0-9a-f]{40}([0-9a-f]{24})?$' \
-    && printf '%s' "${LAB_EXPORTER_RELEASED_AT}" | grep -Eq '^20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{3})?Z$' \
-    && printf '{\n  "contract": "verdify.lab-occurrence-exporter-image-metadata",\n  "schemaVersion": 1,\n  "builderCommit": "%s",\n  "releasedAt": "%s"\n}\n' \
-      "${LAB_EXPORTER_BUILDER_COMMIT}" "${LAB_EXPORTER_RELEASED_AT}" \
-      > /app/occurrence-exporter-image.json \
-    && node /app/scripts/verify-occurrence-exporter-image.mjs > /dev/null
-
-USER 101:101
-CMD ["node", "/app/scripts/verify-occurrence-exporter-image.mjs"]

--- a/site-astro/tests/manifests.test.mjs
+++ b/site-astro/tests/manifests.test.mjs
@@ -286,21 +286,25 @@ test("release runtime images bake a real digest-bound fallback and serve only th
   assert.equal(Object.isFrozen(config.cliEnvironment), true);
 });
 
-test("site target precedes the independent occurrence exporter target for Kaniko", async () => {
+test("release targets stay ordered and the occurrence exporter has an independent Dockerfile", async () => {
   const dockerfile = await readFile(path.join(SITE_ROOT, "Dockerfile.release-runtime"), "utf8");
   const stages = [...dockerfile.matchAll(/^FROM\s+\S+(?:\s+AS\s+(\S+))?\s*$/gmi)]
     .map((match) => match[1] ?? "");
-  assert.deepEqual(stages, ["dependencies", "build", "agent", "site", "occurrence-exporter"]);
-  for (const target of ["agent", "site", "occurrence-exporter"]) {
+  assert.deepEqual(stages, ["dependencies", "build", "agent", "site"]);
+  for (const target of ["agent", "site"]) {
     assert.equal(stages.filter((stage) => stage === target).length, 1, `${target} must be declared exactly once`);
   }
   assert.ok(
-    stages.indexOf("agent") < stages.indexOf("site") && stages.indexOf("site") < stages.indexOf("occurrence-exporter"),
-    "--target site must stop before exporter-only required build arguments",
+    stages.indexOf("agent") < stages.indexOf("site"),
+    "release agent must precede the site target",
   );
+  assert.doesNotMatch(dockerfile, /occurrence-exporter|LAB_EXPORTER_/u);
 
-  const exporterStart = dockerfile.indexOf("FROM dependencies AS occurrence-exporter");
-  const exporter = dockerfile.slice(exporterStart);
+  const exporter = await readFile(path.join(SITE_ROOT, "Dockerfile.occurrence-exporter"), "utf8");
+  const exporterStages = [...exporter.matchAll(/^FROM\s+\S+(?:\s+AS\s+(\S+))?\s*$/gmi)]
+    .map((match) => match[1] ?? "");
+  assert.deepEqual(exporterStages, ["dependencies", ""]);
+  assert.doesNotMatch(exporter, /LAB_RUNTIME_|AS\s+build|Dockerfile\.release-runtime/u);
   assert.match(exporter, /ai\.verdify\.release-authority="none"/u);
   assert.match(exporter, /ai\.verdify\.device-authority="none"/u);
   assert.match(exporter, /ai\.verdify\.live-authority="none"/u);


### PR DESCRIPTION
## What

Move the offline occurrence-exporter image into a dedicated single-purpose Dockerfile while leaving the release-agent and release-site target family unchanged.

## Why

The retained verdify-platform-ci-n4d2g pod proved that Kaniko traverses the release-runtime build stage for the exporter target. That stage requires LAB_RUNTIME inputs, while the exporter correctly receives LAB_EXPORTER inputs, so the exact main build exits 1 before reaching the exporter stage.

## Test

- Lab unit suite: 207/207 passing
- focused Dockerfile contract: passing
- git diff --check: passing
- local Docker daemon unavailable; the decisive proof is the paired in-cluster Kaniko rebuild after the control-plane template merge

No workload, route, credential, production, DNS, Quartz, or device change. Supports #476 and jvallery/agents#2930.