### PR TITLE
gitops: constrain Verdify writers to general workers

### DIFF
--- a/deploy/k8s/base/ingestor-deployment.yaml
+++ b/deploy/k8s/base/ingestor-deployment.yaml
@@ -64,6 +64,12 @@ spec:
       # is safe and makes the arm a pure config flip. A pod with no projected SA
       # token, or with the flag off, degrades to the pre-fence always-held no-op.
       serviceAccountName: verdify-ingestor
+      # Device writers are ordinary control-plane workloads, not GPU services.
+      # Keep the hard class boundary generic so the scheduler can select any
+      # healthy general worker while the prod overlay's soft node6 avoidance
+      # remains an independent preference.
+      nodeSelector:
+        agentfleet.vallery.net/node-class: general
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -173,10 +179,6 @@ spec:
           # with a generous initialDelay so transient DB latency does not restart
           # the single writer. Wired in the containerize PR; omitted here to keep
           # the base manifest free of an entrypoint that does not exist yet.
-      # gated-§3.4: when (and only when) the device-VLAN reachability spike clears
-      # AND verify the exact target and prerequisites, this pod is pinned to a greenhouse-VLAN-reachable node
-      # via nodeSelector / affinity. Left UNSET so the base never schedules it
-      # somewhere assuming reachability it does not have.
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/k8s/components/setpoint-server/setpoint-server.yaml
+++ b/deploy/k8s/components/setpoint-server/setpoint-server.yaml
@@ -52,6 +52,11 @@ spec:
       imagePullSecrets:
         - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
         - name: ghcr-jvallery-readonly
+      # The HA writer needs services-VLAN access but no GPU. Select the general
+      # worker class without hard-pinning a hostname so scheduler failover stays
+      # available across the eligible pool.
+      nodeSelector:
+        agentfleet.vallery.net/node-class: general
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -72,6 +72,7 @@ $PY -m pytest -q \
   tests/test_generate_daily_plan.py \
   tests/test_grafana_cm_check.py \
   tests/test_grafana_manifest_security.py \
+  tests/test_ingestor_setpoint_placement.py \
   tests/test_lab_publish_k3s_guard.py \
   tests/test_mcp_audience_auth.py \
   tests/test_mqtt_fanout.py \

--- a/tests/test_ingestor_setpoint_placement.py
+++ b/tests/test_ingestor_setpoint_placement.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import subprocess
+
+import yaml
+
+EXPECTED_SELECTOR = {"agentfleet.vallery.net/node-class": "general"}
+
+
+def rendered_deployments() -> dict[str, dict]:
+    rendered = subprocess.run(
+        ["kustomize", "build", "deploy/k8s/overlays/prod"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return {
+        resource["metadata"]["name"]: resource
+        for resource in yaml.safe_load_all(rendered)
+        if isinstance(resource, dict) and resource.get("kind") == "Deployment"
+    }
+
+
+def test_prod_device_writers_require_exact_general_worker_selector() -> None:
+    deployments = rendered_deployments()
+
+    for name in ("verdify-ingestor", "verdify-setpoint-server"):
+        pod_spec = deployments[name]["spec"]["template"]["spec"]
+        assert pod_spec["nodeSelector"] == EXPECTED_SELECTOR
+
+
+def test_ingestor_retains_soft_node6_avoidance_and_single_writer_strategy() -> None:
+    ingestor = rendered_deployments()["verdify-ingestor"]
+
+    assert ingestor["spec"]["strategy"] == {"type": "Recreate"}
+    node_affinity = ingestor["spec"]["template"]["spec"]["affinity"]["nodeAffinity"]
+    assert node_affinity == {
+        "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+                "weight": 100,
+                "preference": {
+                    "matchExpressions": [
+                        {
+                            "key": "kubernetes.io/hostname",
+                            "operator": "NotIn",
+                            "values": ["vm-k3s-node6"],
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+
+
+def test_setpoint_server_retains_single_writer_strategy() -> None:
+    setpoint = rendered_deployments()["verdify-setpoint-server"]
+
+    assert setpoint["spec"]["strategy"] == {"type": "Recreate"}


### PR DESCRIPTION
## Summary

- require `agentfleet.vallery.net/node-class: general` on exactly `Deployment/verdify-ingestor` and `Deployment/verdify-setpoint-server`
- retain both Recreate singleton-writer strategies
- retain ingestor preferred hostname `NotIn vm-k3s-node6` affinity
- add focused production-render regression coverage to the hosted local-CI contract

Source-only. This draft does not reconcile or mutate production. Refs #608 and #317.

## Validation

- `python -m pytest -q tests/test_ingestor_setpoint_placement.py tests/test_setpoint_server_db_backend.py tests/test_writer_lease_fence.py` (22 passed)
- `ruff check tests/test_ingestor_setpoint_placement.py`
- `ruff format --check tests/test_ingestor_setpoint_placement.py`
- `bash scripts/gen-config-revision.sh --check` (`95cd4503345c`)
- `kustomize build deploy/k8s/overlays/prod`
- `git diff --check`
- exact two-Deployment server dry-runs against current live state

## Activation boundary (held)

Both live Deployments have a legacy `kubernetes.io/hostname: vm-k3s-node6` nodeSelector owned by `kubectl-patch`, while desired and last-applied omit it. Exact client-side server dry-run preserves that hostname alongside the new general selector, which cannot schedule because node6 is GPU-class. Exact SSA dry-run reports the expected nodeSelector ownership conflict (plus pre-existing image/field managers).

Do not use a plain sync or force-conflicts. At the attended rollout, re-read each Deployment UID/resourceVersion/template preimage, atomically replace the entire nodeSelector map with the exact general selector as part of that workload's guarded rollout, then use only the exact one-resource Argo vector with `prune=false` after source/live match. Roll back with the captured exact template preimage. Ingestor remains last because it is the Recreate single device writer.