### PR TITLE
feat(qual): add the ADR-0010 offline component qualification tools

### DIFF
--- a/.agent-fleet/ci.yaml
+++ b/.agent-fleet/ci.yaml
@@ -53,6 +53,7 @@ checks:
       tests/test_generate_daily_plan.py tests/test_mqtt_fanout.py tests/test_planner_memory_ingest.py
       tests/test_site_content_refresh.py tests/test_slack_config.py tests/test_slack_ops.py
       tests/test_soil_dryout_alert.py tests/test_tempest_sync.py tests/test_writer_lease_fence.py
+      tests/test_component_grid_capture.py tests/test_component_prefix_replay.py
   - name: firmware-logic
     command: "bash -lc ' set -euo pipefail; test -f firmware/test/data/replay_overrides.csv\
       \ || gunzip -k firmware/test/data/replay_overrides.csv.gz; cd firmware; g++\

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -70,6 +70,8 @@ $PY -m pytest -q \
   tests/test_18_twin_divergence_dashboard.py \
   tests/test_20_vision_src_sync.py \
   tests/test_21_config_revision.py \
+  tests/test_component_grid_capture.py \
+  tests/test_component_prefix_replay.py \
   tests/test_action_log_policy_identity.py \
   tests/test_anchor_service_sync.py \
   tests/test_api_public_output_policy.py \

