### PR TITLE
fix(k3s): source-own Verdify Ore outage recovery

### DIFF
--- a/deploy/k8s/argocd/apps/verdify-prod-dark.yaml
+++ b/deploy/k8s/argocd/apps/verdify-prod-dark.yaml
@@ -72,6 +72,12 @@ spec:
         - /spec/volumeClaimTemplates/0/spec/volumeMode
         - /spec/volumeClaimTemplates/0/status
     - kind: PersistentVolumeClaim
+      name: verdify-lab-site-cache
+      namespace: verdify-prod
+      jsonPointers:
+        - /spec/volumeMode
+        - /spec/volumeName
+    - kind: PersistentVolumeClaim
       name: verdify-hermes-iris-data-portable-20260801
       namespace: verdify-prod
       jsonPointers:

--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -75,22 +75,18 @@ spec:
           imagePullSecrets:
             - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
             - name: ghcr-jvallery-readonly
-          # STORAGE PLACEMENT (load-bearing). verdify-lab-site-cache is
-          # ReadWriteOnce on longhorn-v1-rebuildable-rwo and attached to node6. An
-          # RWO volume can be mounted by several pods only when they share a node,
-          # so the surge pod of a rolling update must land on the same node as the
-          # pod it replaces. Without this pin the new pod can be scheduled
-          # elsewhere, fail to attach, and stall the rollout indefinitely (the old
-          # pod keeps serving, so it fails quietly rather than loudly). Was live as
-          # an unrecorded hand patch until 2026-07-27; codified here so a sync
-          # cannot drop it.
-          nodeSelector:
-            kubernetes.io/hostname: vm-k3s-node6
-          tolerations:
-            - key: maintenance.vallery.net/longhorn-recovery
-              operator: Equal
-              value: "true"
-              effect: NoSchedule
+          # STORAGE CO-LOCATION (load-bearing). The publisher and serving Lab
+          # pods co-mount one ReadWriteOnce cache, so a publisher Job must run
+          # in the serving Lab pod's hostname topology. If no Lab pod is
+          # available, leave the Job Pending instead of guessing a node or
+          # risking a cross-node multi-attach.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: lab-site
+                  topologyKey: kubernetes.io/hostname
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -46,9 +46,6 @@ spec:
   # deltas completed, and the database restart count remained unchanged.
   suspend: false
   concurrencyPolicy: Forbid
-  # Temporary maintenance suspension must not release a catch-up publisher
-  # after the quiet window. Skip any missed start older than 30 seconds.
-  startingDeadlineSeconds: 30
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   jobTemplate:
@@ -85,7 +82,7 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchLabels:
-                      app.kubernetes.io/component: lab-site
+                      verdify.ai/lab-cache-cohort: portable-rwo
                   topologyKey: kubernetes.io/hostname
           securityContext:
             runAsNonRoot: true

--- a/deploy/k8s/components/lab-site/lab-publisher.yaml
+++ b/deploy/k8s/components/lab-site/lab-publisher.yaml
@@ -46,6 +46,9 @@ spec:
   # deltas completed, and the database restart count remained unchanged.
   suspend: false
   concurrencyPolicy: Forbid
+  # Temporary maintenance suspension must not release a catch-up publisher
+  # after the quiet window. Skip any missed start older than 30 seconds.
+  startingDeadlineSeconds: 30
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
   jobTemplate:

--- a/deploy/k8s/components/lab-site/lab-site.yaml
+++ b/deploy/k8s/components/lab-site/lab-site.yaml
@@ -125,7 +125,7 @@ spec:
     # Spelled out rather than left to the 25% defaults, because the rounding is
     # load-bearing here: with replicas 1 the surge pod starts BEFORE the old pod
     # drains, so both hold the cache PVC at once. That is only legal while both
-    # land on the same node — see nodeSelector below.
+    # land on the same node — see the required pod affinity below.
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
@@ -139,22 +139,19 @@ spec:
       imagePullSecrets:
         - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
         - name: ghcr-jvallery-readonly
