### PR TITLE
fix(grafana): keep repeat renders on one cache

### DIFF
--- a/deploy/k8s/components/grafana/grafana-render-cache.yaml
+++ b/deploy/k8s/components/grafana/grafana-render-cache.yaml
@@ -110,6 +110,13 @@ metadata:
     app.kubernetes.io/component: grafana-render-cache
 spec:
   type: ClusterIP
+  # Each replica has its own bounded emptyDir cache. Keep a given ingress
+  # source on one replica long enough for an immediate repeat render to hit
+  # the same cache instead of cold-rendering once per endpoint.
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 600
   selector:
     app.kubernetes.io/component: grafana-render-cache
   ports:

--- a/tests/test_grafana_render_cache.py
+++ b/tests/test_grafana_render_cache.py
@@ -78,6 +78,8 @@ def test_render_cache_runtime_is_pinned_unprivileged_and_credential_free():
     assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
     assert "env" not in container and "envFrom" not in container
     assert service["spec"]["ports"] == [{"name": "http", "port": 8080, "targetPort": "http"}]
+    assert service["spec"]["sessionAffinity"] == "ClientIP"
+    assert service["spec"]["sessionAffinityConfig"] == {"clientIP": {"timeoutSeconds": 600}}
     assert policy["spec"]["ingress"][0]["from"][0]["podSelector"]["matchLabels"] == {
         "app.kubernetes.io/component": "edge-traefik"
     }


### PR DESCRIPTION
Fixes the route-canary finding where two emptyDir-backed cache replicas could each cold-render the same request before either returned a HIT.

- add 10-minute ClientIP affinity to the internal render-cache Service
- retain 2 replicas and the existing bounded 5-minute cache contract
- add a fail-closed source regression

Validation:
- 17 focused Grafana tests passed
- prod Kustomize render passed
- Service server dry-run passed
- pre-commit and diff checks passed

The public cache route was rolled back before this PR; no live route remains exposed pending validation.