--- a/scripts/component_grid_capture.py
+++ b/scripts/component_grid_capture.py
@@ -1,0 +1,1316 @@
+#!/usr/bin/env python3
+"""component_grid_capture.py — Tool A, the offline current-state capture.
+
+This tool is the qualification half of the live-grid proof.  It is deliberately
+OFFLINE and NON-ACTUATING: it opens no socket, imports no ESPHome client, reads
+no database, reads no Kubernetes Secret and never invokes a setter or service.
+It consumes ONE input artifact (``verdify-component-grid-capture-input-v1``, see
+INPUT ARTIFACT SCHEMA below) produced by a separately-approved, read-only in-pod
+emitter, and answers three questions with fail-closed evidence:
+
+1. **grid parity** — is the LIVE running device's 48-field entity grid
+   byte-parity with the source ``ENTITY_GRIDS``?  Entity type, numeric
+   (min, max, step) and both route slugs must match exactly, and the attributed
+   entity set must equal ``CANONICAL_FIELD_ORDER`` with nothing missing, extra
+   or duplicated.
+2. **#424 three-layer coherence** — do the *served* (versioned DB/crop-band
+   corridor), *control* (firmware globals actually consumed) and *observed*
+   (raw ``cfg_*`` readback) layers expose the same truthful value, name, unit
+   and a fresh timestamp for every required temperature/VPD series?  A layer
+   that cannot expose a truthful value is classified ``unobservable`` and
+   BLOCKS; convergence is never inferred.
+3. **current state** — is the observed 48-field component state exactly on the
+   deployed entity grid, and what is its ``state_content_sha256`` under the
+   migration-214 cross-language identity?
+
+Only when all three pass does the tool emit the qualified ``GRID_REVISION``
+string.  Together with a separate Tool B order revision that string unblocks
+``verdify_schemas.component_executor.physical_execution_qualified``.  Nothing
+here modifies that module; adopting the revision is a separate reviewed change.
+
+Everything fails closed: a grid mismatch, an off-grid or out-of-range observed
+value, a missing/extra/duplicated entity, a route mismatch, or any layer that
+cannot expose a truthful value produces no revision and a non-zero exit.
+
+Exit code is 0 iff no check FAILs and a revision was emitted.
+
+REVISION-DERIVATION NOTE (deliberate deviation, read before changing)
+--------------------------------------------------------------------
+The grid revision is NOT recomputed here.  It is produced verbatim by
+``verdify_schemas.component_qualification.build_live_entity_grid_evidence``,
+the same pure function the ingestor already calls on its existing authenticated
+enumeration (``ingestor/tasks/component_experiment.py``
+``record_component_grid_firmware_revision``).  ``physical_execution_qualified``
+requires ``observed_grid_revision == GRID_REVISION``, so an offline tool that
+hashed a *different* preimage — for example one that folded the firmware,
+config or registry revision into the grid identity — would derive a revision
+the live ingestor attestation can never reproduce, permanently wedging the
+gate.  Firmware/config/registry pins are therefore carried in the observation
+receipt and in this tool's result payload, exactly where the shipped evidence
+module puts them, not inside the semantic identity of an unchanged grid.
+
+INPUT ARTIFACT SCHEMA (``verdify-component-grid-capture-input-v1``)
+-------------------------------------------------------------------
+A future in-pod ``commissioning_probe`` emitter (#641-gated, root-controller
+owned) must produce exactly this shape.  Every field is read-only device/DB
+metadata; no secret, credential or command belongs in it.  Unknown top-level
+or per-row keys are rejected, so the emitter cannot smuggle extra state past
+this contract::
+
+    {
+      "schema": "verdify-component-grid-capture-input-v1",
+      "device_id": "vallery/greenhouse-controller",   # policy device id, NFC text
+      "observed_at": "2026-08-26T01:02:03.456789Z",   # capture instant, UTC, Z
+      "runtime": {
+        "runtime_instance_id": "<uuid4>",             # ingestor process identity
+        "connection_generation": 7                    # transport generation >= 1
+      },
+      "revisions": {
+        "source_revision": "<40 lowercase hex>",      # running image git sha
+        "firmware_revision": "2026.7.10.1500.09ee886",
+        "config_revision": "<verdify.io/config-revision>",
+        "registry_revision": "<tunable registry pin>",
+        "crop_band_resolver_revision": "<served-layer resolver pin>",
+        "sensor_registry_revision": "<sensor registry pin>"
+      },
+      "entities": [                                   # RAW list_entities_services
+        {                                             # projection — NOT attributed
+          "object_id": "min_fog_on_s",
+          "entity_type": "number" | "switch" | "sensor",
+          "key": 1234,                                # > 0, per-type unique
+          "device_id": 0,                             # optional, default 0
+          "disabled_by_default": false,               # optional, default false
+          "minimum": 15, "maximum": 300, "step": 15,  # numbers only; JSON number
+          "unit": "s",                                #   (binary32 as decoded) or
+          "assumed_state": null                       #   an exact decimal string
+        }, ...
+      ],
+      "observed_components": {                        # #424 observed layer, x48
+        "<canonical_field>": {
+          "slug": "cfg_min_fog_on_s",                 # == registry cfg readback
+          "unit": "s",
+          "observed_at": "2026-08-26T01:01:59.000000Z",
+          "value": 45                                 # raw cfg_* readback value
+        }, ...
+      },
+      "band_layers": [                                # #424 three-layer proof
+        {
+          "series": "vpd_low",                        # >= REQUIRED_BAND_SERIES
+          "served":   {"value": 0.875, "unit": "kPa", "as_of": "...Z",
+                       "source": "fn_band_setpoints(now())"},
+          "control":  {"value": 0.56,  "unit": "kPa", "as_of": "...Z",
+                       "source": "firmware global gh_vpd_low"},
+          "observed": {"value": 0.56,  "unit": "kPa", "as_of": "...Z",
+                       "source": "setpoint_snapshot",
+                       "slug": "cfg___vpd_low__kpa_"}
+        }, ...
+      ]
+    }
+
+A layer whose ``value`` is ``null``, whose ``unit`` is missing/empty, whose
+``as_of`` is missing, in the future or older than ``--max-observation-age-s``,
+or (for ``observed``) whose ``slug`` is missing, cannot expose a truthful value:
+it is classified ``unobservable`` and blocks.  Layers that all expose truthful
+values but disagree are classified ``present`` (the #424 discrepancy is still
+present) and also block.  Only exact agreement is ``resolved``.
+
+Exactness rule for numbers: an artifact may carry a grid/layer number either as
+an exact decimal string (compared with ``Decimal`` equality) or as a JSON number
+decoded from the ESPHome protobuf ``float`` transport (compared by exact
+IEEE-754 binary32 bytes, the same rule ``component_qualification`` already
+uses).  Neither path is a tolerance window: binary32 equality is the exact
+representation the transport can carry, and one adjacent ULP is a mismatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import struct
+import sys
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Literal
+from uuid import UUID
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from verdify_schemas.component_executor import (  # noqa: E402
+    CANONICAL_FIELD_ORDER,
+    ENTITY_GRIDS,
+    ComponentContractError,
+    normalize_complete_state,
+)
+from verdify_schemas.component_executor import GRID_REVISION as SOURCE_GRID_REVISION  # noqa: E402
+from verdify_schemas.component_qualification import (  # noqa: E402
+    ComponentGridEvidenceError,
+    LiveEntityGridEvidence,
+    RuntimeEntityMetadata,
+    build_live_entity_grid_evidence,
+)
+from verdify_schemas.policy_vector import (  # noqa: E402
+    POLICY_VECTOR_SIZE,
+    encode_policy_vector,
+    wire_manifest_digest,
+)
+from verdify_schemas.tunable_registry import REGISTRY, WIRE_SCHEMA_VERSION  # noqa: E402
+
+INPUT_SCHEMA = "verdify-component-grid-capture-input-v1"
+RESULT_SCHEMA = "verdify-component-grid-capture-result-v1"
+# Emitted verbatim so scripts/prepare_component_prefix_replay.py can consume the
+# captured start state as a --current-state input without a translation step.
+CURRENT_STATE_SCHEMA = "verdify-component-current-state-v1"
+POLICY_STATE_DOMAIN = b"verdify-policy-state-content-v1"
+
+# #424 acceptance: "every temperature and VPD low/high/target series relevant to
+# the fast study, not only target difference".  temp_target/vpd_target have no
+# cfg_* number readback (they are computed publishes, migration 182), so their
+# observed slug comes from the artifact rather than the registry.
+REQUIRED_BAND_SERIES: tuple[str, ...] = (
+    "temp_low",
+    "temp_high",
+    "temp_target",
+    "vpd_low",
+    "vpd_high",
+    "vpd_target",
+)
+
+REQUIRED_REVISIONS: tuple[str, ...] = (
+    "source_revision",
+    "firmware_revision",
+    "config_revision",
+    "registry_revision",
+    "crop_band_resolver_revision",
+    "sensor_registry_revision",
+)
+
+DEFAULT_MAX_OBSERVATION_AGE_S = 900
+
+_ENTITY_TYPES = ("number", "switch", "sensor")
+_ENTITY_KEYS = frozenset(
+    {
+        "object_id",
+        "entity_type",
+        "key",
+        "device_id",
+        "disabled_by_default",
+        "minimum",
+        "maximum",
+        "step",
+        "unit",
+        "assumed_state",
+    }
+)
+_LAYER_KEYS = frozenset({"value", "unit", "as_of", "source", "slug"})
+_SERIES_NAME = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_SOURCE_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_QUALIFIED_GRID_REVISION = re.compile(r"^live-entity-grid-v[1-9][0-9]*:sha256:[0-9a-f]{64}$")
+
+Classification = Literal["resolved", "present", "unobservable"]
+
+
+class GridCaptureError(ValueError):
+    """The supplied artifact cannot prove a truthful current-state capture."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pure-logic core
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LiveEntityGrid:
+    """One canonical field as the LIVE device actually exposes it.
+
+    ``esp_object_id`` / ``cfg_readback_object_id`` / ``entity_type`` are ``None``
+    when the device did not expose that route at all; ``compare_live_grid``
+    reports the absence rather than substituting a source value.
+    """
+
+    field_name: str
+    esp_object_id: str | None
+    cfg_readback_object_id: str | None
+    entity_type: str | None
+    minimum: Decimal | float | str | None = None
+    maximum: Decimal | float | str | None = None
+    step: Decimal | float | str | None = None
+
+
+@dataclass(frozen=True)
+class LayerTriple:
+    """One #424 series across the served / control / observed semantic layers."""
+
+    field_name: str
+    served: str | None
+    control: str | None
+    observed: str | None
+    observed_slug: str | None
+    observed_unit: str | None
+    observed_ts: str | None
+    coherent: bool
+    classification: Classification
+    detail: str = ""
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "classification": self.classification,
+            "coherent": self.coherent,
+            "control": self.control,
+            "detail": self.detail,
+            "field_name": self.field_name,
+            "observed": self.observed,
+            "observed_slug": self.observed_slug,
+            "observed_ts": self.observed_ts,
+            "observed_unit": self.observed_unit,
+            "served": self.served,
+        }
+
+
+@dataclass(frozen=True)
+class GridCaptureResult:
+    """The complete, fail-closed capture verdict."""
+
+    grid_parity_ok: bool
+    band_coherence_ok: bool
+    observed_state_ok: bool
+    observed_start_state: dict[str, bool | float] | None
+    observed_state_content_sha256: str | None
+    observed_wire_vector_hex: str | None
+    revisions: dict[str, str]
+    runtime: dict[str, Any]
+    device_id: str
+    observed_at: str
+    live_grid: tuple[LiveEntityGrid, ...]
+    layer_triples: tuple[LayerTriple, ...]
+    grid_content_sha256: str | None
+    observation_receipt_sha256: str | None
+    grid_revision: str | None
+    failures: tuple[str, ...]
+
+    @property
+    def qualified(self) -> bool:
+        return self.grid_revision is not None
+
+
+def _decimal_text(value: Decimal) -> str:
+    """Canonical decimal text: no exponent, no negative zero, no trailing zeros."""
+    text = format(value.normalize(), "f")
+    return "0" if text in {"-0", "-0.0"} else text
+
+
+def _as_decimal(value: object, label: str) -> Decimal:
+    if isinstance(value, bool):
+        raise GridCaptureError(f"{label} must be a number, not bool")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise GridCaptureError(f"{label} must be finite")
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise GridCaptureError(f"{label} is not a decimal number") from exc
+    if not number.is_finite():
+        raise GridCaptureError(f"{label} must be finite")
+    return number
+
+
+def _binary32(value: object, label: str) -> bytes:
+    """Exact IEEE-754 binary32 bytes — the ESPHome protobuf representation."""
+    if isinstance(value, bool):
+        raise GridCaptureError(f"{label} must be a number, not bool")
+    try:
+        numeric = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise GridCaptureError(f"{label} is not a number") from exc
+    if not math.isfinite(numeric):
+        raise GridCaptureError(f"{label} must be finite")
+    try:
+        return struct.pack("!f", numeric)
+    except (OverflowError, struct.error) as exc:
+        raise GridCaptureError(f"{label} is out of binary32 range") from exc
+
+
+def _grid_number_matches(observed: object, expected: Decimal, label: str) -> bool:
+    """Exact equality against one source grid number — never a tolerance window.
+
+    An exact decimal string (or ``Decimal``) is compared with ``Decimal``
+    equality.  A JSON number decoded off the protobuf ``float`` transport is
+    compared by exact binary32 bytes, mirroring
+    ``component_qualification._float32_bytes``: one adjacent ULP is a mismatch,
+    and there is no rounding of a candidate value onto the grid.
+    """
+    if isinstance(observed, (str, Decimal)):
+        return _as_decimal(observed, label) == expected
+    return _binary32(observed, label) == _binary32(expected, f"{label}:expected")
+
+
+def _observed_grid_text(value: object, label: str) -> str:
+    if isinstance(value, (str, Decimal)):
+        return _decimal_text(_as_decimal(value, label))
+    return _decimal_text(_as_decimal(repr(float(value)), label))  # type: ignore[arg-type]
+
+
+def compare_live_grid(live: Sequence[LiveEntityGrid]) -> list[str]:
+    """Return the complete list of grid-parity failures; ``[]`` iff byte-parity.
+
+    Every canonical field must appear exactly once, carry the registry's setter
+    and cfg-readback slugs, carry the source entity type and — for numbers — the
+    exact source ``(minimum, maximum, step)``.  Switches must carry no numeric
+    grid at all, because a switch with a derived numeric grid is a different
+    deployed entity, not a cosmetic difference.
+    """
+    failures: list[str] = []
+    seen: dict[str, int] = {}
+    for row in live:
+        if not isinstance(row, LiveEntityGrid):
+            failures.append(f"invalid_live_grid_row:{row!r}")
+            continue
+        seen[row.field_name] = seen.get(row.field_name, 0) + 1
+
+    expected_fields = set(CANONICAL_FIELD_ORDER)
+    for name in sorted(set(seen) - expected_fields):
+        failures.append(f"extra_entity:{name}")
+    for name in sorted(expected_fields - set(seen)):
+        failures.append(f"missing_entity:{name}")
+    for name in sorted(field for field, count in seen.items() if count > 1):
+        failures.append(f"duplicate_entity:{name}:{seen[name]}")
+
+    by_field = {row.field_name: row for row in live if isinstance(row, LiveEntityGrid)}
+    for field_name in CANONICAL_FIELD_ORDER:
+        row = by_field.get(field_name)
+        if row is None:
+            continue
+        definition = REGISTRY[field_name]
+        expected_grid = ENTITY_GRIDS[field_name]
+
+        if definition.esp_object_id is None or definition.cfg_readback_object_id is None:
+            failures.append(f"source_route_missing:{field_name}")
+            continue
+        if row.esp_object_id is None:
+            failures.append(f"setter_route_absent:{field_name}:{definition.esp_object_id}")
+        elif row.esp_object_id != definition.esp_object_id:
+            failures.append(
+                f"setter_route_mismatch:{field_name}:expected={definition.esp_object_id}:observed={row.esp_object_id}"
+            )
+        if row.cfg_readback_object_id is None:
+            failures.append(f"readback_route_absent:{field_name}:{definition.cfg_readback_object_id}")
+        elif row.cfg_readback_object_id != definition.cfg_readback_object_id:
+            failures.append(
+                f"readback_route_mismatch:{field_name}:expected={definition.cfg_readback_object_id}"
+                f":observed={row.cfg_readback_object_id}"
+            )
+
+        if row.entity_type != expected_grid.entity_type:
+            failures.append(
+                f"entity_type_mismatch:{field_name}:expected={expected_grid.entity_type}:observed={row.entity_type}"
+            )
+            continue
+
+        if expected_grid.entity_type == "switch":
+            if any(value is not None for value in (row.minimum, row.maximum, row.step)):
+                failures.append(f"switch_carries_numeric_grid:{field_name}")
+            continue
+
+        assert expected_grid.minimum is not None and expected_grid.maximum is not None
+        assert expected_grid.step is not None
+        bounds = (
+            ("minimum", row.minimum, expected_grid.minimum),
+            ("maximum", row.maximum, expected_grid.maximum),
+            ("step", row.step, expected_grid.step),
+        )
+        for label, observed, expected in bounds:
+            if observed is None:
+                failures.append(f"number_grid_missing:{field_name}:{label}")
+                continue
+            try:
+                matched = _grid_number_matches(observed, expected, f"{field_name}:{label}")
+            except GridCaptureError as exc:
+                failures.append(f"invalid_number_grid:{field_name}:{label}:{exc}")
+                continue
+            if not matched:
+                observed_text = _observed_grid_text(observed, f"{field_name}:{label}")
+                failures.append(
+                    f"number_grid_mismatch:{field_name}:{label}"
+                    f":expected={_decimal_text(expected)}:observed={observed_text}"
+                )
+    return failures
+
+
+def project_live_entity_grid(entities: Sequence[RuntimeEntityMetadata]) -> tuple[LiveEntityGrid, ...]:
+    """Attribute a raw runtime inventory onto the 48 canonical fields.
+
+    Routes are keyed by ``(entity_type, object_id)``, exactly as
+    ``component_qualification`` keys them: three switch fields
+    (``sw_direct_wet_gate_enabled``, ``sw_fog_closes_vent``,
+    ``sw_mister_closes_vent``) deliberately publish their cfg readback under the
+    SAME slug as their setter, distinguished only by ESPHome entity type, so
+    object_id alone would double-attribute them.
+
+    When the expected setter type is absent the projection still looks for the
+    slug under another type — a route present under the WRONG type must reach
+    ``compare_live_grid`` as an ``entity_type_mismatch`` rather than vanish into
+    ``setter_route_absent`` — but it never re-uses the sensor row that is
+    already serving as that field's readback.  Duplicate routes are surfaced by
+    emitting the field twice; ``compare_live_grid`` reports the duplicate.
+    """
+    by_route: dict[tuple[str, str], list[RuntimeEntityMetadata]] = {}
+    for entity in entities:
+        by_route.setdefault((entity.entity_type, entity.object_id), []).append(entity)
+
+    rows: list[LiveEntityGrid] = []
+    for field_name in CANONICAL_FIELD_ORDER:
+        definition = REGISTRY[field_name]
+        expected_type = ENTITY_GRIDS[field_name].entity_type
+        setter_slug = definition.esp_object_id or ""
+        readback_slug = definition.cfg_readback_object_id or ""
+        found_readbacks = by_route.get(("sensor", readback_slug), [])
+        found_setters = by_route.get((expected_type, setter_slug), [])
+        if not found_setters:
+            for other_type in _ENTITY_TYPES:
+                if other_type == expected_type or (other_type == "sensor" and setter_slug == readback_slug):
+                    continue
+                candidates = by_route.get((other_type, setter_slug), [])
+                if candidates:
+                    found_setters = candidates
+                    break
+        repeats = max(len(found_setters), len(found_readbacks), 1)
+        for index in range(repeats):
+            setter = found_setters[index] if index < len(found_setters) else None
+            readback = found_readbacks[index] if index < len(found_readbacks) else None
+            rows.append(
+                LiveEntityGrid(
+                    field_name=field_name,
+                    esp_object_id=None if setter is None else setter.object_id,
+                    cfg_readback_object_id=None if readback is None else readback.object_id,
+                    entity_type=None if setter is None else setter.entity_type,
+                    minimum=None if setter is None else setter.minimum,
+                    maximum=None if setter is None else setter.maximum,
+                    step=None if setter is None else setter.step,
+                )
+            )
+    return tuple(rows)
+
+
+def _timestamp(value: object, label: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise GridCaptureError(f"{label} must be an RFC-3339 UTC timestamp")
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        moment = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise GridCaptureError(f"{label} is not an RFC-3339 timestamp: {value!r}") from exc
+    if moment.tzinfo is None or moment.utcoffset() is None:
+        raise GridCaptureError(f"{label} must carry an explicit UTC offset")
+    return moment.astimezone(UTC)
+
+
+def _timestamp_text(moment: datetime) -> str:
+    return moment.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _layer_value_text(layer: Mapping[str, Any], label: str) -> str | None:
+    value = layer.get("value")
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return _decimal_text(_as_decimal(value, label))
+
+
+def _layer_freshness(
+    layer: Mapping[str, Any],
+    *,
+    label: str,
+    observed_at: datetime,
+    max_age_s: int,
+) -> str | None:
+    """Return a blocking reason when the layer's timestamp is not truthful."""
+    raw = layer.get("as_of")
+    if raw is None:
+        return f"{label}_timestamp_missing"
+    moment = _timestamp(raw, f"{label}.as_of")
+    age = (observed_at - moment).total_seconds()
+    if age < 0:
+        return f"{label}_timestamp_in_future"
+    if age > max_age_s:
+        return f"{label}_timestamp_stale:{age:.0f}s>{max_age_s}s"
+    return None
+
+
+def evaluate_layer_triple(
+    row: Mapping[str, Any],
+    *,
+    observed_at: datetime,
+    max_age_s: int,
+) -> LayerTriple:
+    """Classify one #424 series as resolved / present / unobservable.
+
+    ``resolved`` requires all three layers to expose a truthful, fresh,
+    unit-coherent value AND exact agreement.  Anything less blocks: a layer that
+    cannot expose a truthful value is ``unobservable``; truthful-but-disagreeing
+    layers are ``present`` (the historical discrepancy is still present).
+    Convergence is never inferred from a tolerance window.
+    """
+    series = row.get("series")
+    if not isinstance(series, str) or _SERIES_NAME.fullmatch(series) is None:
+        raise GridCaptureError(f"band_layers series name is invalid: {series!r}")
+
+    layers: dict[str, Mapping[str, Any]] = {}
+    for name in ("served", "control", "observed"):
+        layer = row.get(name)
+        if not isinstance(layer, Mapping):
+            raise GridCaptureError(f"band_layers[{series}].{name} must be an object")
+        unknown = sorted(set(layer) - _LAYER_KEYS)
+        if unknown:
+            raise GridCaptureError(f"band_layers[{series}].{name} has unknown keys: {unknown}")
+        if name != "observed" and "slug" in layer:
+            raise GridCaptureError(f"band_layers[{series}].{name} must not carry an entity slug")
+        layers[name] = layer
+
+    values: dict[str, str | None] = {}
+    malformed: dict[str, str] = {}
+    for name in ("served", "control", "observed"):
+        try:
+            values[name] = _layer_value_text(layers[name], f"band_layers[{series}].{name}.value")
+        except GridCaptureError as exc:
+            # A malformed number is not a truthful value; it must classify as
+            # unobservable rather than abort the whole capture.
+            values[name] = None
+            malformed[name] = f"{name}_value_invalid:{exc}"
+    served_text, control_text, observed_text = values["served"], values["control"], values["observed"]
+    observed_slug = layers["observed"].get("slug")
+    observed_unit = layers["observed"].get("unit")
+    observed_as_of = layers["observed"].get("as_of")
+    try:
+        observed_ts = (
+            None if observed_as_of is None else _timestamp_text(_timestamp(observed_as_of, f"{series}.observed"))
+        )
+    except GridCaptureError:
+        observed_ts = None
+
+    def triple(classification: Classification, detail: str, coherent: bool = False) -> LayerTriple:
+        return LayerTriple(
+            field_name=series,
+            served=served_text,
+            control=control_text,
+            observed=observed_text,
+            observed_slug=observed_slug if isinstance(observed_slug, str) else None,
+            observed_unit=observed_unit if isinstance(observed_unit, str) else None,
+            observed_ts=observed_ts,
+            coherent=coherent,
+            classification=classification,
+            detail=detail,
+        )
+
+    blockers: list[str] = sorted(malformed.values())
+    for name, text in (("served", served_text), ("control", control_text), ("observed", observed_text)):
+        if text is None and name not in malformed:
+            blockers.append(f"{name}_value_missing")
+        unit = layers[name].get("unit")
+        if not isinstance(unit, str) or not unit:
+            blockers.append(f"{name}_unit_missing")
+        source = layers[name].get("source")
+        if not isinstance(source, str) or not source:
+            blockers.append(f"{name}_provenance_missing")
+        try:
+            stale = _layer_freshness(layers[name], label=name, observed_at=observed_at, max_age_s=max_age_s)
+        except GridCaptureError as exc:
+            stale = f"{name}_timestamp_invalid:{exc}"
+        if stale is not None:
+            blockers.append(stale)
+    if not isinstance(observed_slug, str) or not observed_slug:
+        blockers.append("observed_slug_missing")
+    units = {layers[name].get("unit") for name in ("served", "control", "observed")}
+    if len(units) != 1:
+        blockers.append(f"unit_incoherent:{sorted(str(unit) for unit in units)}")
+    if blockers:
+        return triple("unobservable", ",".join(sorted(set(blockers))))
+
+    if served_text == control_text == observed_text:
+        return triple("resolved", "", coherent=True)
+
+    detail = f"served={served_text} control={control_text} observed={observed_text}"
+    try:
+        differences = {
+            "control_minus_served": _decimal_text(
+                _as_decimal(control_text, "control") - _as_decimal(served_text, "served")
+            ),
+            "observed_minus_control": _decimal_text(
+                _as_decimal(observed_text, "observed") - _as_decimal(control_text, "control")
+            ),
+        }
+        detail = f"{detail} delta={differences}"
+    except GridCaptureError:
+        # Booleans (or any non-numeric layer value) have no difference to report;
+        # the raw three-layer values above are already the whole story.
+        pass
+    return triple("present", detail)
+
+
+def evaluate_layer_triples(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    observed_at: datetime,
+    max_age_s: int,
+    required: Sequence[str] = REQUIRED_BAND_SERIES,
+) -> tuple[tuple[LayerTriple, ...], list[str]]:
+    """Evaluate every supplied series and report the blocking failures."""
+    triples = tuple(evaluate_layer_triple(row, observed_at=observed_at, max_age_s=max_age_s) for row in rows)
+    failures: list[str] = []
+    seen = [triple.field_name for triple in triples]
+    for name in sorted(set(name for name in seen if seen.count(name) > 1)):
+        failures.append(f"duplicate_band_series:{name}")
+    for name in required:
+        if name not in seen:
+            failures.append(f"missing_band_series:{name}")
+    for triple in triples:
+        if triple.classification == "unobservable":
+            failures.append(f"band_layer_unobservable:{triple.field_name}:{triple.detail}")
+        elif not triple.coherent:
+            failures.append(f"band_layer_incoherent:{triple.field_name}:{triple.detail}")
+    return triples, failures
+
+
+def observed_state_content_sha256(normalized: Mapping[str, bool | float]) -> tuple[str, str]:
+    """Reproduce the migration-214 cross-language state identity in Python.
+
+    ``db/migrations/214-confirmed-component-experiment-v2.sql``
+    ``fn_experiment_v2_state_content_sha256(schema_u8, manifest[32], vector[178])``
+    is the golden::
+
+        sha256('verdify-policy-state-content-v1' || 0x00 || schema_u8
+               || wire_manifest_digest[32] || wire_vector[178])
+
+    Returns ``(state_content_sha256, wire_vector_hex)``.
+    """
+    vector = encode_policy_vector(normalized)
+    if len(vector) != POLICY_VECTOR_SIZE or POLICY_VECTOR_SIZE != 178:
+        raise GridCaptureError(f"policy vector must be 178 bytes, got {len(vector)}")
+    manifest = wire_manifest_digest()
+    if len(manifest) != 32:
+        raise GridCaptureError("wire manifest digest must be 32 bytes")
+    digest = hashlib.sha256(
+        POLICY_STATE_DOMAIN + b"\x00" + bytes([WIRE_SCHEMA_VERSION]) + manifest + vector
+    ).hexdigest()
+    return digest, vector.hex()
+
+
+def evaluate_observed_components(
+    observed: Mapping[str, Mapping[str, Any]],
+    *,
+    observed_at: datetime,
+    max_age_s: int,
+) -> tuple[dict[str, bool | float] | None, list[str]]:
+    """Validate the observed cfg readback layer for all 48 component fields."""
+    failures: list[str] = []
+    expected = set(CANONICAL_FIELD_ORDER)
+    provided = set(observed)
+    for name in sorted(provided - expected):
+        failures.append(f"observed_component_unknown:{name}")
+    for name in sorted(expected - provided):
+        failures.append(f"observed_component_missing:{name}")
+
+    raw: dict[str, Any] = {}
+    for field_name in CANONICAL_FIELD_ORDER:
+        row = observed.get(field_name)
+        if row is None:
+            continue
+        if not isinstance(row, Mapping):
+            failures.append(f"observed_component_malformed:{field_name}")
+            continue
+        unknown = sorted(set(row) - {"slug", "unit", "observed_at", "value"})
+        if unknown:
+            failures.append(f"observed_component_unknown_keys:{field_name}:{unknown}")
+            continue
+        expected_slug = REGISTRY[field_name].cfg_readback_object_id
+        if row.get("slug") != expected_slug:
+            failures.append(
+                f"observed_component_slug_mismatch:{field_name}:expected={expected_slug}:observed={row.get('slug')}"
+            )
+        try:
+            stale = _layer_freshness(
+                {"as_of": row.get("observed_at")},
+                label=f"observed_component:{field_name}",
+                observed_at=observed_at,
+                max_age_s=max_age_s,
+            )
+        except GridCaptureError as exc:
+            failures.append(f"observed_component_timestamp_invalid:{field_name}:{exc}")
+            stale = None
+        if stale is not None:
+            failures.append(stale)
+        if "value" not in row or row["value"] is None:
+            failures.append(f"observed_component_value_missing:{field_name}")
+            continue
+        raw[field_name] = row["value"]
+
+    if failures:
+        return None, failures
+
+    try:
+        normalized = normalize_complete_state(raw)
+    except ComponentContractError as exc:
+        return None, [f"observed_component_state_rejected:{exc.code}:{exc.detail}"]
+    return normalized, []
+
+
+def derive_grid_revision(result: GridCaptureResult) -> str | None:
+    """Return the qualified grid revision, or ``None`` when anything blocks.
+
+    The revision is the one ``build_live_entity_grid_evidence`` already produced
+    (see REVISION-DERIVATION NOTE): the offline capture never invents a second
+    preimage, because the runtime attestation must be able to reproduce the same
+    string for ``physical_execution_qualified`` to ever close.
+
+    Grid parity and band coherence are the two semantic gates.  The observed
+    current state is a third: an off-grid, out-of-range, mistyped, mis-slugged,
+    stale, missing or extra readback means the capture did not observe a
+    truthful current state, and a capture that cannot state where the device IS
+    must not hand out a revision that authorizes moving it.
+    """
+    if not (result.grid_parity_ok and result.band_coherence_ok and result.observed_state_ok):
+        return None
+    if result.grid_content_sha256 is None:
+        return None
+    revision = f"live-entity-grid-v1:sha256:{result.grid_content_sha256}"
+    if _QUALIFIED_GRID_REVISION.fullmatch(revision) is None:
+        return None
+    return revision
+
+
+def capture(
+    *,
+    device_id: str,
+    observed_at: datetime,
+    entities: Sequence[RuntimeEntityMetadata],
+    observed_components: Mapping[str, Mapping[str, Any]],
+    band_layers: Sequence[Mapping[str, Any]],
+    revisions: Mapping[str, str],
+    runtime: Mapping[str, Any],
+    max_observation_age_s: int = DEFAULT_MAX_OBSERVATION_AGE_S,
+    required_band_series: Sequence[str] = REQUIRED_BAND_SERIES,
+) -> GridCaptureResult:
+    """Run the whole offline capture and return a fail-closed verdict."""
+    failures: list[str] = []
+    live_grid = project_live_entity_grid(entities)
+    grid_failures = compare_live_grid(live_grid)
+    failures.extend(grid_failures)
+
+    evidence: LiveEntityGridEvidence | None = None
+    try:
+        evidence = build_live_entity_grid_evidence(
+            tuple(entities),
+            device_id=device_id,
+            firmware_revision=revisions["firmware_revision"],
+            source_revision=revisions["source_revision"],
+            runtime_instance_id=str(runtime["runtime_instance_id"]),
+            connection_generation=int(runtime["connection_generation"]),
+            observed_at=observed_at,
+        )
+    except ComponentGridEvidenceError as exc:
+        failures.append(f"live_grid_evidence:{exc.code}:{exc.detail}")
+    except (KeyError, TypeError, ValueError) as exc:
+        failures.append(f"live_grid_evidence_inputs:{exc}")
+    grid_parity_ok = not grid_failures and evidence is not None
+
+    triples, band_failures = evaluate_layer_triples(
+        band_layers,
+        observed_at=observed_at,
+        max_age_s=max_observation_age_s,
+        required=required_band_series,
+    )
+    failures.extend(band_failures)
+    band_coherence_ok = not band_failures
+
+    normalized, state_failures = evaluate_observed_components(
+        observed_components,
+        observed_at=observed_at,
+        max_age_s=max_observation_age_s,
+    )
+    failures.extend(state_failures)
+    state_sha256: str | None = None
+    wire_hex: str | None = None
+    if normalized is not None:
+        try:
+            state_sha256, wire_hex = observed_state_content_sha256(normalized)
+        except (GridCaptureError, ValueError) as exc:
+            failures.append(f"observed_state_identity:{exc}")
+            normalized = None
+    observed_state_ok = normalized is not None and state_sha256 is not None
+
+    result = GridCaptureResult(
+        grid_parity_ok=grid_parity_ok,
+        band_coherence_ok=band_coherence_ok,
+        observed_state_ok=observed_state_ok,
+        observed_start_state=normalized,
+        observed_state_content_sha256=state_sha256,
+        observed_wire_vector_hex=wire_hex,
+        revisions=dict(revisions),
+        runtime=dict(runtime),
+        device_id=device_id,
+        observed_at=_timestamp_text(observed_at),
+        live_grid=live_grid,
+        layer_triples=triples,
+        grid_content_sha256=None if evidence is None else evidence.grid_content_sha256,
+        observation_receipt_sha256=None if evidence is None else evidence.observation_receipt_sha256,
+        grid_revision=None,
+        failures=tuple(failures),
+    )
+    return replace(result, grid_revision=derive_grid_revision(result))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Input artifact parsing (strict; unknown keys are rejected)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GridCaptureError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def _nfc_text(value: object, label: str, *, maximum: int = 200) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise GridCaptureError(f"{label} must be bounded non-empty text")
+    if unicodedata.normalize("NFC", value) != value:
+        raise GridCaptureError(f"{label} must be NFC-normalized text")
+    return value
+
+
+def _entity(row: Mapping[str, Any], index: int) -> RuntimeEntityMetadata:
+    unknown = sorted(set(row) - _ENTITY_KEYS)
+    if unknown:
+        raise GridCaptureError(f"entities[{index}] has unknown keys: {unknown}")
+    entity_type = row.get("entity_type")
+    if entity_type not in _ENTITY_TYPES:
+        raise GridCaptureError(f"entities[{index}].entity_type must be one of {list(_ENTITY_TYPES)}")
+    key = row.get("key")
+    if isinstance(key, bool) or not isinstance(key, int) or key <= 0:
+        raise GridCaptureError(f"entities[{index}].key must be a positive integer")
+    device_id = row.get("device_id", 0)
+    if isinstance(device_id, bool) or not isinstance(device_id, int) or device_id < 0:
+        raise GridCaptureError(f"entities[{index}].device_id must be a non-negative integer")
+    disabled = row.get("disabled_by_default", False)
+    if type(disabled) is not bool:  # noqa: E721 - evidence must not coerce 0/1
+        raise GridCaptureError(f"entities[{index}].disabled_by_default must be an exact boolean")
+    assumed = row.get("assumed_state")
+    if assumed is not None and type(assumed) is not bool:  # noqa: E721
+        raise GridCaptureError(f"entities[{index}].assumed_state must be an exact boolean or null")
+    unit = row.get("unit", "")
+    if not isinstance(unit, str):
+        raise GridCaptureError(f"entities[{index}].unit must be text")
+    numbers: dict[str, Decimal | float | None] = {}
+    for label in ("minimum", "maximum", "step"):
+        value = row.get(label)
+        if value is None:
+            numbers[label] = None
+        elif isinstance(value, str):
+            numbers[label] = _as_decimal(value, f"entities[{index}].{label}")
+        elif isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise GridCaptureError(f"entities[{index}].{label} must be a number, decimal string or null")
+        else:
+            numbers[label] = float(value)
+    return RuntimeEntityMetadata(
+        object_id=_nfc_text(row.get("object_id"), f"entities[{index}].object_id"),
+        entity_type=entity_type,
+        key=key,
+        device_id=device_id,
+        disabled_by_default=disabled,
+        minimum=numbers["minimum"],
+        maximum=numbers["maximum"],
+        step=numbers["step"],
+        unit=unit,
+        assumed_state=assumed,
+    )
+
+
+@dataclass(frozen=True)
+class CaptureInput:
+    """The parsed, structurally-valid input artifact."""
+
+    device_id: str
+    observed_at: datetime
+    entities: tuple[RuntimeEntityMetadata, ...]
+    observed_components: dict[str, dict[str, Any]]
+    band_layers: tuple[dict[str, Any], ...]
+    revisions: dict[str, str]
+    runtime: dict[str, Any]
+
+
+def parse_input_artifact(document: Mapping[str, Any]) -> CaptureInput:
+    """Validate the input artifact's shape; raise ``GridCaptureError`` if unsafe."""
+    if not isinstance(document, Mapping):
+        raise GridCaptureError("input artifact root must be an object")
+    expected_keys = {
+        "schema",
+        "device_id",
+        "observed_at",
+        "runtime",
+        "revisions",
+        "entities",
+        "observed_components",
+        "band_layers",
+    }
+    unknown = sorted(set(document) - expected_keys)
+    if unknown:
+        raise GridCaptureError(f"input artifact has unknown keys: {unknown}")
+    missing = sorted(expected_keys - set(document))
+    if missing:
+        raise GridCaptureError(f"input artifact is missing: {missing}")
+    if document["schema"] != INPUT_SCHEMA:
+        raise GridCaptureError(f"input artifact schema must be {INPUT_SCHEMA!r}")
+
+    revisions_raw = document["revisions"]
+    if not isinstance(revisions_raw, Mapping):
+        raise GridCaptureError("revisions must be an object")
+    unknown = sorted(set(revisions_raw) - set(REQUIRED_REVISIONS))
+    if unknown:
+        raise GridCaptureError(f"revisions has unknown keys: {unknown}")
+    revisions: dict[str, str] = {}
+    for name in REQUIRED_REVISIONS:
+        revisions[name] = _nfc_text(revisions_raw.get(name), f"revisions.{name}")
+    if _SOURCE_REVISION.fullmatch(revisions["source_revision"]) is None:
+        raise GridCaptureError("revisions.source_revision must be a full lowercase Git SHA")
+
+    runtime_raw = document["runtime"]
+    if not isinstance(runtime_raw, Mapping) or set(runtime_raw) != {"runtime_instance_id", "connection_generation"}:
+        raise GridCaptureError("runtime must carry exactly runtime_instance_id and connection_generation")
+    try:
+        instance_id = str(UUID(str(runtime_raw["runtime_instance_id"])))
+    except (TypeError, ValueError) as exc:
+        raise GridCaptureError("runtime.runtime_instance_id must be a UUID") from exc
+    generation = runtime_raw["connection_generation"]
+    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 1:
+        raise GridCaptureError("runtime.connection_generation must be an integer >= 1")
+
+    entities_raw = document["entities"]
+    if not isinstance(entities_raw, list) or not entities_raw:
+        raise GridCaptureError("entities must be a non-empty array")
+    entities = tuple(_entity(row, index) for index, row in enumerate(entities_raw) if isinstance(row, Mapping))
+    if len(entities) != len(entities_raw):
+        raise GridCaptureError("every entities row must be an object")
+
+    observed_raw = document["observed_components"]
+    if not isinstance(observed_raw, Mapping):
+        raise GridCaptureError("observed_components must be an object")
+    observed = {str(name): dict(row) for name, row in observed_raw.items() if isinstance(row, Mapping)}
+    if len(observed) != len(observed_raw):
+        raise GridCaptureError("every observed_components entry must be an object")
+
+    band_raw = document["band_layers"]
+    if not isinstance(band_raw, list):
+        raise GridCaptureError("band_layers must be an array")
+    band_layers = tuple(dict(row) for row in band_raw if isinstance(row, Mapping))
+    if len(band_layers) != len(band_raw):
+        raise GridCaptureError("every band_layers row must be an object")
+
+    return CaptureInput(
+        device_id=_nfc_text(document["device_id"], "device_id"),
+        observed_at=_timestamp(document["observed_at"], "observed_at"),
+        entities=entities,
+        observed_components=observed,
+        band_layers=band_layers,
+        revisions=revisions,
+        runtime={"runtime_instance_id": instance_id, "connection_generation": generation},
+    )
+
+
+def capture_from_artifact(
+    document: Mapping[str, Any],
+    *,
+    max_observation_age_s: int = DEFAULT_MAX_OBSERVATION_AGE_S,
+) -> GridCaptureResult:
+    """Parse then capture — the single entry point the CLI uses."""
+    parsed = parse_input_artifact(document)
+    return capture(
+        device_id=parsed.device_id,
+        observed_at=parsed.observed_at,
+        entities=parsed.entities,
+        observed_components=parsed.observed_components,
+        band_layers=parsed.band_layers,
+        revisions=parsed.revisions,
+        runtime=parsed.runtime,
+        max_observation_age_s=max_observation_age_s,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI (PASS/FAIL/WARN + --json, matching scripts/experiment-*.py)
+# ──────────────────────────────────────────────────────────────────────────────
+
+MAX_FAILURES_LISTED = 25
+
+
+@dataclass
+class Check:
+    name: str
+    status: str  # PASS | FAIL | WARN
+    detail: str = ""
+
+    def payload(self) -> dict[str, str]:
+        return {"detail": self.detail, "name": self.name, "status": self.status}
+
+
+def canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def result_sha256(payload: Mapping[str, Any]) -> str:
+    """Canonical hash of the result — excludes itself and wall-clock fields."""
+    hashed = {k: v for k, v in payload.items() if k not in ("result_sha256", "computed_at")}
+    return hashlib.sha256(canonical_json(hashed).encode()).hexdigest()
+
+
+_BAND_FAILURE_PREFIXES = ("band_layer", "missing_band_series", "duplicate_band_series")
+_STATE_FAILURE_PREFIXES = ("observed_component", "observed_state")
+
+
+def _failure_detail(failures: Sequence[str]) -> str:
+    """Join whole failure strings — never truncate a value mid-digit."""
+    listed = list(failures[:MAX_FAILURES_LISTED])
+    if len(failures) > MAX_FAILURES_LISTED:
+        listed.append(f"(+{len(failures) - MAX_FAILURES_LISTED} more; see --json)")
+    return "; ".join(listed)
+
+
+def build_checks(result: GridCaptureResult, *, expected_grid_revision: str | None) -> list[Check]:
+    checks: list[Check] = []
+    band_failures = [f for f in result.failures if f.startswith(_BAND_FAILURE_PREFIXES)]
+    state_failures = [f for f in result.failures if f.startswith(_STATE_FAILURE_PREFIXES)]
+    grid_failures = [f for f in result.failures if not f.startswith(_BAND_FAILURE_PREFIXES + _STATE_FAILURE_PREFIXES)]
+    checks.append(
+        Check(
+            "grid_parity",
+            "PASS" if result.grid_parity_ok else "FAIL",
+            f"{len(CANONICAL_FIELD_ORDER)}/{len(CANONICAL_FIELD_ORDER)} fields byte-parity with source ENTITY_GRIDS"
+            if result.grid_parity_ok
+            else _failure_detail(grid_failures),
+        )
+    )
+    resolved = sum(1 for t in result.layer_triples if t.classification == "resolved")
+    checks.append(
+        Check(
+            "band_coherence_424",
+            "PASS" if result.band_coherence_ok else "FAIL",
+            f"{resolved}/{len(result.layer_triples)} series resolved across served/control/observed"
+            if result.band_coherence_ok
+            else _failure_detail(band_failures),
+        )
+    )
+    checks.append(
+        Check(
+            "observed_start_state",
+            "PASS" if result.observed_state_ok else "FAIL",
+            f"48/48 on-grid; state_content_sha256={result.observed_state_content_sha256}"
+            if result.observed_state_ok
+            else _failure_detail(state_failures),
+        )
+    )
+    if result.grid_revision is None:
+        checks.append(Check("grid_revision", "FAIL", "no qualified revision emitted (capture blocked)"))
+    elif expected_grid_revision is not None and expected_grid_revision != result.grid_revision:
+        checks.append(
+            Check(
+                "grid_revision",
+                "FAIL",
+                f"expected={expected_grid_revision} derived={result.grid_revision}",
+            )
+        )
+    else:
+        checks.append(Check("grid_revision", "PASS", result.grid_revision))
+        if SOURCE_GRID_REVISION != result.grid_revision:
+            checks.append(
+                Check(
+                    "source_grid_revision_adoption",
+                    "WARN",
+                    "verdify_schemas/component_executor.py GRID_REVISION is still "
+                    f"{SOURCE_GRID_REVISION!r}; a separate reviewed change must adopt {result.grid_revision}",
+                )
+            )
+    return checks
+
+
+def build_payload(
+    result: GridCaptureResult,
+    checks: Sequence[Check],
+    *,
+    max_observation_age_s: int,
+    computed_at: datetime,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "band_coherence": {
+            "ok": result.band_coherence_ok,
+            "required_series": list(REQUIRED_BAND_SERIES),
+            "series": [triple.payload() for triple in result.layer_triples],
+        },
+        "checks": [check.payload() for check in checks],
+        "device_id": result.device_id,
+        "failures": list(result.failures),
+        "grid": {
+            "field_count": len(CANONICAL_FIELD_ORDER),
+            "grid_content_sha256": result.grid_content_sha256,
+            "observation_receipt_sha256": result.observation_receipt_sha256,
+            "parity_ok": result.grid_parity_ok,
+            "wire_manifest_sha256": wire_manifest_digest().hex(),
+            "wire_schema_version": WIRE_SCHEMA_VERSION,
+        },
+        "grid_revision": result.grid_revision,
+        "max_observation_age_s": max_observation_age_s,
+        "observed_at": result.observed_at,
+        "observed_state": {
+            "on_grid": result.observed_state_ok,
+            "state_content_sha256": result.observed_state_content_sha256,
+            "wire_vector_hex": result.observed_wire_vector_hex,
+        },
+        "qualified": result.qualified,
+        "revisions": dict(result.revisions),
+        "runtime": dict(result.runtime),
+        "schema": RESULT_SCHEMA,
+        "source_grid_revision": SOURCE_GRID_REVISION,
+        "source_grid_revision_qualified": _QUALIFIED_GRID_REVISION.fullmatch(SOURCE_GRID_REVISION) is not None,
+    }
+    if result.observed_start_state is not None and result.grid_revision is not None:
+        # Emitted in the prefix-replay tool's own --current-state shape so the
+        # captured start state feeds Tool B without a translation step.
+        payload["current_state_artifact"] = {
+            "device_id": result.device_id,
+            "firmware_revision": result.revisions["firmware_revision"],
+            "grid_revision": result.grid_revision,
+            "observed_at": result.observed_at,
+            "schema": CURRENT_STATE_SCHEMA,
+            "values": dict(result.observed_start_state),
+        }
+    payload["computed_at"] = _timestamp_text(computed_at)
+    payload["result_sha256"] = result_sha256(payload)
+    return payload
+
+
+def write_private_json(payload: Mapping[str, Any], output_path: Path) -> None:
+    """Publish the result at mode 0600 without overwriting anything.
+
+    The payload contains a complete 48-field operational snapshot, so it is
+    written like ``scripts/prepare_component_prefix_replay.py`` publishes its
+    packet: private mode, exclusive create, existing paths refused.
+    """
+    raw = json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n"
+    unresolved = output_path.absolute()
+    if unresolved.exists() or unresolved.is_symlink():
+        raise GridCaptureError(f"output target already exists; overwrite refused: {unresolved}")
+    descriptor = os.open(unresolved, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(raw)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline current-state capture: prove the live entity grid and emit its qualified revision."
+    )
+    parser.add_argument("--input", type=Path, required=True, help=f"path to a {INPUT_SCHEMA} JSON artifact")
+    parser.add_argument("--json", dest="json_out", type=Path, help="write the machine-readable result here (0600)")
+    parser.add_argument(
+        "--max-observation-age-s",
+        type=int,
+        default=DEFAULT_MAX_OBSERVATION_AGE_S,
+        help=f"maximum readback age still considered truthful (default: {DEFAULT_MAX_OBSERVATION_AGE_S})",
+    )
+    parser.add_argument(
+        "--expect-grid-revision",
+        help="fail unless the derived revision equals this value (re-verification of a prior capture)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.max_observation_age_s < 1:
+        parser.exit(2, "grid capture refused: --max-observation-age-s must be >= 1\n")
+    try:
+        raw = args.input.read_bytes()
+    except OSError as exc:
+        parser.exit(2, f"grid capture refused: input artifact is unavailable: {exc}\n")
+    if not raw or len(raw) > 8 * 1024 * 1024:
+        parser.exit(2, "grid capture refused: input artifact is empty or exceeds 8 MiB\n")
+    try:
+        document = json.loads(raw, object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, GridCaptureError) as exc:
+        parser.exit(2, f"grid capture refused: input artifact is not strict UTF-8 JSON: {exc}\n")
+
+    try:
+        result = capture_from_artifact(document, max_observation_age_s=args.max_observation_age_s)
+    except GridCaptureError as exc:
+        parser.exit(2, f"grid capture refused: {exc}\n")
+
+    checks = build_checks(result, expected_grid_revision=args.expect_grid_revision)
+    payload = build_payload(
+        result,
+        checks,
+        max_observation_age_s=args.max_observation_age_s,
+        computed_at=datetime.now(UTC),
+    )
+
+    for check in checks:
+        line = f"{check.status} — {check.name}"
+        if check.detail:
+            line += f": {check.detail}"
+        print(line)
+    failed = sum(1 for check in checks if check.status == "FAIL")
+    warned = sum(1 for check in checks if check.status == "WARN")
+    print(f"SUMMARY: {len(checks) - failed - warned} pass, {warned} warn, {failed} fail")
+    print(f"result_sha256={payload['result_sha256']}")
+    if result.grid_revision is not None and not failed:
+        print(f"grid_revision={result.grid_revision}")
+    else:
+        print("grid_revision=NONE (capture blocked; physical execution stays gated)")
+
+    if args.json_out is not None:
+        try:
+            write_private_json(payload, args.json_out)
+        except (GridCaptureError, OSError) as exc:
+            parser.exit(2, f"grid capture refused: result could not be published privately: {exc}\n")
+        print(f"wrote {args.json_out}")
+    return 1 if failed or result.grid_revision is None else 0
+
+
+__all__ = [
+    "CURRENT_STATE_SCHEMA",
+    "DEFAULT_MAX_OBSERVATION_AGE_S",
+    "INPUT_SCHEMA",
+    "REQUIRED_BAND_SERIES",
+    "RESULT_SCHEMA",
+    "CaptureInput",
+    "Check",
+    "GridCaptureError",
+    "GridCaptureResult",
+    "LayerTriple",
+    "LiveEntityGrid",
+    "build_checks",
+    "build_payload",
+    "canonical_json",
+    "capture",
+    "capture_from_artifact",
+    "compare_live_grid",
+    "derive_grid_revision",
+    "evaluate_layer_triple",
+    "evaluate_layer_triples",
+    "evaluate_observed_components",
+    "main",
+    "observed_state_content_sha256",
+    "parse_input_artifact",
+    "project_live_entity_grid",
+    "result_sha256",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/component_prefix_replay.py
+++ b/scripts/component_prefix_replay.py
@@ -1,0 +1,1320 @@
+#!/usr/bin/env python3
+"""component_prefix_replay.py — Tool B: compiled-prefix replay qualification.
+
+Proves that EVERY intermediate device state ("prefix") of every permitted
+component transition, applied in the fixed source order, is grid-valid,
+clamp-valid and safety-admissible — and derives the ``ORDER_REVISION`` string
+that `verdify_schemas.component_executor.physical_execution_qualified` demands
+(together with a separately-qualified live grid revision from Tool A).
+
+This tool is OFFLINE and NON-ACTUATING by construction.  It never opens a
+socket, never touches PostgreSQL, never invokes kubectl, and never speaks to a
+device.  Its only subprocess is a host C++ compiler plus the compiled firmware
+replay harness in ``firmware/test/`` (see the interlock section below), and its
+only inputs are committed artifacts plus operator-supplied JSON files.
+
+It is the downstream half of ``scripts/prepare_component_prefix_replay.py``:
+that tool enumerates the case list and leaves ``result_slots`` empty; this tool
+adjudicates every case and, only when every case passes every check, emits the
+qualified revision.  Case ids are deliberately spelled identically in both
+tools so the packet and the verdicts can be joined.
+
+Edge set (the permitted directed transitions):
+
+  (a) treatment edges over ``TREATMENT_FIELD_ORDER`` (activation order ==
+      rollback order): baseline→moderate, moderate→baseline,
+      baseline→aggressive, aggressive→baseline.  Every experiment boundary
+      interposes baseline, so those four are the complete permitted set; the
+      change list is the actual difference list from
+      ``fixed_order_differences``.
+  (b) full-48 recovery edges over ``CANONICAL_FIELD_ORDER``: from the compiled
+      ESPHome defaults and from every supplied observed / reboot / reset /
+      common-drift start → baseline, built with
+      ``fixed_order_complete_bundle`` (unconditional, because reboot/reset
+      state is unknown and replaying only apparent differences would preserve
+      an unobserved wrong component).
+
+Pass contract — ALL of these must hold, for every case, or the run fails
+closed with a non-zero exit code and NO ``order_revision``:
+
+  1. grid          — ``normalize_complete_state`` accepts every prefix state;
+  2. fixed order   — the change lists were built from the exact source order
+                     tuples and the ``fixed_order_*`` contracts raised nothing;
+  3. clamps        — every prefix value is inside BOTH the registry (planner)
+                     bounds and the firmware clamp bounds;
+  4. interlock     — the compiled firmware harness admits the prefix state
+                     (see below);
+  5. idempotency   — re-deriving work from an already-confirmed prefix yields
+                     exactly the pending suffix and never re-issues a
+                     confirmed component;
+  6. lands-exact   — each edge's final prefix state is byte-identical to
+                     ``normalize_complete_state(target)``.
+
+INTERLOCK / SAFETY ADMISSIBILITY
+--------------------------------
+The compiled harness driven here is the same one behind ``make
+firmware-invariants``: ``firmware/test/replay_invariants.cpp`` compiled with a
+host C++17 compiler and run over the tracked disturbance corpus
+``firmware/test/data/replay_overrides.csv.gz``, which reconstructs the firmware
+decision for every corpus row from ``greenhouse_logic.h`` and asserts the
+behavioural invariants in ``firmware/test/invariants.h`` (#1..#27, the same set
+``make firmware-invariants`` gates on).
+
+That harness is corpus-fed: it takes its setpoints from the corpus ``sp_*``
+columns, and it has NO surface for injecting an arbitrary complete 48-field
+policy state.  This tool therefore computes the harness's INJECTION COVERAGE
+from source (which ``sp_*`` columns ``replay_invariants.cpp`` actually assigns
+∩ which of those name one of the 48 executor components ∩ which the corpus
+carries) and adjudicates on that arithmetic:
+
+  * a breach  → ``interlock_safe = "unsafe"``  (definitive failure);
+  * no breach AND coverage == all 48 fields → ``interlock_safe = "safe"``;
+  * no breach AND partial coverage → ``interlock_safe = "unproven"``.
+
+A partial-coverage run can FALSIFY a prefix state but cannot certify one, so
+"unproven" blocks ``order_revision`` exactly like a failure.  When the harness
+grows the missing ``sp_*`` columns (or an external full-coverage / HIL runner
+is supplied with ``--interlock external --interlock-harness PATH``) the
+verdicts flip to real "safe" values with no change to this tool.  There is no
+flag that turns an unproven interlock into a pass.
+
+CLI shape mirrors scripts/experiment-verify.py and scripts/experiment-aa-gates.py:
+one PASS/FAIL/WARN line per check, ``--json`` for the machine-readable payload,
+and a canonical result hash (sha256 over the sorted-key compact JSON of the
+payload, excluding the hash itself and any wall-clock field).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from verdify_schemas.component_executor import (  # noqa: E402
+    ACTIVATION_ORDER,
+    CANONICAL_FIELD_ORDER,
+    COMMON_FIELDS,
+    RECOVERY_ORDER,
+    ROLLBACK_ORDER,
+    TREATMENT_FIELD_ORDER,
+    ComponentChange,
+    ComponentContractError,
+    fixed_order_complete_bundle,
+    fixed_order_differences,
+    normalize_complete_state,
+    validate_routine_target,
+)
+from verdify_schemas.policy_vector import decode_policy_vector  # noqa: E402
+from verdify_schemas.tunable_registry import REGISTRY  # noqa: E402
+
+SCHEMA_VERSION = "verdify-component-prefix-replay-verdict-v1"
+ORDER_REVISION_PREFIX = "prefix-replay-v1"
+# Must stay identical to component_executor._QUALIFIED_ORDER_REVISION; asserted
+# at import so a regex drift here cannot mint a string the executor rejects.
+_QUALIFIED_ORDER_REVISION = re.compile(r"^prefix-replay-v[1-9][0-9]*:sha256:[0-9a-f]{64}$")
+
+DEFAULT_PROFILES = REPO_ROOT / "research/planner-efficacy/baseline/planner-switchback-v2-profiles.json"
+DEFAULT_CONSUMER_MANIFEST = REPO_ROOT / "firmware/policy_consumer_manifest.json"
+DEFAULT_CORPUS = REPO_ROOT / "firmware/test/data/replay_overrides.csv.gz"
+INVARIANTS_SOURCE = REPO_ROOT / "firmware/test/replay_invariants.cpp"
+FIRMWARE_LIB = REPO_ROOT / "firmware/lib"
+
+PROFILE_NAMES = ("baseline", "moderate", "aggressive")
+TREATMENT_EDGES = (
+    ("baseline", "moderate"),
+    ("moderate", "baseline"),
+    ("baseline", "aggressive"),
+    ("aggressive", "baseline"),
+)
+# The only orders an edge may be replayed against — the executor's own tuples.
+SOURCE_ORDERS: dict[str, tuple[str, ...]] = {
+    "activation": ACTIVATION_ORDER,
+    "recovery": RECOVERY_ORDER,
+    "rollback": ROLLBACK_ORDER,
+}
+
+SAFE = "safe"
+UNSAFE = "unsafe"
+UNPROVEN = "unproven"
+
+# `sp_*` struct members in the replay harness whose spelling differs from the
+# canonical executor component name.  Empty for replay_invariants.cpp today —
+# kept so a harness that grows `sp_watch_dwell_s`-style columns is picked up by
+# the coverage parser instead of silently dropping out of the coverage count.
+SP_MEMBER_ALIASES: dict[str, str] = {
+    "watch_dwell_s": "vpd_watch_dwell_s",
+    "cool_all_fans_at_high_enabled": "sw_cool_all_fans_at_high_enabled",
+}
+_SP_ASSIGN = re.compile(r'assign_[a-z_]*\(\s*"(?P<column>sp_[a-z0-9_]+)"\s*,\s*sp\.(?P<member>[a-z0-9_]+)')
+
+
+class PrefixReplayError(ValueError):
+    """The offline inputs cannot produce a truthful replay verdict."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Canonical JSON / hashing (same convention as scripts/experiment-aa-gates.py)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def result_sha256(payload: Mapping[str, Any]) -> str:
+    """sha256 over the sorted-key compact JSON, minus the hash and wall clock."""
+    hashed = {k: v for k, v in payload.items() if k not in ("result_sha256", "computed_at")}
+    return hashlib.sha256(canonical_json(hashed).encode()).hexdigest()
+
+
+def _sha256_bytes(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Clamp bounds
+#
+# Single bounds source: the tunable registry, exactly as
+# research/planner-efficacy/baseline/baseline.py::_bounds_ok reads it —
+# (defn.min, defn.max) is the registry/planner contract bound and
+# (defn.fw_clamp_lo, defn.fw_clamp_hi) is the dispatcher+firmware clamp that CI
+# drift-checks against firmware/greenhouse/tunables.yaml.  `_bounds_ok` folds
+# the two into one boolean; the prefix contract needs them adjudicated
+# separately, so they are split here and a unit test asserts the conjunction is
+# still exactly `_bounds_ok`.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _within(value: float | bool, lower: float | None, upper: float | None) -> bool:
+    if isinstance(value, bool):
+        return True  # switches have no numeric envelope; the grid check owns their type
+    numeric = float(value)
+    if lower is not None and numeric < lower:
+        return False
+    return not (upper is not None and numeric > upper)
+
+
+def registry_clamp_ok(field_name: str, value: float | bool) -> bool:
+    """True iff `value` is inside the registry (planner contract) bounds."""
+    definition = REGISTRY[field_name]
+    return _within(value, definition.min, definition.max)
+
+
+def firmware_clamp_ok(field_name: str, value: float | bool) -> bool:
+    """True iff `value` is inside the dispatcher+firmware clamp bounds."""
+    definition = REGISTRY[field_name]
+    return _within(value, definition.fw_clamp_lo, definition.fw_clamp_hi)
+
+
+def _clamp_violations(state: Mapping[str, float | bool], checker) -> tuple[str, ...]:
+    return tuple(f"{name}={state[name]!r}" for name in CANONICAL_FIELD_ORDER if not checker(name, state[name]))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Core value objects
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReplayEdge:
+    """One permitted directed transition and how its setter list is built."""
+
+    edge: str  # e.g. "activation/baseline-to-moderate"
+    kind: str  # activation | rollback | recovery
+    order_name: str  # activation | rollback | recovery
+    order: tuple[str, ...]
+    start_label: str
+    target_label: str
+    start_state: dict[str, float | bool]
+    target_state: dict[str, float | bool]
+    complete_bundle: bool
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "edge": self.edge,
+            "kind": self.kind,
+            "order_name": self.order_name,
+            "start_label": self.start_label,
+            "target_label": self.target_label,
+            "complete_bundle": self.complete_bundle,
+        }
+
+
+@dataclass(frozen=True)
+class PrefixCase:
+    """The COMPLETE 48-field device state after applying the first `index` setters."""
+
+    edge: str
+    order_name: str
+    index: int
+    device_state: dict[str, float | bool]
+    applied_fields: tuple[str, ...]
+    pending_fields: tuple[str, ...]
+
+    @property
+    def case_id(self) -> str:
+        return f"{self.edge}/prefix-{self.index:02d}"
+
+
+@dataclass(frozen=True)
+class PrefixVerdict:
+    case: PrefixCase
+    grid_ok: bool
+    registry_clamp_ok: bool
+    firmware_clamp_ok: bool
+    interlock_safe: str  # safe | unsafe | unproven
+    ok: bool
+    detail: str = ""
+
+    def digest_row(self) -> dict[str, Any]:
+        """The narrow, wall-clock-free row that feeds the ORDER_REVISION hash."""
+        return {
+            "edge": self.case.edge,
+            "firmware_clamp_ok": self.firmware_clamp_ok,
+            "grid_ok": self.grid_ok,
+            "index": self.case.index,
+            "interlock_safe": self.interlock_safe,
+            "ok": self.ok,
+            "order_name": self.case.order_name,
+            "registry_clamp_ok": self.registry_clamp_ok,
+        }
+
+    def payload(self) -> dict[str, Any]:
+        return {**self.digest_row(), "case_id": self.case.case_id, "detail": self.detail}
+
+
+@dataclass
+class ReplayResult:
+    all_pass: bool
+    fixed_order_ok: bool
+    idempotent_ok: bool
+    lands_exact_ok: bool
+    verdicts: list[PrefixVerdict]
+    order_revision: str | None
+    failures: list[str]
+    edges: list[dict[str, Any]] = field(default_factory=list)
+    interlock: dict[str, Any] = field(default_factory=dict)
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "cases": len(self.verdicts),
+            "grid_fail": sum(1 for v in self.verdicts if not v.grid_ok),
+            "clamp_fail": sum(1 for v in self.verdicts if not (v.registry_clamp_ok and v.firmware_clamp_ok)),
+            "interlock_unsafe": sum(1 for v in self.verdicts if v.interlock_safe == UNSAFE),
+            "interlock_unproven": sum(1 for v in self.verdicts if v.interlock_safe == UNPROVEN),
+            "ok": sum(1 for v in self.verdicts if v.ok),
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Interlock probes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class InterlockOutcome:
+    verdict: str  # safe | unsafe | unproven
+    detail: str
+
+
+class InterlockProbe:
+    """Adjudicates one prefix state's safety admissibility.
+
+    `covered_fields` is the set of the 48 components the probe can actually
+    impose on the firmware under test.  A probe whose coverage is not the full
+    48 may return `unsafe` (it observed a real breach) but must never return
+    `safe`; partial coverage is not certification.
+    """
+
+    name = "abstract"
+    covered_fields: frozenset[str] = frozenset()
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "covered_field_count": len(self.covered_fields),
+            "covered_fields": sorted(self.covered_fields),
+            "full_coverage": self.covered_fields == frozenset(CANONICAL_FIELD_ORDER),
+            "probe": self.name,
+        }
+
+    def verdict(self, case: PrefixCase) -> InterlockOutcome:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class UnprovenInterlock(InterlockProbe):
+    """Fail-closed placeholder: every case is `unproven`, never `safe`."""
+
+    name = "unproven"
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def describe(self) -> dict[str, Any]:
+        return {**super().describe(), "reason": self.reason}
+
+    def verdict(self, case: PrefixCase) -> InterlockOutcome:
+        return InterlockOutcome(UNPROVEN, self.reason)
+
+
+def harness_injection_coverage(source: str, corpus_columns: Sequence[str]) -> dict[str, str]:
+    """Map executor component → corpus `sp_*` column the harness actually reads.
+
+    Derived from the harness source rather than a hand-maintained list, so a
+    harness that grows an injection column is credited automatically and one
+    that loses a column is debited automatically.
+    """
+    canonical = frozenset(CANONICAL_FIELD_ORDER)
+    columns = frozenset(corpus_columns)
+    coverage: dict[str, str] = {}
+    for match in _SP_ASSIGN.finditer(source):
+        member = match.group("member")
+        column = match.group("column")
+        component = SP_MEMBER_ALIASES.get(member, member)
+        if component in canonical and column in columns:
+            coverage[component] = column
+    return coverage
+
+
+class CompiledInvariantInterlock(InterlockProbe):
+    """Drives the compiled `replay_invariants` harness over a disturbance corpus.
+
+    For each distinct injected-value tuple the corpus is rewritten with the
+    prefix state imposed on every covered `sp_*` column and the harness is run
+    once; results are cached by tuple, because the covered subset changes far
+    less often than the 48-field prefix state does.
+    """
+
+    name = "compiled-replay-invariants"
+
+    def __init__(
+        self,
+        *,
+        binary: Path,
+        corpus_path: Path,
+        header: list[str],
+        rows: list[str],
+        coverage: Mapping[str, str],
+        workdir: Path,
+        binary_sha256: str,
+        source_sha256: str,
+        corpus_sha256: str,
+    ) -> None:
+        self.binary = binary
+        self.corpus_path = corpus_path
+        self.header = header
+        self.rows = rows
+        self.coverage = dict(coverage)
+        self.covered_fields = frozenset(self.coverage)
+        self.workdir = workdir
+        self.binary_sha256 = binary_sha256
+        self.source_sha256 = source_sha256
+        self.corpus_sha256 = corpus_sha256
+        self._column_index = {name: idx for idx, name in enumerate(header)}
+        self._cache: dict[tuple[tuple[str, str], ...], InterlockOutcome] = {}
+        self.runs = 0
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            **super().describe(),
+            "binary_sha256": self.binary_sha256,
+            "corpus_path": str(self.corpus_path),
+            "corpus_rows": len(self.rows),
+            "corpus_sha256": self.corpus_sha256,
+            "harness_runs": self.runs,
+            "harness_source_sha256": self.source_sha256,
+            "injection_columns": {name: self.coverage[name] for name in sorted(self.coverage)},
+            "uncovered_field_count": len(CANONICAL_FIELD_ORDER) - len(self.covered_fields),
+            "uncovered_treatment_fields": sorted(set(TREATMENT_FIELD_ORDER) - self.covered_fields),
+        }
+
+    @staticmethod
+    def _cell(value: float | bool) -> str:
+        # parse_bool() in the harness accepts t/true/1; parse_float()/parse_int()
+        # take a plain decimal literal.  Never emit an empty cell — that would
+        # silently fall back to the harness default instead of the prefix value.
+        if isinstance(value, bool):
+            return "1" if value else "0"
+        numeric = float(value)
+        return str(int(numeric)) if numeric.is_integer() else repr(numeric)
+
+    def _key(self, state: Mapping[str, float | bool]) -> tuple[tuple[str, str], ...]:
+        return tuple((name, self._cell(state[name])) for name in sorted(self.coverage))
+
+    def _run(self, key: tuple[tuple[str, str], ...]) -> InterlockOutcome:
+        cells = dict(key)
+        targets = [(self._column_index[self.coverage[name]], cells[name]) for name in sorted(self.coverage)]
+        path = self.workdir / f"corpus-{hashlib.sha256(canonical_json(key).encode()).hexdigest()[:16]}.tsv"
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write("\t".join(self.header) + "\n")
+            for row in self.rows:
+                columns = row.split("\t")
+                for index, cell in targets:
+                    columns[index] = cell
+                handle.write("\t".join(columns) + "\n")
+        proc = subprocess.run(  # offline: local binary, local file, no network
+            [str(self.binary), str(path)],
+            capture_output=True,
+            text=True,
+            timeout=1800,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+        path.unlink(missing_ok=True)
+        self.runs += 1
+        evidence = _sha256_bytes((proc.stdout + proc.stderr).encode())
+        if proc.returncode != 0:
+            breach = " | ".join(line for line in proc.stderr.splitlines() if "INVARIANT FAIL" in line)
+            return InterlockOutcome(
+                UNSAFE,
+                f"replay_invariants exit={proc.returncode} evidence={evidence[:16]} {breach}".strip(),
+            )
+        if self.covered_fields != frozenset(CANONICAL_FIELD_ORDER):
+            missing = len(CANONICAL_FIELD_ORDER) - len(self.covered_fields)
+            return InterlockOutcome(
+                UNPROVEN,
+                (
+                    f"no invariant breach over {len(self.rows)} corpus rows (evidence={evidence[:16]}), but the "
+                    f"harness can impose only {len(self.covered_fields)}/48 components — {missing} uncovered, "
+                    "so the prefix state was not actually held during the run"
+                ),
+            )
+        return InterlockOutcome(SAFE, f"no invariant breach over {len(self.rows)} corpus rows evidence={evidence[:16]}")
+
+    def verdict(self, case: PrefixCase) -> InterlockOutcome:
+        key = self._key(case.device_state)
+        cached = self._cache.get(key)
+        if cached is None:
+            cached = self._run(key)
+            self._cache[key] = cached
+        return cached
+
+
+class ExternalHarnessInterlock(InterlockProbe):
+    """Adapter for an operator-supplied full-coverage / HIL runner.
+
+    Protocol: the executable is invoked once per case with a JSON request on
+    stdin and must answer with one JSON object on stdout::
+
+        {"schema": "verdify-component-prefix-interlock-verdict-v1",
+         "case_id": "<echoed>", "verdict": "safe|unsafe|unproven",
+         "covered_fields": [...], "detail": "...", "evidence_sha256": "..."}
+
+    A malformed answer, a mismatched case id, or a "safe" claim that does not
+    also declare all 48 components covered is downgraded to `unproven`.
+    """
+
+    name = "external-harness"
+    REQUEST_SCHEMA = "verdify-component-prefix-interlock-request-v1"
+    VERDICT_SCHEMA = "verdify-component-prefix-interlock-verdict-v1"
+
+    def __init__(self, harness: Path, *, timeout: int = 900) -> None:
+        self.harness = harness
+        self.timeout = timeout
+        self.covered_fields = frozenset()
+        self.calls = 0
+
+    def describe(self) -> dict[str, Any]:
+        return {**super().describe(), "harness": str(self.harness), "calls": self.calls}
+
+    def verdict(self, case: PrefixCase) -> InterlockOutcome:
+        request = {
+            "case_id": case.case_id,
+            "device_state": case.device_state,
+            "edge": case.edge,
+            "index": case.index,
+            "order_name": case.order_name,
+            "schema": self.REQUEST_SCHEMA,
+        }
+        try:
+            proc = subprocess.run(  # offline: operator-supplied local executable
+                [str(self.harness)],
+                input=canonical_json(request),
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return InterlockOutcome(UNPROVEN, f"external harness could not be run: {exc}")
+        self.calls += 1
+        if proc.returncode != 0:
+            return InterlockOutcome(UNPROVEN, f"external harness exit={proc.returncode}: {proc.stderr.strip()[:200]}")
+        try:
+            answer = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return InterlockOutcome(UNPROVEN, "external harness did not emit a JSON verdict")
+        if not isinstance(answer, dict) or answer.get("schema") != self.VERDICT_SCHEMA:
+            return InterlockOutcome(UNPROVEN, "external harness verdict has the wrong schema")
+        if answer.get("case_id") != case.case_id:
+            return InterlockOutcome(UNPROVEN, "external harness answered a different case id")
+        covered = answer.get("covered_fields")
+        if isinstance(covered, list) and all(isinstance(item, str) for item in covered):
+            self.covered_fields = self.covered_fields | frozenset(covered)
+        detail = str(answer.get("detail", ""))[:400]
+        claimed = answer.get("verdict")
+        if claimed == UNSAFE:
+            return InterlockOutcome(UNSAFE, detail or "external harness reported an unsafe prefix state")
+        if claimed != SAFE:
+            return InterlockOutcome(UNPROVEN, detail or f"external harness verdict {claimed!r}")
+        if not isinstance(covered, list) or frozenset(covered) != frozenset(CANONICAL_FIELD_ORDER):
+            return InterlockOutcome(UNPROVEN, "external harness claimed safe without declaring all 48 components")
+        return InterlockOutcome(SAFE, detail or "external harness reported a safe prefix state")
+
+
+def build_compiled_interlock(
+    *,
+    corpus: Path,
+    workdir: Path,
+    compiler: str,
+    max_rows: int = 0,
+) -> InterlockProbe:
+    """Compile and prime the `replay_invariants` harness, or explain why not."""
+    if not INVARIANTS_SOURCE.is_file():
+        return UnprovenInterlock(f"harness source missing: {INVARIANTS_SOURCE}")
+    if not corpus.is_file():
+        return UnprovenInterlock(f"disturbance corpus missing: {corpus}")
+    resolved = shutil.which(compiler)
+    if resolved is None:
+        return UnprovenInterlock(f"no host C++ compiler on PATH ({compiler}) — cannot build the compiled harness")
+
+    binary = workdir / "replay_invariants"
+    build = subprocess.run(  # offline: local toolchain over committed sources
+        [resolved, "-std=c++17", "-O2", "-I", str(FIRMWARE_LIB), "-o", str(binary), str(INVARIANTS_SOURCE)],
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    if build.returncode != 0 or not binary.is_file():
+        return UnprovenInterlock(f"compiled harness build failed: {build.stderr.strip().splitlines()[-1:] or ''}")
+
+    opener = gzip.open if corpus.suffix == ".gz" else open
+    with opener(corpus, "rt", encoding="utf-8", newline="") as handle:  # type: ignore[operator]
+        lines = handle.read().splitlines()
+    if not lines:
+        return UnprovenInterlock(f"disturbance corpus is empty: {corpus}")
+    header = lines[0].split("\t")
+    rows = lines[1:]
+    if max_rows > 0:
+        rows = rows[:max_rows]
+    if not rows:
+        return UnprovenInterlock(f"disturbance corpus has no data rows: {corpus}")
+
+    source = INVARIANTS_SOURCE.read_text(encoding="utf-8")
+    coverage = harness_injection_coverage(source, header)
+    if not coverage:
+        return UnprovenInterlock(
+            "the compiled harness reads none of the 48 executor components from the corpus — nothing to impose"
+        )
+    return CompiledInvariantInterlock(
+        binary=binary,
+        corpus_path=corpus,
+        header=header,
+        rows=rows,
+        coverage=coverage,
+        workdir=workdir,
+        binary_sha256=_sha256_bytes(binary.read_bytes()),
+        source_sha256=_sha256_bytes(source.encode()),
+        corpus_sha256=_sha256_bytes(corpus.read_bytes()),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Prefix enumeration + replay (pure logic; no I/O below this line)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _command_fields(
+    start: Mapping[str, float | bool],
+    target: Mapping[str, float | bool],
+    *,
+    order: Sequence[str],
+    complete_bundle: bool,
+) -> tuple[ComponentChange, ...]:
+    """The exact setter list, built ONLY by the source-locked contracts."""
+    if complete_bundle:
+        return fixed_order_complete_bundle(target, order=order)
+    return fixed_order_differences(start, target, order=order)
+
+
+def enumerate_prefixes(
+    start: Mapping[str, float | bool],
+    target: Mapping[str, float | bool],
+    *,
+    order: Sequence[str],
+    order_name: str,
+    edge: str = "",
+    complete_bundle: bool = False,
+) -> list[PrefixCase]:
+    """Every state reachable by truncating the setter list to length 0..N.
+
+    Each case carries the COMPLETE 48-field state: components the setter list
+    has not reached yet keep the start's value, including a start value that is
+    itself off-grid (a real compiled default may be, and it must be preserved
+    rather than silently repaired — the grid verdict is then the honest one).
+    """
+    changes = _command_fields(start, target, order=order, complete_bundle=complete_bundle)
+    fields = tuple(change.field_name for change in changes)
+    expected = tuple(order) if complete_bundle else tuple(f for f in order if start[f] != target[f])
+    if fields != expected:
+        raise PrefixReplayError(f"{edge or order_name}: setter list is not the fixed source order")
+
+    state: dict[str, float | bool] = dict(start)
+    cases: list[PrefixCase] = []
+    for index in range(len(fields) + 1):
+        if index:
+            change = changes[index - 1]
+            state[change.field_name] = change.value
+        cases.append(
+            PrefixCase(
+                edge=edge or f"{order_name}/prefix",
+                order_name=order_name,
+                index=index,
+                device_state=dict(state),
+                applied_fields=fields[:index],
+                pending_fields=fields[index:],
+            )
+        )
+    return cases
+
+
+def _grade(case: PrefixCase, interlock: InterlockOutcome) -> PrefixVerdict:
+    details: list[str] = []
+    try:
+        normalize_complete_state(case.device_state)
+        grid_ok = True
+    except ComponentContractError as exc:
+        grid_ok = False
+        offender = exc.detail.split("=")[0] if "=" in exc.detail else exc.detail
+        inherited = offender not in case.applied_fields
+        details.append(
+            f"grid {exc.code}: {exc.detail} "
+            f"({'inherited from the start state' if inherited else 'COMMANDED BY THE SETTER LIST'})"
+        )
+
+    registry_bad = _clamp_violations(case.device_state, registry_clamp_ok)
+    firmware_bad = _clamp_violations(case.device_state, firmware_clamp_ok)
+    if registry_bad:
+        details.append("registry clamp: " + ", ".join(registry_bad[:4]))
+    if firmware_bad:
+        details.append("firmware clamp: " + ", ".join(firmware_bad[:4]))
+    if interlock.verdict != SAFE:
+        details.append(f"interlock {interlock.verdict}: {interlock.detail}")
+
+    ok = grid_ok and not registry_bad and not firmware_bad and interlock.verdict == SAFE
+    return PrefixVerdict(
+        case=case,
+        grid_ok=grid_ok,
+        registry_clamp_ok=not registry_bad,
+        firmware_clamp_ok=not firmware_bad,
+        interlock_safe=interlock.verdict,
+        ok=ok,
+        detail="; ".join(details),
+    )
+
+
+def _check_idempotency(edge: ReplayEdge, cases: Sequence[PrefixCase], failures: list[str]) -> bool:
+    """Re-deriving work from a confirmed prefix must yield only the pending suffix.
+
+    This is the property that makes a retry safe: an executor that reconnects
+    after confirming prefix i and re-derives its work list must never re-issue
+    a component it already confirmed, and must still be asked for every
+    component it has not.
+    """
+    ok = True
+    for case in cases:
+        try:
+            replay_now = fixed_order_differences(case.device_state, edge.target_state, order=edge.order)
+        except ComponentContractError as exc:
+            failures.append(f"{case.case_id}: idempotency undecidable ({exc.code}: {exc.detail})")
+            ok = False
+            continue
+        redone = [c.field_name for c in replay_now if c.field_name in case.applied_fields]
+        if redone:
+            failures.append(f"{case.case_id}: confirmed components would be re-issued: {','.join(redone)}")
+            ok = False
+        expected_pending = [f for f in edge.order if case.device_state[f] != edge.target_state[f]]
+        if [c.field_name for c in replay_now] != expected_pending:
+            failures.append(f"{case.case_id}: re-derived work is not the pending suffix")
+            ok = False
+    return ok
+
+
+def replay(
+    edges: Sequence[ReplayEdge],
+    *,
+    interlock: InterlockProbe | None = None,
+    revision_prefix: str = ORDER_REVISION_PREFIX,
+) -> ReplayResult:
+    """Adjudicate every prefix of every edge and derive the qualified revision."""
+    probe = interlock or UnprovenInterlock("no interlock probe supplied")
+    failures: list[str] = []
+    verdicts: list[PrefixVerdict] = []
+    edge_rows: list[dict[str, Any]] = []
+    fixed_order_ok = True
+    idempotent_ok = True
+    lands_exact_ok = True
+
+    if not edges:
+        failures.append("no edges to replay — an empty qualification proves nothing")
+
+    # Check 2, part one: the order constants themselves must still be the
+    # source tuples this tool claims to have qualified.
+    if ACTIVATION_ORDER != TREATMENT_FIELD_ORDER or ROLLBACK_ORDER != TREATMENT_FIELD_ORDER:
+        failures.append("activation/rollback order is no longer TREATMENT_FIELD_ORDER")
+        fixed_order_ok = False
+    if RECOVERY_ORDER != CANONICAL_FIELD_ORDER:
+        failures.append("recovery order is no longer CANONICAL_FIELD_ORDER")
+        fixed_order_ok = False
+
+    for edge in edges:
+        # Check 2, part two: an edge may only be replayed against the exact
+        # source tuple for its order.  A caller that hands in a permuted or
+        # ad-hoc order is building evidence for an order the executor will
+        # never use.
+        expected_order = SOURCE_ORDERS.get(edge.order_name)
+        if expected_order is None or tuple(edge.order) != expected_order:
+            failures.append(f"{edge.edge}: order is not the source {edge.order_name!r} tuple")
+            fixed_order_ok = False
+        try:
+            cases = enumerate_prefixes(
+                edge.start_state,
+                edge.target_state,
+                order=edge.order,
+                order_name=edge.order_name,
+                edge=edge.edge,
+                complete_bundle=edge.complete_bundle,
+            )
+        except (ComponentContractError, PrefixReplayError) as exc:
+            failures.append(f"{edge.edge}: fixed-order build refused ({exc})")
+            fixed_order_ok = False
+            edge_rows.append({**edge.summary(), "prefix_count": 0, "command_fields": []})
+            continue
+
+        command_fields = list(cases[-1].applied_fields)
+        edge_rows.append({**edge.summary(), "prefix_count": len(cases), "command_fields": command_fields})
+
+        for case in cases:
+            verdicts.append(_grade(case, probe.verdict(case)))
+
+        # Check 6: the last prefix state is exactly the normalized target.
+        try:
+            landed = cases[-1].device_state == normalize_complete_state(edge.target_state)
+        except ComponentContractError as exc:
+            failures.append(f"{edge.edge}: target is not grid-normalizable ({exc.code}: {exc.detail})")
+            landed = False
+        if not landed:
+            failures.append(f"{edge.edge}: final prefix state is not the normalized target")
+            lands_exact_ok = False
+
+        # Check 5.
+        if not _check_idempotency(edge, cases, failures):
+            idempotent_ok = False
+
+    failures.extend(f"{v.case.case_id}: {v.detail}" for v in verdicts if not v.ok)
+
+    all_pass = bool(
+        edges
+        and verdicts
+        and fixed_order_ok
+        and idempotent_ok
+        and lands_exact_ok
+        and all(v.ok for v in verdicts)
+        and not failures
+    )
+    result = ReplayResult(
+        all_pass=all_pass,
+        fixed_order_ok=fixed_order_ok,
+        idempotent_ok=idempotent_ok,
+        lands_exact_ok=lands_exact_ok,
+        verdicts=verdicts,
+        order_revision=None,
+        failures=failures,
+        edges=edge_rows,
+        interlock=probe.describe(),
+    )
+    if all_pass:
+        result.order_revision = derive_order_revision(result, revision_prefix=revision_prefix)
+    return result
+
+
+def revision_digest_payload(result: ReplayResult) -> dict[str, Any]:
+    """The exact, wall-clock-free evidence the ORDER_REVISION addresses."""
+    return {
+        "edges": result.edges,
+        "orders": {
+            "activation": list(ACTIVATION_ORDER),
+            "recovery": list(RECOVERY_ORDER),
+            "rollback": list(ROLLBACK_ORDER),
+        },
+        "verdicts": [v.digest_row() for v in result.verdicts],
+    }
+
+
+def derive_order_revision(result: ReplayResult, *, revision_prefix: str = ORDER_REVISION_PREFIX) -> str:
+    """`prefix-replay-v1:sha256:<H2>` — only ever called on an all-pass result.
+
+    H2 addresses the ORDERS + EDGES + VERDICTS and nothing else, so the same
+    edge set adjudicated by two different probes mints the same string.  The
+    probe's own identity and digests are therefore NOT self-evident from the
+    revision: they travel beside it (the `interlock_evidence:` report line, and
+    the `interlock` block inside the --json payload's `result_sha256`).  A
+    reviewer promoting a revision into `component_executor.ORDER_REVISION` must
+    read that provenance, not the revision alone.
+    """
+    if not result.all_pass:
+        raise PrefixReplayError("order_revision is only derivable from an all-pass replay")
+    digest = hashlib.sha256(canonical_json(revision_digest_payload(result)).encode()).hexdigest()
+    revision = f"{revision_prefix}:sha256:{digest}"
+    if _QUALIFIED_ORDER_REVISION.fullmatch(revision) is None:
+        raise PrefixReplayError(f"derived revision does not satisfy the executor contract: {revision}")
+    return revision
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Edge construction from committed artifacts
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def load_profiles(path: Path) -> dict[str, dict[str, float | bool]]:
+    """Decode the three switchback profiles from their canonical wire bytes."""
+    artifact = json.loads(path.read_text(encoding="utf-8"))
+    rows = artifact.get("profiles")
+    if not isinstance(rows, Mapping) or set(rows) != set(PROFILE_NAMES):
+        raise PrefixReplayError(f"{path} must carry exactly baseline/moderate/aggressive profiles")
+    profiles: dict[str, dict[str, float | bool]] = {}
+    for name in PROFILE_NAMES:
+        row = rows[name]
+        if not isinstance(row, Mapping) or not isinstance(row.get("wire_hex"), str):
+            raise PrefixReplayError(f"profile {name} has no wire_hex")
+        try:
+            values = decode_policy_vector(bytes.fromhex(str(row["wire_hex"])))
+            profiles[name] = normalize_complete_state(values)
+        except (ValueError, ComponentContractError) as exc:
+            raise PrefixReplayError(f"profile {name} is not exact-grid canonical: {exc}") from exc
+    return profiles
+
+
+def _prep_module():
+    """Import the sibling preparation tool (shared compiled-default parser)."""
+    path = Path(__file__).resolve().parent / "prepare_component_prefix_replay.py"
+    spec = importlib.util.spec_from_file_location("prepare_component_prefix_replay", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_start_state(path: Path, label: str) -> dict[str, float | bool]:
+    """Read one complete 48-field start state (observed / reboot / reset / drift).
+
+    Accepts either the bare 48-field object or a
+    `verdify-component-current-state-v1` artifact.  Values are validated as
+    finite and inside their source-declared wire bounds but NOT forced onto the
+    entity grid — an off-grid start is exactly what the recovery edge exists to
+    repair, and rounding it here would hide the finding.
+    """
+    prep = _prep_module()
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise PrefixReplayError(f"start state {label} must be a JSON object")
+    values = raw.get("values") if raw.get("schema") == prep.CURRENT_STATE_SCHEMA else raw
+    try:
+        return prep._finite_raw_state(values, f"start state {label}")
+    except prep.PrefixPreparationError as exc:
+        raise PrefixReplayError(str(exc)) from exc
+
+
+def load_compiled_defaults(generated_main: Path, consumer_manifest: Path) -> dict[str, float | bool]:
+    """Extract the 48 compiled ESPHome constructor defaults (no YAML inference)."""
+    prep = _prep_module()
+    try:
+        return prep.extract_compiled_defaults(
+            generated_main.read_bytes(),
+            json.loads(consumer_manifest.read_text(encoding="utf-8")),
+        )
+    except (prep.PrefixPreparationError, OSError, json.JSONDecodeError) as exc:
+        raise PrefixReplayError(f"compiled defaults unavailable: {exc}") from exc
+
+
+def build_edges(
+    profiles: Mapping[str, dict[str, float | bool]],
+    recovery_starts: Mapping[str, dict[str, float | bool]],
+) -> list[ReplayEdge]:
+    """The four permitted treatment edges plus one full-48 recovery per start."""
+    edges: list[ReplayEdge] = []
+    for start_label, target_label in TREATMENT_EDGES:
+        kind = "activation" if start_label == "baseline" else "rollback"
+        edges.append(
+            ReplayEdge(
+                edge=f"{kind}/{start_label}-to-{target_label}",
+                kind=kind,
+                order_name=kind,
+                order=ACTIVATION_ORDER if kind == "activation" else ROLLBACK_ORDER,
+                start_label=start_label,
+                target_label=target_label,
+                start_state=dict(profiles[start_label]),
+                target_state=dict(profiles[target_label]),
+                complete_bundle=False,
+            )
+        )
+    for start_label in sorted(recovery_starts):
+        edges.append(
+            ReplayEdge(
+                edge=f"recovery/{start_label}-to-baseline",
+                kind="recovery",
+                order_name="recovery",
+                order=RECOVERY_ORDER,
+                start_label=start_label,
+                target_label="baseline",
+                start_state=dict(recovery_starts[start_label]),
+                target_state=dict(profiles["baseline"]),
+                complete_bundle=True,
+            )
+        )
+    return edges
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI reporting (PASS/FAIL/WARN, same shape as scripts/experiment-verify.py)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Check:
+    name: str
+    status: str  # PASS | FAIL | WARN
+    detail: str = ""
+
+    def payload(self) -> dict[str, str]:
+        return {"name": self.name, "status": self.status, "detail": self.detail}
+
+
+def _check(name: str, condition: bool, detail: str = "") -> Check:
+    return Check(name, "PASS" if condition else "FAIL", detail)
+
+
+def build_checks(result: ReplayResult, profiles: Mapping[str, dict[str, float | bool]]) -> list[Check]:
+    counts = result.counts()
+    checks: list[Check] = []
+
+    for edge in result.edges:
+        checks.append(
+            Check(
+                f"enumerate/{edge['edge']}",
+                "PASS" if edge["prefix_count"] else "FAIL",
+                f"{edge['prefix_count']} prefixes over {len(edge['command_fields'])} setters "
+                f"({edge['order_name']} order)",
+            )
+        )
+
+    # Routine-target contract: a treatment profile may differ from baseline only
+    # on the 11-field allowlist.  Reuses the executor's own validator.
+    drift: list[str] = []
+    for name in ("moderate", "aggressive"):
+        try:
+            validate_routine_target(profiles["baseline"], profiles[name])
+        except ComponentContractError as exc:
+            drift.append(f"{name}: {exc.code} {exc.detail}")
+    checks.append(
+        _check(
+            "treatment/common-fields-frozen",
+            not drift,
+            "; ".join(drift)
+            or f"moderate+aggressive differ from baseline only on the {len(TREATMENT_FIELD_ORDER)} "
+            f"treatment fields ({len(COMMON_FIELDS)} common fields identical)",
+        )
+    )
+
+    checks.append(
+        _check("fixed-order/source-tuples", result.fixed_order_ok, "change lists built by fixed_order_* contracts")
+    )
+    checks.append(
+        _check(
+            "grid/every-prefix-state",
+            counts["grid_fail"] == 0,
+            f"{counts['grid_fail']}/{counts['cases']} prefix states rejected by normalize_complete_state",
+        )
+    )
+    checks.append(
+        _check(
+            "clamps/registry-and-firmware",
+            counts["clamp_fail"] == 0,
+            f"{counts['clamp_fail']}/{counts['cases']} prefix states outside registry or firmware clamps",
+        )
+    )
+    interlock_detail = (
+        f"{counts['interlock_unsafe']} unsafe, {counts['interlock_unproven']} unproven of {counts['cases']} "
+        f"(probe={result.interlock.get('probe')}, coverage={result.interlock.get('covered_field_count')}/48)"
+    )
+    if counts["interlock_unsafe"]:
+        checks.append(Check("interlock/safety-admissible", "FAIL", interlock_detail))
+    elif counts["interlock_unproven"]:
+        checks.append(
+            Check("interlock/safety-admissible", "FAIL", interlock_detail + " — unproven blocks the revision")
+        )
+    else:
+        checks.append(Check("interlock/safety-admissible", "PASS", interlock_detail))
+    checks.append(
+        _check(
+            "idempotency/no-reissue",
+            result.idempotent_ok,
+            "confirmed prefixes re-derive to the pending suffix only"
+            if result.idempotent_ok
+            else "at least one prefix would re-issue a confirmed component, or is undecidable",
+        )
+    )
+    checks.append(_check("lands-exact/final-state", result.lands_exact_ok, "every edge lands on the normalized target"))
+    return checks
+
+
+def distinct_failures(failures: Sequence[str]) -> dict[str, tuple[int, str]]:
+    """Collapse per-case failure lines to {cause: (count, first example)}.
+
+    The cause key is the message with its leading `case_id: ` stripped and
+    digits masked, so `prefix-00`/`prefix-01` variants of one root cause group.
+    """
+    grouped: dict[str, tuple[int, str]] = {}
+    for failure in failures:
+        _, _, message = failure.partition(": ")
+        cause = re.sub(r"\d+", "#", message or failure)
+        count, exemplar = grouped.get(cause, (0, failure))
+        grouped[cause] = (count + 1, exemplar)
+    return grouped
+
+
+def report(checks: Sequence[Check], result: ReplayResult, failures_shown: int = 12) -> int:
+    for check in checks:
+        line = f"{check.status} — {check.name}"
+        if check.detail:
+            line += f": {check.detail}"
+        print(line)
+    n_fail = sum(1 for c in checks if c.status == "FAIL")
+    n_warn = sum(1 for c in checks if c.status == "WARN")
+    print(f"SUMMARY: {len(checks) - n_fail - n_warn} pass, {n_warn} warn, {n_fail} fail")
+    # An 81-case run repeats the same root cause many times; print one exemplar
+    # per distinct cause with its multiplicity so the real blockers are legible.
+    for reason, (count, exemplar) in list(distinct_failures(result.failures).items())[:failures_shown]:
+        del reason
+        print(f"    ! [x{count}] {exemplar}")
+    remaining = len(distinct_failures(result.failures)) - failures_shown
+    if remaining > 0:
+        print(f"    ! … {remaining} more distinct causes ({len(result.failures)} failure lines total)")
+    # The ORDER_REVISION digest addresses the ORDERS + EDGES + VERDICTS only —
+    # it deliberately says nothing about which probe produced those verdicts.
+    # Never review a bare revision: this line is the provenance that belongs
+    # with it, and --json carries the same block under `interlock` inside the
+    # (provenance-covering) result_sha256.
+    print(
+        "interlock_evidence: "
+        + canonical_json(
+            {
+                key: result.interlock.get(key)
+                for key in (
+                    "probe",
+                    "covered_field_count",
+                    "full_coverage",
+                    "binary_sha256",
+                    "corpus_sha256",
+                    "harness_source_sha256",
+                    "harness_runs",
+                    "harness",
+                    "reason",
+                )
+                if result.interlock.get(key) is not None
+            }
+        )
+    )
+    if result.order_revision:
+        print(f"order_revision={result.order_revision}")
+    else:
+        print("order_revision=NOT EMITTED (replay did not pass every check)")
+    print(
+        f"OVERALL {'PASS' if result.all_pass else 'FAIL'} ({result.counts()['ok']}/{result.counts()['cases']} "
+        "prefix cases admissible)"
+    )
+    return 0 if result.all_pass else 1
+
+
+def _iter_start_args(pairs: Iterable[tuple[str, Path]]) -> dict[str, Path]:
+    seen: dict[str, Path] = {}
+    for label, path in pairs:
+        if label in seen:
+            raise PrefixReplayError(f"duplicate start label {label}")
+        seen[label] = path
+    return seen
+
+
+def _start_arg(value: str) -> tuple[str, Path]:
+    label, separator, raw = value.partition("=")
+    if not separator or not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", label):
+        raise argparse.ArgumentTypeError("start state must be LABEL=PATH with a bounded lowercase label")
+    return label, Path(raw)
+
+
+def _make_interlock(args: argparse.Namespace, workdir: Path) -> InterlockProbe:
+    if args.interlock == "none":
+        return UnprovenInterlock("interlock explicitly disabled (--interlock none); a revision cannot be earned here")
+    if args.interlock == "external":
+        if not args.interlock_harness:
+            return UnprovenInterlock("--interlock external requires --interlock-harness PATH")
+        return ExternalHarnessInterlock(Path(args.interlock_harness))
+    return build_compiled_interlock(
+        corpus=Path(args.interlock_corpus),
+        workdir=workdir,
+        compiler=args.interlock_cxx,
+        max_rows=args.interlock_corpus_rows,
+    )
+
+
+def _run_replay(args: argparse.Namespace) -> int:
+    profiles = load_profiles(Path(args.profiles))
+    starts: dict[str, dict[str, float | bool]] = {}
+    if args.compiled_defaults:
+        starts["compiled-defaults"] = load_compiled_defaults(Path(args.compiled_defaults), Path(args.consumer_manifest))
+    for label, path in _iter_start_args(args.start).items():
+        starts[label] = load_start_state(path, label)
+
+    edges = build_edges(profiles, starts)
+    with tempfile.TemporaryDirectory(prefix="component-prefix-replay-") as tmp:
+        workdir = Path(tmp)
+        probe = _make_interlock(args, workdir)
+        result = replay(edges, interlock=probe)
+
+    if not starts:
+        result.failures.insert(0, "no recovery start supplied (--compiled-defaults / --start) — recovery unqualified")
+        result.all_pass = False
+        result.order_revision = None
+
+    checks = build_checks(result, profiles)
+    exit_code = report(checks, result)
+
+    if args.json_out:
+        payload: dict[str, Any] = {
+            "all_pass": result.all_pass,
+            "checks": [c.payload() for c in checks],
+            "computed_at": datetime.now(UTC).isoformat(timespec="seconds"),
+            "counts": result.counts(),
+            "edges": result.edges,
+            "failures": result.failures,
+            "fixed_order_ok": result.fixed_order_ok,
+            "idempotent_ok": result.idempotent_ok,
+            "interlock": result.interlock,
+            "lands_exact_ok": result.lands_exact_ok,
+            "order_revision": result.order_revision,
+            "orders": revision_digest_payload(result)["orders"],
+            "schema": SCHEMA_VERSION,
+            "verdicts": [v.payload() for v in result.verdicts],
+        }
+        payload["result_sha256"] = result_sha256(payload)
+        Path(args.json_out).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"wrote {args.json_out} (result_sha256={payload['result_sha256']})")
+    return exit_code
+
+
+def _run_probe(args: argparse.Namespace) -> int:
+    """Report exactly what the compiled interlock harness can and cannot impose."""
+    with tempfile.TemporaryDirectory(prefix="component-prefix-probe-") as tmp:
+        probe = build_compiled_interlock(
+            corpus=Path(args.interlock_corpus),
+            workdir=Path(tmp),
+            compiler=args.interlock_cxx,
+            max_rows=args.interlock_corpus_rows,
+        )
+        description = probe.describe()
+    covered = frozenset(description.get("covered_fields", ()))
+    full = description.get("full_coverage", False)
+    checks = [
+        Check(
+            "harness/buildable",
+            "PASS" if probe.name != "unproven" else "FAIL",
+            description.get("reason", f"probe={probe.name}"),
+        ),
+        Check(
+            "harness/full-48-injection",
+            "PASS" if full else "FAIL",
+            f"{len(covered)}/48 components injectable; treatment fields not injectable: "
+            f"{', '.join(sorted(set(TREATMENT_FIELD_ORDER) - covered)) or 'none'}",
+        ),
+    ]
+    for check in checks:
+        print(f"{check.status} — {check.name}: {check.detail}")
+    print(json.dumps(description, indent=2, sort_keys=True))
+    return 0 if full else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _common(target: argparse.ArgumentParser) -> None:
+        target.add_argument(
+            "--interlock",
+            choices=("auto", "external", "none"),
+            default="auto",
+            help="auto = drive the compiled replay_invariants harness (default)",
+        )
+        target.add_argument("--interlock-harness", help="executable adapter for --interlock external")
+        target.add_argument("--interlock-corpus", default=str(DEFAULT_CORPUS))
+        target.add_argument(
+            "--interlock-corpus-rows",
+            type=int,
+            default=0,
+            help="0 = the whole corpus; a positive N truncates it (faster, weaker)",
+        )
+        target.add_argument("--interlock-cxx", default=os.environ.get("CXX", "g++"))
+
+    run = sub.add_parser("replay", help="adjudicate every prefix of every permitted edge")
+    run.add_argument("--profiles", default=str(DEFAULT_PROFILES))
+    run.add_argument("--compiled-defaults", help="ESPHome-generated main.cpp for the candidate build")
+    run.add_argument("--consumer-manifest", default=str(DEFAULT_CONSUMER_MANIFEST))
+    run.add_argument(
+        "--start",
+        action="append",
+        default=[],
+        type=_start_arg,
+        metavar="LABEL=PATH",
+        help="complete 48-field observed/reboot/reset/common-drift start state",
+    )
+    run.add_argument("--json", dest="json_out", help="write the machine-readable verdict payload here")
+    _common(run)
+
+    probe = sub.add_parser("probe-harness", help="report the compiled harness's injection coverage")
+    _common(probe)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "replay":
+            return _run_replay(args)
+        return _run_probe(args)
+    except PrefixReplayError as exc:
+        parser.exit(2, f"prefix replay refused: {exc}\n")
+    return 2
+
+
+# Import-time fail-closed assertion: this tool must mint only strings the
+# executor's own regex accepts.  A drift in either regex fails startup.
+if _QUALIFIED_ORDER_REVISION.pattern != r"^prefix-replay-v[1-9][0-9]*:sha256:[0-9a-f]{64}$":
+    raise RuntimeError("order-revision contract drift")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_component_grid_capture.py
+++ b/tests/test_component_grid_capture.py
@@ -1,0 +1,785 @@
+"""Offline grid capture is exact, deterministic and fails closed.
+
+Every fixture here is synthetic.  Nothing in this module opens a socket, reads
+a database, imports an ESPHome client or touches a device: the capture core is
+pure logic over one JSON artifact, and that is exactly what is asserted.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import hashlib
+import importlib.util
+import json
+import stat
+import struct
+import sys
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from verdify_schemas.component_executor import CANONICAL_FIELD_ORDER, ENTITY_GRIDS
+from verdify_schemas.component_qualification import build_live_entity_grid_evidence
+from verdify_schemas.policy_vector import encode_policy_vector, wire_manifest_digest
+from verdify_schemas.tunable_registry import REGISTRY, WIRE_SCHEMA_VERSION
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "component_grid_capture.py"
+SPEC = importlib.util.spec_from_file_location("component_grid_capture", SCRIPT)
+assert SPEC and SPEC.loader
+cap = importlib.util.module_from_spec(SPEC)
+# Register before exec: @dataclass resolves annotations through
+# sys.modules[cls.__module__] (scripts/experiment-verify.py does the same).
+sys.modules[SPEC.name] = cap
+SPEC.loader.exec_module(cap)
+
+DEVICE_ID = "vallery/greenhouse-controller"
+SOURCE_REVISION = "a" * 40
+FIRMWARE_REVISION = "2026.7.10.1500.09ee886"
+RUNTIME_INSTANCE_ID = "11111111-1111-4111-8111-111111111111"
+OBSERVED_AT = datetime(2026, 8, 26, 1, 2, 3, 456789, tzinfo=UTC)
+LAYER_AS_OF = cap._timestamp_text(OBSERVED_AT - timedelta(seconds=60))
+
+# #424's own historical table: served/control/observed for the six band series.
+# temp/target rows are written coherent so a single mutation isolates one cause.
+BAND_VALUES: dict[str, tuple[str, str]] = {
+    "temp_low": ("75.19", "°F"),
+    "temp_high": ("85.19", "°F"),
+    "temp_target": ("80.19", "°F"),
+    "vpd_low": ("0.875", "kPa"),
+    "vpd_high": ("1.305", "kPa"),
+    "vpd_target": ("1.065", "kPa"),
+}
+BAND_SLUGS: dict[str, str] = {
+    "temp_low": "cfg___temp_low___f_",
+    "temp_high": "cfg___temp_high___f_",
+    "temp_target": "house_temp_target_f",
+    "vpd_low": "cfg___vpd_low__kpa_",
+    "vpd_high": "cfg___vpd_high__kpa_",
+    "vpd_target": "house_vpd_target",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Synthetic fixtures
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def entity_rows() -> list[dict[str, Any]]:
+    """One exact-parity setter + cfg readback pair for each canonical field."""
+    rows: list[dict[str, Any]] = []
+    key = 100
+    for field_name in CANONICAL_FIELD_ORDER:
+        definition = REGISTRY[field_name]
+        grid = ENTITY_GRIDS[field_name]
+        key += 1
+        setter: dict[str, Any] = {
+            "object_id": definition.esp_object_id,
+            "entity_type": grid.entity_type,
+            "key": key,
+            "device_id": 0,
+            "disabled_by_default": False,
+            "unit": "",
+        }
+        if grid.entity_type == "number":
+            setter["minimum"] = str(grid.minimum)
+            setter["maximum"] = str(grid.maximum)
+            setter["step"] = str(grid.step)
+        else:
+            setter["assumed_state"] = False
+        rows.append(setter)
+        key += 1
+        rows.append(
+            {
+                "object_id": definition.cfg_readback_object_id,
+                "entity_type": "sensor",
+                "key": key,
+                "device_id": 0,
+                "disabled_by_default": False,
+                "unit": "",
+            }
+        )
+    return rows
+
+
+def on_grid_value(field_name: str) -> bool | float | str:
+    """A value that is exactly on the deployed grid (its declared minimum)."""
+    grid = ENTITY_GRIDS[field_name]
+    if grid.entity_type == "switch":
+        return False
+    assert grid.minimum is not None
+    return str(grid.minimum)
+
+
+def observed_component_rows() -> dict[str, dict[str, Any]]:
+    return {
+        field_name: {
+            "slug": REGISTRY[field_name].cfg_readback_object_id,
+            "unit": "",
+            "observed_at": LAYER_AS_OF,
+            "value": on_grid_value(field_name),
+        }
+        for field_name in CANONICAL_FIELD_ORDER
+    }
+
+
+def band_layer_rows() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for series, (value, unit) in BAND_VALUES.items():
+        rows.append(
+            {
+                "series": series,
+                "served": {
+                    "value": value,
+                    "unit": unit,
+                    "as_of": LAYER_AS_OF,
+                    "source": "fn_band_setpoints(now())",
+                },
+                "control": {
+                    "value": value,
+                    "unit": unit,
+                    "as_of": LAYER_AS_OF,
+                    "source": f"firmware global gh_{series}",
+                },
+                "observed": {
+                    "value": value,
+                    "unit": unit,
+                    "as_of": LAYER_AS_OF,
+                    "source": "setpoint_snapshot",
+                    "slug": BAND_SLUGS[series],
+                },
+            }
+        )
+    return rows
+
+
+def artifact() -> dict[str, Any]:
+    return {
+        "schema": cap.INPUT_SCHEMA,
+        "device_id": DEVICE_ID,
+        "observed_at": cap._timestamp_text(OBSERVED_AT),
+        "runtime": {"runtime_instance_id": RUNTIME_INSTANCE_ID, "connection_generation": 7},
+        "revisions": {
+            "source_revision": SOURCE_REVISION,
+            "firmware_revision": FIRMWARE_REVISION,
+            "config_revision": "cfg-2026-08-26-01",
+            "registry_revision": "registry-v2",
+            "crop_band_resolver_revision": "fn_band_setpoints-mig-181",
+            "sensor_registry_revision": "sensors-2026-07",
+        },
+        "entities": entity_rows(),
+        "observed_components": observed_component_rows(),
+        "band_layers": band_layer_rows(),
+    }
+
+
+def entity_index(rows: list[dict[str, Any]], object_id: str) -> int:
+    return next(index for index, row in enumerate(rows) if row["object_id"] == object_id)
+
+
+def run(document: dict[str, Any] | None = None) -> Any:
+    return cap.capture_from_artifact(artifact() if document is None else document)
+
+
+def exact_live_grid() -> list[Any]:
+    return list(cap.project_live_entity_grid(cap.parse_input_artifact(artifact()).entities))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Exact parity
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_exact_parity_capture_emits_a_qualified_grid_revision() -> None:
+    result = run()
+    assert result.failures == ()
+    assert result.grid_parity_ok is True
+    assert result.band_coherence_ok is True
+    assert result.observed_state_ok is True
+    assert result.qualified is True
+    assert cap._QUALIFIED_GRID_REVISION.fullmatch(result.grid_revision) is not None
+    assert set(result.observed_start_state) == set(CANONICAL_FIELD_ORDER)
+    assert len(result.live_grid) == len(CANONICAL_FIELD_ORDER)
+    assert {triple.classification for triple in result.layer_triples} == {"resolved"}
+    assert all(triple.coherent for triple in result.layer_triples)
+
+
+def test_grid_revision_is_the_shipped_runtime_attestation_string_not_a_second_preimage() -> None:
+    """The offline revision must be reproducible by the live ingestor attestation.
+
+    ``physical_execution_qualified`` compares the source constant with the
+    ingestor's observed revision, so a locally-invented preimage would wedge the
+    gate permanently.  This binds the tool to the shipped evidence module.
+    """
+    parsed = cap.parse_input_artifact(artifact())
+    evidence = build_live_entity_grid_evidence(
+        parsed.entities,
+        device_id=DEVICE_ID,
+        firmware_revision=FIRMWARE_REVISION,
+        source_revision=SOURCE_REVISION,
+        runtime_instance_id=RUNTIME_INSTANCE_ID,
+        connection_generation=7,
+        observed_at=OBSERVED_AT,
+    )
+    result = run()
+    assert result.grid_revision == evidence.grid_revision
+    assert result.grid_content_sha256 == evidence.grid_content_sha256
+    assert result.observation_receipt_sha256 == evidence.observation_receipt_sha256
+
+
+def test_compare_live_grid_accepts_the_exact_source_projection() -> None:
+    assert cap.compare_live_grid(exact_live_grid()) == []
+
+
+def test_binary32_transport_numbers_are_accepted_and_one_ulp_is_not() -> None:
+    """JSON numbers decoded off the protobuf float are exact, not tolerated."""
+    document = artifact()
+    for row in document["entities"]:
+        if row["entity_type"] != "number":
+            continue
+        for label in ("minimum", "maximum", "step"):
+            row[label] = struct.unpack("!f", struct.pack("!f", float(row[label])))[0]
+    assert run(document).grid_revision == run().grid_revision
+
+    index = entity_index(document["entities"], REGISTRY["direct_wet_stress_vpd_margin_kpa"].esp_object_id)
+    bits = int.from_bytes(struct.pack("!f", float(document["entities"][index]["step"])), "big")
+    document["entities"][index]["step"] = struct.unpack("!f", (bits + 1).to_bytes(4, "big"))[0]
+    result = run(document)
+    assert result.grid_revision is None
+    assert any(
+        failure.startswith("number_grid_mismatch:direct_wet_stress_vpd_margin_kpa:step") for failure in result.failures
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Grid parity failure modes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_missing_field_fails_closed() -> None:
+    rows = exact_live_grid()
+    del rows[3]
+    failures = cap.compare_live_grid(rows)
+    assert any(failure.startswith("missing_entity:") for failure in failures)
+
+
+def test_extra_field_fails_closed() -> None:
+    rows = exact_live_grid()
+    rows.append(
+        cap.LiveEntityGrid(
+            field_name="not_a_component",
+            esp_object_id="set_not_a_component",
+            cfg_readback_object_id="cfg_not_a_component",
+            entity_type="number",
+            minimum=Decimal("0"),
+            maximum=Decimal("1"),
+            step=Decimal("1"),
+        )
+    )
+    assert "extra_entity:not_a_component" in cap.compare_live_grid(rows)
+
+
+def test_duplicated_field_fails_closed() -> None:
+    rows = exact_live_grid()
+    rows.append(rows[0])
+    assert any(failure.startswith("duplicate_entity:") for failure in cap.compare_live_grid(rows))
+
+
+def test_wrong_entity_type_fails_closed() -> None:
+    rows = exact_live_grid()
+    index = next(i for i, row in enumerate(rows) if row.field_name == "sw_dwell_gate_enabled")
+    rows[index] = cap.LiveEntityGrid(
+        field_name="sw_dwell_gate_enabled",
+        esp_object_id=rows[index].esp_object_id,
+        cfg_readback_object_id=rows[index].cfg_readback_object_id,
+        entity_type="number",
+        minimum=Decimal("0"),
+        maximum=Decimal("1"),
+        step=Decimal("1"),
+    )
+    failures = cap.compare_live_grid(rows)
+    assert any(failure.startswith("entity_type_mismatch:sw_dwell_gate_enabled") for failure in failures)
+
+
+def test_switch_with_a_numeric_grid_fails_closed() -> None:
+    rows = exact_live_grid()
+    index = next(i for i, row in enumerate(rows) if row.field_name == "sw_summer_vent_enabled")
+    rows[index] = cap.LiveEntityGrid(
+        field_name="sw_summer_vent_enabled",
+        esp_object_id=rows[index].esp_object_id,
+        cfg_readback_object_id=rows[index].cfg_readback_object_id,
+        entity_type="switch",
+        minimum=Decimal("0"),
+        maximum=Decimal("1"),
+        step=Decimal("1"),
+    )
+    assert "switch_carries_numeric_grid:sw_summer_vent_enabled" in cap.compare_live_grid(rows)
+
+
+@pytest.mark.parametrize("route", ["setter", "readback"])
+def test_route_slug_mismatch_fails_closed(route: str) -> None:
+    rows = exact_live_grid()
+    index = next(i for i, row in enumerate(rows) if row.field_name == "mister_all_kpa")
+    row = rows[index]
+    if route == "setter":
+        rows[index] = cap.LiveEntityGrid(
+            field_name=row.field_name,
+            esp_object_id="set_mister_all_kpa_v2",
+            cfg_readback_object_id=row.cfg_readback_object_id,
+            entity_type=row.entity_type,
+            minimum=row.minimum,
+            maximum=row.maximum,
+            step=row.step,
+        )
+        expected = "setter_route_mismatch:mister_all_kpa"
+    else:
+        rows[index] = cap.LiveEntityGrid(
+            field_name=row.field_name,
+            esp_object_id=row.esp_object_id,
+            cfg_readback_object_id="cfg_mister_all_kpa_v2",
+            entity_type=row.entity_type,
+            minimum=row.minimum,
+            maximum=row.maximum,
+            step=row.step,
+        )
+        expected = "readback_route_mismatch:mister_all_kpa"
+    assert any(failure.startswith(expected) for failure in cap.compare_live_grid(rows))
+
+
+@pytest.mark.parametrize(
+    ("field_name", "label", "mutation"),
+    [
+        # exactly one grid step of drift on each bound — the smallest real
+        # deployed-grid change a firmware/YAML edit can produce.
+        ("min_fog_on_s", "minimum", "30"),
+        ("min_fog_on_s", "maximum", "285"),
+        ("min_fog_on_s", "step", "30"),
+        ("night_vpd_bias_kpa", "maximum", "0.26"),
+        ("direct_wet_stress_vpd_margin_kpa", "step", "0.1"),
+    ],
+)
+def test_one_step_grid_drift_blocks_the_capture(field_name: str, label: str, mutation: str) -> None:
+    document = artifact()
+    index = entity_index(document["entities"], REGISTRY[field_name].esp_object_id)
+    document["entities"][index][label] = mutation
+    result = run(document)
+    assert result.grid_parity_ok is False
+    assert result.grid_revision is None
+    assert any(failure.startswith(f"number_grid_mismatch:{field_name}:{label}") for failure in result.failures)
+
+
+def test_absent_runtime_route_blocks_the_capture() -> None:
+    document = artifact()
+    del document["entities"][entity_index(document["entities"], REGISTRY["min_fog_on_s"].cfg_readback_object_id)]
+    result = run(document)
+    assert result.grid_parity_ok is False
+    assert result.grid_revision is None
+    assert any(failure.startswith("readback_route_absent:min_fog_on_s") for failure in result.failures)
+
+
+def test_child_device_route_blocks_the_capture() -> None:
+    """The executor addresses the primary device; a child route is not it."""
+    document = artifact()
+    document["entities"][entity_index(document["entities"], REGISTRY["min_fog_on_s"].esp_object_id)]["device_id"] = 1
+    result = run(document)
+    assert result.grid_revision is None
+    assert any("component_entity_device_mismatch" in failure for failure in result.failures)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# #424 three-layer coherence
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_historical_424_divergence_is_classified_present_and_blocks() -> None:
+    """The recorded device vpd_low 0.56 vs served 0.875 must never converge."""
+    document = artifact()
+    row = next(entry for entry in document["band_layers"] if entry["series"] == "vpd_low")
+    row["control"]["value"] = "0.56"
+    row["observed"]["value"] = "0.56"
+    result = run(document)
+    triple = next(t for t in result.layer_triples if t.field_name == "vpd_low")
+    assert triple.classification == "present"
+    assert triple.coherent is False
+    assert triple.served == "0.875" and triple.control == "0.56" and triple.observed == "0.56"
+    assert result.band_coherence_ok is False
+    assert result.grid_revision is None
+
+
+@pytest.mark.parametrize(
+    ("layer", "key", "value"),
+    [
+        ("observed", "value", None),
+        ("control", "value", None),
+        ("served", "value", None),
+        ("observed", "slug", None),
+        ("observed", "unit", None),
+        ("control", "unit", ""),
+        ("served", "source", None),
+        ("observed", "as_of", None),
+    ],
+)
+def test_a_layer_that_cannot_expose_a_truthful_value_is_unobservable_and_blocks(
+    layer: str, key: str, value: Any
+) -> None:
+    document = artifact()
+    row = next(entry for entry in document["band_layers"] if entry["series"] == "vpd_low")
+    row[layer][key] = value
+    result = run(document)
+    triple = next(t for t in result.layer_triples if t.field_name == "vpd_low")
+    assert triple.classification == "unobservable"
+    assert triple.coherent is False
+    assert result.band_coherence_ok is False
+    assert result.grid_revision is None
+    assert any(failure.startswith("band_layer_unobservable:vpd_low") for failure in result.failures)
+
+
+def test_stale_and_future_readbacks_are_unobservable() -> None:
+    for offset, marker in ((timedelta(hours=6), "stale"), (timedelta(seconds=-30), "future")):
+        document = artifact()
+        row = next(entry for entry in document["band_layers"] if entry["series"] == "temp_low")
+        row["observed"]["as_of"] = cap._timestamp_text(OBSERVED_AT - offset)
+        result = run(document)
+        triple = next(t for t in result.layer_triples if t.field_name == "temp_low")
+        assert triple.classification == "unobservable"
+        assert marker in triple.detail
+        assert result.grid_revision is None
+
+
+def test_unit_incoherence_between_layers_blocks() -> None:
+    document = artifact()
+    row = next(entry for entry in document["band_layers"] if entry["series"] == "vpd_high")
+    row["control"]["unit"] = "hPa"
+    result = run(document)
+    triple = next(t for t in result.layer_triples if t.field_name == "vpd_high")
+    assert triple.classification == "unobservable"
+    assert "unit_incoherent" in triple.detail
+    assert result.grid_revision is None
+
+
+@pytest.mark.parametrize("series", list(cap.REQUIRED_BAND_SERIES))
+def test_every_required_band_series_must_be_present(series: str) -> None:
+    document = artifact()
+    document["band_layers"] = [row for row in document["band_layers"] if row["series"] != series]
+    result = run(document)
+    assert f"missing_band_series:{series}" in result.failures
+    assert result.band_coherence_ok is False
+    assert result.grid_revision is None
+
+
+def test_duplicate_band_series_blocks() -> None:
+    document = artifact()
+    document["band_layers"].append(copy.deepcopy(document["band_layers"][0]))
+    result = run(document)
+    assert any(failure.startswith("duplicate_band_series:") for failure in result.failures)
+    assert result.grid_revision is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Observed 48-field current state
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_off_grid_observed_value_blocks_the_capture() -> None:
+    document = artifact()
+    grid = ENTITY_GRIDS["min_fog_on_s"]
+    off_grid = grid.minimum + grid.step / 2
+    document["observed_components"]["min_fog_on_s"]["value"] = str(off_grid)
+    result = run(document)
+    assert result.observed_state_ok is False
+    assert result.observed_start_state is None
+    assert result.observed_state_content_sha256 is None
+    assert result.grid_revision is None
+    assert any("value_off_entity_grid" in failure for failure in result.failures)
+
+
+def test_out_of_range_observed_value_blocks_the_capture() -> None:
+    document = artifact()
+    document["observed_components"]["mister_water_budget_gal"]["value"] = "310"
+    result = run(document)
+    assert any("value_outside_entity_grid" in failure for failure in result.failures)
+    assert result.grid_revision is None
+
+
+def test_switch_readback_must_be_an_exact_boolean() -> None:
+    document = artifact()
+    document["observed_components"]["sw_dwell_gate_enabled"]["value"] = 1
+    result = run(document)
+    assert any("wrong_value_type" in failure for failure in result.failures)
+    assert result.grid_revision is None
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra", "slug", "stale"])
+def test_observed_component_layer_failures_fail_closed(mutation: str) -> None:
+    document = artifact()
+    if mutation == "missing":
+        del document["observed_components"]["mister_all_kpa"]
+        expected = "observed_component_missing:mister_all_kpa"
+    elif mutation == "extra":
+        document["observed_components"]["not_a_component"] = {
+            "slug": "cfg_not_a_component",
+            "unit": "",
+            "observed_at": LAYER_AS_OF,
+            "value": "1",
+        }
+        expected = "observed_component_unknown:not_a_component"
+    elif mutation == "slug":
+        document["observed_components"]["mister_all_kpa"]["slug"] = "cfg_mister_all_kpa_v2"
+        expected = "observed_component_slug_mismatch:mister_all_kpa"
+    else:
+        document["observed_components"]["mister_all_kpa"]["observed_at"] = cap._timestamp_text(
+            OBSERVED_AT - timedelta(hours=9)
+        )
+        expected = "observed_component:mister_all_kpa_timestamp_stale"
+    result = run(document)
+    assert any(failure.startswith(expected) for failure in result.failures)
+    assert result.observed_state_ok is False
+    assert result.grid_revision is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cross-language state identity (migration 214)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_state_content_hash_reproduces_the_sql_golden_formula() -> None:
+    """Mirror ``fn_experiment_v2_state_content_sha256`` byte for byte.
+
+    db/migrations/214-confirmed-component-experiment-v2.sql:1266-1288 —
+    sha256('verdify-policy-state-content-v1' || 0x00 || schema_u8 ||
+    manifest[32] || vector[178]); the SQL raises unless the vector is exactly
+    178 bytes and the manifest 32.
+    """
+    result = run()
+    normalized = result.observed_start_state
+    assert normalized is not None
+
+    vector = encode_policy_vector(normalized)
+    manifest = wire_manifest_digest()
+    assert len(vector) == 178
+    assert len(manifest) == 32
+    assert 0 <= WIRE_SCHEMA_VERSION <= 255
+    golden = hashlib.sha256(
+        b"verdify-policy-state-content-v1" + bytes([0x00]) + bytes([WIRE_SCHEMA_VERSION]) + manifest + vector
+    ).hexdigest()
+
+    assert result.observed_state_content_sha256 == golden
+    assert result.observed_wire_vector_hex == vector.hex()
+    assert cap.observed_state_content_sha256(normalized) == (golden, vector.hex())
+
+
+def test_state_content_hash_agrees_with_the_shipped_prefix_replay_implementation() -> None:
+    """Bind to the other in-repo Python implementation of the same golden.
+
+    ``scripts/prepare_component_prefix_replay.py::_state_identity`` already
+    reproduces ``fn_experiment_v2_state_content_sha256``; two independent
+    implementations that disagree would mean one of them is wrong.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "prepare_component_prefix_replay", ROOT / "scripts" / "prepare_component_prefix_replay.py"
+    )
+    assert spec and spec.loader
+    prep = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = prep
+    spec.loader.exec_module(prep)
+
+    result = run()
+    assert result.observed_start_state is not None
+    identity = prep._state_identity(result.observed_start_state)
+    assert identity["entity_grid_valid"] is True
+    assert identity["policy_state_content_sha256"] == result.observed_state_content_sha256
+
+
+def test_state_content_hash_changes_with_one_component_value() -> None:
+    document = artifact()
+    grid = ENTITY_GRIDS["min_fog_on_s"]
+    document["observed_components"]["min_fog_on_s"]["value"] = str(grid.minimum + grid.step)
+    assert run(document).observed_state_content_sha256 != run().observed_state_content_sha256
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Revision determinism and stability
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_same_input_yields_the_same_revision_and_result_hash() -> None:
+    first, second = run(), run()
+    assert first.grid_revision == second.grid_revision
+    assert first.observed_state_content_sha256 == second.observed_state_content_sha256
+    payload_a = cap.build_payload(first, [], max_observation_age_s=900, computed_at=OBSERVED_AT)
+    payload_b = cap.build_payload(second, [], max_observation_age_s=900, computed_at=OBSERVED_AT + timedelta(days=3))
+    assert payload_a["result_sha256"] == payload_b["result_sha256"]
+
+
+def test_runtime_enumeration_order_is_not_part_of_the_identity() -> None:
+    document = artifact()
+    document["entities"] = list(reversed(document["entities"]))
+    assert run(document).grid_revision == run().grid_revision
+
+
+def test_firmware_revision_moves_the_receipt_not_the_grid_identity() -> None:
+    document = artifact()
+    document["revisions"]["firmware_revision"] = "2026.8.26.0000.abcdef0"
+    other = run(document)
+    baseline = run()
+    assert other.grid_revision == baseline.grid_revision
+    assert other.observation_receipt_sha256 != baseline.observation_receipt_sha256
+
+
+@pytest.mark.parametrize("mutation", ["device_id", "readback_unit", "disabled_by_default"])
+def test_any_grid_content_change_moves_the_revision(mutation: str) -> None:
+    document = artifact()
+    if mutation == "device_id":
+        document["device_id"] = "vallery/greenhouse-controller-b"
+    elif mutation == "readback_unit":
+        index = entity_index(document["entities"], REGISTRY["min_fog_on_s"].cfg_readback_object_id)
+        document["entities"][index]["unit"] = "s"
+    else:
+        index = entity_index(document["entities"], REGISTRY["min_fog_on_s"].esp_object_id)
+        document["entities"][index]["disabled_by_default"] = True
+    changed = run(document)
+    assert changed.grid_revision is not None
+    assert changed.grid_revision != run().grid_revision
+
+
+def test_derive_grid_revision_requires_every_gate() -> None:
+    result = run()
+    assert cap.derive_grid_revision(result) == result.grid_revision
+    for gate in ("grid_parity_ok", "band_coherence_ok", "observed_state_ok"):
+        assert cap.derive_grid_revision(dataclasses.replace(result, **{gate: False})) is None
+    assert cap.derive_grid_revision(dataclasses.replace(result, grid_content_sha256=None)) is None
+    assert cap.derive_grid_revision(dataclasses.replace(result, grid_content_sha256="not-a-digest")) is None
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda d: d["entities"].pop(0), id="missing_route"),
+        pytest.param(lambda d: d["band_layers"][0]["observed"].__setitem__("value", None), id="unobservable_layer"),
+        pytest.param(
+            lambda d: d["observed_components"]["min_fog_on_s"].__setitem__("value", "16"), id="off_grid_state"
+        ),
+    ],
+)
+def test_no_revision_is_emitted_on_any_failure(mutate: Any) -> None:
+    document = artifact()
+    mutate(document)
+    result = run(document)
+    assert result.grid_revision is None
+    assert result.qualified is False
+    assert result.failures
+    payload = cap.build_payload(
+        result,
+        cap.build_checks(result, expected_grid_revision=None),
+        max_observation_age_s=900,
+        computed_at=OBSERVED_AT,
+    )
+    assert payload["grid_revision"] is None
+    assert payload["qualified"] is False
+    assert "current_state_artifact" not in payload
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Artifact parsing
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        pytest.param(lambda d: d.__setitem__("schema", "other-v1"), "schema", id="bad_schema"),
+        pytest.param(lambda d: d.__setitem__("surprise", 1), "unknown keys", id="unknown_key"),
+        pytest.param(lambda d: d.pop("band_layers"), "missing", id="missing_section"),
+        pytest.param(
+            lambda d: d["revisions"].__setitem__("source_revision", "unknown"), "Git SHA", id="bad_source_revision"
+        ),
+        pytest.param(
+            lambda d: d["runtime"].__setitem__("connection_generation", 0), "connection_generation", id="bad_generation"
+        ),
+        pytest.param(lambda d: d["runtime"].__setitem__("runtime_instance_id", "nope"), "UUID", id="bad_instance_id"),
+        pytest.param(lambda d: d["entities"][0].__setitem__("key", 0), "positive integer", id="bad_key"),
+        pytest.param(lambda d: d["entities"][0].__setitem__("bonus", 1), "unknown keys", id="entity_unknown_key"),
+        pytest.param(lambda d: d.__setitem__("observed_at", "not-a-time"), "RFC-3339", id="bad_observed_at"),
+    ],
+)
+def test_malformed_artifacts_are_refused(mutate: Any, message: str) -> None:
+    document = artifact()
+    mutate(document)
+    with pytest.raises(cap.GridCaptureError, match=message):
+        cap.parse_input_artifact(document)
+
+
+def test_duplicate_json_keys_are_refused() -> None:
+    with pytest.raises(cap.GridCaptureError, match="duplicate JSON field"):
+        json.loads('{"schema": "a", "schema": "b"}', object_pairs_hook=cap._unique_object)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_cli_passes_and_publishes_a_private_result(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    input_path = tmp_path / "capture-input.json"
+    input_path.write_text(json.dumps(artifact()))
+    output_path = tmp_path / "capture-result.json"
+
+    code = cap.main(["--input", str(input_path), "--json", str(output_path)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "PASS — grid_parity" in out
+    assert "PASS — band_coherence_424" in out
+    assert "WARN — source_grid_revision_adoption" in out  # the source constant is still the placeholder
+    assert "grid_revision=live-entity-grid-v1:sha256:" in out
+    assert "0 fail" in out
+
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
+    payload = json.loads(output_path.read_text())
+    assert payload["schema"] == cap.RESULT_SCHEMA
+    assert payload["qualified"] is True
+    assert payload["grid_revision"] == run().grid_revision
+    assert payload["current_state_artifact"]["schema"] == cap.CURRENT_STATE_SCHEMA
+    assert set(payload["current_state_artifact"]["values"]) == set(CANONICAL_FIELD_ORDER)
+    assert payload["result_sha256"] == cap.result_sha256(payload)
+    assert payload["source_grid_revision_qualified"] is False
+
+    with pytest.raises(SystemExit) as exit_info:
+        cap.main(["--input", str(input_path), "--json", str(output_path)])
+    assert exit_info.value.code == 2
+
+
+def test_cli_fails_closed_and_emits_no_revision(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    document = artifact()
+    document["band_layers"][0]["observed"]["value"] = None
+    input_path = tmp_path / "blocked-input.json"
+    input_path.write_text(json.dumps(document))
+
+    code = cap.main(["--input", str(input_path)])
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "FAIL — band_coherence_424" in out
+    assert "grid_revision=NONE" in out
+
+
+def test_cli_expected_revision_mismatch_fails(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    input_path = tmp_path / "capture-input.json"
+    input_path.write_text(json.dumps(artifact()))
+    code = cap.main(["--input", str(input_path), "--expect-grid-revision", "live-entity-grid-v1:sha256:" + "0" * 64])
+    assert code == 1
+    assert "FAIL — grid_revision" in capsys.readouterr().out
+
+
+def test_cli_refuses_a_missing_or_malformed_artifact(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        cap.main(["--input", str(tmp_path / "absent.json")])
+    assert exit_info.value.code == 2
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not json")
+    with pytest.raises(SystemExit) as exit_info:
+        cap.main(["--input", str(malformed)])
+    assert exit_info.value.code == 2

--- a/tests/test_component_prefix_replay.py
+++ b/tests/test_component_prefix_replay.py
@@ -1,0 +1,642 @@
+"""Offline compiled-prefix replay is exhaustive, order-locked and fail-closed.
+
+Every test here exercises the pure-logic core of
+``scripts/component_prefix_replay.py``: no compiler, no corpus, no device, no
+database.  The compiled interlock harness is stubbed so the qualification
+arithmetic (including the ORDER_REVISION derivation) can be proven without a
+firmware toolchain; ``test_default_compiled_probe_cannot_certify_the_full_grid``
+pins the real coverage arithmetic instead.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from verdify_schemas.component_executor import (
+    ACTIVATION_ORDER,
+    CANONICAL_FIELD_ORDER,
+    COMMON_FIELDS,
+    RECOVERY_ORDER,
+    ROLLBACK_ORDER,
+    TREATMENT_FIELD_ORDER,
+    ComponentContractError,
+    normalize_complete_state,
+)
+from verdify_schemas.tunable_registry import REGISTRY
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "component_prefix_replay.py"
+SPEC = importlib.util.spec_from_file_location("component_prefix_replay", SCRIPT)
+assert SPEC and SPEC.loader
+tool = importlib.util.module_from_spec(SPEC)
+# Register before exec: the module defines dataclasses, and @dataclass resolves
+# annotations through sys.modules[cls.__module__].
+sys.modules[SPEC.name] = tool
+SPEC.loader.exec_module(tool)
+
+BASELINE_SPEC = importlib.util.spec_from_file_location(
+    "planner_efficacy_baseline", ROOT / "research/planner-efficacy/baseline/baseline.py"
+)
+assert BASELINE_SPEC and BASELINE_SPEC.loader
+baseline_mod = importlib.util.module_from_spec(BASELINE_SPEC)
+sys.modules[BASELINE_SPEC.name] = baseline_mod
+BASELINE_SPEC.loader.exec_module(baseline_mod)
+
+COMPILED_DEFAULT_FIXTURE = (
+    ROOT / "tests/fixtures/component_prefix_replay/esphome-2026.6.5-compiled-default-constructors.cpp"
+)
+CONSUMER_MANIFEST = ROOT / "firmware/policy_consumer_manifest.json"
+
+# Expected prefix counts for the committed switchback-v2 profiles: N differing
+# treatment components produce N+1 prefixes (lengths 0..N); a full-48 recovery
+# bundle is unconditional and therefore always 49.
+EXPECTED_TREATMENT_PREFIXES = {
+    "activation/baseline-to-moderate": 7,
+    "rollback/moderate-to-baseline": 7,
+    "activation/baseline-to-aggressive": 9,
+    "rollback/aggressive-to-baseline": 9,
+}
+RECOVERY_PREFIXES = 49
+
+
+# ── fixtures / doubles ───────────────────────────────────────────────────────
+
+
+class StubInterlock(tool.InterlockProbe):
+    """Full-coverage safety probe double — the only way to reach an all-pass run."""
+
+    name = "stub-full-coverage"
+
+    def __init__(self, *, verdict: str = tool.SAFE, unsafe_cases: frozenset[str] = frozenset()) -> None:
+        self.covered_fields = frozenset(CANONICAL_FIELD_ORDER)
+        self._verdict = verdict
+        self._unsafe_cases = unsafe_cases
+        self.seen: list[str] = []
+
+    def verdict(self, case: tool.PrefixCase) -> tool.InterlockOutcome:
+        self.seen.append(case.case_id)
+        if case.case_id in self._unsafe_cases:
+            return tool.InterlockOutcome(tool.UNSAFE, "stubbed breach")
+        return tool.InterlockOutcome(self._verdict, "stub")
+
+
+@pytest.fixture(scope="module")
+def profiles() -> dict[str, dict[str, float | bool]]:
+    return tool.load_profiles(tool.DEFAULT_PROFILES)
+
+
+@pytest.fixture(scope="module")
+def compiled_defaults() -> dict[str, float | bool]:
+    return tool.load_compiled_defaults(COMPILED_DEFAULT_FIXTURE, CONSUMER_MANIFEST)
+
+
+def treatment_edges(profiles: dict[str, dict[str, float | bool]]) -> list[tool.ReplayEdge]:
+    return [edge for edge in tool.build_edges(profiles, {}) if edge.kind != "recovery"]
+
+
+def passing_result(profiles: dict[str, dict[str, float | bool]], **kwargs) -> tool.ReplayResult:
+    return tool.replay(treatment_edges(profiles), interlock=StubInterlock(**kwargs))
+
+
+# ── enumeration ──────────────────────────────────────────────────────────────
+
+
+def test_every_permitted_edge_enumerates_the_expected_prefix_count(profiles) -> None:
+    for edge in treatment_edges(profiles):
+        cases = tool.enumerate_prefixes(
+            edge.start_state,
+            edge.target_state,
+            order=edge.order,
+            order_name=edge.order_name,
+            edge=edge.edge,
+        )
+        assert len(cases) == EXPECTED_TREATMENT_PREFIXES[edge.edge]
+        assert [c.index for c in cases] == list(range(len(cases)))
+        assert cases[0].applied_fields == ()
+        assert cases[-1].pending_fields == ()
+        # Case ids are spelled exactly as scripts/prepare_component_prefix_replay.py
+        # spells them so the preparation packet and these verdicts join.
+        assert cases[3].case_id == f"{edge.edge}/prefix-03"
+
+
+def test_recovery_edge_is_the_unconditional_full_48_bundle(profiles, compiled_defaults) -> None:
+    cases = tool.enumerate_prefixes(
+        compiled_defaults,
+        profiles["baseline"],
+        order=RECOVERY_ORDER,
+        order_name="recovery",
+        edge="recovery/compiled-defaults-to-baseline",
+        complete_bundle=True,
+    )
+    assert len(cases) == RECOVERY_PREFIXES
+    # Unconditional: every one of the 48 components is commanded even where the
+    # start already matches the target.
+    assert cases[-1].applied_fields == CANONICAL_FIELD_ORDER
+    already_equal = [f for f in CANONICAL_FIELD_ORDER if compiled_defaults[f] == profiles["baseline"][f]]
+    assert already_equal, "fixture must contain at least one already-correct component"
+    assert set(already_equal) <= set(cases[-1].applied_fields)
+
+
+def test_every_prefix_carries_the_complete_48_field_state(profiles) -> None:
+    for edge in treatment_edges(profiles):
+        cases = tool.enumerate_prefixes(
+            edge.start_state, edge.target_state, order=edge.order, order_name=edge.order_name, edge=edge.edge
+        )
+        for case in cases:
+            assert set(case.device_state) == set(CANONICAL_FIELD_ORDER)
+            assert len(case.device_state) == 48
+            # Untouched components keep the START value, not the target's.
+            for name in COMMON_FIELDS:
+                assert case.device_state[name] == edge.start_state[name]
+            for name in case.pending_fields:
+                assert case.device_state[name] == edge.start_state[name]
+            for name in case.applied_fields:
+                assert case.device_state[name] == edge.target_state[name]
+
+
+def test_prefix_states_are_snapshots_not_aliases(profiles) -> None:
+    edge = treatment_edges(profiles)[0]
+    cases = tool.enumerate_prefixes(
+        edge.start_state, edge.target_state, order=edge.order, order_name=edge.order_name, edge=edge.edge
+    )
+    cases[0].device_state["fog_escalation_kpa"] = -1.0
+    assert cases[-1].device_state["fog_escalation_kpa"] == edge.target_state["fog_escalation_kpa"]
+
+
+# ── order enforcement ────────────────────────────────────────────────────────
+
+
+def test_source_order_constants_are_the_ones_this_tool_qualifies() -> None:
+    assert ACTIVATION_ORDER == TREATMENT_FIELD_ORDER
+    assert ROLLBACK_ORDER == TREATMENT_FIELD_ORDER
+    assert RECOVERY_ORDER == CANONICAL_FIELD_ORDER
+    assert tool.SOURCE_ORDERS == {
+        "activation": ACTIVATION_ORDER,
+        "recovery": RECOVERY_ORDER,
+        "rollback": ROLLBACK_ORDER,
+    }
+
+
+def test_permuted_order_fails_closed_and_emits_no_revision(profiles) -> None:
+    edge = treatment_edges(profiles)[0]
+    permuted = replace(edge, order=tuple(reversed(ACTIVATION_ORDER)))
+    result = tool.replay([permuted], interlock=StubInterlock())
+    assert result.fixed_order_ok is False
+    assert result.all_pass is False
+    assert result.order_revision is None
+    assert any("is not the source" in f for f in result.failures)
+
+
+def test_recovery_order_must_be_the_full_canonical_order(profiles, compiled_defaults) -> None:
+    with pytest.raises(ComponentContractError) as excinfo:
+        tool.enumerate_prefixes(
+            compiled_defaults,
+            profiles["baseline"],
+            order=TREATMENT_FIELD_ORDER,
+            order_name="recovery",
+            edge="recovery/bad-order",
+            complete_bundle=True,
+        )
+    assert excinfo.value.code == "recovery_order_not_full_canonical"
+
+
+def test_duplicate_order_entries_are_refused(profiles) -> None:
+    with pytest.raises(ComponentContractError) as excinfo:
+        tool.enumerate_prefixes(
+            profiles["baseline"],
+            profiles["moderate"],
+            order=ACTIVATION_ORDER + ACTIVATION_ORDER[:1],
+            order_name="activation",
+            edge="activation/duplicated",
+        )
+    assert excinfo.value.code == "invalid_component_order"
+
+
+# ── grid / clamp failure modes ───────────────────────────────────────────────
+
+
+def test_off_grid_prefix_value_fails_closed(profiles) -> None:
+    off_grid = dict(profiles["baseline"])
+    # mister_engage_delay_s has a 30 s entity step from a 30 s origin, so 45 is
+    # inside every clamp yet not a grid point.
+    off_grid["mister_engage_delay_s"] = 45.0
+    edge = replace(
+        tool.build_edges(profiles, {"drifted": off_grid})[-1],
+        edge="recovery/drifted-to-baseline",
+    )
+    result = tool.replay([edge], interlock=StubInterlock())
+    assert result.all_pass is False
+    assert result.order_revision is None
+    grid_failures = [v for v in result.verdicts if not v.grid_ok]
+    assert grid_failures, "an off-grid start must produce grid-invalid prefixes"
+    assert all("value_off_entity_grid" in v.detail for v in grid_failures)
+    # The prefix that finally repairs the offending component must recover.
+    assert result.verdicts[-1].grid_ok is True
+
+
+def test_off_grid_detail_separates_inherited_from_commanded(profiles) -> None:
+    off_grid = dict(profiles["baseline"])
+    off_grid["mister_engage_delay_s"] = 45.0
+    edge = tool.build_edges(profiles, {"drifted": off_grid})[-1]
+    result = tool.replay([edge], interlock=StubInterlock())
+    first = next(v for v in result.verdicts if not v.grid_ok)
+    assert "inherited from the start state" in first.detail
+    assert "COMMANDED BY THE SETTER LIST" not in first.detail
+
+
+def test_committed_compiled_default_fixture_is_not_entity_grid_clean(compiled_defaults) -> None:
+    """Regression pin on the real finding this tool exists to surface.
+
+    The tracked ESPHome constructor fixture boots ``mister_engage_delay_s`` at
+    45 s, which is inside every clamp but off the 30 s entity step.  Recovery
+    prefixes therefore carry an off-grid component until the recovery command
+    reaches that exact field, and the run must NOT be able to qualify.
+    """
+    with pytest.raises(ComponentContractError) as excinfo:
+        normalize_complete_state(compiled_defaults)
+    assert excinfo.value.code == "value_off_entity_grid"
+    assert "mister_engage_delay_s" in excinfo.value.detail
+
+    index = CANONICAL_FIELD_ORDER.index("mister_engage_delay_s")
+    profiles_ = tool.load_profiles(tool.DEFAULT_PROFILES)
+    edge = tool.build_edges(profiles_, {"compiled-defaults": compiled_defaults})[-1]
+    result = tool.replay([edge], interlock=StubInterlock())
+    assert result.counts()["grid_fail"] == index + 1
+    assert all(v.grid_ok for v in result.verdicts[index + 1 :])
+    assert result.order_revision is None
+
+
+def test_registry_clamp_violation_fails_closed_even_when_grid_valid(profiles) -> None:
+    # band_track_fraction is the one component whose registry contract (pinned
+    # to 0 by ADR-0004) is tighter than both its firmware clamp and its entity
+    # grid, so 0.05 is grid-legal and firmware-legal but registry-illegal.
+    definition = REGISTRY["band_track_fraction"]
+    assert (definition.min, definition.max) == (0.0, 0.0)
+    assert (definition.fw_clamp_lo, definition.fw_clamp_hi) == (0.0, 1.0)
+    assert tool.registry_clamp_ok("band_track_fraction", 0.05) is False
+    assert tool.firmware_clamp_ok("band_track_fraction", 0.05) is True
+
+    drifted = dict(profiles["baseline"])
+    drifted["band_track_fraction"] = 0.05
+    normalize_complete_state(drifted)  # grid-valid by construction
+    edge = tool.build_edges(profiles, {"pinch-drift": drifted})[-1]
+    result = tool.replay([edge], interlock=StubInterlock())
+    assert result.all_pass is False
+    assert result.order_revision is None
+    clamp_failures = [v for v in result.verdicts if not v.registry_clamp_ok]
+    assert clamp_failures
+    assert all(v.grid_ok for v in clamp_failures), "this failure must be clamp-only, not a grid artefact"
+    assert all("registry clamp" in v.detail for v in clamp_failures)
+
+
+def test_firmware_clamp_violation_is_detected() -> None:
+    assert tool.firmware_clamp_ok("temp_hysteresis", 10.0) is False
+    assert tool.registry_clamp_ok("temp_hysteresis", 10.0) is False
+    assert tool.firmware_clamp_ok("temp_hysteresis", 1.0) is True
+
+
+def test_clamp_split_is_exactly_the_baseline_bounds_gate() -> None:
+    """Drift gate: the two halves must still conjoin to baseline.py::_bounds_ok."""
+    for name in CANONICAL_FIELD_ORDER:
+        definition = REGISTRY[name]
+        if definition.wire_kind == "bool":
+            candidates: list[float | bool] = [True, False]
+        else:
+            lo = definition.fw_clamp_lo if definition.fw_clamp_lo is not None else 0.0
+            hi = definition.fw_clamp_hi if definition.fw_clamp_hi is not None else 1.0
+            candidates = [lo, hi, lo - 1.0, hi + 1.0, (lo + hi) / 2.0]
+        for value in candidates:
+            expected = baseline_mod._bounds_ok(definition, value)
+            actual = tool.registry_clamp_ok(name, value) and tool.firmware_clamp_ok(name, value)
+            assert actual == expected, f"{name}={value!r}"
+
+
+# ── landing / idempotency ────────────────────────────────────────────────────
+
+
+def test_every_edge_lands_exactly_on_the_normalized_target(profiles) -> None:
+    result = passing_result(profiles)
+    assert result.lands_exact_ok is True
+    for edge in treatment_edges(profiles):
+        cases = tool.enumerate_prefixes(
+            edge.start_state, edge.target_state, order=edge.order, order_name=edge.order_name, edge=edge.edge
+        )
+        assert cases[-1].device_state == normalize_complete_state(edge.target_state)
+
+
+def test_treatment_edge_whose_start_drifted_on_a_common_field_does_not_land(profiles) -> None:
+    drifted = dict(profiles["baseline"])
+    # A common (non-treatment) component moved to another legal grid point: the
+    # treatment setter list cannot repair it, so the edge cannot land.
+    assert "vent_exchange_fraction" in COMMON_FIELDS
+    drifted["vent_exchange_fraction"] = 0.35 if profiles["baseline"]["vent_exchange_fraction"] != 0.35 else 0.4
+    normalize_complete_state(drifted)
+    edge = tool.ReplayEdge(
+        edge="activation/drifted-to-moderate",
+        kind="activation",
+        order_name="activation",
+        order=ACTIVATION_ORDER,
+        start_label="drifted",
+        target_label="moderate",
+        start_state=drifted,
+        target_state=dict(profiles["moderate"]),
+        complete_bundle=False,
+    )
+    result = tool.replay([edge], interlock=StubInterlock())
+    assert result.lands_exact_ok is False
+    assert result.all_pass is False
+    assert result.order_revision is None
+    assert any("not the normalized target" in f for f in result.failures)
+
+
+def test_idempotency_holds_for_every_permitted_edge(profiles) -> None:
+    result = passing_result(profiles)
+    assert result.idempotent_ok is True
+
+
+def test_a_lost_confirmation_breaks_idempotency_and_is_reported(profiles) -> None:
+    edge = treatment_edges(profiles)[0]
+    cases = tool.enumerate_prefixes(
+        edge.start_state, edge.target_state, order=edge.order, order_name=edge.order_name, edge=edge.edge
+    )
+    # Simulate a case that CLAIMS a component was confirmed while the device
+    # state still shows the start value — the exact hazard the check exists for.
+    lying = replace(cases[1], device_state=dict(edge.start_state))
+    failures: list[str] = []
+    assert tool._check_idempotency(edge, [lying], failures) is False
+    assert any("re-issued" in f for f in failures)
+
+
+# ── interlock ────────────────────────────────────────────────────────────────
+
+
+def test_missing_interlock_probe_is_unproven_not_pass(profiles) -> None:
+    result = tool.replay(treatment_edges(profiles), interlock=None)
+    assert result.all_pass is False
+    assert result.order_revision is None
+    assert {v.interlock_safe for v in result.verdicts} == {tool.UNPROVEN}
+    assert all(v.ok is False for v in result.verdicts)
+
+
+def test_unproven_interlock_blocks_even_when_everything_else_passes(profiles) -> None:
+    result = tool.replay(treatment_edges(profiles), interlock=StubInterlock(verdict=tool.UNPROVEN))
+    assert result.fixed_order_ok and result.idempotent_ok and result.lands_exact_ok
+    assert all(v.grid_ok and v.registry_clamp_ok and v.firmware_clamp_ok for v in result.verdicts)
+    assert result.all_pass is False
+    assert result.order_revision is None
+
+
+def test_a_single_unsafe_prefix_fails_the_whole_run(profiles) -> None:
+    edges = treatment_edges(profiles)
+    result = tool.replay(edges, interlock=StubInterlock(unsafe_cases=frozenset({f"{edges[0].edge}/prefix-02"})))
+    assert result.all_pass is False
+    assert result.order_revision is None
+    assert result.counts()["interlock_unsafe"] == 1
+
+
+def test_default_compiled_probe_cannot_certify_the_full_grid() -> None:
+    """The shipped harness is corpus-fed: it can falsify, it cannot certify."""
+    source = tool.INVARIANTS_SOURCE.read_text(encoding="utf-8")
+    # Coverage is derived from the harness source ∩ the corpus header, so use
+    # the union of every sp_* column the harness could possibly read.
+    columns = [f"sp_{name}" for name in CANONICAL_FIELD_ORDER] + [
+        "sp_temp_low",
+        "sp_temp_high",
+        "sp_vpd_low",
+        "sp_vpd_high",
+        "sp_watch_dwell_s",
+    ]
+    coverage = tool.harness_injection_coverage(source, columns)
+    assert set(coverage) < set(CANONICAL_FIELD_ORDER), "coverage must be a strict subset today"
+    assert "fog_escalation_kpa" in coverage
+    assert set(TREATMENT_FIELD_ORDER) - set(coverage), "most treatment components are not injectable"
+
+
+def test_harness_coverage_ignores_columns_the_corpus_does_not_carry() -> None:
+    source = 'assign_positive_float("sp_fog_escalation_kpa", sp.fog_escalation_kpa);'
+    assert tool.harness_injection_coverage(source, []) == {}
+    assert tool.harness_injection_coverage(source, ["sp_fog_escalation_kpa"]) == {
+        "fog_escalation_kpa": "sp_fog_escalation_kpa"
+    }
+
+
+def test_unproven_probe_never_reports_safe() -> None:
+    probe = tool.UnprovenInterlock("no toolchain")
+    case = tool.PrefixCase(
+        edge="e", order_name="activation", index=0, device_state={}, applied_fields=(), pending_fields=()
+    )
+    assert probe.verdict(case).verdict == tool.UNPROVEN
+    assert probe.describe()["full_coverage"] is False
+
+
+def test_external_harness_safe_claim_without_full_coverage_is_downgraded(tmp_path) -> None:
+    script = tmp_path / "harness.py"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "req = json.load(sys.stdin)\n"
+        "print(json.dumps({'schema': 'verdify-component-prefix-interlock-verdict-v1',\n"
+        "                  'case_id': req['case_id'], 'verdict': 'safe',\n"
+        "                  'covered_fields': ['fog_escalation_kpa'], 'detail': 'partial'}))\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    probe = tool.ExternalHarnessInterlock(script)
+    case = tool.PrefixCase(
+        edge="e", order_name="activation", index=0, device_state={}, applied_fields=(), pending_fields=()
+    )
+    outcome = probe.verdict(case)
+    assert outcome.verdict == tool.UNPROVEN
+    assert "without declaring all 48" in outcome.detail
+
+
+def test_external_harness_answering_the_wrong_case_is_downgraded(tmp_path) -> None:
+    script = tmp_path / "harness.py"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "json.load(sys.stdin)\n"
+        "print(json.dumps({'schema': 'verdify-component-prefix-interlock-verdict-v1',\n"
+        "                  'case_id': 'someone-elses-case', 'verdict': 'safe',\n"
+        f"                  'covered_fields': {json.dumps(list(CANONICAL_FIELD_ORDER))}}}))\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    probe = tool.ExternalHarnessInterlock(script)
+    case = tool.PrefixCase(
+        edge="e", order_name="activation", index=0, device_state={}, applied_fields=(), pending_fields=()
+    )
+    assert probe.verdict(case).verdict == tool.UNPROVEN
+
+
+# ── ORDER_REVISION derivation ────────────────────────────────────────────────
+
+
+def test_all_pass_run_emits_a_revision_the_executor_regex_accepts(profiles) -> None:
+    result = passing_result(profiles)
+    assert result.all_pass is True
+    assert result.failures == []
+    assert result.order_revision is not None
+    assert tool._QUALIFIED_ORDER_REVISION.fullmatch(result.order_revision)
+    assert result.order_revision.startswith("prefix-replay-v1:sha256:")
+
+
+def test_revision_hash_is_deterministic_across_independent_runs(profiles) -> None:
+    first = passing_result(profiles)
+    second = passing_result(profiles)
+    assert first.order_revision == second.order_revision
+
+
+def test_revision_digest_excludes_wall_clock_and_free_text(profiles) -> None:
+    result = passing_result(profiles)
+    payload = tool.revision_digest_payload(result)
+    assert set(payload) == {"edges", "orders", "verdicts"}
+    assert payload["orders"] == {
+        "activation": list(ACTIVATION_ORDER),
+        "recovery": list(RECOVERY_ORDER),
+        "rollback": list(ROLLBACK_ORDER),
+    }
+    for row in payload["verdicts"]:
+        assert set(row) == {
+            "edge",
+            "firmware_clamp_ok",
+            "grid_ok",
+            "index",
+            "interlock_safe",
+            "ok",
+            "order_name",
+            "registry_clamp_ok",
+        }
+    serialized = tool.canonical_json(payload)
+    assert "detail" not in serialized
+    assert "computed_at" not in serialized
+    assert "result_sha256" not in serialized
+    # No ISO-8601 instant may leak into evidence that must re-derive identically.
+    assert not re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", serialized)
+
+
+def test_any_verdict_change_changes_the_revision(profiles) -> None:
+    result = passing_result(profiles)
+    mutated = tool.ReplayResult(
+        all_pass=True,
+        fixed_order_ok=True,
+        idempotent_ok=True,
+        lands_exact_ok=True,
+        verdicts=[replace(result.verdicts[0], grid_ok=False), *result.verdicts[1:]],
+        order_revision=None,
+        failures=[],
+        edges=result.edges,
+    )
+    assert tool.derive_order_revision(mutated) != result.order_revision
+
+
+def test_a_different_edge_set_changes_the_revision(profiles) -> None:
+    treatment_only = passing_result(profiles)
+    with_recovery = tool.replay(
+        tool.build_edges(profiles, {"observed": dict(profiles["baseline"])}), interlock=StubInterlock()
+    )
+    assert with_recovery.all_pass is True
+    assert with_recovery.order_revision != treatment_only.order_revision
+
+
+def test_revision_is_never_derived_from_a_failing_result(profiles) -> None:
+    failing = tool.replay(treatment_edges(profiles), interlock=StubInterlock(verdict=tool.UNPROVEN))
+    assert failing.order_revision is None
+    with pytest.raises(tool.PrefixReplayError):
+        tool.derive_order_revision(failing)
+
+
+def test_empty_edge_set_cannot_qualify_anything() -> None:
+    result = tool.replay([], interlock=StubInterlock())
+    assert result.all_pass is False
+    assert result.order_revision is None
+    assert any("empty qualification" in f for f in result.failures)
+
+
+# ── reporting ────────────────────────────────────────────────────────────────
+
+
+def test_distinct_failures_collapses_per_case_repetition() -> None:
+    grouped = tool.distinct_failures(
+        [
+            "recovery/x-to-baseline/prefix-00: grid value_off_entity_grid: mister_engage_delay_s=45.0",
+            "recovery/x-to-baseline/prefix-01: grid value_off_entity_grid: mister_engage_delay_s=45.0",
+            "activation/a-to-b/prefix-00: interlock unproven: no harness",
+        ]
+    )
+    assert len(grouped) == 2
+    counts = sorted(count for count, _ in grouped.values())
+    assert counts == [1, 2]
+    assert all(exemplar.startswith(("recovery/", "activation/")) for _, exemplar in grouped.values())
+
+
+# ── loading / CLI plumbing ───────────────────────────────────────────────────
+
+
+def test_profiles_decode_from_the_committed_wire_bytes(profiles) -> None:
+    assert set(profiles) == {"baseline", "moderate", "aggressive"}
+    for values in profiles.values():
+        assert set(values) == set(CANONICAL_FIELD_ORDER)
+        assert values == normalize_complete_state(values)
+
+
+def test_start_state_accepts_both_the_bare_and_wrapped_artifact(tmp_path, profiles) -> None:
+    bare = tmp_path / "bare.json"
+    bare.write_text(json.dumps(profiles["baseline"]), encoding="utf-8")
+    assert tool.load_start_state(bare, "bare") == profiles["baseline"]
+
+    wrapped = tmp_path / "wrapped.json"
+    wrapped.write_text(
+        json.dumps(
+            {
+                "device_id": "esp32-vallery",
+                "firmware_revision": "2026.8.26.0000.abcdef0",
+                "grid_revision": "live-entity-grid-v1:sha256:" + "a" * 64,
+                "observed_at": "2026-08-26T01:00:00.000000Z",
+                "schema": "verdify-component-current-state-v1",
+                "values": profiles["baseline"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert tool.load_start_state(wrapped, "wrapped") == profiles["baseline"]
+
+
+def test_start_state_refuses_an_incomplete_snapshot(tmp_path, profiles) -> None:
+    partial = dict(profiles["baseline"])
+    partial.pop("fog_escalation_kpa")
+    path = tmp_path / "partial.json"
+    path.write_text(json.dumps(partial), encoding="utf-8")
+    with pytest.raises(tool.PrefixReplayError):
+        tool.load_start_state(path, "partial")
+
+
+def test_cli_replay_without_a_toolchain_exits_nonzero_and_prints_no_revision(capsys, profiles) -> None:
+    exit_code = tool.main(["replay", "--interlock", "none"])
+    captured = capsys.readouterr().out
+    assert exit_code == 1
+    assert "order_revision=NOT EMITTED" in captured
+    assert "prefix-replay-v1:sha256:" not in captured
+    assert "OVERALL FAIL" in captured
+    assert "SUMMARY:" in captured
+
+
+def test_cli_json_payload_carries_a_reproducible_result_hash(tmp_path, capsys) -> None:
+    out = tmp_path / "verdict.json"
+    tool.main(["replay", "--interlock", "none", "--json", str(out)])
+    capsys.readouterr()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema"] == tool.SCHEMA_VERSION
+    assert payload["order_revision"] is None
+    assert payload["all_pass"] is False
+    assert payload["result_sha256"] == tool.result_sha256(payload)
+    # The hash must ignore the wall clock.
+    shifted = {**payload, "computed_at": "1999-01-01T00:00:00+00:00"}
+    assert tool.result_sha256(shifted) == payload["result_sha256"]


### PR DESCRIPTION
## Why

`physical_execution_qualified()` (`verdify_schemas/component_executor.py:58-70`) gates **every experiment-owned device write** on `GRID_REVISION` and `ORDER_REVISION`. Both are deliberate unqualified placeholders today (`:34-35`), and **nothing in the repo could produce them** — ADR-0010 mandates a current-state capture and a compiled prefix replay, and neither existed. This adds those two tools.

Both are **fully offline and non-actuating**: no device, no network, no DB writes, no secrets. Both **fail closed** — no revision on any failure. Flipping the two constants stays a separate reviewed change that must ship with its evidence artifacts.

## `scripts/component_grid_capture.py` — Tool A

Proves the live 48-entity grid is byte-parity with source `ENTITY_GRIDS`, captures the #424 served/control/observed three-layer coherence, and captures the 48-field observed start state. It consumes a documented input artifact (`verdify-component-grid-capture-input-v1`) so the device-touching read stays a thin, separately #641-gated emitter.

**Load-bearing design note:** it reuses `component_qualification.build_live_entity_grid_evidence` instead of hashing the grid a second time. The runtime compares the *ingestor's attested* revision to `GRID_REVISION`, and that attestation **deliberately excludes firmware** (`component_qualification.py:329-339`; `test_component_grid_qualification.py:103-113` asserts two firmware revisions give the *same* grid revision). A second preimage folding firmware/config/registry in would emit a string the runtime can never reproduce — **permanently wedging the gate**. A test locks the tool to the shipped attestation string.

## `scripts/component_prefix_replay.py` — Tool B

Enumerates every intermediate device state of every permitted transition in its fixed order and adjudicates each on grid validity, fixed order, registry+firmware clamps, interlock safety, idempotency and lands-exact.

| edge | order | setters | prefixes |
|---|---|---|---|
| baseline↔moderate | treatment | 6 | 7 each |
| baseline↔aggressive | treatment | 8 | 9 each |
| `<start>`→baseline recovery | canonical 48 | 48 (unconditional) | 49 each |

**81 cases** with one recovery start.

`interlock_safe` is **tri-state** (`safe`/`unsafe`/`unproven`), not a bool: the tracked compiled harness is corpus-fed and can impose only **3 of 48** components — *10 of the 11 treatment fields are not injectable at all*. A 3/48 run can falsify a prefix but cannot certify one, so it reports `unproven` and **refuses the revision** rather than passing silently. Coverage is derived from the harness source ∩ corpus header, so it auto-credits future `sp_*` columns; `--interlock external` accepts a full-coverage/HIL runner.

## Two findings that need decisions (NOT resolved here)

1. **Off-grid compiled default.** The tracked fixture boots `mister_engage_delay_s = 45.0` — inside every clamp but **off the entity grid** (step 30 from origin 30). At canonical index 26, recovery prefixes 00–26 are grid-invalid and idempotency is undecidable for them. Implemented strictly per contract; the verdict distinguishes *inherited from start state* vs *commanded by the setter list*. If inherited off-grid values should be tolerated until repaired, that is a contract change.
2. **`temp_target` / `vpd_target` have no `cfg_*` readback route** (migration 182 makes them computed publishes). Absent a truthful control-layer value they classify `unobservable` and block.

Also worth propagating: three switch fields (`direct_wet_gate_enabled`, `fog_closes_vent`, `mister_closes_vent`) publish setter and cfg readback under the **same slug**, distinguished only by entity type — routes must be keyed by `(entity_type, object_id)`.

## Remaining work before these can qualify anything

- The per-prefix admissibility of the **45 uncovered components** needs either a full-48 injection surface in `replay_emit`/`replay_invariants` or an external HIL runner behind `--interlock external`.
- Tool A's live read needs the #641-gated `commissioning_probe` plus a ~10-line read-only ingestor accessor (described in the tool, not applied here): `min/max/step` are already retained at `ingestor/ingestor.py:1611-1640`; the staged inventory is simply module-private with no accessor.

## Verification

- **109 tests pass** (70 grid-capture + 39 prefix-replay); neighbouring component/qualification suites re-run green; `ruff check` + `ruff format --check` clean.
- Both suites wired into the `.agent-fleet/ci.yaml` `platform-tests` allowlist and `scripts/ci-local.sh` — otherwise they would never run (real CI uses an explicit allowlist).
- The grid-capture suite is placed under `tests/`, not `scripts/tests/`, which `pyproject` `testpaths` never collects; its root resolution was corrected for the move.

Refs #641 #642 #588 #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)