-      # STORAGE PLACEMENT (load-bearing). verdify-lab-site-cache is
-      # ReadWriteOnce on longhorn-v1-rebuildable-rwo and attached to node6. An
-      # RWO volume can be mounted by several pods only when they share a node,
-      # so the surge pod of a rolling update must land on the same node as the
-      # pod it replaces. Without this pin the new pod can be scheduled
-      # elsewhere, fail to attach, and stall the rollout indefinitely (the old
-      # pod keeps serving, so it fails quietly rather than loudly). Was live as
-      # an unrecorded hand patch until 2026-07-27; codified here so a sync
-      # cannot drop it.
-      nodeSelector:
-        kubernetes.io/hostname: vm-k3s-node6
-      tolerations:
-        - key: maintenance.vallery.net/longhorn-recovery
-          operator: Equal
-          value: "true"
-          effect: NoSchedule
+      # STORAGE CO-LOCATION (load-bearing). verdify-lab-site-cache is
+      # ReadWriteOnce, so every replica and rolling surge pod must share one
+      # node while they co-mount it. Required self-affinity expresses that
+      # relationship without pinning the workload to a named machine:
+      # Kubernetes permits the first matching pod to seed the group, then
+      # schedules every later matching pod into the same hostname topology.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: lab-site
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/deploy/k8s/components/lab-site/lab-site.yaml
+++ b/deploy/k8s/components/lab-site/lab-site.yaml
@@ -135,6 +135,7 @@ spec:
       labels:
         app.kubernetes.io/part-of: verdify
         app.kubernetes.io/component: lab-site
+        verdify.ai/lab-cache-cohort: portable-rwo
     spec:
       imagePullSecrets:
         - name: zot-origin-cluster-pull  # zot origin (ADR-0021); ghcr kept during transition
@@ -143,14 +144,16 @@ spec:
       # ReadWriteOnce, so every replica and rolling surge pod must share one
       # node while they co-mount it. Required self-affinity expresses that
       # relationship without pinning the workload to a named machine:
-      # Kubernetes permits the first matching pod to seed the group, then
-      # schedules every later matching pod into the same hostname topology.
+      # The cache-cohort label is deliberately narrower than the Deployment
+      # selector. It lets a new portable cohort seed beside the temporary
+      # stateless Ore-outage Pods, then keeps every later cache consumer on the
+      # same hostname.
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app.kubernetes.io/component: lab-site
+                  verdify.ai/lab-cache-cohort: portable-rwo
               topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true

--- a/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
+++ b/deploy/k8s/overlays/prod/ha-stateless-spread.patch.yaml
@@ -24,10 +24,11 @@
 # NOT touched here: verdify-ingestor / verdify-setpoint-server (single-writer
 # device path — gated ha-3), grafana (RWO PVC singleton — stays replicas:1).
 #
-# 2026-06-17 storage exception: lab-site now uses the rebuildable
-# verdify-lab-site-cache PVC on node-local-temp-rwo. It keeps two replicas, but
-# uses ScheduleAnyway so both pods may co-locate on the cache PV node; hard
-# hostname spread conflicts with a shared node-local RWO cache.
+# Storage exception: lab-site uses the shared ReadWriteOnce
+# verdify-lab-site-cache PVC. It keeps two replicas, but uses ScheduleAnyway
+# while required pod affinity co-locates both replicas on whichever eligible
+# worker hosts the portable cache; hard hostname spread conflicts with a shared
+# RWO cache.
 #
 # ha-5 (#230, this commit): verdify-planner added — the last replicas:1
 # stateless serving surface. It is a stateless HTTP service (run state lives in

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -123,6 +123,10 @@ components:
   - ../../components/ha-gap-backfill
 
 patches:
+  # ORE OUTAGE: production serves the already-qualified direct Astro image while
+  # the portable Lab cache/publisher contract is normalized off node6. This is
+  # prod-only; staging and development retain the cache-backed Lab component.
+  - path: ore-outage-lab-recovery.patch.yaml
   # Reconcile the live, verified 2026-08-01 Hermes PVC cutover.
   - path: hermes-data-portable.patch.yaml
   # The old, detached pre-portable claim has a readable Completed backup and no

