### PR TITLE
fix(grafana): keep browsers on one render cache

### DIFF
--- a/deploy/k8s/components/grafana/graphs-ingressroute.yaml
+++ b/deploy/k8s/components/grafana/graphs-ingressroute.yaml
@@ -33,6 +33,18 @@ spec:
       services:
         - name: verdify-grafana-render-cache
           port: 8080
+          # Cache storage is intentionally pod-local. Pin a browser to one
+          # replica for the bounded cache lifetime so an immediate repeat
+          # render is a HIT instead of a second cold render on its peer.
+          # This cookie carries no identity or authorization state.
+          sticky:
+            cookie:
+              name: verdify_render_cache
+              httpOnly: true
+              secure: true
+              sameSite: Lax
+              path: /render/
+              maxAge: 300
     - kind: Rule
       match: Host(`graphs.verdify.ai`)
       middlewares:

--- a/tests/test_grafana_render_cache.py
+++ b/tests/test_grafana_render_cache.py
@@ -22,7 +22,22 @@ def test_public_render_path_uses_cache_without_becoming_a_second_grafana_front_d
 
     assert routes[0]["match"] == "Host(`graphs.verdify.ai`) && PathPrefix(`/render/`)"
     assert routes[0]["priority"] == 100
-    assert routes[0]["services"] == [{"name": "verdify-grafana-render-cache", "port": 8080}]
+    assert routes[0]["services"] == [
+        {
+            "name": "verdify-grafana-render-cache",
+            "port": 8080,
+            "sticky": {
+                "cookie": {
+                    "name": "verdify_render_cache",
+                    "httpOnly": True,
+                    "secure": True,
+                    "sameSite": "Lax",
+                    "path": "/render/",
+                    "maxAge": 300,
+                }
+            },
+        }
+    ]
     assert routes[1]["match"] == "Host(`graphs.verdify.ai`)"
     assert routes[1]["services"] == [{"name": "verdify-grafana", "port": 3000}]
 


### PR DESCRIPTION
## Summary
- add a bounded, non-auth Traefik affinity cookie to the Grafana render-cache route
- keep repeated browser renders on one pod-local cache replica
- lock the exact cookie contract in focused tests

## Validation
- `python -m pytest -q tests/test_grafana*.py` (17 passed)
- production Kustomize render
- server-side dry-run of the IngressRoute
- `git diff --check`

Live route remains rolled back to direct Grafana until this exact revision is green and the attended MISS-to-HIT canary passes.