### PR TITLE
fix(build): include migration ledger in image context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -72,10 +72,10 @@ db
 hermes
 
 # db/ is excluded above (the api/mcp/ingestor images never touch it), but the
-# verdify-migrate image (db/Dockerfile.migrate) COPYs three files out of it:
-# db/schema.sql, db/migrate.sh, and db/migrations/000-fresh-schema-hypertable-
-# repair.sql. Re-include only those — keep the other migrations, init/, @eaDir,
-# and the restore manifests out of every build context.
+# verdify-migrate image (db/Dockerfile.migrate) COPYs the schema, both runners,
+# every top-level numbered migration, and the two ledger SQL files. Re-include
+# exactly those — keep init/, migration fixtures/tests, roles, @eaDir, and the
+# restore manifests out of every build context.
 # KANIKO QUIRK (2026-07-11, found when the in-cluster zot build shipped an
 # empty COPY): unlike BuildKit, kaniko will NOT restore `!db/schema.sql` while
 # the `db` DIRECTORY itself is still excluded — every COPY logged "No files to
@@ -85,9 +85,13 @@ hermes
 db/*
 !db/schema.sql
 !db/migrate.sh
+!db/apply-migrations.sh
 !db/migrations
 db/migrations/*
-!db/migrations/000-fresh-schema-hypertable-repair.sql
+!db/migrations/*.sql
+!db/ledger
+db/ledger/*
+!db/ledger/*.sql
 
 # --- secrets / local env (NEVER bake into an image; secrets come from k8s) ---
 .env

--- a/tests/test_experiment_schema_migration.py
+++ b/tests/test_experiment_schema_migration.py
@@ -19,6 +19,7 @@ ROLES_SQL = REPO_ROOT / "db" / "roles" / "experiment-roles.sql"
 LEDGER_SQL = REPO_ROOT / "db" / "ledger" / "schema_migrations.sql"
 BACKFILL_SQL = REPO_ROOT / "db" / "ledger" / "backfill_ledger.sql"
 DOCKERFILE = REPO_ROOT / "db" / "Dockerfile.migrate"
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 MIGRATE_SH = REPO_ROOT / "db" / "migrate.sh"
 
 REQUIRED_TABLES = [
@@ -268,6 +269,23 @@ def test_migrate_image_carries_migrations_and_runner():
     assert "COPY db/ledger/ /db/ledger/" in docker
     assert "COPY db/apply-migrations.sh /usr/local/bin/apply-migrations.sh" in docker
     assert "check_migration_rollback_safety.py" in docker
+
+    ignore_lines = DOCKERIGNORE.read_text().splitlines()
+    ordered_reincludes = [
+        "!db",
+        "db/*",
+        "!db/schema.sql",
+        "!db/migrate.sh",
+        "!db/apply-migrations.sh",
+        "!db/migrations",
+        "db/migrations/*",
+        "!db/migrations/*.sql",
+        "!db/ledger",
+        "db/ledger/*",
+        "!db/ledger/*.sql",
+    ]
+    indexes = [ignore_lines.index(line) for line in ordered_reincludes]
+    assert indexes == sorted(indexes), "Kaniko re-include rules must stay ordered"
 
 
 def test_migrate_sh_ledger_branch_is_opt_in_and_comment_fixed():


### PR DESCRIPTION
Fixes the fail-closed Kaniko error exposed by main Workflow `verdify-platform-ci-znmfx`: `db/Dockerfile.migrate` copies the full numbered migration set, ledger SQL, and runner, while `.dockerignore` still admitted only the historical three-file layout.

The new ordered negations admit exactly the two runners, top-level numbered SQL files, and ledger SQL files while keeping init, fixtures/tests, roles, and restore manifests excluded. A regression locks Kaniko-sensitive ordering.

Validation: focused migration/runner tests 8/8 PASS; local BuildKit full image build PASS with every COPY and final chmod succeeding; pre-commit and diff check PASS. No image push or live change from the local proof.