### PR TITLE
gitops(stage): pin current reviewed Lab static image

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -13,7 +13,7 @@ images:
   # release; changing it requires its own reviewed exact-source pin.
   - name: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-astro
-    digest: sha256:878c522740a44df44369dae1154b162b485a29d4b4b45d9ad48e20a44f22d56b
+    digest: sha256:1852cf2523041ef840b3eb1092050e4b3b19d2027494fc6b6c9809b930de93b7
   # These exact-source runtime images remain dormant under the replicas-zero
   # patch. A separate reviewed activation must add the store contract and raise
   # replicas; digest presence alone is not rollout authority.


### PR DESCRIPTION
## What

Pin the public Lab-stage static Deployment to the latest successfully built and probed Astro image:

`registry.vallery.net/verdifyconsultancy/verdify-lab-astro@sha256:1852cf2523041ef840b3eb1092050e4b3b19d2027494fc6b6c9809b930de93b7`

## Source and evidence

- exact image source: `a761589abdc038d835598faac5456203ff8e70b1`
- canonical workflow: `verdify-platform-ci-sn8mt`
- `build-lab-astro`: Succeeded, emitted the exact digest/source/release-time tuple
- `probe-lab-stage-image`: Succeeded
- full workflow: Succeeded
- current `main` descendants `96c7a3d` and `52d80fc` are digest-pin-only changes; no rendered Astro source changed after `a761589`

## Local verification

- `git diff --check`
- rendered Lab-stage overlay: 9 resources
- stage manifest contract: 10/10
- static Deployment: 2 replicas, exact new digest
- release runtime: 0 replicas with #545's reviewed runtime pins
- stage IngressRoute still targets only `verdify-lab-astro-stage`

## Expected user-visible result

This makes the public stage build identity current. There are no component,
style, content, navigation, font, or other rendered-site changes between the
currently served source `1963141` and `a761589`; therefore appearance is
expected to remain equivalent. The 143 graph and two camera fallbacks require
the separately gated occurrence/reporting activation and are not bypassed here.

After merge, use the reviewed exact-revision stage actuator, require 2/2 Ready
on this digest, run T0/T+10 public acceptance, then restore manual Argo posture.

Stage only. No production sync, DNS, Quartz, device/VLAN, database, credential,
reporting/store activation, or route switch.
