### PR TITLE
fix(k8s): constrain Verdify Traefik to general workers

### DIFF
--- a/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
+++ b/deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml
@@ -43,6 +43,8 @@ spec:
         app.kubernetes.io/part-of: verdify
         app.kubernetes.io/component: edge-traefik
     spec:
+      nodeSelector:
+        agentfleet.vallery.net/node-class: general
       serviceAccountName: verdify-traefik
       # HA ha-1 / Lane A (#229): serving-tier priority so the tier-2 edge proxy
       # is preempted only after batch, and never starved under node pressure.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -100,6 +100,7 @@ $PY -m pytest -q \
   tests/test_twin_agreement_report.py \
   tests/test_twin_asof_migration.py \
   tests/test_twin_live_driver.py \
+  tests/test_verdify_traefik_placement.py \
   tests/test_writer_lease_fence.py
 
 step "migration rollback safety classification"

--- a/scripts/validate-verdify-traefik-placement.py
+++ b/scripts/validate-verdify-traefik-placement.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate the production tier-2 proxy's general-worker HA contract."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+DEFAULT_MANIFEST = Path("deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml")
+
+
+def load_deployment(path: Path) -> dict:
+    documents = [document for document in yaml.safe_load_all(path.read_text()) if document]
+    for document in documents:
+        if document.get("kind") == "Deployment" and document.get("metadata", {}).get("name") == "verdify-traefik":
+            return document
+    raise ValueError("missing Deployment/verdify-traefik")
+
+
+def placement_violations(deployment: dict) -> list[str]:
+    violations: list[str] = []
+    spec = deployment.get("spec", {})
+    pod = spec.get("template", {}).get("spec", {})
+
+    expected_selector = {"agentfleet.vallery.net/node-class": "general"}
+    if pod.get("nodeSelector") != expected_selector:
+        violations.append("verdify-traefik must require exactly the general-worker selector")
+
+    strategy = spec.get("strategy", {})
+    rolling = strategy.get("rollingUpdate", {})
+    if (
+        spec.get("replicas") != 2
+        or strategy.get("type") != "RollingUpdate"
+        or rolling.get("maxUnavailable") != 0
+        or rolling.get("maxSurge") != 1
+    ):
+        violations.append("verdify-traefik must retain the two-replica zero-unavailable rollout")
+
+    expected_spread = [
+        {
+            "maxSkew": 1,
+            "topologyKey": "kubernetes.io/hostname",
+            "whenUnsatisfiable": "DoNotSchedule",
+            "matchLabelKeys": ["pod-template-hash"],
+            "labelSelector": {"matchLabels": {"app.kubernetes.io/name": "verdify-traefik"}},
+        }
+    ]
+    if pod.get("topologySpreadConstraints") != expected_spread:
+        violations.append("verdify-traefik must retain hard hostname spread")
+
+    if any(item.get("key") == "dedicated" for item in pod.get("tolerations", [])):
+        violations.append("verdify-traefik must not tolerate a dedicated worker")
+
+    persistent_claims = [
+        volume.get("persistentVolumeClaim", {}).get("claimName")
+        for volume in pod.get("volumes", [])
+        if volume.get("persistentVolumeClaim")
+    ]
+    if persistent_claims:
+        violations.append("verdify-traefik must remain stateless")
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", nargs="?", type=Path, default=DEFAULT_MANIFEST)
+    args = parser.parse_args()
+
+    try:
+        deployment = load_deployment(args.manifest)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"verdify-traefik placement validation failed: {exc}")
+        return 1
+
+    violations = placement_violations(deployment)
+    if violations:
+        for violation in violations:
+            print(f"verdify-traefik placement violation: {violation}")
+        return 1
+
+    print("verdify-traefik placement validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verdify_traefik_placement.py
+++ b/tests/test_verdify_traefik_placement.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import copy
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "deploy/k8s/overlays/prod/traefik/verdify-traefik-deployment.yaml"
+VALIDATOR = ROOT / "scripts/validate-verdify-traefik-placement.py"
+
+
+def load_documents() -> list[dict]:
+    return [document for document in yaml.safe_load_all(SOURCE.read_text()) if document]
+
+
+def deployment(documents: list[dict]) -> dict:
+    return next(
+        document
+        for document in documents
+        if document.get("kind") == "Deployment" and document.get("metadata", {}).get("name") == "verdify-traefik"
+    )
+
+
+def run_validator(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(VALIDATOR), str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_source_contract_passes() -> None:
+    result = run_validator(SOURCE)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ("gpu", "exactly the general-worker selector"),
+        ("hard_hostname", "exactly the general-worker selector"),
+        ("soft_spread", "retain hard hostname spread"),
+        ("allow_unavailable", "two-replica zero-unavailable rollout"),
+        ("pvc", "must remain stateless"),
+        ("dedicated_toleration", "must not tolerate a dedicated worker"),
+    ],
+)
+def test_negative_placement_contracts(tmp_path: Path, mutation: str, expected: str) -> None:
+    documents = copy.deepcopy(load_documents())
+    workload = deployment(documents)
+    pod = workload["spec"]["template"]["spec"]
+
+    if mutation == "gpu":
+        pod["nodeSelector"]["agentfleet.vallery.net/node-class"] = "gpu"
+    elif mutation == "hard_hostname":
+        pod["nodeSelector"]["kubernetes.io/hostname"] = "vm-k3s-node5"
+    elif mutation == "soft_spread":
+        pod["topologySpreadConstraints"][0]["whenUnsatisfiable"] = "ScheduleAnyway"
+    elif mutation == "allow_unavailable":
+        workload["spec"]["strategy"]["rollingUpdate"]["maxUnavailable"] = 1
+    elif mutation == "pvc":
+        pod["volumes"] = [{"name": "data", "persistentVolumeClaim": {"claimName": "unexpected"}}]
+    elif mutation == "dedicated_toleration":
+        pod["tolerations"] = [{"key": "dedicated", "operator": "Exists", "effect": "NoSchedule"}]
+    else:
+        raise AssertionError(f"unhandled mutation: {mutation}")
+
+    candidate = tmp_path / "verdify-traefik.yaml"
+    candidate.write_text(yaml.safe_dump_all(documents, sort_keys=False))
+    result = run_validator(candidate)
+
+    assert result.returncode != 0
+    assert expected in result.stdout + result.stderr


