### PR TITLE
fix(lab): allow full public-tree scan budget

### DIFF
--- a/scripts/prepare-lab-cache.sh
+++ b/scripts/prepare-lab-cache.sh
@@ -43,9 +43,9 @@ CACHE_LOCK_HELPER="${VERDIFY_CACHE_LOCK_HELPER:-/usr/local/bin/prepare-lab-cache
 if [[ ! -f "$CACHE_LOCK_HELPER" && -f "$SCRIPT_DIR/prepare-lab-cache-lock.py" ]]; then
   CACHE_LOCK_HELPER="$SCRIPT_DIR/prepare-lab-cache-lock.py"
 fi
-PUBLIC_OUTPUT_GUARD_TIMEOUT="${VERDIFY_PUBLIC_OUTPUT_GUARD_TIMEOUT:-120}"
+PUBLIC_OUTPUT_GUARD_TIMEOUT="${VERDIFY_PUBLIC_OUTPUT_GUARD_TIMEOUT:-300}"
 if ! [[ "$PUBLIC_OUTPUT_GUARD_TIMEOUT" =~ ^[0-9]+$ ]] \
-    || ((PUBLIC_OUTPUT_GUARD_TIMEOUT < 30 || PUBLIC_OUTPUT_GUARD_TIMEOUT > 120)); then
+    || ((PUBLIC_OUTPUT_GUARD_TIMEOUT < 30 || PUBLIC_OUTPUT_GUARD_TIMEOUT > 600)); then
   echo "Lab cache public validation configuration failed" >&2
   exit 2
 fi

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1166,6 +1166,8 @@ def test_publisher_image_and_ci_own_the_canonical_cache_scanner_and_shared_packa
     assert "VERDIFY_PUBLIC_OUTPUT_GUARD=/usr/local/bin/check-public-output" in dockerfile
     assert "prepare-lab-cache-lock.py /usr/local/bin/prepare-lab-cache-lock" in dockerfile
     assert "VERDIFY_PUBLIC_OUTPUT_GUARD:-/usr/local/bin/check-public-output" in initializer
+    assert "VERDIFY_PUBLIC_OUTPUT_GUARD_TIMEOUT:-300" in initializer
+    assert "PUBLIC_OUTPUT_GUARD_TIMEOUT > 600" in initializer
     assert initializer.count('validate_public_tree "$BOOTSTRAP"') == 1
     assert initializer.count('validate_public_tree "$LEGACY"') == 1
     assert 'validate_public_tree "$candidate"' in initializer


### PR DESCRIPTION
Fix the production lab-publisher initialization failure exposed during REL-3. The canonical public-output scan completed cleanly in 125 seconds, but `prepare-lab-cache` still enforced the obsolete 120-second ceiling while the rebuild path and performance contract already use 300 seconds with a 600-second upper bound.

This aligns the cache initializer to that existing bounded contract and adds a focused source assertion. The exact live tree scanned cleanly; no content remediation is involved.

Validation:
- `bash -n scripts/prepare-lab-cache.sh`
- focused contract test PASS
- full lab guard file: PR-owned contract PASS; 12 current-main macOS `chmod --` portability failures reproduced
- `git diff --check` PASS

No live workload, content, database, firmware, or device mutation in this PR.