### PR TITLE
fix(hermes): replace prolonged disconnected client

### DIFF
--- a/deploy/k8s/components/hermes-iris/hermes-config.yaml
+++ b/deploy/k8s/components/hermes-iris/hermes-config.yaml
@@ -30,11 +30,15 @@ data:
     """Hermes probes: configured tools, MCP server, and in-process client state."""
     import argparse
     import datetime
+    import fcntl
     import json
+    import math
     import os
     import re
     import sys
+    import time
     import urllib.request
+    from pathlib import Path
 
     REQUIRED = {
         "acknowledge_trigger", "alerts", "climate", "crop_history",
@@ -44,19 +48,38 @@ data:
         "plan_status", "position_current", "scorecard", "set_plan",
         "set_tunable", "slack_ops", "topology",
     }
-    LOG_TIMESTAMP = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})")
-    CONNECTED = (
-        "MCP server 'verdify_greenhouse' (HTTP): registered",
+    PROBE_STATE_SCHEMA = 1
+    MCP_LOG_LINE = re.compile(
+        r"^(?P<stamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) "
+        r"(?:DEBUG|INFO|WARNING|ERROR|CRITICAL)(?: \[[^]\r\n]+\])? "
+        r"tools\.mcp_tool: (?P<message>.*)$"
+    )
+    FULL_DISCOVERY = re.compile(
+        r"^MCP server 'verdify_greenhouse' \(HTTP\): registered \d+ tool\(s\): .*$"
     )
     DISCONNECTED = (
-        "MCP server 'verdify_greenhouse' connection lost",
-        "MCP server 'verdify_greenhouse' is not connected",
-        "MCP server 'verdify_greenhouse' is unreachable after",
-        "Failed to connect to MCP server 'verdify_greenhouse'",
+        re.compile(
+            r"^MCP server 'verdify_greenhouse': reconnect requested — "
+            r"tearing down (?:SSE|HTTP|legacy HTTP) session$"
+        ),
+        re.compile(
+            r"^MCP server 'verdify_greenhouse' connection lost "
+            r"\(attempt \d+/\d+\), reconnecting in \d+s: .*$"
+        ),
+        re.compile(
+            r"^Failed to connect to MCP server 'verdify_greenhouse'"
+            r"(?: \(command=.*\))?: .*$"
+        ),
     )
     FATAL = (
-        "MCP server 'verdify_greenhouse' failed after",
-        "MCP server 'verdify_greenhouse' failed initial connection after",
+        re.compile(
+            r"^MCP server 'verdify_greenhouse' failed after \d+ "
+            r"reconnection attempts, giving up: .*$"
+        ),
+        re.compile(
+            r"^MCP server 'verdify_greenhouse' failed initial connection after "
+            r"\d+ attempts, giving up: .*$"
+        ),
     )
 
     def configured_tool_names(config):
@@ -102,48 +125,163 @@ data:
             start_ticks = float(process_stat.read().split()[21])
         return boot_epoch + (start_ticks / os.sysconf("SC_CLK_TCK"))
 
-    def _line_epoch(line):
-        match = LOG_TIMESTAMP.match(line)
+    def _lifecycle_event(line):
+        """Parse only lifecycle records emitted by the pinned MCP client logger."""
+        match = MCP_LOG_LINE.match(line)
         if not match:
             return None
-        stamp = datetime.datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S,%f")
-        return stamp.replace(tzinfo=datetime.timezone.utc).timestamp()
+        stamp = datetime.datetime.strptime(match.group("stamp"), "%Y-%m-%d %H:%M:%S,%f")
+        event_at = stamp.replace(tzinfo=datetime.timezone.utc).timestamp()
+        message = match.group("message")
+        if any(pattern.fullmatch(message) for pattern in FATAL):
+            return event_at, "fatal", message
+        if FULL_DISCOVERY.fullmatch(message):
+            return event_at, "full_discovery", message
+        if any(pattern.fullmatch(message) for pattern in DISCONNECTED):
+            return event_at, "disconnect", message
+        return None
 
-    def hermes_client_state(log_paths, started_at):
-        """Reduce post-start Hermes log markers to connected/disconnected/fatal."""
-        events = []
-        for path in log_paths:
+    def _new_client_state(started_at):
+        return {
+            "schema_version": PROBE_STATE_SCHEMA,
+            "process_started_at": started_at,
+            "state": "unknown",
+            "fatal": False,
+            "last_event_at": None,
+            "unacknowledged_disconnect_since": None,
+            "signal_source": "none",
+        }
+
+    def _load_client_state(path, started_at):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return _new_client_state(started_at)
+        try:
+            same_process = abs(float(payload["process_started_at"]) - started_at) < 0.001
+        except (KeyError, TypeError, ValueError):
+            same_process = False
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != PROBE_STATE_SCHEMA
+            or not same_process
+            or payload.get("state") not in {"unknown", "connected", "disconnected", "fatal"}
+            or not isinstance(payload.get("fatal"), bool)
+        ):
+            return _new_client_state(started_at)
+        return payload
+
+    def _write_client_state(path, state):
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        try:
+            with temporary.open("w", encoding="utf-8") as stream:
+                json.dump(state, stream, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, path)
+        finally:
             try:
-                with open(path, encoding="utf-8", errors="replace") as stream:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _log_candidates(log_paths):
+        """Read active logs plus one rotation; the persisted latch spans later rotation."""
+        seen = set()
+        for raw_path in log_paths:
+            for candidate in (Path(raw_path), Path(f"{raw_path}.1")):
+                if candidate not in seen:
+                    seen.add(candidate)
+                    yield candidate
+
+    def _lifecycle_events(log_paths, started_at):
+        events = []
+        identities = set()
+        for source_order, path in enumerate(_log_candidates(log_paths)):
+            try:
+                with path.open(encoding="utf-8", errors="replace") as stream:
                     for sequence, line in enumerate(stream):
-                        event_at = _line_epoch(line)
-                        # Persistent PVC logs survive pod replacement. Untimestamped
-                        # and pre-start lines can never describe this process.
-                        if event_at is None or event_at < started_at - 2:
+                        event = _lifecycle_event(line)
+                        if event is None or event[0] < started_at:
                             continue
-                        events.append((event_at, sequence, line))
+                        identity = event
+                        if identity in identities:
+                            continue
+                        identities.add(identity)
+                        events.append((*event, source_order, sequence))
             except FileNotFoundError:
                 continue
-        state = "unknown"
-        fatal = False
-        last_event_at = None
-        for event_at, _sequence, line in sorted(events):
-            if any(marker in line for marker in FATAL) and "giving up" in line:
-                state = "fatal"
-                fatal = True
-                last_event_at = event_at
-            elif any(marker in line for marker in CONNECTED):
-                state = "connected"
-                fatal = False
-                last_event_at = event_at
-            elif any(marker in line for marker in DISCONNECTED):
-                state = "disconnected"
-                last_event_at = event_at
-        return {
-            "state": state,
-            "fatal": fatal,
-            "last_event_at": last_event_at,
-        }
+        return sorted(events, key=lambda item: (item[0], item[3], item[4]))
+
+    def _reduce_client_events(state, events):
+        baseline = state.get("last_event_at")
+        for event_at, kind, _message, _source_order, _sequence in events:
+            if baseline is not None and event_at <= baseline:
+                continue
+            if kind == "fatal":
+                state["state"] = "fatal"
+                state["fatal"] = True
+                state["unacknowledged_disconnect_since"] = (
+                    state.get("unacknowledged_disconnect_since") or event_at
+                )
+                state["signal_source"] = "fatal_log"
+            elif kind == "full_discovery":
+                state["state"] = "connected"
+                state["fatal"] = False
+                state["unacknowledged_disconnect_since"] = None
+                state["signal_source"] = "full_discovery_log"
+            elif kind == "disconnect":
+                if state.get("state") not in {"disconnected", "fatal"}:
+                    state["unacknowledged_disconnect_since"] = event_at
+                if not state.get("fatal"):
+                    state["state"] = "disconnected"
+                state["signal_source"] = "disconnect_log"
+            state["last_event_at"] = event_at
+        return state
+
+    def hermes_client_state(log_paths, started_at, state_path=None):
+        """Persist the first post-start negative event across Hermes log rotation.
+
+        The pinned client logs full discovery only at initial registration; a
+        successful automatic background reconnect is silent. Therefore a
+        disconnect remains unacknowledged until a real later full-discovery log
+        or process replacement. This is a negative latch, not a live socket test.
+        """
+        if state_path is None:
+            return _reduce_client_events(
+                _new_client_state(started_at),
+                _lifecycle_events(log_paths, started_at),
+            )
+        path = Path(state_path)
+        lock_path = path.with_name(f".{path.name}.lock")
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            state = _load_client_state(path, started_at)
+            state = _reduce_client_events(state, _lifecycle_events(log_paths, started_at))
+            _write_client_state(path, state)
+            return state
+
+    def unacknowledged_disconnect_for_seconds(client, now=None):
+        """Age of the first negative marker not followed by full discovery."""
+        disconnected_since = client.get("unacknowledged_disconnect_since")
+        if client.get("state") not in {"disconnected", "fatal"} or disconnected_since is None:
+            return None
+        observed_at = time.time() if now is None else now
+        return max(0.0, observed_at - disconnected_since)
+
+    def unacknowledged_disconnect_restart_policy(raw):
+        """Parse the opt-in negative-latch threshold without creating restart loops."""
+        if raw is None or not raw.strip():
+            return None, None
+        try:
+            seconds = float(raw)
+        except ValueError:
+            return None, "not_numeric"
+        if not math.isfinite(seconds) or not 60 <= seconds <= 86400:
+            return None, "outside_60_86400_seconds"
+        return seconds, None
 
     def mcp_server_ready():
         url = os.environ.get(
@@ -170,10 +308,52 @@ data:
             "HERMES_CLIENT_LOG_PATHS",
             "/opt/data/logs/agent.log:/opt/data/logs/errors.log",
         ).split(":")
