### PR TITLE
fix(lab): bound publisher missed-run catchup

### DIFF
--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -37,6 +37,10 @@ metadata:
     app.kubernetes.io/component: lab-publisher
 spec:
   schedule: "*/10 * * * *"
+  # A run may legitimately cross the next ten-minute boundary while rebuilding
+  # the cache. Do not replay that missed tick after the active Job exits: doing
+  # so creates a permanent catch-up chain when runtime is just over ten minutes.
+  startingDeadlineSeconds: 30
   # Re-enabled after the repaired image passed its production recovery canary
   # on 2026-07-11: one bounded attempt per step, 323 pages emitted, all S3
   # deltas completed, and the database restart count remained unchanged.

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1139,6 +1139,9 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
 
     publisher_container = publisher_spec["containers"][0]
     publisher_env = {item["name"]: item.get("value") for item in publisher_container["env"]}
+    assert cronjob["spec"]["schedule"] == "*/10 * * * *"
+    assert cronjob["spec"]["concurrencyPolicy"] == "Forbid"
+    assert cronjob["spec"]["startingDeadlineSeconds"] == 30
     assert publisher_env["LAB_WORK_ROOT"] == "/work/publisher"
     step_timeout = int(publisher_env["VERDIFY_PUBLISH_STEP_TIMEOUT"])
     rebuild_timeout = int(publisher_env["VERDIFY_PUBLISH_REBUILD_TIMEOUT"])


### PR DESCRIPTION
The production lab publisher now takes slightly longer than its ten-minute cadence. With `Forbid` and no missed-start deadline, Kubernetes immediately replayed each skipped tick after completion and created a permanent catch-up chain.

This adds a 30-second `startingDeadlineSeconds` bound while preserving the ten-minute schedule, `Forbid`, the 1800-second Job deadline, and `backoffLimit: 0`. The focused contract test now fails closed if that scheduler guard is removed.

Validation:
- focused scheduler/cache-layout contract: PASS
- Ruff check/format: PASS
- prod render contract: PASS
- server dry-run: PASS
- diff check: PASS

Live safety: the CronJob was temporarily suspended with an exact UID/RV/spec-tested patch after the first source-restored run succeeded and the skipped 04:50 tick was immediately replayed. The already-started second Job is continuing unchanged; no Job was deleted or interrupted.