### PR TITLE
fix(prod): reconcile Hermes portable state claim

### DIFF
--- a/deploy/k8s/argocd/apps/verdify-prod-dark.yaml
+++ b/deploy/k8s/argocd/apps/verdify-prod-dark.yaml
@@ -60,6 +60,29 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: verdify-prod
+  ignoreDifferences:
+    # Bound fields are assigned by Kubernetes and are not a migration signal.
+    # Both the active portable claim and retained rollback claim are explicit
+    # desired resources; neither may be pruned by an Application reconcile.
+    - group: apps
+      kind: StatefulSet
+      name: verdify-db
+      namespace: verdify-prod
+      jsonPointers:
+        - /spec/volumeClaimTemplates/0/spec/volumeMode
+        - /spec/volumeClaimTemplates/0/status
+    - kind: PersistentVolumeClaim
+      name: verdify-hermes-iris-data
+      namespace: verdify-prod
+      jsonPointers:
+        - /spec/volumeMode
+        - /spec/volumeName
+    - kind: PersistentVolumeClaim
+      name: verdify-hermes-iris-data-portable-20260801
+      namespace: verdify-prod
+      jsonPointers:
+        - /spec/volumeMode
+        - /spec/volumeName
   # MANUAL SYNC: no automated block (prod adoption is operator-paced; see header).
   # prune stays false at the app level; operator-initiated syncs must use the
   # ArgoCD prune confirmation explicitly and NEVER prune the verdify-db

--- a/deploy/k8s/components/hermes-iris/hermes-iris.yaml
+++ b/deploy/k8s/components/hermes-iris/hermes-iris.yaml
@@ -38,6 +38,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: verdify-hermes-iris-data
+  annotations:
+    # Retained rollback material after the 2026-08-01 portable-R2 migration.
+    # Deleting this claim is a separate, explicitly destructive transaction.
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: hermes-iris

--- a/deploy/k8s/overlays/prod/hermes-data-portable-pvc.yaml
+++ b/deploy/k8s/overlays/prod/hermes-data-portable-pvc.yaml
@@ -1,0 +1,24 @@
+# Production adoption of the attended portable-R2 migration completed under
+# jvallery/proxmox-infrastructure#86 on 2026-08-01. The exact bound PV is pinned
+# so Git describes the existing data-bearing claim instead of provisioning a
+# blank replacement. The original verdify-hermes-iris-data PVC remains rendered
+# by the component as retained rollback material; cleanup is a separate action.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: verdify-hermes-iris-data-portable-20260801
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: hermes-iris
+    app.kubernetes.io/name: verdify-hermes-iris
+    maintenance.vallery.net/transaction: oro-issue-94
+    storage.vallery.net/policy: rebuildable-replicated-r2
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-v1-rebuildable-rwo
+  volumeMode: Filesystem
+  volumeName: pvc-6b6b2f30-c414-4325-a803-87b19010851f
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/k8s/overlays/prod/hermes-data-portable-pvc.yaml
+++ b/deploy/k8s/overlays/prod/hermes-data-portable-pvc.yaml
@@ -7,6 +7,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: verdify-hermes-iris-data-portable-20260801
+  annotations:
+    # This is the active data-bearing claim. Never couple its deletion to an
+    # Application manifest reshuffle or selective workload reconciliation.
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: hermes-iris

--- a/deploy/k8s/overlays/prod/hermes-data-portable.patch.yaml
+++ b/deploy/k8s/overlays/prod/hermes-data-portable.patch.yaml
@@ -1,0 +1,13 @@
+# Keep the production Hermes Deployment on the verified, data-bearing portable
+# R2 claim. This is a live-state reconciliation, not a new migration.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-hermes-iris
+spec:
+  template:
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: verdify-hermes-iris-data-portable-20260801

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -36,6 +36,10 @@ resources:
   - db-watchdog.yaml
   - writer-watchdog.yaml
   - ingestor-state-pvc.yaml
+  # #575 / proxmox-infrastructure#86: adopt the already-migrated portable R2
+  # Hermes run-state claim in Git while retaining the original component claim
+  # as rollback material. The paired patch changes only the Hermes data volume.
+  - hermes-data-portable-pvc.yaml
   # Plant-observation pipeline (#436): GitOps-owned CronJob + generated
   # verdify-vision-src ConfigMap. Pulls the production ingestor digest from the
   # zot origin with zot-origin-cluster-pull ONLY (ADR-0021 — the transitional
@@ -119,6 +123,9 @@ components:
   - ../../components/ha-gap-backfill
 
 patches:
+  # Reconcile the live, verified 2026-08-01 Hermes PVC cutover. The original
+  # verdify-hermes-iris-data claim remains declared and must not be deleted.
+  - path: hermes-data-portable.patch.yaml
   # PROD DB STORAGE RECONCILE: restate verdify-db's volumeClaimTemplate onto
   # Longhorn NVMe RWO storage to match the migrated live prod DB. git==live
   # -> no immutable-field StatefulSet patch attempt. See

