### PR TITLE
ci: repo-wide static validation inside the existing gate

### DIFF
--- a/docs/ci/zero-paid-runner-ledger.md
+++ b/docs/ci/zero-paid-runner-ledger.md
@@ -32,6 +32,32 @@ Consequently this ledger records dispositions, evidence, measurements and
 rollback rather than a migration. No ARC scale sets, namespaces, runner images
 or Kubernetes resources were created (all four were out of scope).
 
+### 1.1 If you were sent here to "add CI to this repo"
+
+An empty `.github/workflows/` reads like a missing-CI gap. It is not — it is
+the deliberate 2026-07-11 end state, and adding a workflow is the one change
+this repo actively rejects. Before writing a workflow file, note that **both**
+available runner choices are dead ends today:
+
+| Approach | Outcome |
+| --- | --- |
+| `runs-on: ubuntu-latest` (or any `ubuntu-*`/`windows-*`/`macos-*`) | Fails `tests/test_no_workflow_uses_a_github_hosted_runner`, which runs inside `ci-local.sh`. The required check `Verdify Platform / Argo PR CI` goes **red**, so the PR is unmergeable. |
+| `runs-on: self-hosted` | Passes the label guard, but `repos/.../actions/runners` is `total_count: 0` — no runner is registered to this repo, so the job **queues forever** and never reports. |
+
+Either way `tests/test_workflow_directory_is_still_empty_on_this_branch` also
+trips. Reintroduction is a gated operator decision (§7), not an autonomous one.
+
+**Add the validation to the gate instead.** `scripts/ci-local.sh` is what runs
+on every PR, so new static checks belong there — that is where
+`tests/test_static_repo_hygiene.py` (repo-wide Python compile, YAML parse,
+merge-marker and Dockerfile base-image checks, plus a SOPS encryption *shape*
+check) was wired on 2026-08-02, closing a real coverage hole: the gate's ruff
+invocation names only seven paths and `pyproject.toml` excludes
+`planner_graph/`, leaving 68 tracked `.py` files — the whole production
+`planner_graph/` package among them — with no syntax coverage at all. The
+`check-yaml` / `check-merge-conflict` hooks in `.pre-commit-config.yaml` were
+likewise advisory-only, because `ci-local.sh` never invokes pre-commit.
+
 ## 2. Workflow ledger — dispositions
 
 ### 2.1 Live surface (registered with GitHub today)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -79,6 +79,7 @@ $PY -m pytest -q \
   tests/test_soil_dryout_alert.py \
   tests/test_solar_band_anchors.py \
   tests/test_solar_constants_check.py \
+  tests/test_static_repo_hygiene.py \
   tests/test_tempest_sync.py \
   tests/test_writer_lease_fence.py
 

