### PR TITLE
docs(ci): describe the CI that exists, not the one that was deleted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,14 @@ Handoff protocol:
   device-write gate**. NOTE: `verdify-www` (verdify.ai/www marketing) and
   `verdify-crm` are SEPARATE products in SEPARATE repos — unrelated to the
   greenhouse, do not touch.
-- **Pipeline (single-env, ZOT as of 2026-07-11 / ADR-0021):** GitHub Actions
-  VALIDATES only — `Container Publish` builds every image with `push: false`
-  (a Dockerfile/COPY break still fails the push/PR). PUBLISHING is in-cluster:
+- **Pipeline (single-env, ZOT as of 2026-07-11 / ADR-0021):** there are no
+  GitHub Actions in this repo — `.github/workflows/` is deliberately empty and
+  guarded by `tests/test_no_workflow_uses_a_github_hosted_runner` and
+  `test_workflow_directory_is_still_empty_on_this_branch`. VALIDATION is
+  in-cluster: the `verdify-platform-pr-ci` Argo Events sensor runs
+  `scripts/ci-local.sh` with `CI_BASE_REF` set and reports the GitHub commit
+  status `Verdify Platform / Argo PR CI`, which is the single required check on
+  `main` (see `docs/ci/zero-paid-runner-ledger.md`). PUBLISHING is in-cluster:
   `repo-build` Argo Workflows in ns `agent-fleet-ci` (Kaniko) build the exact
   main revision and push `registry.vallery.net/verdifyconsultancy/<image>@sha256`
   to the zot origin; digests are pinned into `overlays/prod/kustomization.yaml`