--- a/tests/test_17_planner_health_surface.py
+++ b/tests/test_17_planner_health_surface.py
@@ -981,6 +981,7 @@ def test_rendered_prod_hermes_supervision_preserves_singleton_exact_pin_and_both
         "verdify-hermes-iris-data-portable-20260801"
     )
     portable_pvc = pvc_by_name["verdify-hermes-iris-data-portable-20260801"]
+    assert portable_pvc["metadata"]["annotations"]["argocd.argoproj.io/sync-options"] == "Prune=false"
     assert portable_pvc["spec"] == {
         "accessModes": ["ReadWriteOnce"],
         "resources": {"requests": {"storage": "5Gi"}},
@@ -991,7 +992,8 @@ def test_rendered_prod_hermes_supervision_preserves_singleton_exact_pin_and_both
     assert portable_pvc["metadata"]["labels"]["storage.vallery.net/policy"] == "rebuildable-replicated-r2"
     # The pre-migration claim remains desired rollback material; no cleanup is
     # coupled to the current-data adoption.
-    assert "verdify-hermes-iris-data" in pvc_by_name
+    retained_pvc = pvc_by_name["verdify-hermes-iris-data"]
+    assert retained_pvc["metadata"]["annotations"]["argocd.argoproj.io/sync-options"] == "Prune=false"
     assert mount_by_name["tmp"]["mountPath"] == "/tmp"  # noqa: S108 - asserted ephemeral emptyDir mount
     assert env_by_name["HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS"] == "600"
     assert env_by_name["HERMES_MCP_PROBE_STATE_PATH"] == (

--- a/tests/test_17_planner_health_surface.py
+++ b/tests/test_17_planner_health_surface.py
@@ -941,6 +941,11 @@ def test_rendered_prod_hermes_supervision_preserves_singleton_exact_pin_and_both
         for resource in resources
         if resource.get("kind") == "Deployment" and resource.get("metadata", {}).get("name") == "verdify-hermes-iris"
     )
+    pvc_by_name = {
+        resource["metadata"]["name"]: resource
+        for resource in resources
+        if resource.get("kind") == "PersistentVolumeClaim"
+    }
     container = workload["spec"]["template"]["spec"]["containers"][0]
     env_by_name = {item["name"]: item.get("value") for item in container["env"]}
     init_by_name = {item["name"]: item for item in workload["spec"]["template"]["spec"]["initContainers"]}
@@ -972,6 +977,21 @@ def test_rendered_prod_hermes_supervision_preserves_singleton_exact_pin_and_both
     }
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
     assert volume_by_name["tmp"]["emptyDir"] == {}
+    assert volume_by_name["data"]["persistentVolumeClaim"]["claimName"] == (
+        "verdify-hermes-iris-data-portable-20260801"
+    )
+    portable_pvc = pvc_by_name["verdify-hermes-iris-data-portable-20260801"]
+    assert portable_pvc["spec"] == {
+        "accessModes": ["ReadWriteOnce"],
+        "resources": {"requests": {"storage": "5Gi"}},
+        "storageClassName": "longhorn-v1-rebuildable-rwo",
+        "volumeMode": "Filesystem",
+        "volumeName": "pvc-6b6b2f30-c414-4325-a803-87b19010851f",
+    }
+    assert portable_pvc["metadata"]["labels"]["storage.vallery.net/policy"] == "rebuildable-replicated-r2"
+    # The pre-migration claim remains desired rollback material; no cleanup is
+    # coupled to the current-data adoption.
+    assert "verdify-hermes-iris-data" in pvc_by_name
     assert mount_by_name["tmp"]["mountPath"] == "/tmp"  # noqa: S108 - asserted ephemeral emptyDir mount
     assert env_by_name["HERMES_MCP_UNACKNOWLEDGED_DISCONNECT_RESTART_SECONDS"] == "600"
     assert env_by_name["HERMES_MCP_PROBE_STATE_PATH"] == (


### PR DESCRIPTION
## Summary

- Adopt the existing data-bearing `verdify-hermes-iris-data-portable-20260801` PVC at its exact bound PV.
- Keep the Hermes Deployment on that current portable R2 claim while preserving the original `verdify-hermes-iris-data` PVC as rollback material.
- Add a rendered-prod regression assertion for both claims and the exact Deployment binding.

## Why

PR #577 correctly fixes Hermes client supervision, but the existing source still referenced the pre-migration PVC. A selective sync at merged revision `2ed0e2da` would have switched the pod away from the current portable claim. The live cutover was completed under `jvallery/proxmox-infrastructure#86/#94`; this PR reconciles that already-proven state before deployment. It does not create, copy, delete, or migrate data.

## Validation

- `make VENV=/Users/jason/repos/verdify-platform/.venv lint` passed.
- `tests/test_17_planner_health_surface.py`: 43 passed, 3 skipped.
- Prod kustomize render succeeds.
- `kubectl diff` for both Hermes PVCs, ConfigMap, and Deployment contains only the intended PR #577 ConfigMap/supervision changes; neither PVC differs and the current portable claim reference has no diff.
- Pre-commit hooks passed.

Relates to #575 and #427.