### PR TITLE
Keep Grafana render cache on general nodes

### DIFF
--- a/deploy/k8s/components/grafana/grafana-render-cache.yaml
+++ b/deploy/k8s/components/grafana/grafana-render-cache.yaml
@@ -25,6 +25,8 @@ spec:
         app.kubernetes.io/component: grafana-render-cache
     spec:
       automountServiceAccountToken: false
+      nodeSelector:
+        agentfleet.vallery.net/node-class: general
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/tests/test_grafana_render_cache.py
+++ b/tests/test_grafana_render_cache.py
@@ -66,6 +66,7 @@ def test_render_cache_runtime_is_pinned_unprivileged_and_credential_free():
     container = pod["containers"][0]
 
     assert deployment["spec"]["replicas"] == 2
+    assert pod["nodeSelector"] == {"agentfleet.vallery.net/node-class": "general"}
     assert pod["topologySpreadConstraints"][0]["topologyKey"] == "kubernetes.io/hostname"
     assert pod["topologySpreadConstraints"][0]["minDomains"] == 2
     assert pod["topologySpreadConstraints"][0]["whenUnsatisfiable"] == "DoNotSchedule"


### PR DESCRIPTION
Adds the hard `agentfleet.vallery.net/node-class: general` selector to the not-yet-created Grafana render-cache Deployment so REL-3 wave 2 cannot schedule it onto a GPU-class node. The two-replica hard hostname spread, availability policy, immutable image, and stateless cache contract are unchanged. Adds an exact regression assertion. Focused tests, Kustomize render, exact five-resource server dry-run, pre-commit, and diff checks pass. No live resource was created or changed. Tracks #608.