### PR TITLE
fix(prod): preserve planner DB endpoint through mapped psql

### DIFF
--- a/deploy/k8s/components/ingestor-gather-script/gather-script-configmap.yaml
+++ b/deploy/k8s/components/ingestor-gather-script/gather-script-configmap.yaml
@@ -77,6 +77,17 @@ data:
     # preserves prior VM argv). The PGOPTIONS statement-timeout is injected as a
     # docker-exec extra flag in docker-exec mode. Call sites add -c "...".
     . "$(dirname "${BASH_SOURCE[0]}")/lib/psql-verdify.sh"
+    # verdify_psql_cmd is captured through process substitution below. Exports made
+    # inside that subshell cannot reach the eventual psql process, so materialize
+    # the non-secret connection environment in this parent shell first.
+    case "${VERDIFY_PSQL_MODE:-}" in
+      direct|in-cluster)
+        export PGHOST="${PGHOST:-${DB_HOST:-localhost}}"
+        export PGPORT="${PGPORT:-${DB_PORT:-5432}}"
+        export PGDATABASE="${PGDATABASE:-${VERDIFY_DB_NAME:-verdify}}"
+        export PGUSER="${PGUSER:-${VERDIFY_DB_USER:-verdify}}"
+        ;;
+    esac
     mapfile -t DB < <(verdify_psql_cmd -e "PGOPTIONS=-c statement_timeout=${DB_STATEMENT_TIMEOUT_MS}")
     DB+=(-t -A)
     mapfile -t DB_OPTIONAL < <(verdify_psql_cmd -e "PGOPTIONS=-c statement_timeout=${DB_OPTIONAL_STATEMENT_TIMEOUT_MS}")

--- a/deploy/k8s/overlays/prod/ingestor-gather-mount.patch.yaml
+++ b/deploy/k8s/overlays/prod/ingestor-gather-mount.patch.yaml
@@ -50,6 +50,10 @@ metadata:
   name: verdify-ingestor
 spec:
   template:
+    metadata:
+      annotations:
+        # Deterministic restart trigger for the static subPath-mounted scripts.
+        verdify.io/gather-script-revision: "pghost-parent-env-v1"
     spec:
       initContainers:
         # ADDITIVE to the base wait-for-db initContainer (strategic merge keys by

--- a/scripts/gather-plan-context.sh
+++ b/scripts/gather-plan-context.sh
@@ -43,6 +43,17 @@ DB_OPTIONAL_STATEMENT_TIMEOUT_MS="${VERDIFY_PLANNER_OPTIONAL_DB_STATEMENT_TIMEOU
 # preserves prior VM argv). The PGOPTIONS statement-timeout is injected as a
 # docker-exec extra flag in docker-exec mode. Call sites add -c "...".
 . "$(dirname "${BASH_SOURCE[0]}")/lib/psql-verdify.sh"
+# verdify_psql_cmd is captured through process substitution below. Exports made
+# inside that subshell cannot reach the eventual psql process, so materialize
+# the non-secret connection environment in this parent shell first.
+case "${VERDIFY_PSQL_MODE:-}" in
+  direct|in-cluster)
+    export PGHOST="${PGHOST:-${DB_HOST:-localhost}}"
+    export PGPORT="${PGPORT:-${DB_PORT:-5432}}"
+    export PGDATABASE="${PGDATABASE:-${VERDIFY_DB_NAME:-verdify}}"
+    export PGUSER="${PGUSER:-${VERDIFY_DB_USER:-verdify}}"
+    ;;
+esac
 mapfile -t DB < <(verdify_psql_cmd -e "PGOPTIONS=-c statement_timeout=${DB_STATEMENT_TIMEOUT_MS}")
 DB+=(-t -A)
 mapfile -t DB_OPTIONAL < <(verdify_psql_cmd -e "PGOPTIONS=-c statement_timeout=${DB_OPTIONAL_STATEMENT_TIMEOUT_MS}")

--- a/tests/test_experiment_gather_mode.py
+++ b/tests/test_experiment_gather_mode.py
@@ -121,6 +121,16 @@ def _run_gather(tmp_path: Path, args: list[str], env_extra: dict[str, str] | Non
     )
 
 
+def test_gather_materializes_direct_pg_env_before_process_substitution():
+    """The mapped psql argv must inherit TCP connection variables, not a local socket."""
+    source = GATHER_SCRIPT.read_text()
+    source_pos = source.index('. "$(dirname "${BASH_SOURCE[0]}")/lib/psql-verdify.sh"')
+    mapfile_pos = source.index("mapfile -t DB < <(verdify_psql_cmd", source_pos)
+    block = source[source_pos:mapfile_pos]
+    for key in ("PGHOST", "PGPORT", "PGDATABASE", "PGUSER"):
+        assert f"export {key}=" in block
+
+
 @pytest.fixture(autouse=True)
 def _clean_experiment_env(monkeypatch):
     monkeypatch.delenv("VERDIFY_POLICY_VECTOR_MODE", raising=False)


### PR DESCRIPTION
Fixes the live REL-3 Ingestor planner-context regression observed after the cdeb image rollout: the mapped psql argv inherited no PGHOST because exports inside process substitution cannot reach the caller, so psql fell back to a local socket.

This change exports only non-secret PGHOST/PGPORT/PGDATABASE/PGUSER in the parent gather shell before mapfile, updates the deployed ConfigMap mirror, and adds an Ingestor-only deterministic restart annotation so the static subPath mount is reread. It does not change the writer image, placement, lease, or any Secret.

Validation: focused backend/mirror/regression tests pass; config-revision remains exact; targeted server dry-runs show only the gather ConfigMap and the Ingestor pod annotation.