### PR TITLE
fix: sync declarative AI guidance copy

### DIFF
--- a/deploy/k8s/vision/src/ai.yaml
+++ b/deploy/k8s/vision/src/ai.yaml
@@ -79,8 +79,8 @@ context:
 #   - ingestor/planner_routing.py (classify_severity + pick_instance + sla_for)
 #   - ingestor/alert_monitor rule 7 (SLA-breach detection)
 # Contract spec: docs/iris-planner-contract.md §2.F (SLA) + §2.G (routing).
-# Repo source selects GPT-5.6 Sol xhigh for Hermes. Live activation is a
-# separate gated step; the instance field is an audit label only.
+# Repo source selects GPT-5.6 Sol xhigh for Hermes. Live activation follows the
+# declarative deployment and technical validation; the instance field is an audit label only.
 planner_routing:
   # After validated activation, required full-plan cycles use the same
   # Hermes/GPT-5.6 Sol profile as other triggers. This value is an audit label


### PR DESCRIPTION
## Summary
- make the vision ConfigMap source byte-identical to canonical `config/ai.yaml`
- remove the stale “separate gated step” copy left by the lifecycle-guidance cleanup

## Validation
- `cmp -s config/ai.yaml deploy/k8s/vision/src/ai.yaml`
- `uv run --extra dev pytest -q tests/test_20_vision_src_sync.py` (7 passed)
- `git diff --check`