@@ -257,9 +262,9 @@ Post-2026-04-21 incident (sprint-15/15.1 fix-it-forward spiral producing repeate
 
 5. **Stress-window warning.** If outdoor_temp > 85°F forecast for the next 24 hours, `make firmware-deploy` reports it as operator context but does not block. Severe alerts, 48-hour bake, and weekly OTA limits remain hard gates.
 
-6. **Every new tunable needs a `cfg_*` readback.** CI job `no-new-fire-and-forget` enforces this on PRs touching `firmware/greenhouse/tunables.yaml`. Fire-and-forget tunables are silent-push-corruption risks.
+6. **Every new tunable needs a `cfg_*` readback.** The `no-new-fire-and-forget` gate in `scripts/ci-local.sh` enforces this on PRs touching `firmware/greenhouse/tunables.yaml`. It is diff-scoped, so it only runs when `CI_BASE_REF` is set — which the in-cluster PR CI does, and a bare local `make ci` does not. Fire-and-forget tunables are silent-push-corruption risks.
 
-7. **Schema changes require explicit restart documentation.** If a PR touches `verdify_schemas/**`, `ingestor/entity_map.py`, or `mcp/server.py`, the PR body must mention which services need to bounce post-merge (`verdify-mcp`, `verdify-ingestor`). CI job `service-restart-drift-guard` enforces this. Observed need from the 2026-04-21 MCP staleness incident.
+7. **Schema changes require explicit restart documentation.** If a PR touches `verdify_schemas/**`, `ingestor/entity_map.py`, or `mcp/server.py`, the PR body must mention which services need to bounce post-merge (`verdify-mcp`, `verdify-ingestor`). The `service-restart drift guard` gate in `scripts/ci-local.sh` enforces this; like rule 6 it is diff-scoped behind `CI_BASE_REF`. Observed need from the 2026-04-21 MCP staleness incident.
 
 8. **Every firmware PR must show a replay-diff.** `make ci` with `CI_BASE_REF=<base>` runs `scripts/firmware-replay-diff.sh` against merge-base. Default `THRESHOLD_PCT=0` means zero mode/relay divergence allowed. Intentional divergence (e.g. Phase 2 dwell-gate rollout) requires coordinator approval + explicit `THRESHOLD_PCT` override in the PR.
 

--- a/docs/design/verdify-cicd-program.md
+++ b/docs/design/verdify-cicd-program.md
@@ -1,5 +1,20 @@
 # Verdify CI/CD Self-Refactor Program (Golden-Path)
 
+> **SUPERSEDED 2026-07-11 — HISTORICAL RECORD ONLY.** This document plans a GitHub
+> Actions pipeline (`container-publish.yml`, the `jvallery/agents` reusable
+> container-build workflow, `ghcr.io/jvallery/verdify-<comp>` tags). **None of it
+> exists.** All eight workflow files were deleted in `6c7abe14` and
+> `.github/workflows/` is now deliberately empty and test-guarded. Publishing
+> moved to the in-cluster zot origin (`registry.vallery.net`) per ADR-0021, and
+> the merge gate is the commit status `Verdify Platform / Argo PR CI` produced by
+> the `verdify-platform-pr-ci` Argo Events sensor. It also predates the
+> 2026-06-10/06-16 single-branch simplification, so its `live/platform-main`
+> ground-truth section describes a retired branch.
+>
+> **For the current pipeline read `docs/ci/zero-paid-runner-ledger.md`,
+> `docs/runbooks/prod-promotion.md`, and `ARGOCD.md`.** Do not implement anything
+> below.
+
 **Status:** DESIGN ONLY — no cluster created, no images pushed, no production changed, no
 device/secret/firmware touched. This is the P1 deliverable of the CI/CD golden-path
 self-refactor, the Verdify-specific equivalent of the fleet's `gravity-k3s-program.md`.

--- a/docs/runbooks/prod-promotion.md
+++ b/docs/runbooks/prod-promotion.md
@@ -7,14 +7,18 @@
 path anymore.
 
 **ZOT MIGRATION (2026-07-11, ADR-0021):** publishing moved OFF GHCR to the
-in-cluster zot origin (`registry.vallery.net`). GitHub Actions now VALIDATES
-builds only (`Container Publish` runs every Dockerfile with `push: false`).
+in-cluster zot origin (`registry.vallery.net`). GitHub Actions was removed in
+the same change — the `Container Publish`, `CI`, and `K8s Manifests` workflows
+no longer exist and last ran 2026-07-11. `.github/workflows/` is deliberately
+empty and two tests keep it that way.
 
 ## Flow
 
-1. Merge to `main` with `make ci` green (GitHub Actions is REMOVED as of
-   2026-07-11 — `scripts/ci-local.sh` is the entire validation gate, runnable
-   on any host or in the in-cluster `verdify-platform-ci` Workflow).
+1. Merge to `main` with `make ci` green. `scripts/ci-local.sh` is the entire
+   validation gate, runnable on any host; in-cluster the
+   `verdify-platform-pr-ci` sensor runs it with `CI_BASE_REF` set and reports
+   the commit status `Verdify Platform / Argo PR CI`, the single required check
+   on `main`.
 3. Publish happens IN-CLUSTER: submit one `repo-build` Argo Workflow per
    changed image in namespace `agent-fleet-ci` (Kaniko builds the exact main
    revision and pushes `registry.vallery.net/verdifyconsultancy/<image>@sha256:…`


### PR DESCRIPTION
## What this fixes

Three documents in this repo assert a GitHub Actions pipeline that was deleted on 2026-07-11 in `6c7abe14` ("remove GitHub Actions: make ci / scripts/ci-local.sh is the gate; CI runs in-cluster").

### Probe (2026-08-02)

```
$ gh api repos/VerdifyConsultancy/verdify-platform/actions/workflows --jq '.workflows[]|"\(.state)\t\(.name)\t\(.path)"'
active  Dependency Graph        dynamic/dependabot/update-graph

$ gh api repos/VerdifyConsultancy/verdify-platform/contents/.github/workflows
404 Not Found

$ gh run list --repo VerdifyConsultancy/verdify-platform --workflow "Container Publish" --limit 1
2026-07-11  Container Publish  push/main  completed/success      <- last run, three weeks ago
```

### The corrections

| File | Claimed | Actually true |
|---|---|---|
| `CLAUDE.md` (pipeline bullet) | "GitHub Actions VALIDATES only — `Container Publish` builds every image with `push: false`" | No workflows exist. `.github/workflows/` is empty and guarded by `tests/test_no_workflow_uses_a_github_hosted_runner` + `test_workflow_directory_is_still_empty_on_this_branch`. The same file already said the opposite at lines 62 and 220. |
| `docs/runbooks/prod-promotion.md` §ZOT MIGRATION | same `Container Publish` claim | contradicted itself four lines later ("GitHub Actions is REMOVED as of 2026-07-11") |
| `CLAUDE.md` rules 6 + 7 | "CI job `no-new-fire-and-forget`", "CI job `service-restart-drift-guard`" | **No job of either name exists anywhere.** They are steps in `scripts/ci-local.sh` (lines 116 and 126), diff-scoped behind `CI_BASE_REF` — so they run in the in-cluster PR CI but **not** in a bare local `make ci`. That distinction was previously invisible to anyone reading the rule. |
| `docs/design/verdify-cicd-program.md` (2026-05-30, 591 lines) | plans `container-publish.yml`, the `jvallery/agents` reusable container-build workflow, and `ghcr.io/jvallery/verdify-<comp>` tags | all eight workflows deleted; publishing is the in-cluster zot origin per ADR-0021. Also predates the 2026-06-10/06-16 single-branch simplification, so its `live/platform-main` ground-truth section describes a retired branch. |

`verdify-cicd-program.md` gets a SUPERSEDED banner rather than deletion — it is a useful historical record of how the estate got here. Its body is untouched.

### What I verified is correct and did NOT change

- `docs/ci/zero-paid-runner-ledger.md` accurately documents `Verdify Platform / Argo PR CI`, its `app_id: null / strict: true` protection entry, and the in-cluster replacement. Left alone (also being edited by #560).
- `ARGOCD.md` accurately describes the Argo Event → `repo-build` → zot digest path.
- The merge gate is genuinely real. I traced it end to end in the cluster rather than trusting the name:
  - `verdify-platform-pr-ci` sensor fires on `opened|reopened|synchronize`;
  - `trusted-precheck` writes `full` for every head branch that is not `ci/lab-stage-pin-*`;
  - `when: validation-mode == 'full'` then delegates to `templateRef: {name: verdify-platform-ci, template: validate}`, which runs `bash scripts/ci-local.sh` with `CI_BASE_REF` set.

  So the required check does execute this repo's real test gate, including the diff-scoped rule 6/7 guards. I had initially suspected it was only a digest-pin shape validator; that was wrong, and the corrected description is what this PR writes down.

### Not addressed here

The required check has posted nothing since 2026-07-29 — that is a live outage in `jvallery/agents`, already filed as #561, and not a documentation problem. This PR will therefore sit at `pending` like #558 and #559 until that is fixed.

No CI was invented to match a doc. Only claims were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7TPQfeNd8bAt4RvuXK7YU