### PR TITLE
fix(grafana): make oversized dashboards deliverable

### DIFF
--- a/deploy/k8s/components/grafana/generated/dashboards-cm-0.yaml
+++ b/deploy/k8s/components/grafana/generated/dashboards-cm-0.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: verdify-grafana-dashboards-0
   annotations:
-    argocd.argoproj.io/sync-options: ServerSideApply=true
+    argocd.argoproj.io/sync-options: Replace=true
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: grafana

--- a/deploy/k8s/components/grafana/generated/dashboards-cm-1.yaml
+++ b/deploy/k8s/components/grafana/generated/dashboards-cm-1.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: verdify-grafana-dashboards-1
   annotations:
-    argocd.argoproj.io/sync-options: ServerSideApply=true
+    argocd.argoproj.io/sync-options: Replace=true
   labels:
     app.kubernetes.io/part-of: verdify
     app.kubernetes.io/component: grafana

--- a/tests/test_grafana_dashboard_sync_contract.py
+++ b/tests/test_grafana_dashboard_sync_contract.py
@@ -1,0 +1,27 @@
+"""Fail-closed delivery contract for the oversized Grafana dashboard ConfigMaps."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATED = ROOT / "deploy/k8s/components/grafana/generated"
+
+
+def _sync_option(bucket: int) -> str:
+    document = yaml.safe_load((GENERATED / f"dashboards-cm-{bucket}.yaml").read_text())
+    return document["metadata"]["annotations"]["argocd.argoproj.io/sync-options"]
+
+
+def test_changed_oversized_buckets_use_in_place_replace_without_force():
+    # These ConfigMaps exceed the client-side last-applied annotation limit and
+    # their changed data keys conflict under SSA. Argo's Replace option uses
+    # kubectl replace for an existing object; Force must remain absent so the
+    # ConfigMap is updated in place rather than deleted and recreated.
+    assert _sync_option(0) == "Replace=true"
+    assert _sync_option(1) == "Replace=true"
+
+
+def test_unchanged_dashboard_buckets_keep_their_existing_ssa_contract():
+    assert _sync_option(2) == "ServerSideApply=true"
+    assert _sync_option(3) == "ServerSideApply=true"


### PR DESCRIPTION
Use Argo resource-level Replace=true for the two changed oversized dashboard ConfigMaps. Existing objects are updated through kubectl replace without Force, avoiding both the client-side last-applied annotation limit and the current SSA field conflicts. Unchanged buckets retain ServerSideApply=true. Adds a fail-closed regression for the exact split. Source only; no live dashboard or Grafana reconciliation. REL-3 #608.