### PR TITLE
fix(backfill): retry transient Home Assistant history errors

### DIFF
--- a/deploy/k8s/components/ha-gap-backfill/backfill-ha-gaps.py
+++ b/deploy/k8s/components/ha-gap-backfill/backfill-ha-gaps.py
@@ -20,6 +20,8 @@ import math
 import os
 import re
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from bisect import bisect_right
@@ -64,6 +66,9 @@ GREENHOUSE_ID = os.environ.get("GREENHOUSE_ID", "vallery")
 DEFAULT_HA_URL = "http://192.168.30.107:8123"
 DEFAULT_HA_TOKEN_FILE = "/mnt/agents/shared/credentials/ha_token.txt"
 ADVISORY_LOCK_NAME = "verdify-ha-gap-backfill"
+HA_READ_ATTEMPTS = 3
+HA_RETRY_DELAY_SECONDS = 2
+HA_RETRYABLE_HTTP_STATUS = {404, 408, 425, 429, 500, 502, 503, 504}
 
 SAMPLE_TABLES = ("climate", "diagnostics", "setpoint_snapshot", "energy")
 WRITE_TABLES = (*SAMPLE_TABLES, "equipment_state", "system_state")
@@ -187,7 +192,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ha-url", default=os.environ.get("HA_URL", DEFAULT_HA_URL))
     parser.add_argument("--ha-token-file", default=os.environ.get("HA_TOKEN_FILE", DEFAULT_HA_TOKEN_FILE))
     parser.add_argument("--batch-size", type=int, default=25, help="HA history entity batch size")
-    parser.add_argument("--history-carry-minutes", type=float, default=20.0, help="pre-window HA history for carry-forward")
+    parser.add_argument(
+        "--history-carry-minutes", type=float, default=20.0, help="pre-window HA history for carry-forward"
+    )
     parser.add_argument("--log-level", default=os.environ.get("LOG_LEVEL", "INFO"))
     return parser.parse_args()
 