--- a/tests/test_static_repo_hygiene.py
+++ b/tests/test_static_repo_hygiene.py
@@ -1,0 +1,232 @@
+"""Repo-wide static validation: parse/compile every tracked source file.
+
+The pre-merge gate (`scripts/ci-local.sh`) leans on ruff for Python quality,
+but ruff only scans the paths that target names explicitly —
+`ingestor/ api/ mcp/ scripts/*.py tests/ verdify_public/ verdify_schemas/` —
+and `pyproject.toml` additionally sets `extend-exclude = ["planner_graph"]`.
+That leaves **68 tracked `.py` files with no syntax coverage at all**, including
+the entire 50-file `planner_graph/` package that ships as a production k3s
+image, plus `slack_ops/`, `planning/`, `deploy/`, `site-astro/`, `twin/` and
+`slack_config.py`. A syntax error in any of them merges clean today and fails
+at container start.
+
+The same hole exists for the non-Python surface. `.pre-commit-config.yaml`
+carries `check-yaml`, `check-json` and `check-merge-conflict`, but
+`ci-local.sh` never invokes pre-commit — those hooks only fire for developers
+who ran `pre-commit install` locally, so they are advisory, not enforced. This
+module makes the cheap, unambiguous checks part of the required gate.
+
+Everything here is hermetic by construction: it reads tracked files off disk
+and parses them. No network, no database, no cluster, no secrets, no
+subprocess beyond `git ls-files`. Nothing here decrypts or inspects the *value*
+of any SOPS-encrypted field.
+
+Companion guard: `tests/test_no_hosted_runner_workflows.py` (CI execution
+policy). CI topology and rationale: `docs/ci/zero-paid-runner-ledger.md`.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Binary/vendored trees are excluded from the byte-level scans by virtue of
+# using `git ls-files` (tracked files only) plus an explicit suffix filter —
+# never a hand-maintained directory allowlist that silently rots.
+BINARY_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".pdf",
+    ".gz", ".zip", ".tar", ".bin", ".woff", ".woff2", ".ttf", ".otf",
+}  # fmt: skip
+
+
+def _tracked(*patterns: str) -> list[Path]:
+    """Tracked files matching `patterns` (all tracked files when empty).
+
+    Fails closed: if `git ls-files` cannot run, the gate errors rather than
+    silently validating zero files — the failure mode that would make every
+    assertion below vacuously true.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", *patterns],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [ROOT / name for name in result.stdout.split("\0") if name]
+
+
+def _read_text(path: Path) -> str | None:
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+class _TagTolerantLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates unknown tags so ESPHome YAML is still parsed.
+
+    `firmware/greenhouse.yaml` uses ESPHome's `!include` / `!secret` / `!lambda`
+    tags, which plain `yaml.safe_load` rejects. `.pre-commit-config.yaml` simply
+    excludes `firmware/` from `check-yaml` and gives up on it entirely. Skipping
+    only the *tag semantics* is strictly better: indentation, structure and
+    duplicate-key-free mapping syntax are still validated across the firmware
+    tree, which is where a malformed edit would otherwise reach the ESP32.
+
+    Nothing is resolved or executed — unknown tags collapse to their underlying
+    scalar/sequence/mapping node.
+    """
+
+
+def _construct_unknown(loader, tag_suffix, node):  # noqa: ARG001
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_mapping(node)
+
+
+_TagTolerantLoader.add_multi_constructor("", _construct_unknown)
+
+
+def test_every_tracked_python_file_compiles():
+    """Every tracked `.py` must parse — including the trees ruff never sees."""
+    sources = _tracked("*.py")
+    assert sources, "no tracked Python files found — the file discovery itself is broken"
+
+    failures: list[str] = []
+    for path in sources:
+        try:
+            ast.parse(path.read_bytes(), filename=str(path))
+        except SyntaxError as exc:
+            failures.append(f"{path.relative_to(ROOT)}:{exc.lineno}: {exc.msg}")
+        except ValueError as exc:  # e.g. source containing null bytes
+            failures.append(f"{path.relative_to(ROOT)}: {exc}")
+
+    assert not failures, "Python files that do not compile:\n  " + "\n  ".join(failures)
+
+
+def test_every_tracked_yaml_file_parses():
+    """Every tracked YAML document must parse, firmware/ included."""
+    sources = _tracked("*.yml", "*.yaml")
+    assert sources, "no tracked YAML files found — the file discovery itself is broken"
+
+    failures: list[str] = []
+    for path in sources:
+        text = _read_text(path)
+        if text is None:
+            continue
+        try:
+            list(yaml.load_all(text, Loader=_TagTolerantLoader))
+        except yaml.YAMLError as exc:
+            detail = str(exc).replace("\n", " ")[:200]
+            failures.append(f"{path.relative_to(ROOT)}: {detail}")
+
+    assert not failures, "YAML files that do not parse:\n  " + "\n  ".join(failures)
+
+
+def test_no_unresolved_merge_conflict_markers():
+    """A committed conflict marker breaks whatever consumes the file at runtime."""
+    # Built at runtime so this file — which necessarily mentions the markers —
+    # cannot match itself.
+    opening = "<" * 7
+    closing = ">" * 7
+
+    failures: list[str] = []
+    for path in _tracked():
+        text = _read_text(path)
+        if text is None:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if line.startswith(opening) or line.startswith(closing):
+                failures.append(f"{path.relative_to(ROOT)}:{lineno}")
+
+    assert not failures, "unresolved merge-conflict markers:\n  " + "\n  ".join(failures)
+
+
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<ref>\S+)(?:\s+AS\s+(?P<stage>\S+))?\s*$", re.IGNORECASE)
+
+
+def _dockerfiles() -> list[Path]:
+    return sorted(p for p in _tracked() if p.name == "Dockerfile" or p.name.startswith("Dockerfile."))
+
+
+def test_every_dockerfile_declares_a_pinned_base_image():
+    """Each `FROM` must name a prior stage, a build arg, or an explicitly tagged image.
+
+    An untagged or `:latest` base makes the image non-reproducible: the same
+    commit builds differently tomorrow. Multi-stage internal references
+    (`FROM base AS builder`) are resolved against stages declared earlier in the
+    same file rather than being mistaken for untagged images.
+    """
+    dockerfiles = _dockerfiles()
+    assert dockerfiles, "no Dockerfiles found — the file discovery itself is broken"
+
+    failures: list[str] = []
+    for path in dockerfiles:
+        rel = path.relative_to(ROOT)
+        stages: set[str] = set()
+        from_count = 0
+
+        for lineno, line in enumerate((_read_text(path) or "").splitlines(), start=1):
+            match = _FROM_RE.match(line)
+            if not match:
+                continue
+            from_count += 1
+            ref = match.group("ref")
+            stage = match.group("stage")
+
+            if ref.lower() in stages or "$" in ref or "@sha256:" in ref:
+                pass  # prior stage, build-arg driven, or digest-pinned
+            elif ":" not in ref.rsplit("/", 1)[-1]:
+                failures.append(f"{rel}:{lineno}: untagged base image {ref!r} (not a prior stage)")
+            elif ref.rsplit(":", 1)[1] == "latest":
+                failures.append(f"{rel}:{lineno}: mutable ':latest' base image {ref!r}")
+
+            if stage:
+                stages.add(stage.lower())
+
+        if from_count == 0:
+            failures.append(f"{rel}: contains no FROM instruction")
+
+    assert not failures, "Dockerfile base-image problems:\n  " + "\n  ".join(failures)
+
+
+def test_sops_named_manifests_are_actually_encrypted():
+    """A `*.sops.yaml` that is not encrypted is a plaintext secret in git history.
+
+    Shape only. This reads key *names* and asserts each secret value carries the
+    SOPS `ENC[` ciphertext envelope; it never decrypts, and no value is included
+    in any assertion message. Mirrors the `encrypted_regex: ^(data|stringData)$`
+    contract in `.sops.yaml`.
+    """
+    encrypted = [p for p in _tracked("deploy/k8s/**") if p.name.endswith((".sops.yaml", ".sops.yml"))]
+    assert encrypted, "no *.sops.yaml manifests found — the SOPS naming convention or discovery changed"
+
+    failures: list[str] = []
+    for path in encrypted:
+        rel = path.relative_to(ROOT)
+        document = yaml.safe_load(_read_text(path) or "") or {}
+
+        if "sops" not in document:
+            failures.append(f"{rel}: no top-level 'sops' metadata block — file is not SOPS-encrypted")
+            continue
+
+        payload = {**(document.get("data") or {}), **(document.get("stringData") or {})}
+        if not payload:
+            failures.append(f"{rel}: no data/stringData keys to encrypt")
+            continue
+
+        for key, value in payload.items():
+            if not (isinstance(value, str) and value.startswith("ENC[")):
+                failures.append(f"{rel}: key {key!r} is not SOPS ciphertext")
+
+    assert not failures, "SOPS-named manifests that are not properly encrypted:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
## What

Adds `tests/test_static_repo_hygiene.py` — five hermetic repo-wide static checks — and wires it into the pure-logic list in `scripts/ci-local.sh` so it runs on every PR under the existing required check.

## Why this is not a `.github/workflows/` file

This started as "give the repo its first CI — `.github/` has only `CODEOWNERS`, nothing runs on a PR". The first half is true. The second is not, and the empty workflow directory is the deliberate end state of the 2026-07-11 cutover, not a gap.

Both runner options are dead ends today, so a workflow would have shipped a red or a never-reporting check:

| Approach | Outcome |
| --- | --- |
| `runs-on: ubuntu-latest` (any `ubuntu-`/`windows-`/`macos-` label) | Trips `test_no_workflow_uses_a_github_hosted_runner`, which runs *inside* `ci-local.sh`. The required check `Verdify Platform / Argo PR CI` goes **red** → unmergeable. |
| `runs-on: self-hosted` | Passes the label guard, but `repos/.../actions/runners` is `total_count: 0` — no runner is registered to this repo, so the job **queues forever**. |

Either way `test_workflow_directory_is_still_empty_on_this_branch` also trips. Reintroduction is a gated operator decision per `docs/ci/zero-paid-runner-ledger.md` §7, not an autonomous one.

So the validation goes where PRs actually execute: the gate. §1.1 of the ledger now records this, so the next person arriving with the same premise finds the answer before writing a workflow.

## The coverage hole this closes

The gate's ruff invocation names seven paths, and `pyproject.toml` sets `extend-exclude = ["planner_graph"]`. That leaves **68 tracked `.py` files with no syntax coverage at all** — including the entire 50-file `planner_graph/` package, which ships as a production k3s image. A syntax error there merges clean and fails at container start.

Same hole on the non-Python surface: `.pre-commit-config.yaml` carries `check-yaml`, `check-json` and `check-merge-conflict`, but **`ci-local.sh` never invokes pre-commit** — those hooks only fire for developers who ran `pre-commit install`. Advisory, not enforced.

## The checks

All hermetic — no network, database, cluster or secret, and no subprocess beyond `git ls-files`.

| # | Check | Scope on current tree |
| --- | --- | --- |
| 1 | Every tracked `.py` compiles | 287 files |
| 2 | Every tracked YAML parses | 219 files |
| 3 | No unresolved merge-conflict markers | all tracked text |
| 4 | Every Dockerfile has a pinned, resolvable base | 13 files |
| 5 | `*.sops.yaml` files are actually encrypted | 2 files |

Notes on the two non-obvious ones:

- **(2) parses `firmware/` too**, which `check-yaml` excludes outright. A tag-tolerant `SafeLoader` skips ESPHome `!include`/`!secret`/`!lambda` tag *semantics* while still validating indentation and structure — the firmware tree is exactly where a malformed edit reaches the ESP32. Nothing is resolved or executed.
- **(5) is shape-only.** It asserts each secret value carries the SOPS `ENC[` envelope and never decrypts. No value appears in any assertion message.

(4) resolves multi-stage references, so `FROM base AS builder` is correctly treated as a prior stage rather than an untagged image.

## Verification

- All five pass on the current tree.
- Each was confirmed to **fail with a precise message** when a matching defect is introduced, then reverted — a guard that cannot go red is not a guard.
- `scripts/ci-local.sh` was run end-to-end on this branch **and on a pristine `origin/main` worktree**. Both produce the identical 16 failures in `test_lab_publish_k3s_guard.py` / `test_public_output_guard.py` → **zero regression from this change**. Those 16 are pre-existing and macOS-only (BSD `chmod`/`date`, Linux-only `renameat2 RENAME_EXCHANGE`); the gate is green on Linux, where it actually runs.
- `ruff check` and `ruff format --check` clean; pre-commit hooks pass.

## Deliberately out of scope

- **No `.github/workflows/`** — see above.
- **No deploy, publish, or image-build job.** Static validation only; nothing touches the cluster, the ArgoCD sync policy, or firmware OTA.
- **No plaintext-Secret check.** `deploy/k8s` legitimately carries six `*.placeholder.yaml` Secrets plus two cnpg dev fixtures. A blanket rule would need a bespoke allowlist codifying today's layout rather than a principle, so it was left out.
- **No additional `Makefile` target wired in.** The validation targets beyond `make ci` need docker, a live database, MQTT or the ESP32; none run hermetically.

## Two defects found while doing this — neither fixed here

1. **The required check has been dark since 2026-07-29.** `Verdify Platform / Argo PR CI` last posted at `2026-07-29T00:07:14Z`. PRs #558 (opened 07-31) and #559 (opened 07-31) both have a **completely empty** status rollup — the required context never arrived, so neither can merge. This PR will very likely be in the same position; the gate result above was produced out-of-band per ledger §8.2 step 1.
2. **`make ci` does not pass on macOS.** `ci-local.sh` bills itself as "runnable anywhere (operator host, k3s pod, …)", `CLAUDE.md` calls it THE validation gate, and ledger §8.2 names `make ci` on an operator host as *the* fallback when the cluster is unavailable. On macOS 16 tests fail on unmodified `main`. Given (1), that fallback is exactly what an operator would reach for right now, and on a MacBook it does not work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7TPQfeNd8bAt4RvuXK7YU
