### PR TITLE
fix(firmware): pin qualified ESPHome builder image

### DIFF
--- a/deploy/k8s/components/firmware-builder/firmware-builder.yaml
+++ b/deploy/k8s/components/firmware-builder/firmware-builder.yaml
@@ -119,7 +119,7 @@ spec:
             - name: builder
               # Official ESPHome image: carries the esphome CLI; PlatformIO
               # pulls the xtensa toolchain into the cache PVC on first run.
-              image: ghcr.io/esphome/esphome:2026.6.5
+              image: ghcr.io/esphome/esphome:2026.6.5@sha256:ffe23402d169fc9b8ff29fc3c9fc13b3c47e8a53726fce4569e2280bd534c84c
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities: {drop: ["ALL"]}

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -65,6 +65,7 @@ $PY -m pytest -q \
   tests/test_experiment_schema_migration.py \
   tests/test_experiment_verify.py \
   tests/test_experiment_workers.py \
+  tests/test_firmware_builder_image.py \
   tests/test_firmware_crop_agnostic_guard.py \
   tests/test_forecast_action_engine_path.py \
   tests/test_g5_dualwrite_validation.py \

--- a/tests/test_firmware_builder_image.py
+++ b/tests/test_firmware_builder_image.py
@@ -1,0 +1,27 @@
+"""Fail closed if the attended firmware builder regains a mutable image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "deploy/k8s/components/firmware-builder/firmware-builder.yaml"
+ESPHOME_IMAGE = (
+    "ghcr.io/esphome/esphome:2026.6.5@sha256:ffe23402d169fc9b8ff29fc3c9fc13b3c47e8a53726fce4569e2280bd534c84c"
+)
+
+
+def test_firmware_builder_uses_the_qualified_immutable_esphome_image() -> None:
+    cronjob = next(
+        document
+        for document in yaml.safe_load_all(MANIFEST.read_text())
+        if document and document.get("kind") == "CronJob"
+    )
+    containers = cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"]
+    builder = next(container for container in containers if container["name"] == "builder")
+
+    assert builder["image"] == ESPHOME_IMAGE
+    assert cronjob["spec"]["suspend"] is True
+    assert next(entry for entry in builder["env"] if entry["name"] == "FLASH")["value"] == "0"


### PR DESCRIPTION
Pins the REL-3-qualified ESPHome 2026.6.5 image to sha256:ffe23402d169fc9b8ff29fc3c9fc13b3c47e8a53726fce4569e2280bd534c84c. Adds a fail-closed regression that also preserves suspend=true and FLASH=0, and wires it into the local CI gate.\n\nValidated: focused 9/9; exact registry digest; prod render; server-side dry-run; migration/dashboard/config/policy/native/twin gates. Mac-only Docker/live-schema and GNU/Linux filesystem tests remain environment-dependent and unrelated to this three-file source pin. No live sync, firmware build, flash, or device write.