### PR TITLE
fix(grafana): isolate maintenance jobs from service

### DIFF
--- a/deploy/k8s/components/grafana/band-curve-refresh-cronjob.yaml
+++ b/deploy/k8s/components/grafana/band-curve-refresh-cronjob.yaml
@@ -23,12 +23,15 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/part-of: verdify
-            app.kubernetes.io/component: grafana
+            # Keep maintenance Pods outside the Grafana Service selector. A
+            # refresh Pod has no HTTP port and must never become a Grafana
+            # EndpointSlice target while the Job is running.
+            app.kubernetes.io/component: grafana-maintenance
         spec:
           restartPolicy: Never
           # Co-locate with the DB pod so the refresh connection never crosses
-          # the Flannel overlay mesh. DB ingress is allowed by the grafana DB
-          # NetworkPolicy in grafana.yaml.
+          # the Flannel overlay mesh. DB ingress is allowed by the dedicated
+          # grafana-maintenance peer in grafana.yaml.
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/k8s/components/grafana/grafana.yaml
+++ b/deploy/k8s/components/grafana/grafana.yaml
@@ -432,6 +432,9 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/component: grafana
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: grafana-maintenance
       ports:
         - protocol: TCP
           port: 5432

--- a/tests/test_grafana_render_cache.py
+++ b/tests/test_grafana_render_cache.py
@@ -90,3 +90,29 @@ def test_render_cache_runtime_is_pinned_unprivileged_and_credential_free():
             "files": ["default.conf=nginx-render-cache.conf"],
         }
     ]
+
+
+def test_grafana_service_never_selects_band_curve_maintenance_jobs():
+    grafana_documents = _documents("grafana.yaml")
+    deployment = next(document for document in grafana_documents if document["kind"] == "Deployment")
+    service = next(document for document in grafana_documents if document["kind"] == "Service")
+    database_policy = next(
+        document
+        for document in grafana_documents
+        if document["kind"] == "NetworkPolicy" and document["metadata"]["name"] == "allow-db-from-grafana"
+    )
+    refresh = _documents("band-curve-refresh-cronjob.yaml")[0]
+
+    service_selector = service["spec"]["selector"]
+    grafana_labels = deployment["spec"]["template"]["metadata"]["labels"]
+    refresh_labels = refresh["spec"]["jobTemplate"]["spec"]["template"]["metadata"]["labels"]
+
+    assert all(grafana_labels.get(key) == value for key, value in service_selector.items())
+    assert not all(refresh_labels.get(key) == value for key, value in service_selector.items())
+    assert refresh_labels["app.kubernetes.io/component"] == "grafana-maintenance"
+
+    allowed_components = {
+        peer["podSelector"]["matchLabels"]["app.kubernetes.io/component"]
+        for peer in database_policy["spec"]["ingress"][0]["from"]
+    }
+    assert allowed_components == {"grafana", "grafana-maintenance"}


### PR DESCRIPTION
Fixes the live T+10 finding where `verdify-band-curve-refresh` Pods temporarily matched `Service/verdify-grafana`, producing a bogus Ready EndpointSlice target with no HTTP port.

- label only refresh Job Pods as `grafana-maintenance`
- retain DB access through a separate NetworkPolicy peer
- add a fail-closed selector-overlap regression

Validation:
- 34 focused Grafana/migration tests passed
- prod Kustomize render passed
- CronJob and NetworkPolicy server dry-runs passed
- pre-commit hooks and diff-check passed

No Grafana Pod template, dashboard, route, Secret, or storage object changes.
