### PR TITLE
gitops(stage): pin exact Lab runtime images for f0951fa

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -19,10 +19,13 @@ images:
   # replicas; digest presence alone is not rollout authority.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-agent
-    digest: sha256:3ae9f1f2cec8ee3d6748a37bf2ce8d9a780230d1ad5ef69ebdd35ce1d7f3fac9
+    digest: sha256:b9df7c23f2e0dd18ee5f76ddf7a8b6a2fe3698a1f9c0e14cb07454f5f809c861
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-release-nginx
-    digest: sha256:004320c7ba9b4d038509f86d8929f5d60dd68dc4455251b2cb068e6f769074ee
+    digest: sha256:88ba3cb8b56e003f0f3efde0959e72a79a05f12f2353d9854508aa5f2c888cb1
+  - name: registry.vallery.net/verdifyconsultancy/verdify-lab-occurrence-exporter
+    newName: registry.vallery.net/verdifyconsultancy/verdify-lab-occurrence-exporter
+    digest: sha256:a809d11cf1a46a3ba5ea0839654b6a736cdc0a0b4b8a1e9e05b938c6cc08de4a
 
 patches:
   - path: lab-release-runtime-dormant.patch.yaml


### PR DESCRIPTION
Stage-only digest pin for the exact-source dormant release-agent, nginx, and packaged occurrence-exporter images (jvallery/agents#2930; VerdifyConsultancy/verdify-platform#476 and #480).

Source revision: f0951fa04574b17ea8b96e3f6cd4146119cb1af8
Runtime pin-set: sha256:5a3268ebc5832c9e64a42f7abfba8202cd7b84bdcf36a5b4325b527abe7db94c

The first pin adds the exact fourth occurrence-exporter image-transformer entry; later pins may rotate any non-empty subset within the closed three-runtime-image set in one digest-only commit. The serving static Astro digest is unchanged. No exporter workload, route, store credential, or runtime authority is added; the existing release runtime remains replicas=0 and unrouted.

Verification:
- Canonical exact-image exporter probe verdify-exporter-probe-projected-token-ql5cw: Succeeded
- kubectl kustomize deploy/k8s/overlays/lab-stage | node site-astro/scripts/verify-rendered-stage.mjs: verified 9 resources
- node --test site-astro/tests/manifests.test.mjs: 10/10
- git diff --check: clean

Review and merge do not authorize runtime activation, production cutover, or production APPLY.