### PR TITLE
fix(mcp): disable VM publish trigger in k3s

### DIFF
--- a/deploy/k8s/base/mcp-deployment.yaml
+++ b/deploy/k8s/base/mcp-deployment.yaml
@@ -78,6 +78,12 @@ spec:
             # env entries (POSTGRES_PASSWORD above + DB_* from envFrom).
             - name: DB_DSN
               value: "postgresql://$(DB_USER):$(POSTGRES_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            # The legacy VM uses a local systemd path unit for immediate site
+            # publishing. In k3s, the source-owned lab-publisher CronJob is the
+            # publisher; disable the VM-only file trigger instead of writing to
+            # the container's intentionally read-only root filesystem.
+            - name: VERDIFY_SITE_PUBLISH_TRIGGER_PATH
+              value: ""
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -105,6 +105,10 @@ if _env_path.exists():
 # in-cluster Postgres endpoint moves this service off the VM with no code change.
 # Default below preserves the live VM connection (localhost:5432).
 DB_DSN = os.environ.get("DB_DSN", f"postgresql://verdify:{_db_pass}@localhost:5432/verdify")
+SITE_PUBLISH_TRIGGER_PATH = os.environ.get(
+    "VERDIFY_SITE_PUBLISH_TRIGGER_PATH",
+    "/var/local/verdify/state/plan-publish-trigger",
+).strip()
 MCP_DB_STATEMENT_TIMEOUT_MS = max(
     1000,
     int(os.environ.get("VERDIFY_MCP_DB_STATEMENT_TIMEOUT_MS", "15000")),
@@ -3427,9 +3431,10 @@ async def set_plan(
             from datetime import UTC
             from datetime import datetime as _dt
 
-            trigger_path = Path("/var/local/verdify/state/plan-publish-trigger")
-            trigger_path.parent.mkdir(parents=True, exist_ok=True)
-            trigger_path.write_text(f"{plan.plan_id}\n{_dt.now(UTC).isoformat()}\n")
+            if SITE_PUBLISH_TRIGGER_PATH:
+                trigger_path = Path(SITE_PUBLISH_TRIGGER_PATH)
+                trigger_path.parent.mkdir(parents=True, exist_ok=True)
+                trigger_path.write_text(f"{plan.plan_id}\n{_dt.now(UTC).isoformat()}\n")
         except Exception as e:  # never block plan persistence on trigger failures
             log_msg = f"plan-publish trigger write failed (non-fatal): {e}"
             print(log_msg)
@@ -3832,10 +3837,11 @@ async def plan_evaluate(plan_id: str, outcome_score: int, actual_outcome: str, l
 
         site_publish_triggered = False
         try:
-            trigger_path = Path("/var/local/verdify/state/plan-publish-trigger")
-            trigger_path.parent.mkdir(parents=True, exist_ok=True)
-            trigger_path.write_text(f"evaluation:{ev.plan_id}\n{datetime.now(ZoneInfo('UTC')).isoformat()}\n")
-            site_publish_triggered = True
+            if SITE_PUBLISH_TRIGGER_PATH:
+                trigger_path = Path(SITE_PUBLISH_TRIGGER_PATH)
+                trigger_path.parent.mkdir(parents=True, exist_ok=True)
+                trigger_path.write_text(f"evaluation:{ev.plan_id}\n{datetime.now(ZoneInfo('UTC')).isoformat()}\n")
+                site_publish_triggered = True
         except Exception as e:  # never block evaluation persistence on publish trigger failures
             print(f"plan-evaluate publish trigger write failed (non-fatal): {e}")
 

--- a/tests/test_12_fidelity.py
+++ b/tests/test_12_fidelity.py
@@ -1895,7 +1895,7 @@ def test_plan_evaluate_triggers_public_site_publish():
     start = server.index("async def plan_evaluate")
     end = server.index("@mcp.tool()", start + 1) if "@mcp.tool()" in server[start + 1 :] else len(server)
     body = server[start:end]
-    assert 'Path("/var/local/verdify/state/plan-publish-trigger")' in body
+    assert "SITE_PUBLISH_TRIGGER_PATH" in body
     assert "evaluation:{ev.plan_id}" in body
     assert "site_publish_triggered" in body
 
@@ -2113,9 +2113,15 @@ def test_mcp_set_plan_triggers_public_site_publish():
     start = server.index("async def set_plan")
     end = server.index("@mcp.tool()", start + 1)
     body = server[start:end]
-    assert 'Path("/var/local/verdify/state/plan-publish-trigger")' in body
+    assert "SITE_PUBLISH_TRIGGER_PATH" in body
     assert "trigger_path.write_text" in body
     assert "plan.plan_id" in body
+
+
+def test_k3s_mcp_disables_vm_only_site_publish_file_trigger():
+    deployment = (REPO_ROOT / "deploy" / "k8s" / "base" / "mcp-deployment.yaml").read_text()
+    assert "VERDIFY_SITE_PUBLISH_TRIGGER_PATH" in deployment
+    assert 'value: ""' in deployment
 
 
 def test_mcp_set_plan_populates_plan_journal_feedback_fields():


### PR DESCRIPTION
The k3s MCP deployment runs with an intentionally read-only root filesystem, but the planner tools still attempted to write the legacy VM systemd path trigger after successful DB persistence.

This keeps the VM default intact, makes the trigger path configurable, and explicitly disables it only in the k3s Deployment where the source-owned lab-publisher CronJob performs publication.

Validated:
- focused site-publish fidelity tests: PASS
- Ruff + py_compile: PASS
- prod Kustomize render: PASS
- Deployment server dry-run: PASS
- live diff: only the empty VERDIFY_SITE_PUBLISH_TRIGGER_PATH env entry

Post-merge restart: verdify-mcp