-        client = hermes_client_state(log_paths, started_at)
+        state_path = os.environ.get(
+            "HERMES_MCP_PROBE_STATE_PATH",
+            "/tmp/verdify-hermes-mcp-probe-state.json",
+        )
+        probe_state_error = None
+        try:
+            client = hermes_client_state(log_paths, started_at, state_path=state_path)
+        except Exception as exc:
+            # A broken probe state must remove the pod from readiness without
+            # creating an opaque liveness restart loop.
+            probe_state_error = type(exc).__name__
+            client = {
+                "schema_version": PROBE_STATE_SCHEMA,
+                "process_started_at": started_at,
+                "state": "probe_error",
+                "fatal": False,
+                "last_event_at": None,
+                "unacknowledged_disconnect_since": None,
+                "signal_source": "probe_state_error",
+            }
         if args.mode == "liveness":
-            alive = not client["fatal"]
-            print(json.dumps({"alive": alive, "client": client}, sort_keys=True))
+            unacknowledged_restart_seconds, timeout_config_error = (
+                unacknowledged_disconnect_restart_policy(
+                    os.environ.get("HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS")
+                )
+            )
+            unacknowledged_for = unacknowledged_disconnect_for_seconds(client)
+            restart_reason = None
+            if client["fatal"]:
+                restart_reason = "fatal_reconnect_exhaustion"
+            elif (
+                unacknowledged_restart_seconds is not None
+                and unacknowledged_for is not None
+                and unacknowledged_for >= unacknowledged_restart_seconds
+            ):
+                restart_reason = "mcp_client_unacknowledged_disconnect_timeout"
+            alive = restart_reason is None
+            print(json.dumps({
+                "alive": alive,
+                "client": client,
+                "unacknowledged_disconnect_for_seconds": unacknowledged_for,
+                "unacknowledged_disconnect_restart_seconds": unacknowledged_restart_seconds,
+                "timeout_config_error": timeout_config_error,
+                "probe_state_error_class": probe_state_error,
+                "restart_reason": restart_reason,
+            }, sort_keys=True))
             return 0 if alive else 1
 
         with open("/opt/data/config.yaml", encoding="utf-8") as config_file:
@@ -195,6 +375,7 @@ data:
             "unexpected_configured_tools": unexpected_configured,
             "missing_server_tools": missing_server_tools,
             "mcp_server_error_class": server_error,
+            "probe_state_error_class": probe_state_error,
         }, sort_keys=True))
         return 0 if ready else 1
 

--- a/deploy/k8s/components/hermes-iris/hermes-iris.yaml
+++ b/deploy/k8s/components/hermes-iris/hermes-iris.yaml
@@ -145,6 +145,15 @@ spec:
               value: /opt/data/slack.yaml
             - name: HERMES_MCP_READINESS_URL
               value: http://verdify-mcp.verdify-prod.svc:8000/readyz
+            - name: HERMES_MCP_PROBE_STATE_PATH
+              value: /tmp/verdify-hermes-mcp-probe-state.json
+            # The pinned client emits no positive marker after automatic
+            # background reconnect. Latch any post-start disconnect that lacks a
+            # later full-discovery marker; after 10 minutes, two failed 15s
+            # liveness probes replace the process to obtain a truthful fresh
+            # registration. This may replace a client that recovered silently.
+            - name: HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS
+              value: "600"
           securityContext:
             allowPrivilegeEscalation: false
             # hermes writes run state under /opt/data (PVC); root FS can stay RO.
@@ -180,7 +189,7 @@ spec:
             initialDelaySeconds: 45
             periodSeconds: 15
             timeoutSeconds: 5
-            failureThreshold: 1
+            failureThreshold: 2
           readinessProbe:
             exec:
               command: ["python3", "/etc/verdify/hermes-config/tool-readiness.py", "--mode", "readiness"]

--- a/tests/test_17_planner_health_surface.py
+++ b/tests/test_17_planner_health_surface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -377,6 +378,10 @@ def _hermes_probe_namespace(source: str) -> dict[str, object]:
     return namespace
 
 
+def _hermes_mcp_log(stamp: str, message: str, level: str = "INFO", logger: str = "tools.mcp_tool") -> str:
+    return f"{stamp} {level} {logger}: {message}\n"
+
+
 def test_hermes_readiness_covers_the_exact_configured_mcp_allowlist(mcp_server):
     _manifest, profile, readiness_source = _hermes_config_documents()
     configured = set(profile["mcp_servers"]["verdify_greenhouse"]["tools"]["include"])
