### PR TITLE
fix(rel3): bound Quartz rebuild separately

### DIFF
--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -139,6 +139,12 @@ spec:
                 # 45s DB statement_timeout keep the #454 pressure profile.
                 - name: VERDIFY_PUBLISH_STEP_TIMEOUT
                   value: "180"
+                # Quartz crossed the generic 180-second generator ceiling as
+                # the public tree grew. Keep generators tightly bounded while
+                # allowing only the final local rebuild up to five minutes.
+                # The Job's 900-second deadline remains the outer hard stop.
+                - name: VERDIFY_PUBLISH_REBUILD_TIMEOUT
+                  value: "300"
                 # Bound report-generation queries so a public-site refresh can
                 # never starve the control database. PGOPTIONS is consumed by
                 # the psql shim/libpq clients used by the publisher scripts.

--- a/scripts/publish-site-content.sh
+++ b/scripts/publish-site-content.sh
@@ -76,6 +76,7 @@ fi
 # does not leave the units failed. The unit exits non-zero at the end iff a
 # step ultimately failed, so genuine breakage is still surfaced to systemd.
 STEP_TIMEOUT=${VERDIFY_PUBLISH_STEP_TIMEOUT:-120}   # seconds per attempt (0 disables)
+REBUILD_TIMEOUT=${VERDIFY_PUBLISH_REBUILD_TIMEOUT:-300} # Quartz cold-cache build (30..600s)
 STEP_RETRIES=${VERDIFY_PUBLISH_STEP_RETRIES:-3}     # total attempts per step
 STEP_RETRY_DELAY=${VERDIFY_PUBLISH_STEP_RETRY_DELAY:-5} # seconds between attempts
 LOCKED_RC=${VERDIFY_PUBLISH_LOCKED_RC:-0}
@@ -188,7 +189,11 @@ report_failed_steps() {
   fi
 
   if [[ "$REBUILD" == true ]]; then
-    run_step "$SCRIPT_ROOT/rebuild-site.sh"
+    # Quartz has a materially different cold-cache runtime from the small
+    # generators above. Keep their tighter network/DB timeout, but give the
+    # final local build its own bounded window. Assignment-scoping means
+    # run_step sees this value only for the rebuild invocation.
+    STEP_TIMEOUT="$REBUILD_TIMEOUT" run_step "$SCRIPT_ROOT/rebuild-site.sh"
     if [[ ${#FAILED_STEPS[@]} -eq 0 ]]; then
       echo "[$(date -Is)] Site content publish complete: reason_class=${REASON_CLASS}, date=${DATE}" | tee -a "$LOG"
     fi

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1141,6 +1141,8 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     publisher_env = {item["name"]: item.get("value") for item in publisher_container["env"]}
     assert publisher_env["LAB_WORK_ROOT"] == "/work/publisher"
     assert publisher_env["VERDIFY_PUBLISH_STEP_TIMEOUT"] == "180"
+    assert publisher_env["VERDIFY_PUBLISH_REBUILD_TIMEOUT"] == "300"
+    assert cronjob["spec"]["jobTemplate"]["spec"]["activeDeadlineSeconds"] == 900
 
     for pod_spec in (publisher_spec, site_spec):
         pod_security = pod_spec["securityContext"]

--- a/tests/test_publish_site_content_guard.py
+++ b/tests/test_publish_site_content_guard.py
@@ -121,6 +121,7 @@ def harness(tmp_path: Path):
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         'touch "${FIXTURE_STATE_DIR}/rebuild.called"\n'
+        'if [[ "${FIXTURE_REBUILD_HANG:-}" == "1" ]]; then sleep 30; fi\n'
         'if [[ "${FIXTURE_REBUILD_FAIL:-}" == "1" ]]; then exit 1; fi\n',
         encoding="utf-8",
     )
@@ -151,6 +152,7 @@ def harness(tmp_path: Path):
                 "VERDIFY_PUBLISH_LOCK": str(lock),
                 # Fast, deterministic guard knobs for tests.
                 "VERDIFY_PUBLISH_STEP_TIMEOUT": "2",
+                "VERDIFY_PUBLISH_REBUILD_TIMEOUT": "2",
                 "VERDIFY_PUBLISH_STEP_RETRIES": "3",
                 "VERDIFY_PUBLISH_STEP_RETRY_DELAY": "0",
                 "FIXTURE_STATE_DIR": str(state_dir),
@@ -258,6 +260,25 @@ def test_failed_rebuild_never_logs_complete(harness):
     assert rc == 1, out
     assert (state_dir / "rebuild.called").is_file()
     assert "Site content publish complete" not in out
+    assert "rebuild/promotion blocked" in out
+
+
+def test_rebuild_uses_its_own_bounded_timeout(harness):
+    rc, out, state_dir = harness(
+        {
+            "FIXTURE_REBUILD_HANG": "1",
+            "VERDIFY_PUBLISH_STEP_TIMEOUT": "1",
+            "VERDIFY_PUBLISH_REBUILD_TIMEOUT": "2",
+            "VERDIFY_PUBLISH_STEP_RETRIES": "1",
+        },
+        timeout_s=10,
+        rebuild=True,
+    )
+
+    assert rc == 1, out
+    assert (state_dir / "rebuild.called").is_file()
+    assert "TIMEOUT after 2s" in out
+    assert "TIMEOUT after 1s" not in out
     assert "rebuild/promotion blocked" in out
 
 


### PR DESCRIPTION
REL-3 corrective follow-up for #608.

Five consecutive natural lab-publisher Jobs exposed a distinct timeout after the earlier public-output scan fix: the candidate guard passed, but `rebuild-site.sh` hit the generic 180-second generator ceiling and correctly blocked promotion.

This change keeps ordinary generator/network/DB work at 180 seconds, adds an independently bounded 300-second Quartz rebuild window under the existing 900-second Job deadline, and adds runtime/source regressions. It does not change content, PVCs, firmware, Grafana, routes, or database behavior.

Validation:
- `PYTHONPATH=$PWD uv run --with pytest --with pyyaml pytest -q tests/test_publish_site_content_guard.py tests/test_lab_publish_k3s_guard.py::test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget` — 15 passed
- `bash -n scripts/publish-site-content.sh`
- `git diff --check`
- full combined local lab-publisher suite: 46 passed; 12 current-main macOS-only `chmod --` fixture failures reproduced and unchanged

After merge, build and pin an immutable publisher image, reconcile only the CronJob, then require a natural Job success before resuming the Grafana release wave.