### PR TITLE
fix(lab): pin extended scanner image

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -267,4 +267,4 @@ images:
   # GITHUB_TOKEN can publish immutable CI-built digests.
   - name: ghcr.io/verdifyconsultancy/verdify-lab-publisher-k3s
     newName: registry.vallery.net/verdifyconsultancy/verdify-lab-publisher-k3s
-    digest: sha256:6450415420fb3bc76fb5444986eda44dfc1273dad56afa841e31bb751787840c
+    digest: sha256:af16d6e7678a08e728ff1b6a0939a7f069a8d8dbe1f4ae170b9e4a7ace92140b


### PR DESCRIPTION
Pin the exact Zot image built from merged PR #613 so the production lab initializer uses the bounded 300-second public-output scan budget.

Artifact:
- source revision `0da164a8262694f0f288c0a7a09cb7547ab80908`
- workflow `verdify-platform-build-lab-publisher-r2-sc5gn` Succeeded
- digest `sha256:af16d6e7678a08e728ff1b6a0939a7f069a8d8dbe1f4ae170b9e4a7ace92140b`
- independent in-cluster immutable-digest pull and contract probe PASS

Focused contract test, exact two-resource server dry-run, Kustomize render, and diff check pass. No live sync, content write, firmware, or device action in this PR.