### PR TITLE
k8s(lab): replace node6 pins with RWO co-location

### DIFF
--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -65,22 +65,18 @@ spec:
           imagePullSecrets:
             - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
             - name: ghcr-jvallery-readonly
-          # STORAGE PLACEMENT (load-bearing). verdify-lab-site-cache is
-          # ReadWriteOnce on longhorn-v1-rebuildable-rwo and attached to node6. An
-          # RWO volume can be mounted by several pods only when they share a node,
-          # so the surge pod of a rolling update must land on the same node as the
-          # pod it replaces. Without this pin the new pod can be scheduled
-          # elsewhere, fail to attach, and stall the rollout indefinitely (the old
-          # pod keeps serving, so it fails quietly rather than loudly). Was live as
-          # an unrecorded hand patch until 2026-07-27; codified here so a sync
-          # cannot drop it.
-          nodeSelector:
-            kubernetes.io/hostname: vm-k3s-node6
-          tolerations:
-            - key: maintenance.vallery.net/longhorn-recovery
-              operator: Equal
-              value: "true"
-              effect: NoSchedule
+          # STORAGE CO-LOCATION (load-bearing). The publisher and serving Lab
+          # pods co-mount one ReadWriteOnce cache, so a publisher Job must run
+          # in the serving Lab pod's hostname topology. If no Lab pod is
+          # available, leave the Job Pending instead of guessing a node or
+          # risking a cross-node multi-attach.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: lab-site
+                  topologyKey: kubernetes.io/hostname
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -42,6 +42,9 @@ spec:
   # deltas completed, and the database restart count remained unchanged.
   suspend: false
   concurrencyPolicy: Forbid
+  # Temporary maintenance suspension must not release a catch-up publisher
+  # after the quiet window. Skip any missed start older than 30 seconds.
+  startingDeadlineSeconds: 30
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   jobTemplate:

--- a/deploy/k8s/components/lab-site/lab-site.yaml
+++ b/deploy/k8s/components/lab-site/lab-site.yaml
@@ -125,7 +125,7 @@ spec:
     # Spelled out rather than left to the 25% defaults, because the rounding is
     # load-bearing here: with replicas 1 the surge pod starts BEFORE the old pod
     # drains, so both hold the cache PVC at once. That is only legal while both
-    # land on the same node — see nodeSelector below.
+    # land on the same node — see the required pod affinity below.
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
@@ -139,22 +139,19 @@ spec:
       imagePullSecrets:
         - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
         - name: ghcr-jvallery-readonly
-      # STORAGE PLACEMENT (load-bearing). verdify-lab-site-cache is
-      # ReadWriteOnce on longhorn-v1-rebuildable-rwo and attached to node6. An
-      # RWO volume can be mounted by several pods only when they share a node,
-      # so the surge pod of a rolling update must land on the same node as the
-      # pod it replaces. Without this pin the new pod can be scheduled
-      # elsewhere, fail to attach, and stall the rollout indefinitely (the old
-      # pod keeps serving, so it fails quietly rather than loudly). Was live as
-      # an unrecorded hand patch until 2026-07-27; codified here so a sync
-      # cannot drop it.
-      nodeSelector:
-        kubernetes.io/hostname: vm-k3s-node6
-      tolerations:
-        - key: maintenance.vallery.net/longhorn-recovery
-          operator: Equal
-          value: "true"
-          effect: NoSchedule
+      # STORAGE CO-LOCATION (load-bearing). verdify-lab-site-cache is
+      # ReadWriteOnce, so every replica and rolling surge pod must share one
+      # node while they co-mount it. Required self-affinity expresses that
+      # relationship without pinning the workload to a named machine:
+      # Kubernetes permits the first matching pod to seed the group, then
+      # schedules every later matching pod into the same hostname topology.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: lab-site
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
+++ b/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
@@ -24,10 +24,11 @@
 # NOT touched here: verdify-ingestor / verdify-setpoint-server (single-writer
 # device path — gated ha-3), grafana (RWO PVC singleton — stays replicas:1).
 #
-# 2026-06-17 storage exception: lab-site now uses the rebuildable
-# verdify-lab-site-cache PVC on node-local-temp-rwo. It keeps two replicas, but
-# uses ScheduleAnyway so both pods may co-locate on the cache PV node; hard
-# hostname spread conflicts with a shared node-local RWO cache.
+# Storage exception: lab-site uses the shared ReadWriteOnce
+# verdify-lab-site-cache PVC. It keeps two replicas, but uses ScheduleAnyway
+# while required pod affinity co-locates both replicas on whichever eligible
+# worker hosts the portable cache; hard hostname spread conflicts with a shared
+# RWO cache.
 #
 # ha-5 (#230, this commit): verdify-planner added — the last replicas:1
 # stateless serving surface. It is a stateless HTTP service (run state lives in

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1087,16 +1087,29 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     assert publisher_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
     assert site_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
 
