### PR TITLE
ci: adopt the regenerated .agent-fleet/ci.yaml (verdify-experiment-v2-orchestrator)

### DIFF
--- a/.agent-fleet/ci.yaml
+++ b/.agent-fleet/ci.yaml
@@ -15,6 +15,9 @@ images:
 - name: verdify-migrate
   dockerfile: db/Dockerfile.migrate
   context: .
+- name: verdify-experiment-v2-orchestrator
+  dockerfile: experiment_orchestrator/Dockerfile
+  context: .
 - name: verdify-planner
   dockerfile: planner_graph/Dockerfile
   context: .


### PR DESCRIPTION
Managed-file distribution from jvallery/agents#4022: the registry now authorizes the verdify-experiment-v2-orchestrator build profile (experiment_orchestrator/Dockerfile, context .). Before the first build-classified push after the orchestrator lands, main also needs experiment_orchestrator/Dockerfile and a ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator images entry in deploy/k8s/overlays/prod/kustomization.yaml (newName registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator + a valid sha256 digest line) - the pin actuator rewrites in place and now advances only api/mcp/ingestor/migrate/experiment-v2-orchestrator.