### PR TITLE
build: pin every container base to an immutable digest

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,7 +26,7 @@
 # and the unauth-write escape hatch is closed in the k3s ConfigMap, NOT here.
 # ============================================================================
 
-FROM python:3.13-slim AS base
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS base
 
 # Runtime-only system deps. curl for the healthcheck; ca-certificates for the
 # outbound contact-form SMTP / go2rtc-Frigate proxy calls. No build toolchain.

--- a/db/Dockerfile.migrate
+++ b/db/Dockerfile.migrate
@@ -12,7 +12,7 @@
 # BuildKit COPY heredoc, which Kaniko does NOT support — the in-cluster zot
 # build failed with exit 1. The old reason for inlining, an unreliable
 # NFS-backed worktree, retired with the VM).
-FROM postgres:16-alpine
+FROM postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
 COPY db/schema.sql /db/schema.sql
 COPY db/migrations/000-fresh-schema-hypertable-repair.sql /db/000-fresh-schema-hypertable-repair.sql
 COPY db/migrate.sh /usr/local/bin/migrate.sh

--- a/ingestor/Dockerfile
+++ b/ingestor/Dockerfile
@@ -31,7 +31,7 @@
 #     -t ghcr.io/verdifyconsultancy/verdify-ingestor:dev .
 # ============================================================================
 
-FROM python:3.13-slim AS base
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -35,7 +35,7 @@
 #                            DB_HOST/DB_PASS — see the k3s ConfigMap reconcile.)
 # ============================================================================
 
-FROM python:3.13-slim AS base
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \

--- a/planner_graph/Dockerfile
+++ b/planner_graph/Dockerfile
@@ -13,7 +13,7 @@
 #   docker build -f planner_graph/Dockerfile \
 #     -t ghcr.io/verdifyconsultancy/verdify-planner:dev .
 # ============================================================================
-FROM python:3.12-slim AS builder
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -29,7 +29,7 @@ COPY planner_graph ./planner_graph
 
 RUN uv sync --frozen --no-dev
 
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/scripts/Dockerfile.lab-publisher
+++ b/scripts/Dockerfile.lab-publisher
@@ -5,7 +5,7 @@
 # artifacts with S3-compatible object storage and writes the live public tree to
 # the lab cache PVC mounted at /work/publisher/public.
 
-FROM node:22-bookworm-slim AS final
+FROM node:22-bookworm-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS final
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       awscli \

--- a/scripts/Dockerfile.setpoint-server
+++ b/scripts/Dockerfile.setpoint-server
@@ -35,7 +35,7 @@
 #     -t ghcr.io/verdifyconsultancy/verdify-setpoint-server:dev .
 # ============================================================================
 