-    # STORAGE PLACEMENT. The cache PVC is ReadWriteOnce and node-attached, so an
-    # RWO volume is only co-mountable by pods sharing a node. Both workloads must
-    # therefore pin the same node, and the Deployment's surge pod (maxSurge 1,
-    # maxUnavailable 0 with replicas 1 starts before the old pod drains) must land
-    # there too or the rollout stalls on a failed attach. This was live only as an
-    # unrecorded hand patch until 2026-07-27; assert it so a sync cannot drop it.
+    # STORAGE CO-LOCATION. The cache PVC is ReadWriteOnce, so the serving pods,
+    # rollout surge, and publisher must share a hostname. Required pod affinity
+    # preserves that relationship without pinning the group to one named worker.
     assert deployment["spec"]["replicas"] == 1
     assert deployment["spec"]["strategy"]["rollingUpdate"] == {"maxUnavailable": 0, "maxSurge": 1}
+    expected_co_location = {
+        "podAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/component": "lab-site",
+                        },
+                    },
+                    "topologyKey": "kubernetes.io/hostname",
+                },
+            ],
+        },
+    }
     for pod_spec in (publisher_spec, site_spec):
-        assert pod_spec["nodeSelector"] == {"kubernetes.io/hostname": "vm-k3s-node6"}
+        assert "nodeSelector" not in pod_spec
+        assert pod_spec["affinity"] == expected_co_location
+        assert not pod_spec.get("tolerations")
         cache_volume = next(volume for volume in pod_spec["volumes"] if volume["name"] == "lab-cache")
         assert cache_volume["persistentVolumeClaim"]["claimName"] == "verdify-lab-site-cache"
     cache_pvc = _resource(publisher_docs, "PersistentVolumeClaim", "verdify-lab-site-cache")

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1084,6 +1084,7 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     publisher_spec = cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]
     site_spec = deployment["spec"]["template"]["spec"]
 
+    assert cronjob["spec"]["startingDeadlineSeconds"] == 30
     assert publisher_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
     assert site_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
 


### PR DESCRIPTION
## Summary

- remove the exact `vm-k3s-node6` selector from the Lab Deployment and publisher CronJob
- remove the stale Longhorn recovery toleration from both recurring templates
- add required same-host pod affinity so the serving replicas, rollout surge, and publisher continue to co-mount the shared RWO cache safely
- add `startingDeadlineSeconds: 30` so a temporary maintenance suspension cannot release stale publisher runs as a catch-up burst
- update the production spread rationale and enforce the exact no-host-pin/co-location/deadline contract in tests

## Why

The workloads have a real co-location requirement, not a hardware dependency. Both mount `verdify-lab-site-cache` as `ReadWriteOnce`, so they must share a hostname while concurrent. An exact node6 selector encoded that relationship as permanent machine identity. Required pod affinity expresses the actual dependency and lets the group move as one unit after its legacy hostname-affined PV is replaced.

Kubernetes self-affinity permits the first Lab pod to seed the group; later replicas and rollout surge pods must join its hostname. Publisher Jobs require a serving Lab pod and otherwise remain Pending rather than risking a cross-node multi-attach.

The publisher runs every ten minutes. Kubernetes counts schedules missed while a CronJob is suspended; without a starting deadline, lifting a three-hour maintenance suspension can immediately create a stale run. The 30-second deadline is above the controller's 10-second scheduling check interval and expires a missed start well before the next ten-minute schedule.

## Hard gate / safety

**Draft source only. Do not merge, sync, or apply until #557 and [jvallery/proxmox-infrastructure#83](https://github.com/jvallery/proxmox-infrastructure/issues/83) open their gates.**

The currently bound PV still has hard node6 hostname affinity from the former strict-local rebuildable policy. This PR does not modify, delete, recreate, snapshot, or migrate that PVC/PV/Longhorn volume. Claim replacement requires a separate explicit Jason destructive approval with content/S3 ledger, quiesce, rollback hold, and endpoint acceptance.

No production mutation, Argo operation, database/device-writer change, drain, VM action, or physical power-off occurred.

Refs #557
Coordinator: [jvallery/agents#217](https://github.com/jvallery/agents/issues/217)
Quiet-window gate: [jvallery/proxmox-infrastructure#92](https://github.com/jvallery/proxmox-infrastructure/issues/92)
Kubernetes suspension behavior: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-suspension

## Validation

Passed:

- 46/46 `tests/test_lab_publish_k3s_guard.py` tests with the repository's GNU coreutils runtime assumption
- exact changed manifest contract test, including `startingDeadlineSeconds: 30`
- production `kustomize build` (105 documents) and rendered CronJob readback
- Ruff lint and format
- schema and device-write suites
- YAML/pre-commit hooks
- `git diff --check`

The canonical `scripts/ci-local.sh` passes all change-relevant stages before reaching four macOS-host failures in untouched atomic-publish tests (`flock` behavior and Linux `renameat2`). The same exact four tests were already documented as failing on pristine `origin/main`; they are baseline/environment parity, not introduced by this diff. The broad `make test` target also includes live Docker, systemd, database, API, and website checks that are not runnable on this Mac.