--- a/deploy/k8s/overlays/prod/ore-outage-lab-recovery.patch.yaml
+++ b/deploy/k8s/overlays/prod/ore-outage-lab-recovery.patch.yaml
@@ -1,0 +1,50 @@
+# Temporary, source-owned production recovery for the Ore motherboard outage.
+#
+# The validated direct Astro artifact keeps the public site independent of the
+# cache PVC while the publisher continues refreshing that portable cache. The
+# cohort label and source component affinity keep the eventual cache-backed
+# rollback ordered without naming a worker. Remove this patch only after the
+# portable cache serving rollout is separately accepted.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-lab
+  annotations:
+    operations.vallery.net/temporary-direct-astro: ore-motherboard-outage-20260824:stage-proven-image
+    operations.vallery.net/temporary-image-substitution: ore-motherboard-outage-20260824:stale-ghcr-to-validated-internal-astro
+    operations.vallery.net/temporary-placement: ore-motherboard-outage-20260824
+spec:
+  template:
+    metadata:
+      annotations:
+        operations.vallery.net/temporary-direct-astro: ore-motherboard-outage-20260824:stage-proven-image
+        operations.vallery.net/temporary-placement: ore-motherboard-outage-20260824
+    spec:
+      initContainers:
+        - $patch: replace
+      containers:
+        - name: lab-site
+          image: registry.vallery.net/verdifyconsultancy/verdify-lab-astro@sha256:1852cf2523041ef840b3eb1092050e4b3b19d2027494fc6b6c9809b930de93b7
+          volumeMounts:
+            - $patch: replace
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+      volumes:
+        - $patch: replace
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: verdify-lab-publisher
+  annotations:
+    operations.vallery.net/temporary-placement: ore-motherboard-outage-20260824

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1099,7 +1099,7 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
                 {
                     "labelSelector": {
                         "matchLabels": {
-                            "app.kubernetes.io/component": "lab-site",
+                            "verdify.ai/lab-cache-cohort": "portable-rwo",
                         },
                     },
                     "topologyKey": "kubernetes.io/hostname",
@@ -1113,6 +1113,16 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
         assert not pod_spec.get("tolerations")
         cache_volume = next(volume for volume in pod_spec["volumes"] if volume["name"] == "lab-cache")
         assert cache_volume["persistentVolumeClaim"]["claimName"] == "verdify-lab-site-cache"
+    assert deployment["spec"]["template"]["metadata"]["labels"]["verdify.ai/lab-cache-cohort"] == "portable-rwo"
+
+    application = yaml.safe_load((REPO_ROOT / "deploy/k8s/argocd/apps/verdify-prod-dark.yaml").read_text())
+    lab_cache_ignore = next(
+        item
+        for item in application["spec"]["ignoreDifferences"]
+        if item.get("kind") == "PersistentVolumeClaim" and item.get("name") == "verdify-lab-site-cache"
+    )
+    assert lab_cache_ignore["namespace"] == "verdify-prod"
+    assert lab_cache_ignore["jsonPointers"] == ["/spec/volumeMode", "/spec/volumeName"]
     cache_pvc = _resource(publisher_docs, "PersistentVolumeClaim", "verdify-lab-site-cache")
     assert cache_pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
     assert [item["name"] for item in publisher_spec["initContainers"]] == ["prepare-private-work-root"]
@@ -1179,6 +1189,68 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
             capabilities = security["capabilities"]
             assert capabilities.get("add", []) == []
             assert "ALL" in capabilities["drop"]
+
+
+def test_rendered_prod_ore_recovery_keeps_qualified_site_and_portable_publisher():
+    rendered = subprocess.run(
+        ["kustomize", "build", "deploy/k8s/overlays/prod"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    resources = [resource for resource in yaml.safe_load_all(rendered) if isinstance(resource, dict)]
+    deployment = next(
+        resource
+        for resource in resources
+        if resource.get("kind") == "Deployment" and resource.get("metadata", {}).get("name") == "verdify-lab"
+    )
+    cronjob = next(
+        resource
+        for resource in resources
+        if resource.get("kind") == "CronJob" and resource.get("metadata", {}).get("name") == "verdify-lab-publisher"
+    )
+    pvc = next(
+        resource
+        for resource in resources
+        if resource.get("kind") == "PersistentVolumeClaim"
+        and resource.get("metadata", {}).get("name") == "verdify-lab-site-cache"
+    )
+
+    deployment_pod = deployment["spec"]["template"]["spec"]
+    publisher_pod = cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    site_container = next(item for item in deployment_pod["containers"] if item["name"] == "lab-site")
+    expected_affinity = {
+        "podAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchLabels": {"verdify.ai/lab-cache-cohort": "portable-rwo"},
+                    },
+                    "topologyKey": "kubernetes.io/hostname",
+                },
+            ],
+        },
+    }
+
+    assert deployment["spec"]["replicas"] == 2
+    assert "nodeSelector" not in deployment_pod
+    assert deployment_pod["affinity"] == expected_affinity
+    assert deployment_pod["initContainers"] == []
+    assert site_container["image"] == (
+        "registry.vallery.net/verdifyconsultancy/verdify-lab-astro"
+        "@sha256:1852cf2523041ef840b3eb1092050e4b3b19d2027494fc6b6c9809b930de93b7"
+    )
+    assert {item["name"] for item in site_container["volumeMounts"]} == {"tmp", "nginx-cache", "nginx-run"}
+    assert {item["name"] for item in deployment_pod["volumes"]} == {"tmp", "nginx-cache", "nginx-run"}
+    assert deployment["metadata"]["annotations"]["operations.vallery.net/temporary-placement"] == (
+        "ore-motherboard-outage-20260824"
+    )
+
+    assert "nodeSelector" not in publisher_pod
+    assert publisher_pod["affinity"] == expected_affinity
+    assert cronjob["spec"]["startingDeadlineSeconds"] == 30
+    assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
+    assert pvc["spec"]["storageClassName"] == "longhorn-v1-rebuildable-rwo"
 
 
 def test_publisher_image_and_ci_own_the_canonical_cache_scanner_and_shared_package():

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1088,16 +1088,29 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     assert publisher_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
     assert site_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
 
