### PR TITLE
fix(lab): allow cold-cache publisher completion

### DIFF
--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -46,10 +46,13 @@ spec:
   failedJobsHistoryLimit: 5
   jobTemplate:
     spec:
-      # The normal publish is roughly 1-3 minutes. Bound cold-cache/S3 cases to
-      # ten minutes so a disconnected optional generator cannot retain the DB
-      # or cache PVC indefinitely.
-      activeDeadlineSeconds: 900
+      # The publisher itself is normally brief, but preparing the private work
+      # root can take about 12 minutes when the durable cache must pull the
+      # current ~400 MiB S3 tree. Allow that cold-cache phase plus the bounded
+      # five-minute rebuild without letting a disconnected generator retain the
+      # DB or cache PVC indefinitely. Forbid concurrency still prevents overlap
+      # with the ten-minute schedule while a run is active.
+      activeDeadlineSeconds: 1800
       # A failed publisher can leave its canceled/disconnected PostgreSQL query
       # running until the backend reaches a send boundary. Retrying the pod in
       # the same Job then overlaps another full export despite Forbid at the
@@ -142,7 +145,7 @@ spec:
                 # Quartz crossed the generic 180-second generator ceiling as
                 # the public tree grew. Keep generators tightly bounded while
                 # allowing only the final local rebuild up to five minutes.
-                # The Job's 900-second deadline remains the outer hard stop.
+                # The Job's 1800-second deadline remains the outer hard stop.
                 - name: VERDIFY_PUBLISH_REBUILD_TIMEOUT
                   value: "300"
                 # Bound report-generation queries so a public-site refresh can

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1145,8 +1145,9 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     job_deadline = cronjob["spec"]["jobTemplate"]["spec"]["activeDeadlineSeconds"]
     assert step_timeout == 180
     assert rebuild_timeout == 300
-    assert job_deadline == 900
+    assert job_deadline == 1800
     assert step_timeout < rebuild_timeout < job_deadline
+    assert job_deadline >= 2 * (step_timeout + rebuild_timeout)
 
     for pod_spec in (publisher_spec, site_spec):
         pod_security = pod_spec["securityContext"]


### PR DESCRIPTION
## Outcome

Raise only the Lab Publisher Job outer deadline from 900s to 1800s while retaining `concurrencyPolicy: Forbid` and `backoffLimit: 0`.

## Production evidence

Natural Job `verdify-lab-publisher-29789440` (UID `dcf82b36-dd96-40ed-b275-4d107c0a7fdd`) started at 02:41:34Z on the previously qualified publisher digest. Its cache initializer completed successfully after 12 minutes at 02:53:36Z. The publisher then began normally, downloaded the exact current ~401.6 MiB public tree, passed the public-output guard, and reached the bounded rebuild, but the Job controller killed it at the exact 900-second outer deadline at 02:56:34Z (`DeadlineExceeded`). No retry occurred (`backoffLimit: 0`) and no overlapping Job ran (`Forbid`).

The existing 900-second contract is therefore smaller than the observed safe cold-cache phase plus the existing 300-second rebuild budget. The 1800-second cap bounds the whole run while allowing that evidence-backed path.

## Validation

- Exact deadline contract test: PASS
- Ruff: PASS
- Kustomize prod render: PASS
- Server-side dry-run of only `CronJob/verdify-lab-publisher`: PASS
- Rendered final image remains exact `sha256:afcaf247...`; no other resource or field change
- macOS-only broader shell fixtures retain their existing BSD `chmod --` incompatibility and unrelated live-Docker expectations; the changed contract test passes independently

Live rollout remains held. After merge, deliver only this CronJob at the exact merged revision, then require two natural new-image successful jobs before the final Lab Deployment rollout.