-FROM python:3.13-slim AS base
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/tests/test_dockerfile_base_pinning.py
+++ b/tests/test_dockerfile_base_pinning.py
@@ -1,0 +1,72 @@
+"""Every container base must be immutably pinned.
+
+ADR-0021 moved publishing to the in-cluster Kaniko path and the zot origin, but
+the *inputs* to that build were still mutable public tags (`python:3.13-slim`,
+`postgres:16-alpine`, ...). A mutable tag means two builds of the same commit
+can produce different images, which defeats the immutable-digest contract the
+overlays and ArgoCD rely on, and it silently re-points the supply chain
+whenever upstream moves a tag.
+
+This guard fails on any `FROM` that is not one of:
+  * a digest-pinned reference (`repo:tag@sha256:...`),
+  * a reference to an earlier stage in the same Dockerfile, or
+  * a build argument (`${...}`), whose value is pinned by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FROM_RE = re.compile(r"^\s*FROM\s+(?P<ref>\S+)(?:\s+AS\s+(?P<stage>\S+))?", re.IGNORECASE | re.MULTILINE)
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+
+def _is_dockerfile(path: Path) -> bool:
+    """Match `Dockerfile`, `Dockerfile.<variant>` and `<variant>.Dockerfile` only.
+
+    Deliberately narrow: a substring match also catches this test module (and
+    its .pyc), whose `from __future__ import ...` then parses as a FROM line.
+    """
+    name = path.name
+    return name == "Dockerfile" or name.startswith("Dockerfile.") or name.endswith(".Dockerfile")
+
+
+def _dockerfiles() -> list[Path]:
+    found = [
+        path
+        for path in REPO_ROOT.rglob("*")
+        if path.is_file()
+        and _is_dockerfile(path)
+        and ".git" not in path.parts
+        and "node_modules" not in path.parts
+        and "__pycache__" not in path.parts
+    ]
+    assert found, "no Dockerfiles discovered — the guard would pass vacuously"
+    return sorted(found)
+
+
+@pytest.mark.parametrize("dockerfile", _dockerfiles(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_every_external_base_image_is_digest_pinned(dockerfile: Path):
+    text = dockerfile.read_text(encoding="utf-8")
+    stages: set[str] = set()
+    unpinned: list[str] = []
+
+    for match in FROM_RE.finditer(text):
+        reference = match.group("ref")
+        if reference.casefold() in stages:
+            pass  # earlier stage in this same file
+        elif reference.startswith("$"):
+            pass  # build arg; the caller supplies the pinned value
+        elif not DIGEST_RE.search(reference):
+            unpinned.append(reference)
+        if match.group("stage"):
+            stages.add(match.group("stage").casefold())
+
+    assert not unpinned, (
+        f"{dockerfile.relative_to(REPO_ROOT)} has mutable base reference(s): {unpinned}. "
+        "Pin as repo:tag@sha256:<digest> so a rebuild of this commit is reproducible."
+    )

--- a/twin/Dockerfile
+++ b/twin/Dockerfile
@@ -13,7 +13,7 @@
 # migration), tracked separately on issue #34 as needs:root.
 
 # ── stage 1: compile the gated --stream harness (replay_emit_follow) ──────────
-FROM gcc:13-bookworm AS build
+FROM gcc:13-bookworm@sha256:3e239a5ea77200b9163c825a0a5ebc17ca99f3bbb4d08241ee0fb9c174325880 AS build
 WORKDIR /src
 # Only the firmware sources are needed; greenhouse_logic.h is header-only.
 COPY firmware/lib /src/firmware/lib
@@ -29,7 +29,7 @@ RUN g++ -std=c++17 -O2 -DREPLAY_EMIT_STREAM \
 # ── stage 2: minimal hardened runtime ─────────────────────────────────────────
 # python:3.12-slim gives us psycopg for the INSERT-only sink without pulling a
 # compiler into the runtime image. No docker.sock, no actuation client.
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 RUN pip install --no-cache-dir "psycopg[binary]>=3.1" \
     && useradd --create-home --uid 10001 twin
 COPY --from=build /src/replay_emit_follow /usr/local/bin/replay_emit_follow


### PR DESCRIPTION
## Why

ADR-0021 moved publishing to the in-cluster Kaniko path and the zot origin, but the
**inputs** to that build were still mutable public tags. Two builds of the same commit
could produce different images, which defeats the immutable-digest contract the overlays
and ArgoCD reconcile against, and silently re-points the supply chain whenever upstream
moves a tag.

Only `site-astro/*` was already pinned. This brings the other eight Dockerfiles to the
same standard, keeping the readable tag next to the digest so the intended version stays
reviewable.

| base | digest |
| --- | --- |
| `python:3.13-slim` | `sha256:6771159c…` |
| `python:3.12-slim` | `sha256:57cd7c3a…` |
| `postgres:16-alpine` | `sha256:57c72fd2…` |
| `node:22-bookworm-slim` | `sha256:6c74791e…` |
| `gcc:13-bookworm` | `sha256:3e239a5e…` |

## Guard

`tests/test_dockerfile_base_pinning.py` fails any `FROM` that is not digest-pinned, an
earlier stage in the same file, or a build argument. Discovery is deliberately narrow:
matching `dockerfile` as a substring also picks up the test module itself, whose
`from __future__ import ...` parses as a FROM line.

## Verification

- All **7** distinct pinned digests resolve upstream (HTTP 200, registry manifest API).
- Guard passes over **13** Dockerfiles; negative control (unpinning `api/Dockerfile`)
  reproduces the failure, so it is not vacuous.
- `ruff check` clean repo-wide.
- Full `tests/` diffed against `origin/main`: failure set **identical** at 145
  pre-existing environmental failures (no docker socket / no live stack). No new failures.

## What this does NOT fix

The build is still **not hermetic**. These bases are fetched from Docker Hub at build
time and are **not** mirrored into the zot origin — the origin currently holds 35
repositories and **none** of the CI or base images.

The CI images used by the `agent-fleet-ci` WorkflowTemplates are also still external and
still mutable tags: `quay.io/argoproj/argoexec:v4.0.5`,
`gcr.io/kaniko-project/executor:v1.23.2-debug`,
`mirror.gcr.io/library/node:22-bookworm`, `mirror.gcr.io/library/python:3.13-bookworm`,
`alpine/git:2.47.1`. Those templates carry
`argocd.argoproj.io/tracking-id: agent-fleet-ci-workflows` and are owned by the fleet
control-plane repo, not this one — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