@@ -406,42 +411,329 @@ def test_hermes_client_state_ignores_persistent_prestart_history(tmp_path):
     started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
     log_path = tmp_path / "agent.log"
     log_path.write_text(
-        "2026-07-10 11:59:00,000 WARNING MCP server 'verdify_greenhouse' "
-        "failed after 5 reconnection attempts, giving up: old\n"
-        "2026-07-10 12:00:01,000 INFO MCP server 'verdify_greenhouse' "
-        "(HTTP): registered 23 tool(s): climate\n"
+        _hermes_mcp_log(
+            "2026-07-10 11:59:00,000",
+            "MCP server 'verdify_greenhouse' failed after 5 reconnection attempts, giving up: old",
+            "WARNING",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+        )
     )
 
     state = client_state([str(log_path)], started_at)
 
     assert state["state"] == "connected"
     assert state["fatal"] is False
+    assert state["signal_source"] == "full_discovery_log"
 
 
-def test_hermes_client_state_disconnect_then_recover(tmp_path):
+def test_hermes_persisted_state_does_not_inherit_immediate_prior_process_disconnect(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    first_started_at = datetime(2026, 7, 10, 11, 59, tzinfo=UTC).timestamp()
+    replacement_started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    state_path = tmp_path / "probe-state.json"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 11:59:59,500",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 4/5), reconnecting in 60s: old process",
+            "WARNING",
+        )
+    )
+
+    first = client_state([str(log_path)], first_started_at, state_path=state_path)
+    log_path.replace(tmp_path / "agent.log.1")
+    log_path.write_text("")
+    replacement = client_state([str(log_path)], replacement_started_at, state_path=state_path)
+
+    assert first["state"] == "disconnected"
+    assert replacement["state"] == "unknown"
+    assert replacement["process_started_at"] == replacement_started_at
+    assert replacement["unacknowledged_disconnect_since"] is None
+
+
+def test_hermes_silent_background_reconnect_stays_latched_across_log_rotation(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    state_path = tmp_path / "probe-state.json"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 1/5), reconnecting in 1s: reset",
+            "WARNING",
+        )
+    )
+    disconnected = client_state([str(log_path)], started_at, state_path=state_path)
+
+    # Exact pinned upstream behavior: _run_http() can reconnect successfully,
+    # but emits no new full-discovery/registered line. Rotate away the first
+    # negative marker and leave only later retry chatter in the active log.
+    log_path.replace(tmp_path / "agent.log.1")
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:02:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 4/5), reconnecting in 8s: reset",
+            "WARNING",
+        )
+    )
+    after_rotation = client_state([str(log_path)], started_at, state_path=state_path)
+    (tmp_path / "agent.log.1").unlink()
+    log_path.write_text("")
+    after_original_marker_is_gone = client_state([str(log_path)], started_at, state_path=state_path)
+
+    expected_since = datetime(2026, 7, 10, 12, 1, tzinfo=UTC).timestamp()
+    for state in (disconnected, after_rotation, after_original_marker_is_gone):
+        assert state["state"] == "disconnected"
+        assert state["fatal"] is False
+        assert state["unacknowledged_disconnect_since"] == expected_since
+    assert after_rotation["last_event_at"] == datetime(2026, 7, 10, 12, 2, tzinfo=UTC).timestamp()
+    assert state_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_hermes_real_full_rediscovery_marker_acknowledges_latched_disconnect(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    state_path = tmp_path / "probe-state.json"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 1/5), reconnecting in 1s: reset",
+            "WARNING",
+        )
+    )
+    disconnected = client_state([str(log_path)], started_at, state_path=state_path)
+    with log_path.open("a") as stream:
+        stream.write(
+            _hermes_mcp_log(
+                "2026-07-10 12:03:00,000",
+                "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+            )
+        )
+    acknowledged = client_state([str(log_path)], started_at, state_path=state_path)
+
+    assert disconnected["state"] == "disconnected"
+    assert acknowledged["state"] == "connected"
+    assert acknowledged["unacknowledged_disconnect_since"] is None
+    assert acknowledged["signal_source"] == "full_discovery_log"
+
+
+def test_hermes_clean_reconnect_request_latches_silent_http_session_replacement(tmp_path):
     _manifest, _profile, source = _hermes_config_documents()
     namespace = _hermes_probe_namespace(source)
     client_state = namespace["hermes_client_state"]
     started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
     log_path = tmp_path / "agent.log"
     log_path.write_text(
-        "2026-07-10 12:00:01,000 INFO MCP server 'verdify_greenhouse' "
-        "(HTTP): registered 23 tool(s): climate\n"
-        "2026-07-10 12:01:00,000 WARNING MCP server 'verdify_greenhouse' "
-        "connection lost (attempt 1/5), reconnecting in 1s: reset\n"
-    )
-    disconnected = client_state([str(log_path)], started_at)
-    with log_path.open("a") as stream:
-        stream.write(
-            "2026-07-10 12:01:02,000 INFO MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate\n"
+        _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
         )
+        + _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse': reconnect requested — tearing down HTTP session",
+        )
+    )
 
