### PR TITLE
docs: make planning ledgers non-authoritative

### DIFF
--- a/ACCESS_MATRIX.md
+++ b/ACCESS_MATRIX.md
@@ -1,5 +1,10 @@
 # Verdify Platform Access Matrix
 
+> Technical capability inventory only. This file records observed access and
+> tool surfaces; it does not grant execution authority, require approval, or
+> define workflow prerequisites. Current credentials and live probes determine
+> available mechanics; root `AGENTS.md` and the user's request govern work.
+
 Last updated: 2026-07-14
 
 Agent name: `verdify-platform`
@@ -14,7 +19,7 @@ does not include raw secret values.
 | GitHub Project Board | Project scope available through local `gh`; project #5 includes lane epics and current Lab children | Maintain issue fields, native parents, and blockers | Project only | Verdify org/project admins | Available |
 | In-cluster CI/publishing | Argo Events/Workflows + Kaniko; exact revisions publish to Zot | Submit/observe validated repo-build workflows; no GitHub Actions publishing | `agent-fleet-ci` / repo scope | Agent Fleet + repo owners | Available through the fixed pipeline |
 | Zot application images | `registry.vallery.net` digest pins; in-cluster origin push | Resolve/pin immutable digests through CI | Verdify image namespace | Agent Fleet / registry owners | CI-owned |
-| GHCR holdovers | Read-only legacy production references only | Retire through the gated migration; never publish new images | Legacy Quartz runtime | Repo/Jason | Retirement pending #482 |
+| GHCR holdovers | Read-only legacy production references only | Retire through the validated migration; never publish new images | Legacy Quartz runtime | Repo/Jason | Retirement pending #482 |
 | `verdify-prod` namespace | Repo manifests; no live write used in this docs pass | Read for diagnostics; writes use GitOps preflight and rollback | Namespace | Platform/GitOps owners | Available with safeguards |
 | ArgoCD apps | App YAML in repo | Read app health; sync prod with exact-target preflight and rollback | `verdify-prod-dark` | Platform/GitOps owners | Available |
 | Kubernetes Secrets | Names/key contracts only | Metadata/status only; no values | Namespace-local | Secret-delivery owner | Values out of scope |

--- a/EPICS.md
+++ b/EPICS.md
@@ -1,5 +1,9 @@
 # Verdify Platform Epics
 
+> Optional planning and status reference. Epics and milestones record context;
+> they are not execution authority, prerequisites, or a required workflow. Work
+> directly from the user's request, current repository state, and live evidence.
+
 Last updated: 2026-06-23
 
 Agent name: `verdify-platform`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Verdify Platform History
 
+> Context and evidence only. This file is not current agent guidance, a task
+> queue, or a required handoff. Current source, live state, root `AGENTS.md`, and
+> the user's request supersede its entries.
+
 Last updated: 2026-06-23
 
 Agent name: `verdify-platform`

--- a/LANES.md
+++ b/LANES.md
@@ -1,5 +1,8 @@
 # Verdify — Floating-Corridor Replan: Lanes, Waves & Worktree Kickoff
 
+> Optional ownership and planning map. Lanes describe likely domain ownership;
+> they are not dispatch, permission, approval, or routing boundaries. Work
+> directly from the user's request, current repository state, and live evidence.
 > **Lab-lane staleness notice (2026-07-13):** This file is a generated
 > 2026-06-22 floating-corridor planning snapshot. Its L8/#351 Lab entries and
 > the worktree kickoff below are not the execution plan for the Quartz-to-Astro

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,5 +1,9 @@
 # Verdify Platform Milestones
 
+> Optional planning and status reference. Epics and milestones record context;
+> they are not execution authority, prerequisites, or a required workflow. Work
+> directly from the user's request, current repository state, and live evidence.
+
 Last updated: 2026-07-14
 
 Agent name: `verdify-platform`

--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -1,12 +1,17 @@
 # Verdify Platform Project Board
 
