### PR TITLE
ci: restore registry-owned validation profile

### DIFF
--- a/.agent-fleet/ci.yaml
+++ b/.agent-fleet/ci.yaml
@@ -32,6 +32,29 @@ images:
   context: site-astro
 checks:
   steps:
-  - name: platform
+  - name: platform-static
     command: uv sync --python 3.12 --extra dev --extra api --extra planner --extra
-      planner-graph && bash scripts/ci-local.sh
+      planner-graph && uv run ruff check ingestor/ api/ mcp/ scripts/*.py tests/ verdify_schemas/
+      && uv run ruff format --check ingestor/ api/ mcp/ scripts/*.py tests/ verdify_schemas/
+  - name: platform-tests
+    command: uv sync --python 3.12 --extra dev --extra api --extra planner --extra
+      planner-graph && uv pip install --python .venv/bin/python -r ingestor/requirements-image.txt
+      && uv run pytest -q verdify_schemas/tests/ --ignore=verdify_schemas/tests/test_climate_intent.py
+      --ignore=verdify_schemas/tests/test_drift_guards.py --ignore=verdify_schemas/tests/test_mcp_responses.py
+      --ignore=verdify_schemas/tests/test_relationships.py --ignore=verdify_schemas/tests/test_tunables.py
+      --ignore=verdify_schemas/tests/test_vault_writers.py --ignore=verdify_schemas/tests/test_views.py
+      && uv run pytest -q tests/test_device_write_gate.py tests/test_migration_rollback_safety.py
+      tests/test_14_site_doctor.py tests/test_climate_intent_replay_evaluator.py tests/test_g5_dualwrite_validation.py
+      tests/test_generate_daily_plan.py tests/test_mqtt_fanout.py tests/test_planner_memory_ingest.py
+      tests/test_site_content_refresh.py tests/test_slack_config.py tests/test_slack_ops.py
+      tests/test_soil_dryout_alert.py tests/test_tempest_sync.py tests/test_writer_lease_fence.py
+  - name: firmware-logic
+    command: "bash -lc ' set -euo pipefail; test -f firmware/test/data/replay_overrides.csv\
+      \ || gunzip -k firmware/test/data/replay_overrides.csv.gz; cd firmware; g++\
+      \ -std=c++17 -I lib -o test/test_greenhouse test/test_greenhouse_logic.cpp;\
+      \ ./test/test_greenhouse; g++ -std=c++17 -O2 -I lib -o test/replay_overrides\
+      \ test/replay_overrides.cpp; ./test/replay_overrides test/data/replay_overrides.csv\
+      \ | tail -30; g++ -std=c++17 -O2 -I lib -o test/replay_invariants test/replay_invariants.cpp;\
+      \ set +e; ./test/replay_invariants test/data/replay_overrides.csv; rc=$?; set\
+      \ -e; if [ \"$rc\" -eq 2 ]; then\n  echo \"replay corpus predates invariant\
+      \ schema; accepted legacy corpus\";\n  exit 0;\nfi; exit \"$rc\" '"


### PR DESCRIPTION
Closes #566.

Fleet convergence: jvallery/agents#3507.

The current `main` validation block drifted from the admission policy generated by the fleet registry. Restore the exact managed `.agent-fleet/ci.yaml` so the owning repo pod can submit the fixed validation profile.

Checks:
- managed spec is byte-identical to `jvallery/agents` generated `gh-1247193937.yaml`
- YAML parse: pass
- `git diff --check`: pass

After merge, `repo-verdifyconsultancy-verdify-platform-0` will submit and wait for the validation Workflow at the merged SHA; all nine image builds are being proven independently through the same pod.