### PR DESCRIPTION
Refs #609
Coordinates #608 and #317
Parent compute lane: jvallery/proxmox-infrastructure#197

## Outcome

Source-only placement correction for the stateless two-replica tier-2 proxy:

- add exactly `agentfleet.vallery.net/node-class=general` to `Deployment/verdify-prod/verdify-traefik`;
- preserve replicas=2, RollingUpdate maxUnavailable=0/maxSurge=1, hard hostname spread, PDB/Service/policy/RBAC/routes, image, and all device/data-path resources;
- add a standalone placement validator and six negative regressions;
- wire the focused test into the repository's existing `make ci` contract.

No live Application, Deployment, Pod, Service, EndpointSlice, policy, route, PVC, database, or writer resource was changed.

## Exact source/live preimage

Current `origin/main` render is byte-equivalent to the live Deployment before this selector:

- Deployment UID `c5ac81e4-ee08-491e-81d0-a8e240fb5cc9`, 2/2 Ready.
- Pod UID `77d682b3-8e31-460d-8ef9-7a7b3301cbbe`: node5, Ready, restart0.
- Pod UID `5c0572f6-c506-4df8-918b-47dfc3785abf`: GPU worker, Ready, restart4.
- Service UID `bf23d4ad-8291-4fbe-a1a6-0a2dfe4bc39e`, ClusterIP `10.43.211.164`; EndpointSlice UID `b9130a9c-f195-4c0b-8fb5-e0f28e50590c`.
- No PVC, volume, mount, or state migration.
- API/lab/graphs routes HTTP 200; exact public probes=1; Ready replicas=2; no firing Traefik alerts.

Exact `kubectl diff` is only the Pod-template selector plus generation bookkeeping. Server-side dry-run retains the two-replica zero-unavailable rollout, hard spread, empty volume set, and exact image.

## Delivery hold

`verdify-prod-dark` remains manual and currently has the qualified 79-object release set OutOfSync. This PR must not trigger a live reconcile.

Future delivery is owned by #608's networking wave and #317's explicit-vector workaround:

- reconcile only `apps:Deployment:verdify-prod/verdify-traefik`;
- verify the recorded operation vector immediately;
- never broad sync or prune;
- stop without retry if the vector is absent, rewritten, narrow, or contains another resource;
- retain one Ready endpoint while the second replica rolls onto node4.

## Validation

- pre-commit ruff, format, whitespace, YAML, merge, and private-key hooks: PASS
- focused ruff check/format: PASS
- `python3 scripts/validate-verdify-traefik-placement.py`: PASS
- `pytest -q tests/test_verdify_traefik_placement.py`: 7 PASS
- negative cases: GPU selector, hard hostname, soft spread, nonzero maxUnavailable, PVC, and dedicated toleration all fail closed
- `kubectl kustomize deploy/k8s/overlays/prod`: PASS
- exact Deployment `kubectl diff` and server-side dry-run: PASS
- `git diff --check`: PASS
- scoped gitleaks: no leaks

The full repository CI command now includes the new test; no local full live-stack gate was invoked from this compute lane.

## Rollback

Revert this source commit and submit the same one-Deployment explicit Argo vector. Preserve maxUnavailable=0 and verify two Ready Service endpoints plus all public routes during rollback.