-    recovered = client_state([str(log_path)], started_at)
+    state = client_state([str(log_path)], started_at)
 
-    assert disconnected["state"] == "disconnected"
-    assert disconnected["fatal"] is False
-    assert recovered["state"] == "connected"
-    assert recovered["fatal"] is False
+    assert state["state"] == "disconnected"
+    assert state["fatal"] is False
+    assert state["unacknowledged_disconnect_since"] == datetime(2026, 7, 10, 12, 1, tzinfo=UTC).timestamp()
+    assert state["signal_source"] == "disconnect_log"
+
+
+def test_hermes_lifecycle_parser_rejects_other_loggers_and_unstructured_text(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    spoofed = "MCP server 'verdify_greenhouse' connection lost (attempt 1/5)"
+    log_path.write_text(
+        _hermes_mcp_log("2026-07-10 12:01:00,000", spoofed, "WARNING", logger="agent.runner")
+        + f"2026-07-10 12:02:00,000 WARNING prompt text: {spoofed}\n"
+    )
+
+    state = client_state([str(log_path)], started_at)
+
+    assert state["state"] == "unknown"
+    assert state["last_event_at"] is None
+
+
+def test_hermes_lifecycle_parser_rejects_embedded_markers_from_same_logger(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse': malformed tool_calls arguments from LLM: "
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+            "WARNING",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:02:00,000",
+            "remote tool error text: MCP server 'verdify_greenhouse' failed after 5 "
+            "reconnection attempts, giving up: injected",
+            "WARNING",
+        )
+    )
+
+    state = client_state([str(log_path)], started_at)
+
+    assert state["state"] == "unknown"
+    assert state["fatal"] is False
+    assert state["last_event_at"] is None
+
+
+def test_hermes_disconnect_exception_text_cannot_spoof_fatal_or_recovery(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 1/5), reconnecting in 1s: "
+            "MCP server 'verdify_greenhouse' failed after 5 reconnection attempts, giving up: injected; "
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+            "WARNING",
+        )
+    )
+
+    state = client_state([str(log_path)], started_at)
+
+    assert state["state"] == "disconnected"
+    assert state["fatal"] is False
+    assert state["signal_source"] == "disconnect_log"
+
+
+def test_hermes_unacknowledged_disconnect_age_uses_first_negative_marker(tmp_path):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    client_state = namespace["hermes_client_state"]
+    disconnect_age = namespace["unacknowledged_disconnect_for_seconds"]
+    started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
+    log_path = tmp_path / "agent.log"
+    log_path.write_text(
+        _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:01:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 1/5), reconnecting in 1s: reset",
+            "WARNING",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:02:00,000",
+            "MCP server 'verdify_greenhouse' connection lost (attempt 4/5), reconnecting in 8s: reset",
+            "WARNING",
+        )
+    )
+
+    state = client_state([str(log_path)], started_at)
+    now = datetime(2026, 7, 10, 12, 11, 1, tzinfo=UTC).timestamp()
+
+    assert state["state"] == "disconnected"
+    assert state["last_event_at"] == datetime(2026, 7, 10, 12, 2, tzinfo=UTC).timestamp()
+    assert state["unacknowledged_disconnect_since"] == datetime(2026, 7, 10, 12, 1, tzinfo=UTC).timestamp()
+    assert disconnect_age(state, now=now) == 601
+
+
+def test_hermes_liveness_replaces_only_prolonged_unacknowledged_disconnect_or_fatal(monkeypatch, capsys):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    monkeypatch.setenv("HERMES_PROCESS_START_EPOCH", "0")
+    monkeypatch.setenv("HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS", "600")
+    namespace["time"] = SimpleNamespace(time=lambda: 1_000.0)
+
+    client = {
+        "state": "disconnected",
+        "fatal": False,
+        "last_event_at": 500.0,
+        "unacknowledged_disconnect_since": 401.0,
+    }
+    namespace["hermes_client_state"] = lambda *_args, **_kwargs: client
+    assert namespace["main"](["--mode", "liveness"]) == 0
+    recent = json.loads(capsys.readouterr().out)
+    assert recent["alive"] is True
+    assert recent["restart_reason"] is None
+
+    client["unacknowledged_disconnect_since"] = 400.0
+    assert namespace["main"](["--mode", "liveness"]) == 1
+    stale = json.loads(capsys.readouterr().out)
+    assert stale["alive"] is False
+    assert stale["unacknowledged_disconnect_for_seconds"] == 600
+    assert stale["restart_reason"] == "mcp_client_unacknowledged_disconnect_timeout"
+
+    client.update({"state": "unknown", "unacknowledged_disconnect_since": None})
+    assert namespace["main"](["--mode", "liveness"]) == 0
+    unknown = json.loads(capsys.readouterr().out)
+    assert unknown["alive"] is True
+
+    client.update({"state": "fatal", "fatal": True})
+    assert namespace["main"](["--mode", "liveness"]) == 1
+    fatal = json.loads(capsys.readouterr().out)
+    assert fatal["restart_reason"] == "fatal_reconnect_exhaustion"
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected_error"),
+    [
+        (None, None),
+        ("not-a-number", "not_numeric"),
+        ("nan", "outside_60_86400_seconds"),
+        ("-1", "outside_60_86400_seconds"),
+        ("59", "outside_60_86400_seconds"),
+        ("86401", "outside_60_86400_seconds"),
+    ],
+)
+def test_hermes_unacknowledged_disconnect_timeout_is_opt_in_and_invalid_values_fail_open(
+    configured, expected_error, monkeypatch, capsys
+):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    monkeypatch.setenv("HERMES_PROCESS_START_EPOCH", "0")
+    if configured is None:
+        monkeypatch.delenv("HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS", configured)
+    namespace["time"] = SimpleNamespace(time=lambda: 10_000.0)
+    namespace["hermes_client_state"] = lambda *_args, **_kwargs: {
+        "state": "disconnected",
+        "fatal": False,
+        "last_event_at": 100.0,
+        "unacknowledged_disconnect_since": 100.0,
+    }
+
+    assert namespace["main"](["--mode", "liveness"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["alive"] is True
+    assert payload["unacknowledged_disconnect_restart_seconds"] is None
+    assert payload["timeout_config_error"] == expected_error
+    assert payload["restart_reason"] is None
 
 
 def test_hermes_client_state_fatal_reconnect_exhaustion(tmp_path):
@@ -451,10 +743,15 @@ def test_hermes_client_state_fatal_reconnect_exhaustion(tmp_path):
     started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
     log_path = tmp_path / "errors.log"
     log_path.write_text(
-        "2026-07-10 12:00:01,000 INFO MCP server 'verdify_greenhouse' "
-        "(HTTP): registered 23 tool(s): climate\n"
-        "2026-07-10 12:02:00,000 WARNING MCP server 'verdify_greenhouse' "
-        "failed after 5 reconnection attempts, giving up: reset\n"
+        _hermes_mcp_log(
+            "2026-07-10 12:00:01,000",
+            "MCP server 'verdify_greenhouse' (HTTP): registered 23 tool(s): climate",
+        )
+        + _hermes_mcp_log(
+            "2026-07-10 12:02:00,000",
+            "MCP server 'verdify_greenhouse' failed after 5 reconnection attempts, giving up: reset",
+            "WARNING",
+        )
     )
 
     state = client_state([str(log_path)], started_at)
@@ -463,20 +760,110 @@ def test_hermes_client_state_fatal_reconnect_exhaustion(tmp_path):
     assert state["fatal"] is True
 
 
-def test_actual_python3_liveness_probe_restarts_only_on_poststart_fatal(tmp_path):
+def test_hermes_readiness_main_fails_closed_across_client_server_and_config_matrix(monkeypatch, capsys):
+    manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+    config_text = manifest["data"]["config.yaml"]
+    missing_config = config_text.replace("        - lessons\n", "")
+    unexpected_config = config_text.replace(
+        "        - lessons\n",
+        "        - lessons\n        - unexpected_tool\n",
+    )
+    monkeypatch.setenv("HERMES_PROCESS_START_EPOCH", "0")
+
+    cases = [
+        ("connected", False, (True, [], None), config_text, True),
+        ("unknown", False, (True, [], None), config_text, False),
+        ("disconnected", False, (True, [], None), config_text, False),
+        ("fatal", True, (True, [], None), config_text, False),
+        ("connected", False, (False, [], "TimeoutError"), config_text, False),
+        ("connected", False, (False, ["set_plan"], None), config_text, False),
+        ("connected", False, (True, [], None), missing_config, False),
+        ("connected", False, (True, [], None), unexpected_config, False),
+    ]
+    for state, fatal, server_result, configured, expected_ready in cases:
+        namespace["hermes_client_state"] = lambda *_args, _state=state, _fatal=fatal, **_kwargs: {
+            "state": _state,
+            "fatal": _fatal,
+            "last_event_at": 1.0,
+            "unacknowledged_disconnect_since": 1.0 if _state in {"disconnected", "fatal"} else None,
+        }
+        namespace["mcp_server_ready"] = lambda _result=server_result: _result
+        namespace["open"] = lambda *_args, _configured=configured, **_kwargs: io.StringIO(_configured)
+
+        return_code = namespace["main"](["--mode", "readiness"])
+        payload = json.loads(capsys.readouterr().out)
+
+        assert return_code == (0 if expected_ready else 1)
+        assert payload["ready"] is expected_ready
+
+
+def test_hermes_mcp_server_ready_checks_http_status_payload_and_required_tools(monkeypatch):
+    _manifest, _profile, source = _hermes_config_documents()
+    namespace = _hermes_probe_namespace(source)
+
+    class Response(io.StringIO):
+        def __init__(self, payload, status=200):
+            super().__init__(json.dumps(payload))
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+    required = sorted(namespace["REQUIRED"])
+    monkeypatch.setattr(
+        namespace["urllib"].request,
+        "urlopen",
+        lambda *_args, **_kwargs: Response({"ready": True, "required_tools": required}),
+    )
+    assert namespace["mcp_server_ready"]() == (True, [], None)
+
+    monkeypatch.setattr(
+        namespace["urllib"].request,
+        "urlopen",
+        lambda *_args, **_kwargs: Response({"ready": True, "required_tools": required[1:]}),
+    )
+    ready, missing, error = namespace["mcp_server_ready"]()
+    assert ready is False
+    assert missing == [required[0]]
+    assert error is None
+
+    monkeypatch.setattr(
+        namespace["urllib"].request,
+        "urlopen",
+        lambda *_args, **_kwargs: Response({"ready": True, "required_tools": required}, status=503),
+    )
+    assert namespace["mcp_server_ready"]()[0] is False
+
+    def timeout(*_args, **_kwargs):
+        raise TimeoutError("bounded test timeout")
+
+    monkeypatch.setattr(namespace["urllib"].request, "urlopen", timeout)
+    assert namespace["mcp_server_ready"]() == (False, [], "TimeoutError")
+
+
+def test_actual_python3_liveness_probe_replaces_unacknowledged_disconnect_or_fatal(tmp_path):
     manifest, _profile, source = _hermes_config_documents()
     probe_path = tmp_path / "tool-readiness.py"
     log_path = tmp_path / "agent.log"
     probe_path.write_text(source)
     started_at = datetime(2026, 7, 10, 12, tzinfo=UTC).timestamp()
     log_path.write_text(
-        "2026-07-10 11:59:00,000 WARNING MCP server 'verdify_greenhouse' "
-        "failed after 5 reconnection attempts, giving up: old\n"
+        _hermes_mcp_log(
+            "2026-07-10 11:59:00,000",
+            "MCP server 'verdify_greenhouse' failed after 5 reconnection attempts, giving up: old",
+            "WARNING",
+        )
     )
     env = {
         **os.environ,
         "HERMES_PROCESS_START_EPOCH": str(started_at),
         "HERMES_CLIENT_LOG_PATHS": str(log_path),
+        "HERMES_MCP_PROBE_STATE_PATH": str(tmp_path / "probe-state.json"),
+        "HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS": "600",
     }
     live = subprocess.run(
         ["python3", str(probe_path), "--mode", "liveness"],
@@ -487,8 +874,26 @@ def test_actual_python3_liveness_probe_restarts_only_on_poststart_fatal(tmp_path
     )
     with log_path.open("a") as stream:
         stream.write(
-            "2026-07-10 12:02:00,000 WARNING MCP server 'verdify_greenhouse' "
-            "failed after 5 reconnection attempts, giving up: reset\n"
+            _hermes_mcp_log(
+                "2026-07-10 12:01:00,000",
+                "MCP server 'verdify_greenhouse' connection lost (attempt 1/5), reconnecting in 1s: reset",
+                "WARNING",
+            )
+        )
+    disconnected = subprocess.run(
+        ["python3", str(probe_path), "--mode", "liveness"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    with log_path.open("a") as stream:
+        stream.write(
+            _hermes_mcp_log(
+                "2026-07-10 12:02:00,000",
+                "MCP server 'verdify_greenhouse' failed after 5 reconnection attempts, giving up: reset",
+                "WARNING",
+            )
         )
     fatal = subprocess.run(
         ["python3", str(probe_path), "--mode", "liveness"],
@@ -503,11 +908,75 @@ def test_actual_python3_liveness_probe_restarts_only_on_poststart_fatal(tmp_path
     probes = workload["spec"]["template"]["spec"]["containers"][0]
 
     assert live.returncode == 0
+    assert disconnected.returncode == 1
+    assert json.loads(disconnected.stdout)["restart_reason"] == ("mcp_client_unacknowledged_disconnect_timeout")
     assert fatal.returncode == 1
     assert json.loads(fatal.stdout)["client"]["fatal"] is True
     assert container["data"]["tool-readiness.py"] == source
     assert probes["readinessProbe"]["exec"]["command"][0] == "python3"
     assert probes["livenessProbe"]["exec"]["command"][-1] == "liveness"
+    assert probes["livenessProbe"]["failureThreshold"] == 2
+    env_by_name = {item["name"]: item["value"] for item in probes["env"]}
+    assert env_by_name["HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS"] == "600"
+    assert workload["spec"]["replicas"] == 1
+    assert workload["spec"]["strategy"]["type"] == "Recreate"
+    expected_digest = (
+        "nousresearch/hermes-agent@sha256:a7111ab1cc43b5a1bc76090a505d6462aa1af4b43f603f0113bf5eb121aec72e"
+    )
+    assert probes["image"] == expected_digest
+    init_by_name = {item["name"]: item for item in workload["spec"]["template"]["spec"]["initContainers"]}
+    assert init_by_name["seed-config"]["image"] == expected_digest
+
+
+def test_rendered_prod_hermes_supervision_preserves_singleton_exact_pin_and_both_probes():
+    rendered = subprocess.run(
+        ["kustomize", "build", "deploy/k8s/overlays/prod"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    resources = [resource for resource in yaml.safe_load_all(rendered) if isinstance(resource, dict)]
+    workload = next(
+        resource
+        for resource in resources
+        if resource.get("kind") == "Deployment" and resource.get("metadata", {}).get("name") == "verdify-hermes-iris"
+    )
+    container = workload["spec"]["template"]["spec"]["containers"][0]
+    env_by_name = {item["name"]: item.get("value") for item in container["env"]}
+    init_by_name = {item["name"]: item for item in workload["spec"]["template"]["spec"]["initContainers"]}
+    volume_by_name = {item["name"]: item for item in workload["spec"]["template"]["spec"]["volumes"]}
+    mount_by_name = {item["name"]: item for item in container["volumeMounts"]}
+    expected_digest = (
+        "nousresearch/hermes-agent@sha256:a7111ab1cc43b5a1bc76090a505d6462aa1af4b43f603f0113bf5eb121aec72e"
+    )
+    readiness = container["readinessProbe"]
+    liveness = container["livenessProbe"]
+
+    assert workload["spec"]["replicas"] == 1
+    assert workload["spec"]["strategy"]["type"] == "Recreate"
+    assert container["image"] == expected_digest
+    assert init_by_name["seed-config"]["image"] == expected_digest
+    assert readiness == {
+        "exec": {"command": ["python3", "/etc/verdify/hermes-config/tool-readiness.py", "--mode", "readiness"]},
+        "failureThreshold": 1,
+        "initialDelaySeconds": 15,
+        "periodSeconds": 10,
+        "timeoutSeconds": 5,
+    }
+    assert liveness == {
+        "exec": {"command": ["python3", "/etc/verdify/hermes-config/tool-readiness.py", "--mode", "liveness"]},
+        "failureThreshold": 2,
+        "initialDelaySeconds": 45,
+        "periodSeconds": 15,
+        "timeoutSeconds": 5,
+    }
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    assert volume_by_name["tmp"]["emptyDir"] == {}
+    assert mount_by_name["tmp"]["mountPath"] == "/tmp"  # noqa: S108 - asserted ephemeral emptyDir mount
+    assert env_by_name["HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS"] == "600"
+    assert env_by_name["HERMES_MCP_PROBE_STATE_PATH"] == (
+        "/tmp/verdify-hermes-mcp-probe-state.json"  # noqa: S108 - non-secret per-process probe state
+    )
 
 
 def test_materializer_runs_one_canonical_final_normalization_per_output(mcp_server, monkeypatch):


### PR DESCRIPTION
## Summary

- Persist the pinned Hermes MCP client lifecycle as per-process probe state so a disconnect remains latched across log rotation until a real full-discovery registration or process replacement.
- Keep readiness fail-closed on the exact configured tool allowlist, Verdify MCP readiness, and the in-process client being connected.
- Fail liveness after a 600-second unacknowledged disconnect, or immediately on fatal reconnect exhaustion, so Kubernetes can replace the stale client.
- Preserve the exact pinned Hermes image, singleton replica count, Recreate strategy, read-only root filesystem, and strict readiness timing.

## Scope

This is the narrow Hermes-only split from draft PR #576 for issue #427. The three changed files match draft head e38e5bde758268aa3842075841712a44ca72e895 exactly:

- deploy/k8s/components/hermes-iris/hermes-config.yaml
- deploy/k8s/components/hermes-iris/hermes-iris.yaml
- tests/test_17_planner_health_surface.py

No ingestor, backfill, storage, database, Makefile, CI-script, image, or unrelated documentation changes are included.

## Validation

- Focused Hermes suite: 40 passed, 3 skipped.
- Authoritative local gate executed with CI_BASE_REF=origin/main: ruff lint passed; ruff format passed; schema suites passed; device-write gate passed.
- The pure-logic/contract suite excluding the two Linux-only public-output modules passed.
- Migration rollback classification, generated Grafana ConfigMap parity, solar constant guard, firmware-twin compile, production kustomize render, and all diff-scoped gates passed.
- On macOS, the uninterrupted authoritative script stops on 16 unchanged Linux-primitive tests in test_lab_publish_k3s_guard.py and test_public_output_guard.py: BSD chmod/date incompatibility and unavailable renameat2. This branch does not modify those tests or their implementation surfaces.

Relates to #427. Split from #576.

No merge, image build, Argo sync, Kubernetes mutation, database mutation, device action, or live change was performed.