### PR TITLE
test: use active Python for placement validator

### DIFF
--- a/tests/test_verdify_traefik_placement.py
+++ b/tests/test_verdify_traefik_placement.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -26,7 +27,7 @@ def deployment(documents: list[dict]) -> dict:
 
 def run_validator(path: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["python3", str(VALIDATOR), str(path)],
+        [sys.executable, str(VALIDATOR), str(path)],
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- execute the Verdify Traefik placement validator with the same Python interpreter running pytest
- preserve every placement contract and negative assertion
- unblock the in-cluster validation inherited by the merged Grafana dwell revision

## Evidence

- exact failure on merged Grafana head `9d757c45d19a372327899980dc2fdb6fe3605b09`: system `python3` could not import PyYAML while the active CI venv already imports it for the test module
- focused Traefik + Grafana suites: 19/19 PASS
- Ruff and pre-commit: PASS
- `git diff --check`: PASS

Source/test-only. No Kubernetes reconciliation or workload change. Tracks jvallery/proxmox-infrastructure#198 and #194.