-    # STORAGE PLACEMENT. The cache PVC is ReadWriteOnce and node-attached, so an
-    # RWO volume is only co-mountable by pods sharing a node. Both workloads must
-    # therefore pin the same node, and the Deployment's surge pod (maxSurge 1,
-    # maxUnavailable 0 with replicas 1 starts before the old pod drains) must land
-    # there too or the rollout stalls on a failed attach. This was live only as an
-    # unrecorded hand patch until 2026-07-27; assert it so a sync cannot drop it.
+    # STORAGE CO-LOCATION. The cache PVC is ReadWriteOnce, so the serving pods,
+    # rollout surge, and publisher must share a hostname. Required pod affinity
+    # preserves that relationship without pinning the group to one named worker.
     assert deployment["spec"]["replicas"] == 1
     assert deployment["spec"]["strategy"]["rollingUpdate"] == {"maxUnavailable": 0, "maxSurge": 1}
+    expected_co_location = {
+        "podAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/component": "lab-site",
+                        },
+                    },
+                    "topologyKey": "kubernetes.io/hostname",
+                },
+            ],
+        },
+    }
     for pod_spec in (publisher_spec, site_spec):
-        assert pod_spec["nodeSelector"] == {"kubernetes.io/hostname": "vm-k3s-node6"}
+        assert "nodeSelector" not in pod_spec
+        assert pod_spec["affinity"] == expected_co_location
+        assert not pod_spec.get("tolerations")
         cache_volume = next(volume for volume in pod_spec["volumes"] if volume["name"] == "lab-cache")
         assert cache_volume["persistentVolumeClaim"]["claimName"] == "verdify-lab-site-cache"
     cache_pvc = _resource(publisher_docs, "PersistentVolumeClaim", "verdify-lab-site-cache")

--- a/tests/test_lab_publish_k3s_guard.py
+++ b/tests/test_lab_publish_k3s_guard.py
@@ -1084,6 +1084,7 @@ def test_deployed_cache_layout_is_unique_restricted_and_preserves_time_budget():
     publisher_spec = cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]
     site_spec = deployment["spec"]["template"]["spec"]
 
+    assert cronjob["spec"]["startingDeadlineSeconds"] == 30
     assert publisher_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
     assert site_spec["securityContext"]["fsGroupChangePolicy"] == "OnRootMismatch"
 


### PR DESCRIPTION
## Summary

- replace the dead node6 Lab placement with portable RWO cohort affinity
- keep production on the qualified direct Astro artifact during the Ore outage
- preserve the portable Longhorn publisher cache and bound missed CronJob starts
- ignore only Kubernetes-assigned fields on the recreated cache PVC

## Safety

- no Frigate development resources are changed
- the production serving image remains the digest already proven live
- rendered production guards reject node6 affinity, cache mounting by site pods, and stale image regression

## Validation

- focused Lab source and rendered-production tests pass
- Ruff check and format check pass
- production kustomize build passes
- pre-commit hooks pass