@@ -555,8 +562,24 @@ def ha_get_json(ha_url: str, token: str, path: str, timeout: int = 60) -> Any:
         f"{ha_url.rstrip('/')}{path}",
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
+    for attempt in range(1, HA_READ_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as error:
+            if error.code not in HA_RETRYABLE_HTTP_STATUS or attempt == HA_READ_ATTEMPTS:
+                raise
+            delay = HA_RETRY_DELAY_SECONDS * 2 ** (attempt - 1)
+            LOG.warning(
+                "HA read returned retryable HTTP %s; attempt %s/%s, retrying in %ss",
+                error.code,
+                attempt,
+                HA_READ_ATTEMPTS,
+                delay,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError("unreachable HA retry state")
 
 
 def fetch_current_entities(ha_url: str, token: str) -> set[str]:
@@ -758,7 +781,9 @@ def full_scan_windows(start: datetime, end: datetime, max_minutes: float) -> lis
     return split_windows([Window(ceil_time(start, 60), floor_time(end, 60), ("full-scan",))], max_minutes)
 
 
-async def detect_windows(conn: asyncpg.Connection, args: argparse.Namespace, start: datetime, end: datetime) -> list[Window]:
+async def detect_windows(
+    conn: asyncpg.Connection, args: argparse.Namespace, start: datetime, end: datetime
+) -> list[Window]:
     if args.full_scan:
         return full_scan_windows(start, end, args.max_backfill_minutes)
 
@@ -896,7 +921,11 @@ async def backfill_climate(
         rows.append(row)
     if not rows:
         return 0
-    insert_columns = ["ts", "greenhouse_id", *sorted({key for row in rows for key in row if key not in {"ts", "greenhouse_id"}})]
+    insert_columns = [
+        "ts",
+        "greenhouse_id",
+        *sorted({key for row in rows for key in row if key not in {"ts", "greenhouse_id"}}),
+    ]
     return await insert_dict_rows(conn, "climate", insert_columns, rows, args.apply)
 
 
@@ -946,7 +975,11 @@ async def backfill_diagnostics(
         rows.append(row)
     if not rows:
         return 0
-    insert_columns = ["ts", "greenhouse_id", *sorted({key for row in rows for key in row if key not in {"ts", "greenhouse_id"}})]
+    insert_columns = [
+        "ts",
+        "greenhouse_id",
+        *sorted({key for row in rows for key in row if key not in {"ts", "greenhouse_id"}}),
+    ]
     return await insert_dict_rows(conn, "diagnostics", insert_columns, rows, args.apply)
 
 
@@ -1205,7 +1238,8 @@ async def backfill_window(
     history_start = window.start - timedelta(minutes=args.history_carry_minutes)
     histories = fetch_history(args.ha_url, token, mappings.all_entities, history_start, window.end, args.batch_size)
     representative_ok = any(
-        history.value_at(window.start) is not None or any(True for _ in history.events_between(window.start, window.end))
+        history.value_at(window.start) is not None
+        or any(True for _ in history.events_between(window.start, window.end))
         for entity_id, history in histories.items()
         if entity_id in REPRESENTATIVE_HA_ENTITIES
     )
@@ -1266,7 +1300,9 @@ def compute_range(args: argparse.Namespace, token: str) -> tuple[datetime, datet
 
 async def async_main() -> int:
     args = parse_args()
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s")
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s"
+    )
     token = load_ha_token(args.ha_token_file)
     start, end = compute_range(args, token)
     mode = "APPLY" if args.apply else "DRY-RUN"

--- a/tests/test_13_operational_recovery.py
+++ b/tests/test_13_operational_recovery.py
@@ -10,10 +10,16 @@ Covers fixes from ingestor/sprint-25.1:
 from __future__ import annotations
 
 import asyncio
+import io
+import runpy
 import subprocess
 import sys
+import urllib.error
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 from verdify_schemas.tunable_registry import (
     BAND_OWNED_REG,
@@ -114,6 +120,44 @@ def test_prod_ha_gap_backfill_cronjob_mounts_script_and_ha_token():
     assert "name: allow-db-from-ha-gap-backfill" in cron
     assert "app.kubernetes.io/component: ha-gap-backfill" in cron
     assert "deploy/k8s/components/ha-gap-backfill/backfill-ha-gaps.py" in wrapper
+
+
+def _ha_gap_backfill_globals():
+    return runpy.run_path("deploy/k8s/components/ha-gap-backfill/backfill-ha-gaps.py")
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("http://home-assistant/api/history", code, "test", {}, io.BytesIO())
+
+
+def test_ha_gap_backfill_retries_transient_history_http_errors():
+    module = _ha_gap_backfill_globals()
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"status":"ok"}'
+
+    with (
+        patch("urllib.request.urlopen", side_effect=[_http_error(404), _http_error(503), response]) as urlopen,
+        patch("time.sleep") as sleep,
+    ):
+        result = module["ha_get_json"]("http://home-assistant", "redacted", "/api/history/period/test")
+
+    assert result == {"status": "ok"}
+    assert urlopen.call_count == 3
+    assert sleep.call_args_list == [call(2), call(4)]
+
+
+def test_ha_gap_backfill_does_not_retry_authentication_errors():
+    module = _ha_gap_backfill_globals()
+
+    with (
+        patch("urllib.request.urlopen", side_effect=_http_error(401)) as urlopen,
+        patch("time.sleep") as sleep,
+        pytest.raises(urllib.error.HTTPError, match="HTTP Error 401"),
+    ):
+        module["ha_get_json"]("http://home-assistant", "redacted", "/api/history/period/test")
+
+    urlopen.assert_called_once()
+    sleep.assert_not_called()
 
 
 def test_derived_history_reconcile_script_uses_canonical_daily_refresh():


### PR DESCRIPTION
The production HA gap backfill failed at 2026-08-24 12:23Z on a transient Home Assistant history HTTP 404 after succeeding one hour earlier. This adds three bounded attempts with 2s/4s backoff for retryable history-read HTTP statuses while preserving immediate failure for authentication errors.

Scope is analytics-only: no firmware, device writer, schema, migration, or production workload image change.

Validation:
- make VENV=/Users/jason/repos/verdify-platform/.venv lint
- focused HA gap-backfill tests: 4 passed
- py_compile for the mounted script
- kubectl kustomize deploy/k8s/overlays/prod
- pre-commit hooks green

The broader operational-recovery test file has three unrelated existing failures: one stale synology-iscsi assertion and two laptop Docker DB assumptions.