### PR TITLE
fix(grafana): require attended ready dwell

### DIFF
--- a/deploy/k8s/components/grafana/grafana.yaml
+++ b/deploy/k8s/components/grafana/grafana.yaml
@@ -43,6 +43,11 @@ metadata:
     app.kubernetes.io/component: grafana
 spec:
   replicas: 1
+  # Attended REL-3 activation: a candidate must remain Ready for two full
+  # minutes before Kubernetes may scale the old pod down. Combined with the
+  # surge-first strategy below, this creates a real observation window rather
+  # than retiring the known-good pod on the candidate's first Ready sample.
+  minReadySeconds: 120
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana

--- a/tests/test_grafana_manifest_security.py
+++ b/tests/test_grafana_manifest_security.py
@@ -116,9 +116,12 @@ def test_renderer_port_is_not_exposed_by_the_public_service_or_network_policy():
     assert ingress_ports == [3000]
 
 
-def test_surge_first_rollout_retains_the_old_pod_until_the_candidate_is_ready():
-    strategy = _deployment()["spec"]["strategy"]
+def test_surge_first_rollout_requires_a_two_minute_ready_candidate_dwell():
+    spec = _deployment()["spec"]
+    strategy = spec["strategy"]
 
+    assert spec["replicas"] == 1
+    assert spec["minReadySeconds"] == 120
     assert strategy == {
         "type": "RollingUpdate",
         "rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1},


### PR DESCRIPTION
## Summary
- add `spec.minReadySeconds: 120` only to `Deployment/verdify-grafana`
- preserve `replicas: 1`, `maxUnavailable: 0`, and `maxSurge: 1` so the candidate must remain Ready for two minutes before the old pod can retire
- strengthen the exact Grafana rollout regression

## Exact render identities
- rollback render SHA-256: `0fa25d90e9a630388ffd52811adf0b94b6cbece6fa40492fb93e4ebe9a3751a8`
- rollback spec SHA-256: `f5f04b526a1465820bda94c541030e610c2b0f670f4f927c0f34b2ebdf0183f0`
- forward render SHA-256: `ba195d44e57420e47c4f635cb028bbeebc558c2510160a1798e3a2048d050d4b`
- forward spec SHA-256: `e321267144bd18b4f6016d9d088ad2635d356e9a9e0fa1f402fc9a21458f4217`

## Validation
- 12 focused Grafana manifest/render-cache/dashboard tests: PASS
- Ruff: PASS
- prod Kustomize render exact contract: PASS
- normal client-apply server dry-run of only Deployment/verdify-prod/verdify-grafana: PASS, no force
- SSA preflight intentionally conflicts with historical `codex-ssa`/`kubectl` field owners; activation must use the normal non-SSA Argo resource-selective path and must not use force
- laptop full runtime suite is not a valid gate here: 1513 passed / 163 failed because legacy Docker/systemd/live-service tests expect the retired Linux VM environment, plus macOS fork/renameat2 limits. The PR-owned focused tests are green; hosted CI is authoritative.

## Delivery boundary
Source only. Do not sync Grafana, dashboards, route, render cache, or any other Verdify resource in this PR. Future activation is an attended exact one-Deployment Argo sync with prune/force forbidden.

Tracks VerdifyConsultancy/verdify-platform#608 and jvallery/proxmox-infrastructure#198.