### PR TITLE
fix(ci): hydrate Lab snapshot before image builds

### DIFF
--- a/.agent-fleet/ci.yaml
+++ b/.agent-fleet/ci.yaml
@@ -27,9 +27,11 @@ images:
 - name: verdify-lab
   dockerfile: Dockerfile.production
   context: site-astro
+  test: cd site-astro && npm ci --no-audit --no-fund && npm run snapshot:hydrate
 - name: verdify-lab-astro
   dockerfile: Dockerfile
   context: site-astro
+  test: cd site-astro && npm ci --no-audit --no-fund && npm run snapshot:hydrate
 checks:
   steps:
   - name: platform-static


### PR DESCRIPTION
## Source

- Closes #568
- Fleet source: https://github.com/jvallery/agents/issues/3507
- Depends on central generated-contract PR: https://github.com/jvallery/agents/pull/3572

## Change

Publish the central generated `.agent-fleet/ci.yaml` contract that hydrates the ignored immutable Lab snapshot in the generic prebuild step before Kaniko runs for both Lab image profiles.

No product code, deploy manifest, runtime permission, or production evidence policy changes. `Dockerfile.production` remains fail-closed until the snapshot is approval-eligible.

## Verification

- file is byte-identical to the artifact generated by central PR #3572
- YAML parse passes
- `git diff --check` passes

## Post-merge proof

From the exact owning `repo-verdifyconsultancy-verdify-platform-0` pod:

- run `agent-ci-build --submit --wait --image verdify-lab-astro` at merged `main`; expect a pushed digest
- run `agent-ci-build --submit --wait --image verdify-lab`; expect hydration to pass and the existing approval-eligible evidence gate to block until approved content exists