+> Optional planning and status reference. Project boards and issue metadata
+> record context; they are not execution authority, prerequisites, or a required
+> workflow. Work directly from the user's request, current repository state, and
+> live evidence.
+
 Last updated: 2026-07-14
 
 Agent name: `verdify-platform`
 
 ## Connection Status
 
-- Required board: `verdify-platform`.
+- Recorded board: `verdify-platform`.
 - Current board: `VerdifyConsultancy` project #5,
   <https://github.com/orgs/VerdifyConsultancy/projects/5>.
 - Current finding: the exact `verdify-platform` board exists with 45 issue
@@ -17,17 +22,17 @@ Agent name: `verdify-platform`
   `planning/backlog.yaml`.
 - 2026-07-13: L9 (#351) is promoted from a generic pipeline audit to the
   **lab Quartz→Astro migration program** (In Progress/P1/XL). The
-  authoritative decomposition, phase gates, and branch dispositions live in
+  detailed decomposition, validation milestones, and branch history live in
   `docs/plans/lab-astro-migration.md`; nine surface child issues follow
   under G3.
 - Legacy/evidence cards remain on the board so old issue history is not lost;
   they are no longer the primary planning decomposition.
-- Required fallback: keep `## Project Tracking` in every new or materially
-  updated issue because issue bodies remain durable when project fields drift.
+- Optional issue-body mirror: `## Project Tracking` can preserve planning
+  metadata when project fields drift.
 
-Workflow details live in `docs/PROJECT_BOARD_WORKFLOW.md`.
+Historical board-workflow details live in `docs/PROJECT_BOARD_WORKFLOW.md`.
 
-## Required Issue Block
+## Optional Issue Metadata Example
 
 ```markdown
 ## Project Tracking
@@ -52,8 +57,8 @@ Statuses: `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`.
 Fields: `Priority`, `Effort`, `Component`, `Sprint`, `Epic`, `Agent Lane`,
 `Milestone`, `Related Issues/PRs`, `Dependencies`, `Evidence`.
 
-Board cards are EPICS. Child issues/tasks can exist, but planning decisions
-happen at the lane-epic level unless a child issue is explicitly operator-scoped.
+Board cards group planning context as EPICS. Child issues and tasks may carry
+more detail; neither representation is a prerequisite for requested work.
 
 ## 2026-06-23 Audit Overlay
 
@@ -80,14 +85,14 @@ Immediate planning changes:
   heat-dehum episodes. The #327 moisture-estimator source path is also wired:
   firmware publishes `climate_moisture_exchange`, the ingestor stores it in
   `climate_action_log.source_system_state`, and `outcome_kpi()` summarizes it
-  when rows exist. Live rows still require the gated OTA plus service deploy;
+  when rows exist. Live rows still require a validated OTA plus service deploy;
   durable DB/dashboard rollups remain open.
 - 2026-06-23 local #383 policy progress: firmware source now has a bounded
   closed-vent `heat_dehum` path for low-wet night rows when the estimator says
   heat-assist is effective and venting is stale, overcooling, or weak. It is
   headroom-limited, heat1-only, VPD-priority tagged, and mirrored into the
-  firmware twin. Offline firmware gates passed; live proof still requires the
-  gated OTA/deploy path and before/after outcome KPI review.
+  firmware twin. Offline firmware checks passed; live proof still requires the
+  validated OTA/deploy path and before/after outcome KPI review.
 - 2026-06-23 tracker cleanup done for #359, #365, #371, #293, #377, #327,
   plus #361, #378, and #379; #17/#20 superseded/closed, #366 closed, and #383
   created.

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1,5 +1,9 @@
 # Verdify Platform Sprints
 
+> Optional planning and history reference. No sprint selection, sprint artifact,
+> board update, or routing step is required for repository work. Work directly
+> from the user's request, current repository state, and live evidence.
+
 Last updated: 2026-06-17
 
 Agent name: `verdify-platform`


### PR DESCRIPTION
## Summary

- classify planning, status, history, access, and coordination ledgers by purpose
- remove board, sprint, routing, and approval prerequisites
- preserve technical validation, exact-target, and rollback safeguards

## Validation

- Planning schema validator; diff check; Markdown results match the pre-existing baseline