### PR TITLE
feat(m8): converge safe-off proof and lock day-one design

### DIFF
--- a/db/migrations/238-experiment-v2-separate-day1-authorization.sql
+++ b/db/migrations/238-experiment-v2-separate-day1-authorization.sql
@@ -1,0 +1,305 @@
+-- 238-experiment-v2-separate-day1-authorization.sql
+--
+-- Keep the one internal, insert-once OS-CSPRNG finalization introduced by
+-- migration 214, but restore the independent #642 authorization boundary.
+-- Migration 224 finalized the design and manufactured randomized_day_1
+-- approval in the same scheduler transaction.  That made the approval an
+-- implementation side effect instead of a distinct audited operator command.
+--
+-- This forward correction deliberately leaves finalized blinded assignments
+-- untouched.  The replacement public scheduler entrypoint can finalize once,
+-- then returns a treatment-free awaiting state until the authenticated API has
+-- recorded the separate approval.  Additional insert guards prevent a
+-- selector context, selector choice, or randomized work row from bypassing the
+-- gate even if a narrower internal function is invoked directly.
+
+ALTER FUNCTION public.fn_experiment_v2_direct_launch_cycle(uuid,text)
+    RENAME TO fn_experiment_v2_direct_launch_cycle_pre238;
+
+REVOKE ALL PRIVILEGES ON FUNCTION
+    public.fn_experiment_v2_direct_launch_cycle_pre238(uuid,text)
+    FROM PUBLIC CASCADE;
+REVOKE ALL PRIVILEGES ON FUNCTION
+    public.fn_experiment_v2_direct_launch_cycle_pre238(uuid,text)
+    FROM verdify_experiment_shadow_scheduler CASCADE;
+
+CREATE OR REPLACE FUNCTION public.fn_experiment_v2_direct_launch_cycle(
+    p_experiment_id uuid,
+    p_actor text DEFAULT current_user
+) RETURNS TABLE (
+    action text,
+    subject_id uuid,
+    lifecycle_status text,
+    admission_state text,
+    resolved_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $body$
+DECLARE
+    v_exp public.control_experiments%ROWTYPE;
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext(
+        'experiment-v2-direct-launch-cycle-' || p_experiment_id::text));
+    SELECT * INTO v_exp FROM public.control_experiments
+     WHERE experiment_id = p_experiment_id FOR UPDATE;
+    IF v_exp.experiment_id <> '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid OR
+       v_exp.protocol_version <> 2 OR v_exp.execution_phase <> 'randomized' OR
+       NOT EXISTS (
+           SELECT 1 FROM public.experiment_v2_direct_launch_waivers waiver
+            WHERE waiver.experiment_id = p_experiment_id
+              AND waiver.revision_bundle_sha256 = v_exp.revision_bundle_sha256
+              AND waiver.issue_number = 642) THEN
+        RAISE EXCEPTION 'direct launch cycle is restricted to the exact accepted-risk study';
+    END IF;
+
+    -- Finalization remains internal and exactly once.  The function accepts no
+    -- secret, RNG, replacement, or redraw input; exact replay returns the
+    -- existing insert-once receipt from migration 214.
+    IF v_exp.status = 'locked' THEN
+        PERFORM * FROM public.fn_experiment_v2_finalize_randomization(
+            p_experiment_id, p_actor);
+        SELECT * INTO v_exp FROM public.control_experiments
+         WHERE experiment_id = p_experiment_id FOR UPDATE;
+    END IF;
+
+    IF v_exp.status = 'aborted' THEN
+        RETURN QUERY SELECT 'randomization_aborted'::text, NULL::uuid,
+            v_exp.status, v_exp.admission_state, v_now;
+        RETURN;
+    END IF;
+    IF v_exp.status NOT IN ('armed', 'running') THEN
+        RAISE EXCEPTION 'direct launch finalization did not produce one armed randomized design';
+    END IF;
+
+    -- This is the intentional pause.  Only a later authenticated API command
+    -- may record the separate API-mediated day-1 approval.  Do not create a
+    -- selector context, choice, work row, exposure, or admission transition.
+    IF NOT EXISTS (
+        SELECT 1 FROM public.experiment_v2_approvals approval
+         WHERE approval.experiment_id = p_experiment_id
+           AND approval.revision_bundle_sha256 = v_exp.revision_bundle_sha256
+           AND approval.approval_kind = 'randomized_day_1'
+           AND approval.issue_number = 642
+           AND approval.approved_by LIKE 'verdify-api:%') THEN
+        RETURN QUERY SELECT 'awaiting_separate_day1_approval'::text, NULL::uuid,
+            v_exp.status, v_exp.admission_state, v_now;
+        RETURN;
+    END IF;
+
+    RETURN QUERY SELECT *
+      FROM public.fn_experiment_v2_direct_launch_cycle_pre238(
+          p_experiment_id, p_actor);
+END;
+$body$;
+
+CREATE OR REPLACE FUNCTION public.fn_experiment_v2_require_day1_approval()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $body$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM public.control_experiments experiment
+          JOIN public.experiment_v2_approvals approval
+            ON approval.experiment_id = experiment.experiment_id
+           AND approval.revision_bundle_sha256 = experiment.revision_bundle_sha256
+           AND approval.approval_kind = 'randomized_day_1'
+           AND approval.issue_number = 642
+           AND approval.approved_by LIKE 'verdify-api:%'
+         WHERE experiment.experiment_id = NEW.experiment_id
+           AND experiment.protocol_version = 2
+           AND experiment.execution_phase = 'randomized'
+           AND experiment.status IN ('armed', 'running')) THEN
+        RAISE EXCEPTION 'randomized day work requires separate audited #642 approval';
+    END IF;
+    RETURN NEW;
+END;
+$body$;
+
+CREATE OR REPLACE FUNCTION public.fn_experiment_v2_day1_approval_audit_binding()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $body$
+BEGIN
+    IF NEW.approval_kind = 'randomized_day_1' AND
+       (NEW.issue_number <> 642 OR
+        NEW.approved_by !~ '^verdify-api:[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,95}$') THEN
+        RAISE EXCEPTION '#642 day-1 approval requires a separate authenticated API audit reference';
+    END IF;
+    RETURN NEW;
+END;
+$body$;
+
+DROP TRIGGER IF EXISTS trg_experiment_v2_selector_context_day1_approval
+    ON public.experiment_v2_selector_contexts;
+CREATE TRIGGER trg_experiment_v2_selector_context_day1_approval
+    BEFORE INSERT ON public.experiment_v2_selector_contexts
+    FOR EACH ROW EXECUTE FUNCTION public.fn_experiment_v2_require_day1_approval();
+
+DROP TRIGGER IF EXISTS trg_experiment_v2_selector_choice_day1_approval
+    ON public.experiment_v2_selector_choices;
+CREATE TRIGGER trg_experiment_v2_selector_choice_day1_approval
+    BEFORE INSERT ON public.experiment_v2_selector_choices
+    FOR EACH ROW EXECUTE FUNCTION public.fn_experiment_v2_require_day1_approval();
+
+DROP TRIGGER IF EXISTS trg_experiment_v2_randomized_work_day1_approval
+    ON public.experiment_v2_work;
+CREATE TRIGGER trg_experiment_v2_randomized_work_day1_approval
+    BEFORE INSERT ON public.experiment_v2_work
+    FOR EACH ROW
+    WHEN (NEW.operation_kind = 'randomized_assignment')
+    EXECUTE FUNCTION public.fn_experiment_v2_require_day1_approval();
+
+DROP TRIGGER IF EXISTS trg_experiment_v2_day1_approval_audit_binding
+    ON public.experiment_v2_approvals;
+CREATE TRIGGER trg_experiment_v2_day1_approval_audit_binding
+    BEFORE INSERT ON public.experiment_v2_approvals
+    FOR EACH ROW EXECUTE FUNCTION
+        public.fn_experiment_v2_day1_approval_audit_binding();
+
+-- Blinded, treatment-free launch/kill/rollback observability.  The function
+-- reports only the existence of finalization/approval artifacts, never the
+-- schedule, mapping, secret, arm resolution, provider response, or efficacy.
+CREATE OR REPLACE FUNCTION public.fn_experiment_v2_launch_gate_status()
+RETURNS TABLE (
+    experiment_id uuid,
+    lifecycle_status text,
+    execution_phase text,
+    admission_state text,
+    component_enabled boolean,
+    design_locked boolean,
+    randomization_finalized boolean,
+    randomized_day_1_approved boolean,
+    launch_gate text,
+    open_exposure_count integer,
+    kill_action text,
+    rollback_action text,
+    rollback_ready boolean,
+    resolved_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $body$
+DECLARE
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    RETURN QUERY
+    SELECT e.experiment_id, e.status, e.execution_phase, e.admission_state,
+           e.component_enabled,
+           e.design_lock_sha256 IS NOT NULL,
+           finalized.present,
+           approved.present,
+           CASE
+               WHEN e.admission_state = 'emergency_hold' THEN 'emergency_hold'
+               WHEN exposures.open_count > 0 THEN 'exposure_active'
+               WHEN e.design_lock_sha256 IS NULL THEN 'awaiting_design_lock'
+               WHEN NOT finalized.present THEN 'awaiting_internal_finalization'
+               WHEN NOT approved.present THEN 'awaiting_separate_day1_approval'
+               WHEN e.admission_state <> 'closed' THEN 'admission_not_closed'
+               ELSE 'authorized_closed'
+           END,
+           exposures.open_count,
+           CASE WHEN e.admission_state = 'emergency_hold'
+                THEN 'already_held'
+                ELSE 'set_admission:emergency_hold' END,
+           CASE
+               WHEN exposures.open_count > 0 THEN 'exposure_close_first'
+               WHEN e.admission_state = 'emergency_hold' THEN 'facility_yielded'
+               WHEN NOT baseline.present THEN 'facility_authorized_baseline_recovery'
+               WHEN e.component_enabled THEN 'coarse_disable_after_baseline'
+               ELSE 'dormant_baseline_confirmed'
+           END,
+           exposures.open_count = 0 AND baseline.present AND
+               e.admission_state <> 'emergency_hold',
+           v_now
+      FROM public.control_experiments e
+      LEFT JOIN LATERAL (
+          SELECT EXISTS (
+              SELECT 1 FROM public.experiment_v2_randomization randomized
+               WHERE randomized.experiment_id = e.experiment_id
+                 AND randomized.design_lock_sha256 = e.design_lock_sha256)
+              AS present
+      ) finalized ON true
+      LEFT JOIN LATERAL (
+          SELECT EXISTS (
+              SELECT 1 FROM public.experiment_v2_approvals approval
+               WHERE approval.experiment_id = e.experiment_id
+                 AND approval.revision_bundle_sha256 = e.revision_bundle_sha256
+                 AND approval.approval_kind = 'randomized_day_1'
+                 AND approval.issue_number = 642
+                 AND approval.approved_by LIKE 'verdify-api:%') AS present
+      ) approved ON true
+      LEFT JOIN LATERAL (
+          SELECT count(*)::integer AS open_count
+            FROM public.experiment_v2_exposures exposure
+            LEFT JOIN public.experiment_v2_exposure_closures closure
+              USING (exposure_id)
+           WHERE exposure.experiment_id = e.experiment_id
+             AND closure.exposure_id IS NULL
+      ) exposures ON true
+      LEFT JOIN LATERAL (
+          SELECT EXISTS (
+              SELECT 1
+                FROM public.experiment_v2_work work
+                JOIN public.experiment_v2_work_events recovered
+                  USING (experiment_id, work_id)
+                JOIN public.experiment_v2_state_artifacts state
+                  ON state.experiment_id = work.experiment_id
+                 AND state.profile = 'baseline'
+                 AND state.state_content_sha256 = work.target_state_content_sha256
+               WHERE work.experiment_id = e.experiment_id
+                 AND work.operation_kind = 'baseline_recovery'
+                 AND work.revision_bundle_sha256 = e.revision_bundle_sha256
+                 AND work.lease_generation = e.lease_generation
+                 AND recovered.event_kind = 'recovered'
+                 AND (SELECT count(*)
+                        FROM public.experiment_v2_observation_receipts receipt
+                       WHERE receipt.experiment_id = work.experiment_id
+                         AND receipt.work_id = work.work_id
+                         AND receipt.policy_state_content_sha256 =
+                             work.target_state_content_sha256) >= 2) AS present
+      ) baseline ON true
+     WHERE e.protocol_version = 2 AND e.kind = 'randomized';
+END;
+$body$;
+
+ALTER FUNCTION public.fn_experiment_v2_direct_launch_cycle(uuid,text)
+    OWNER TO verdify_experiment_v2_owner;
+ALTER FUNCTION public.fn_experiment_v2_require_day1_approval()
+    OWNER TO verdify_experiment_v2_owner;
+ALTER FUNCTION public.fn_experiment_v2_day1_approval_audit_binding()
+    OWNER TO verdify_experiment_v2_owner;
+ALTER FUNCTION public.fn_experiment_v2_launch_gate_status()
+    OWNER TO verdify_experiment_v2_owner;
+
+REVOKE ALL PRIVILEGES ON FUNCTION
+    public.fn_experiment_v2_direct_launch_cycle(uuid,text)
+    FROM PUBLIC CASCADE;
+REVOKE ALL PRIVILEGES ON FUNCTION
+    public.fn_experiment_v2_launch_gate_status()
+    FROM PUBLIC CASCADE;
+GRANT EXECUTE ON FUNCTION
+    public.fn_experiment_v2_direct_launch_cycle(uuid,text)
+    TO verdify_experiment_shadow_scheduler;
+GRANT EXECUTE ON FUNCTION
+    public.fn_experiment_v2_launch_gate_status()
+    TO verdify;
+
+DO $audit$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM public.experiment_v2_approvals approval
+         WHERE approval.approval_kind = 'randomized_day_1'
+           AND (approval.issue_number <> 642 OR
+                approval.approved_by !~
+                    '^verdify-api:[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,95}$')) THEN
+        RAISE EXCEPTION 'existing randomized day-1 approval lacks a separate authenticated API audit reference';
+    END IF;
+END
+$audit$;

--- a/db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql
+++ b/db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql
@@ -34,4 +34,125 @@ BEGIN
 END
 $assertions$;
 
+-- Exercise the immutable production-shaped lineage retained in the restored
+-- dump. This is intentionally read-only: it proves that the exact fault and
+-- two-receipt recovery which migration 236 rejected on the expired predecessor
+-- authorization are admitted by 237's current-work range instead. It accepts
+-- either the unresolved pre-call shape or the append-only post-call shape.
+DO $live_shaped_recovery$
+DECLARE
+    v_candidate_count integer;
+    v_old_range_rejection_count integer;
+    v_exact_receipt_count integer;
+BEGIN
+    WITH candidates AS (
+        SELECT auth.authorization_id,
+               auth.proof_valid_range,
+               aggressive.work_id AS aggressive_work_id,
+               aggressive.created_at AS aggressive_created_at,
+               fault.recorded_at AS fault_at,
+               recovery.work_id AS recovery_work_id,
+               recovery.valid_range AS recovery_valid_range,
+               recovered.recorded_at AS recovered_at,
+               (SELECT count(DISTINCT receipt.receipt_id)::integer
+                  FROM public.experiment_v2_observation_receipts receipt
+                 WHERE receipt.experiment_id = auth.experiment_id
+                   AND receipt.work_id = recovery.work_id) AS receipt_count,
+               (SELECT encode(digest(convert_to(
+                           'verdify-direct-proof-startup-raw-reset-v3|' ||
+                           auth.authorization_id::text || '|' ||
+                           aggressive.work_id::text || '|' ||
+                           recovery.work_id::text || '|' ||
+                           string_agg(receipt.observation_receipt_sha256, '|'
+                                      ORDER BY receipt.persisted_at,
+                                               receipt.receipt_id),
+                           'UTF8'), 'sha256'), 'hex')
+                  FROM public.experiment_v2_observation_receipts receipt
+                 WHERE receipt.experiment_id = auth.experiment_id
+                   AND receipt.work_id = recovery.work_id) AS evidence_sha256
+          FROM public.experiment_v2_direct_proof_authorizations auth
+          JOIN public.experiment_v2_direct_proof_attempt_work mapped
+            ON mapped.authorization_id = auth.authorization_id
+           AND mapped.stage = 'aggressive'
+          JOIN public.experiment_v2_work aggressive
+            ON aggressive.experiment_id = auth.experiment_id
+           AND aggressive.work_id = mapped.work_id
+          JOIN public.experiment_v2_runtime_faults fault
+            ON fault.experiment_id = auth.experiment_id
+           AND fault.fault_source = 'raw_reset_epoch'
+           AND fault.reported_fault_kind = 'reboot'
+           AND fault.admission_state_after = 'baseline_recovery'
+           AND fault.authority_hold_required
+           AND NOT fault.facility_authority_yielded
+           AND fault.recorded_at > aggressive.created_at
+          JOIN public.experiment_v2_work recovery
+            ON recovery.experiment_id = fault.experiment_id
+           AND recovery.work_id = fault.recovery_work_id
+          JOIN public.experiment_v2_work_events recovered
+            ON recovered.experiment_id = recovery.experiment_id
+           AND recovered.work_id = recovery.work_id
+           AND recovered.event_kind = 'recovered'
+         WHERE auth.experiment_id =
+                   '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid
+           AND fault.recorded_at <@ recovery.valid_range
+           AND recovered.recorded_at <@ recovery.valid_range
+           AND recovery.created_at >= aggressive.created_at
+           AND NOT lower_inf(recovery.valid_range)
+           AND NOT upper_inf(recovery.valid_range)
+           AND lower_inc(recovery.valid_range)
+           AND NOT upper_inc(recovery.valid_range)
+           AND upper(recovery.valid_range) - lower(recovery.valid_range) =
+               interval '5 minutes'
+           AND recovery.expires_at = upper(recovery.valid_range)
+           AND recovery.parent_work_id IS NULL
+           AND recovery.operation_kind = 'baseline_recovery'
+           AND recovery.target_profile = 'baseline'
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_exposures exposure
+                WHERE exposure.experiment_id = auth.experiment_id
+                  AND exposure.work_id = aggressive.work_id)
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_direct_proof_receipts proof
+                WHERE proof.authorization_id = auth.authorization_id)
+    )
+    SELECT count(*) FILTER (WHERE receipt_count >= 2),
+           count(*) FILTER (
+               WHERE receipt_count >= 2
+                 AND NOT (
+                     fault_at <@ proof_valid_range AND
+                     recovered_at <@ proof_valid_range)),
+           count(*) FILTER (
+               WHERE receipt_count >= 2
+                 AND EXISTS (
+                     SELECT 1
+                       FROM public.experiment_v2_direct_proof_emergency_recovery_receipts sealed
+                      WHERE sealed.authorization_id = candidates.authorization_id
+                        AND sealed.recovery_work_id = candidates.recovery_work_id
+                        AND sealed.recovery_evidence_sha256 =
+                            candidates.evidence_sha256))
+      INTO v_candidate_count, v_old_range_rejection_count,
+           v_exact_receipt_count
+      FROM candidates;
+
+    IF v_candidate_count < 1 OR v_old_range_rejection_count < 1 THEN
+        RAISE EXCEPTION
+            'restored production-shaped migration 237 recovery lineage is absent or still depends on predecessor authorization time';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM public.experiment_v2_direct_proof_emergency_recovery_receipts sealed
+          JOIN public.experiment_v2_direct_proof_authorizations auth
+            USING (authorization_id)
+         WHERE auth.experiment_id =
+                   '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid
+           AND sealed.recorded_by LIKE 'gitops:%') AND
+       v_exact_receipt_count < 1 THEN
+        RAISE EXCEPTION
+            'migration 237 sealed receipt does not reproduce from its exact two observation receipts';
+    END IF;
+END
+$live_shaped_recovery$;
+
 ROLLBACK;

--- a/deploy/k8s/activations/experiment-v2-direct-proof/README.md
+++ b/deploy/k8s/activations/experiment-v2-direct-proof/README.md
@@ -1,0 +1,31 @@
+# Experiment v2 direct-proof activation
+
+This directory is the deliberate, one-shot GitOps surface for a future attended
+baseline → aggressive → baseline physical proof. It is not referenced by the
+ordinary production overlay or any ArgoCD Application.
+
+The committed render is intentionally dormant:
+
+- the proof Job is suspended;
+- the singleton ingestor remains component-off, active-ID empty, and vector-off;
+- every authorization and bounded-window value is an invalid placeholder.
+
+After Wave 0 convergence and a fresh facility window, create a new append-only
+attempt by changing only `activation-values.patch.yaml` in a dedicated commit:
+
+1. Supply the exact experiment UUID, new unique authorization/facility refs,
+   UTC start/end (3 minutes through 12 hours), supervisor, rescue owner, and
+   actor metadata, plus the exact current 12-character config revision.
+2. Replace `dormant-no-authority` with a unique attempt marker, set the component
+   to `enabled`, and bind the exact active experiment ID. Keep vector mode `off`.
+3. Replace the invalid Job image with the exact current production API digest,
+   add only any currently justified scheduling constraints, then set the Job's
+   `spec.suspend` to `false`.
+4. Render this directory, inspect the complete diff, and point Argo at this path
+   only for the authorized attempt. Never add the proof component back to the
+   ordinary production kustomization.
+5. After the immutable receipt (success or failure), return Argo to the ordinary
+   production path. Do not rewrite or reuse an earlier attempt.
+
+The database proof/attempt/recovery ledgers remain append-only. Removing an
+expired manifest from ordinary desired state does not delete prior evidence.

--- a/deploy/k8s/activations/experiment-v2-direct-proof/activation-values.patch.yaml
+++ b/deploy/k8s/activations/experiment-v2-direct-proof/activation-values.patch.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: experiment-v2-direct-proof-activation
+data:
+  VERDIFY_DIRECT_PROOF_EXPERIMENT_ID: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_FACILITY_AUTHORIZATION_REF: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZED_FROM: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZED_TO: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_SUPERVISOR_ROLE: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_RESCUE_OWNER_ROLE: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_ACTOR: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_CONFIG_REVISION: "REPLACE_BEFORE_ACTIVATION"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-ingestor
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/direct-proof-activation: "dormant-no-authority"
+    spec:
+      containers:
+        - name: ingestor
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-direct-proof
+spec:
+  suspend: true
+  template:
+    spec:
+      containers:
+        - name: direct-proof
+          # The activation overlay wraps prod after its image transformer has
+          # run, so require a deliberate current immutable pin here as well.
+          image: invalid.local/replace-before-activation:never

--- a/deploy/k8s/activations/experiment-v2-direct-proof/kustomization.yaml
+++ b/deploy/k8s/activations/experiment-v2-direct-proof/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Deliberate one-shot render only. No ArgoCD Application points here, and the
+# ordinary deploy/k8s/overlays/prod render never references this directory.
+resources:
+  - ../../overlays/prod
+
+components:
+  - ../../components/experiment-v2-direct-proof
+
+patches:
+  - path: activation-values.patch.yaml

--- a/deploy/k8s/base/mcp-deployment.yaml
+++ b/deploy/k8s/base/mcp-deployment.yaml
@@ -155,13 +155,10 @@ metadata:
     app.kubernetes.io/component: mcp
 spec:
   type: ClusterIP   # never a raw LB IP — DANGER surface (handoff §3.2)
-  # FastMCP streamable-http keeps session state in-process. Keep each client pod
-  # pinned to one MCP replica so Hermes session requests do not bounce between
-  # pods and return 404/session-terminated during tool calls.
-  sessionAffinity: ClientIP
-  sessionAffinityConfig:
-    clientIP:
-      timeoutSeconds: 10800
+  # mcp/server.py uses MCP SDK >=1.27's stateless Streamable HTTP mode. Every
+  # request carries its own bearer audience and protocol context, so kube-proxy
+  # may distribute calls across both replicas without Mcp-Session-Id loss.
+  sessionAffinity: None
   selector:
     app.kubernetes.io/component: mcp
   ports:

--- a/deploy/k8s/components/experiment-v2-design-lock/README.md
+++ b/deploy/k8s/components/experiment-v2-design-lock/README.md
@@ -1,0 +1,28 @@
+# Dormant design-lock stage
+
+This component is intentionally absent from every overlay. It is the first of
+three separate GitOps stages for #588/#642 and must not be selected until the
+fresh #641 proof receipt and exact runtime identities exist.
+
+Before selection, generate two canonical ConfigMaps from the exact qualified
+image/source revision:
+
+- `verdify-experiment-v2-launch-design`, key `design.json`, validated by
+  `experiment_orchestrator.launch_artifacts`;
+- `verdify-experiment-v2-selector-identity`, key `identity.json`, validated by
+  `SelectorIdentity.parse`.
+
+The PreSync preflight has only OpenAI HTTPS authority. It persists a
+metadata-only termination receipt containing provider/model/identity/request/
+response hashes, but not the selected profile, credential, response body,
+mapping, or randomization material. The next hook calls only the authenticated
+component lifecycle API to consume the already sealed proof and lock the
+canonical design.
+
+Sync then enables only the lifecycle scheduler. Migration 238 permits its
+internal OS-CSPRNG finalization exactly once, but returns
+`awaiting_separate_day1_approval`. The selector, freezer, API experiment
+consumer, and bounded ingestor executor remain coarse-off, admission remains
+closed, and generalized vector mode remains off. Replace this stage first with
+the authorization-only component. Only after its #642 receipt is retained may
+a later Git change select the separate randomized-day1 activation.

--- a/deploy/k8s/components/experiment-v2-design-lock/design-lock-job.yaml
+++ b/deploy/k8s/components/experiment-v2-design-lock/design-lock-job.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-design-lock
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-design-lock
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: experiment-v2-design-lock
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: zot-origin-cluster-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: design-lock
+          image: ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator
+          command:
+            - python
+            - -m
+            - experiment_orchestrator.launch_control
+            - lock-design
+            - --audit-ref
+            - issue-642-design-lock
+            - --design
+            - /etc/verdify/experiment-v2-launch/design.json
+          env:
+            - name: VERDIFY_EXPERIMENT_API_BASE_URL
+              value: http://verdify-api:8000
+            - name: VERDIFY_EXPERIMENT_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-app-secrets
+                  key: VERDIFY_EXPERIMENT_API_TOKEN
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 192Mi
+          volumeMounts:
+            - name: launch-design
+              mountPath: /etc/verdify/experiment-v2-launch
+              readOnly: true
+      volumes:
+        - name: launch-design
+          configMap:
+            name: verdify-experiment-v2-launch-design

--- a/deploy/k8s/components/experiment-v2-design-lock/kustomization.yaml
+++ b/deploy/k8s/components/experiment-v2-design-lock/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - runtime-artifacts.yaml
+  - openai-preflight-job.yaml
+  - design-lock-job.yaml
+
+patches:
+  - path: lifecycle-finalization.patch.yaml

--- a/deploy/k8s/components/experiment-v2-design-lock/lifecycle-finalization.patch.yaml
+++ b/deploy/k8s/components/experiment-v2-design-lock/lifecycle-finalization.patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-lifecycle
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/design-finalization-stage: "awaiting-separate-day1-approval"
+    spec:
+      containers:
+        - name: lifecycle
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+            - name: VERDIFY_EXPERIMENT_V2_LIFECYCLE_PLAN_SHA256
+              value: "d8c5a474dd2ead40d5e4acaca9be7edd34a7626f16611b388542018c6ca79c2b"

--- a/deploy/k8s/components/experiment-v2-design-lock/openai-preflight-job.yaml
+++ b/deploy/k8s/components/experiment-v2-design-lock/openai-preflight-job.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-openai-preflight
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-openai-preflight
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: experiment-v2-openai-preflight
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: zot-origin-cluster-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: preflight
+          image: ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator
+          command:
+            - python
+            - -m
+            - experiment_orchestrator.preflight
+            - --identity
+            - /etc/verdify/experiment-v2-selector/identity.json
+          env:
+            - name: VERDIFY_EXPERIMENT_SELECTOR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-hermes
+                  key: OPENAI_API_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: selector-identity
+              mountPath: /etc/verdify/experiment-v2-selector
+              readOnly: true
+      volumes:
+        - name: selector-identity
+          configMap:
+            name: verdify-experiment-v2-selector-identity

--- a/deploy/k8s/components/experiment-v2-design-lock/runtime-artifacts.yaml
+++ b/deploy/k8s/components/experiment-v2-design-lock/runtime-artifacts.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verdify-experiment-v2-lifecycle-plan
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-lifecycle
+data:
+  plan.json: '{"action":"boundary","experiment_id":"45039c86-c1d9-52f6-a0a9-d94a17bc4b14","schema":"verdify-experiment-v2-lifecycle-plan-v1"}'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verdify-experiment-v2-direct-launch-basis
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-design-lock
+data:
+  basis.json: |-
+    {"accepted_underpowered_design":true,"candidate_start_local_date":"2026-11-02","experiment_id":"45039c86-c1d9-52f6-a0a9-d94a17bc4b14","generalized_vector_mode":"off","missed_start_policy":"new_preregistration_and_new_design_lock","modeled_joint_advance_power":"0.13776","provider_contract":{"model":"gpt-5.6-sol","profile_only":true,"reasoning_effort":"medium","strict_structured_output":true,"tools":false},"randomization_contract":{"caller_supplied_randomness":false,"draws":1,"no_redraw":true,"source":"internal_os_csprng"},"randomized_pair_count":30,"schema":"verdify-experiment-v2-direct-launch-basis-v1","selection_policy":"earliest_unused_future_offset_stable_60_day_window_at_lock_time","study_id":"verdify-confirmed-component-switchback-v2-2026-08","timezone":"America/Denver","window_days":60}

--- a/deploy/k8s/components/experiment-v2-direct-proof/activation-configmap.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/activation-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: experiment-v2-direct-proof-activation
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-direct-proof
+data:
+  # This component is deliberately incapable of running as committed. A fresh
+  # attended activation patches every value below, enables the singleton
+  # ingestor, and unsuspends the Job together in the isolated activation path.
+  VERDIFY_DIRECT_PROOF_EXPERIMENT_ID: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_FACILITY_AUTHORIZATION_REF: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZED_FROM: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_AUTHORIZED_TO: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_SUPERVISOR_ROLE: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_RESCUE_OWNER_ROLE: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_ACTOR: "REPLACE_BEFORE_ACTIVATION"
+  VERDIFY_DIRECT_PROOF_CONFIG_REVISION: "REPLACE_BEFORE_ACTIVATION"

--- a/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-configmap.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-configmap.yaml
@@ -19,18 +19,41 @@ data:
 
     import asyncpg
 
-    EXPERIMENT_ID = "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
-    AUTHORIZATION_REF = (
-        "codex-session:jason-vallery:2026-08-28:"
-        "extended-through-23:00-MT"
+    def required_activation_value(name):
+        value = os.environ.get(name, "").strip()
+        if not value or value.startswith("REPLACE_BEFORE_ACTIVATION"):
+            raise RuntimeError(f"direct-proof activation value is absent: {name}")
+        return value
+
+    def activation_time(name):
+        value = required_activation_value(name)
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise RuntimeError(f"direct-proof activation time is invalid: {name}")
+        if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+            raise RuntimeError(f"direct-proof activation time must be UTC: {name}")
+        return parsed.astimezone(UTC)
+
+    EXPERIMENT_ID = required_activation_value("VERDIFY_DIRECT_PROOF_EXPERIMENT_ID")
+    try:
+        uuid.UUID(EXPERIMENT_ID)
+    except ValueError:
+        raise RuntimeError("direct-proof experiment ID is not a UUID")
+    AUTHORIZATION_REF = required_activation_value("VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF")
+    FACILITY_AUTHORIZATION_REF = required_activation_value(
+        "VERDIFY_DIRECT_PROOF_FACILITY_AUTHORIZATION_REF"
     )
-    FACILITY_AUTHORIZATION_REF = (
-        "codex-session:jason-vallery:2026-08-28:"
-        "physical-recovery-and-proof"
-    )
-    AUTHORIZED_FROM = datetime(2026, 8, 28, 17, 45, tzinfo=UTC)
-    AUTHORIZED_TO = datetime(2026, 8, 29, 5, 0, tzinfo=UTC)
-    ACTOR = "gitops:issue-641-direct-proof-startup-rollover-retry"
+    AUTHORIZED_FROM = activation_time("VERDIFY_DIRECT_PROOF_AUTHORIZED_FROM")
+    AUTHORIZED_TO = activation_time("VERDIFY_DIRECT_PROOF_AUTHORIZED_TO")
+    if not timedelta(minutes=3) <= AUTHORIZED_TO - AUTHORIZED_FROM <= timedelta(hours=12):
+        raise RuntimeError("direct-proof activation window must be between 3 minutes and 12 hours")
+    SUPERVISOR_ROLE = required_activation_value("VERDIFY_DIRECT_PROOF_SUPERVISOR_ROLE")
+    RESCUE_OWNER_ROLE = required_activation_value("VERDIFY_DIRECT_PROOF_RESCUE_OWNER_ROLE")
+    ACTOR = required_activation_value("VERDIFY_DIRECT_PROOF_ACTOR")
+    EXPECTED_CONFIG_REVISION = required_activation_value("VERDIFY_DIRECT_PROOF_CONFIG_REVISION")
+    if not re.fullmatch(r"[0-9a-f]{12}", EXPECTED_CONFIG_REVISION):
+        raise RuntimeError("direct-proof config revision must be a 12-character lowercase hex digest")
     RUNTIME_REGISTRATION_SETTLE_SECONDS = 5 * 60
     SHA256 = re.compile(r"^[0-9a-f]{64}$")
 
@@ -163,7 +186,7 @@ data:
             fail("candidate revision changed during the direct proof")
         if lease is not None and row["lease_generation"] != lease:
             fail("lease generation changed during the direct proof")
-        if row["config_revision"] != "4dbb2e691d91":
+        if row["config_revision"] != EXPECTED_CONFIG_REVISION:
             fail("runtime candidate config revision is not the corrected source")
         if open_exposures is not None and row["open_exposure_count"] != open_exposures:
             fail("open exposure count differs from the expected proof boundary")
@@ -660,8 +683,8 @@ data:
                     lower_inc=True,
                     upper_inc=False,
                 ),
-                "Jason Vallery",
-                "Jason Vallery",
+                SUPERVISOR_ROLE,
+                RESCUE_OWNER_ROLE,
                 ACTOR,
             )
             if aggressive_work_id is None:

--- a/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-job.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-job.yaml
@@ -11,8 +11,11 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "1"
-    operations.vallery.net/temporary-node-exclusion: vm-k3s-node4,vm-k3s-node6:cni-pod-sandbox-timeout:2026-08-28
 spec:
+  # Safe component default. A fresh attended activation must explicitly patch
+  # this to false in the isolated activation render after supplying a new exact
+  # authorization/window and enabling only the existing singleton ingestor.
+  suspend: true
   backoffLimit: 0
   activeDeadlineSeconds: 6600
   ttlSecondsAfterFinished: 3600
@@ -33,14 +36,6 @@ spec:
           type: RuntimeDefault
       imagePullSecrets:
         - name: zot-origin-cluster-pull
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: NotIn
-                    values: [vm-k3s-node4, vm-k3s-node6]
       containers:
         - name: direct-proof
           image: ghcr.io/verdifyconsultancy/verdify-api
@@ -48,6 +43,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: verdify-config
+            - configMapRef:
+                name: experiment-v2-direct-proof-activation
           env:
             - name: LIFECYCLE_DB_USER
               valueFrom:

--- a/deploy/k8s/components/experiment-v2-direct-proof/ingestor-activation.patch.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/ingestor-activation.patch.yaml
@@ -6,9 +6,10 @@ spec:
   template:
     metadata:
       annotations:
-        # One attended #641 proof epoch. Removing this component removes the
-        # overrides and annotation, forcing the sole writer back to coarse off.
-        verdify.io/direct-proof-activation: "2026-08-28-jason-vallery-retry-2"
+        # Dormant component default. The isolated activation render must replace
+        # this marker with a fresh unique attempt reference in the same commit
+        # that supplies a current bounded window and unsuspends the proof Job.
+        verdify.io/direct-proof-activation: "dormant-no-authority"
     spec:
       containers:
         - name: ingestor
@@ -16,6 +17,6 @@ spec:
             - name: VERDIFY_POLICY_VECTOR_MODE
               value: "off"
             - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
-              value: "enabled"
+              value: "off"
             - name: VERDIFY_ACTIVE_EXPERIMENT_ID
-              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+              value: ""

--- a/deploy/k8s/components/experiment-v2-direct-proof/kustomization.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
+  - activation-configmap.yaml
   - direct-proof-configmap.yaml
   - direct-proof-job.yaml
 

--- a/deploy/k8s/components/experiment-v2-randomized-day1-activation/README.md
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-activation/README.md
@@ -1,0 +1,26 @@
+# Dormant randomized day-1 activation
+
+This component is intentionally absent from every overlay. It is a separate
+GitOps stage from both `experiment-v2-design-lock` and
+`experiment-v2-randomized-day1-authorization` and must not be combined with
+either one. It contains no approval command. Migration 238 requires the prior
+API audit identity before any randomized selector context, choice, or work can
+be inserted.
+
+Only a later, separately reviewed selection of this component enables the
+lifecycle, selector, freezer, API consumer, and the existing bounded component
+executor for the exact experiment ID. Generalized vector mode stays off
+everywhere.
+
+Before selection, require the exact design/source/image/Argo pins, a retained
+metadata-only OpenAI preflight receipt, an `armed / randomized / closed`
+database state, exactly one randomization receipt, zero open exposures, and the
+retained receipt from the separate attended #642 authorization component. The
+selector and outcome identity ConfigMaps must be the exact hash-bound artifacts
+consumed by the design lock.
+
+Rollback is the sibling `experiment-v2-randomized-day1-rollback` component. It
+first uses the audited API emergency-hold command, whose database function
+closes exposure in the same transaction, and then rolls every workload back to
+coarse-off/empty-ID while preserving generalized vectors off. Baseline recovery
+after facility yield remains a separate facility-authorized action.

--- a/deploy/k8s/components/experiment-v2-randomized-day1-activation/kustomization.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-activation/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - runtime-artifacts.yaml
+
+patches:
+  - path: workload-activation.patch.yaml

--- a/deploy/k8s/components/experiment-v2-randomized-day1-activation/runtime-artifacts.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-activation/runtime-artifacts.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verdify-experiment-v2-lifecycle-plan
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-lifecycle
+data:
+  plan.json: '{"action":"boundary","experiment_id":"45039c86-c1d9-52f6-a0a9-d94a17bc4b14","schema":"verdify-experiment-v2-lifecycle-plan-v1"}'

--- a/deploy/k8s/components/experiment-v2-randomized-day1-activation/workload-activation.patch.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-activation/workload-activation.patch.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-ingestor
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "authorized"
+    spec:
+      containers:
+        - name: ingestor
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-api
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "authorized"
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-lifecycle
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "authorized"
+    spec:
+      containers:
+        - name: lifecycle
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+            - name: VERDIFY_EXPERIMENT_V2_LIFECYCLE_PLAN_SHA256
+              value: "d8c5a474dd2ead40d5e4acaca9be7edd34a7626f16611b388542018c6ca79c2b"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-selector
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "authorized"
+    spec:
+      containers:
+        - name: selector
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-freezer
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "authorized"
+    spec:
+      containers:
+        - name: freezer
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "enabled"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"

--- a/deploy/k8s/components/experiment-v2-randomized-day1-authorization/README.md
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-authorization/README.md
@@ -1,0 +1,11 @@
+# Dormant randomized day-1 authorization command
+
+This component is intentionally absent from every overlay. It contains only
+the distinct, authenticated #642 approval command. It does not patch or enable
+any workload and therefore cannot activate randomized operation.
+
+Select it only after the design-lock stage has finalized exactly once and the
+blinded launch status reports `awaiting_separate_day1_approval`, closed
+admission, and zero open exposures. Retain the treatment-free API receipt,
+remove this one-shot component, and review the separate
+`experiment-v2-randomized-day1-activation` component in a later Git change.

--- a/deploy/k8s/components/experiment-v2-randomized-day1-authorization/day1-approval-job.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-authorization/day1-approval-job.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-day1-approval
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-day1-approval
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: experiment-v2-day1-approval
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: zot-origin-cluster-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: approve-day1
+          image: ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator
+          command:
+            - python
+            - -m
+            - experiment_orchestrator.launch_control
+            - approve-day1
+            - --audit-ref
+            - issue-642-randomized-day1-approval
+          env:
+            - name: VERDIFY_EXPERIMENT_API_BASE_URL
+              value: http://verdify-api:8000
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+            - name: VERDIFY_EXPERIMENT_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-app-secrets
+                  key: VERDIFY_EXPERIMENT_API_TOKEN
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 192Mi

--- a/deploy/k8s/components/experiment-v2-randomized-day1-authorization/kustomization.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-authorization/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - day1-approval-job.yaml

--- a/deploy/k8s/components/experiment-v2-randomized-day1-rollback/README.md
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-rollback/README.md
@@ -1,0 +1,13 @@
+# Dormant exposure-close-first rollback
+
+This component is intentionally absent from every overlay. When selected
+instead of the day-1 activation, its PreSync hook calls the authenticated
+`set_admission:emergency_hold` command. The database closes every open exposure
+before revoking experiment authority and records the facility yield. Sync then
+sets every experiment consumer to coarse-off, clears the active experiment ID,
+and keeps generalized vectors off.
+
+This is a kill/yield stage, not permission to fabricate baseline recovery.
+Afterward, baseline recovery requires a separate immutable facility
+authorization, exclusive writer execution, and two fresh current-generation
+confirming receipts before ordinary ownership restoration.

--- a/deploy/k8s/components/experiment-v2-randomized-day1-rollback/emergency-hold-job.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-rollback/emergency-hold-job.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-emergency-hold
+  labels:
+    app.kubernetes.io/part-of: verdify
+    app.kubernetes.io/component: experiment-v2-emergency-hold
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: verdify
+        app.kubernetes.io/component: experiment-v2-emergency-hold
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: zot-origin-cluster-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: emergency-hold
+          image: ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator
+          command:
+            - python
+            - -m
+            - experiment_orchestrator.launch_control
+            - emergency-hold
+            - --audit-ref
+            - issue-642-exposure-close-first-rollback
+          env:
+            - name: VERDIFY_EXPERIMENT_API_BASE_URL
+              value: http://verdify-api:8000
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+            - name: VERDIFY_EXPERIMENT_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: verdify-app-secrets
+                  key: VERDIFY_EXPERIMENT_API_TOKEN
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 192Mi

--- a/deploy/k8s/components/experiment-v2-randomized-day1-rollback/kustomization.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-rollback/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - emergency-hold-job.yaml
+
+patches:
+  - path: workload-disable.patch.yaml

--- a/deploy/k8s/components/experiment-v2-randomized-day1-rollback/workload-disable.patch.yaml
+++ b/deploy/k8s/components/experiment-v2-randomized-day1-rollback/workload-disable.patch.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-ingestor
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "emergency-hold"
+    spec:
+      containers:
+        - name: ingestor
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verdify-api
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "emergency-hold"
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-lifecycle
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "emergency-hold"
+    spec:
+      containers:
+        - name: lifecycle
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-selector
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "emergency-hold"
+    spec:
+      containers:
+        - name: selector
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiment-v2-freezer
+spec:
+  template:
+    metadata:
+      annotations:
+        verdify.io/randomized-day1-stage: "emergency-hold"
+    spec:
+      containers:
+        - name: freezer
+          env:
+            - name: VERDIFY_POLICY_VECTOR_MODE
+              value: "off"
+            - name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED
+              value: "off"
+            - name: VERDIFY_ACTIVE_EXPERIMENT_ID
+              value: ""

--- a/deploy/k8s/components/grafana/generated/dashboards-cm-2.yaml
+++ b/deploy/k8s/components/grafana/generated/dashboards-cm-2.yaml
@@ -168,10 +168,32 @@ data:
               }
             }
           ]
+        },
+        {
+          "id": 7,
+          "type": "table",
+          "title": "Launch authorization and exposure-close-first rollback",
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "targets": [
+            {
+              "rawSql": "SELECT experiment_id AS \"Experiment\", lifecycle_status AS \"Lifecycle\", execution_phase AS \"Phase\", admission_state AS \"Admission\", design_locked AS \"Design locked\", randomization_finalized AS \"Finalized once\", randomized_day_1_approved AS \"Day-1 approved\", launch_gate AS \"Launch gate\", open_exposure_count AS \"Open exposures\", kill_action AS \"Kill action\", rollback_action AS \"Rollback action\", rollback_ready AS \"Rollback ready\" FROM public.fn_experiment_v2_launch_gate_status() ORDER BY experiment_id",
+              "refId": "A",
+              "format": "table",
+              "datasource": {
+                "uid": "verdify-tsdb",
+                "type": "grafana-postgresql-datasource"
+              }
+            }
+          ]
         }
       ],
       "schemaVersion": 39,
-      "version": 1,
+      "version": 2,
       "style": "light"
     }
   band-tuning-diurnal.json: |

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -116,11 +116,10 @@ components:
   # vectors. It cannot enable the component, open admission, randomize, or write
   # a device. Exact replay is idempotent after migration 221.
   - ../../components/experiment-v2-direct-launch-bootstrap
-  # ONE ATTENDED RETRY ONLY (Jason Vallery, 2026-08-28 06:00-18:00 UTC):
-  # temporarily arms only the ingestor's bounded component executor and runs
-  # the immutable baseline -> aggressive -> baseline PostSync proof. Remove
-  # immediately after its PASS receipt to Recreate the sole writer coarse-off.
-  - ../../components/experiment-v2-direct-proof
+  # Direct physical proof is deliberately absent from ordinary production.
+  # A fresh attended attempt must use the separate, suspended activation render
+  # under deploy/k8s/activations/experiment-v2-direct-proof and be removed again
+  # after its append-only receipt. Ordinary convergence stays coarse-off.
   # #124 verdify-lab — the public Quartz research site (lab.verdify.ai). Pure web
   # tier, stateless (no PVC), NO device path. Built from the
   # verdify-site-legacy Dockerfile.k3s (see components/lab-site/lab-site.yaml).

--- a/experiment_orchestrator/launch_artifacts.py
+++ b/experiment_orchestrator/launch_artifacts.py
@@ -1,0 +1,225 @@
+"""Canonical source contract for the dormant M8 direct-launch packet.
+
+This module prepares and validates metadata only.  It cannot lock a database,
+finalize randomization, call a provider, or reach a device.  The actual design
+lock remains owned by the authenticated lifecycle API and the exactly-once
+randomization draw remains owned by PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from .contracts import ContractError, canonical_json_bytes, require_sha256, require_uuid
+
+DESIGN_SCHEMA = "verdify-experiment-v2-direct-launch-design-v2"
+EXPERIMENT_ID = "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+STUDY_ID = "verdify-confirmed-component-switchback-v2-2026-08"
+TIMEZONE = "America/Denver"
+WINDOW_DAYS = 60
+PAIR_COUNT = 30
+MODELED_JOINT_ADVANCE_POWER = "0.13776"
+SELECTOR_CONTEXT_CUTOFF_LOCAL = "23:45:00"
+
+_FIELDS = frozenset(
+    {
+        "accepted_underpowered_design",
+        "analyzer_environment_sha256",
+        "context_schema_sha256",
+        "design_lock_sha256",
+        "endpoint_artifact_sha256",
+        "experiment_id",
+        "generalized_vector_mode",
+        "modeled_joint_advance_power",
+        "outcome_schema_sha256",
+        "power_artifact_sha256",
+        "randomized_pair_count",
+        "rollback_artifact_sha256",
+        "schedule_schema_sha256",
+        "schema",
+        "selector_artifact_sha256",
+        "selector_context_cutoff_local",
+        "selector_identity_sha256",
+        "source_git_sha",
+        "study_id",
+        "study_start_local_date",
+        "timezone",
+        "window_days",
+    }
+)
+_SHA_FIELDS = frozenset(
+    {
+        "analyzer_environment_sha256",
+        "context_schema_sha256",
+        "endpoint_artifact_sha256",
+        "outcome_schema_sha256",
+        "power_artifact_sha256",
+        "rollback_artifact_sha256",
+        "schedule_schema_sha256",
+        "selector_artifact_sha256",
+        "selector_identity_sha256",
+    }
+)
+_FORBIDDEN_TOKENS = frozenset(
+    {
+        "mapping",
+        "mapping_secret",
+        "physical_arm",
+        "randomization_secret",
+        "secret",
+        "x_physical_arm",
+        "y_physical_arm",
+    }
+)
+
+
+def _exact_local_date(value: object) -> str:
+    if not isinstance(value, str):
+        raise ContractError("study_start_local_date must be canonical YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ContractError("study_start_local_date must be canonical YYYY-MM-DD") from exc
+    if parsed.isoformat() != value:
+        raise ContractError("study_start_local_date must be canonical YYYY-MM-DD")
+    return value
+
+
+def _window_has_one_utc_offset(start_local_date: str) -> bool:
+    start = date.fromisoformat(start_local_date)
+    zone = ZoneInfo(TIMEZONE)
+    offsets = {
+        datetime.combine(start + timedelta(days=offset), datetime.min.time(), tzinfo=zone).utcoffset()
+        for offset in range(WINDOW_DAYS + 1)
+    }
+    return len(offsets) == 1
+
+
+def earliest_offset_stable_start(*, not_before: date) -> date:
+    """Return the earliest future 60-day local window with one UTC offset."""
+
+    if type(not_before) is not date:
+        raise TypeError("not_before must be an exact date")
+    for offset in range(732):
+        candidate = not_before + timedelta(days=offset)
+        if _window_has_one_utc_offset(candidate.isoformat()):
+            return candidate
+    raise ContractError("no offset-stable 60-day start exists in the two-year search horizon")
+
+
+@dataclass(frozen=True)
+class DirectLaunchDesign:
+    payload: Mapping[str, Any]
+    canonical_bytes: bytes
+    canonical_sha256: str
+
+    @property
+    def experiment_id(self) -> str:
+        return str(self.payload["experiment_id"])
+
+    @property
+    def study_start_local_date(self) -> str:
+        return str(self.payload["study_start_local_date"])
+
+    def api_lock_fields(self) -> dict[str, object]:
+        """Return only fields accepted by the audited direct-launch command."""
+
+        keys = (
+            "study_start_local_date",
+            "randomized_pair_count",
+            "selector_context_cutoff_local",
+            "design_lock_sha256",
+            "source_git_sha",
+            "schedule_schema_sha256",
+            "selector_identity_sha256",
+            "selector_artifact_sha256",
+            "context_schema_sha256",
+            "endpoint_artifact_sha256",
+            "outcome_schema_sha256",
+            "analyzer_environment_sha256",
+            "power_artifact_sha256",
+        )
+        return {key: self.payload[key] for key in keys}
+
+
+def parse_direct_launch_design(
+    raw: bytes,
+    *,
+    now_local_date: date | None = None,
+) -> DirectLaunchDesign:
+    if type(raw) is not bytes or len(raw) > 65_536:
+        raise ContractError("direct-launch design must be bounded immutable bytes")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ContractError("direct-launch design is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict) or set(payload) != _FIELDS:
+        raise ContractError("direct-launch design field set differs from the source contract")
+    if canonical_json_bytes(payload, reject_forbidden_fields=False) != raw:
+        raise ContractError("direct-launch design is not canonical JSON")
+    if _FORBIDDEN_TOKENS & set(payload):
+        raise ContractError("restricted randomization material is forbidden from the launch design")
+    if payload["schema"] != DESIGN_SCHEMA:
+        raise ContractError("direct-launch design schema mismatch")
+    if require_uuid(payload["experiment_id"], "experiment_id") != EXPERIMENT_ID:
+        raise ContractError("direct-launch design experiment identity mismatch")
+    if payload["study_id"] != STUDY_ID or payload["timezone"] != TIMEZONE:
+        raise ContractError("direct-launch design study identity mismatch")
+    if (
+        payload["window_days"] != WINDOW_DAYS
+        or payload["randomized_pair_count"] != PAIR_COUNT
+        or payload["selector_context_cutoff_local"] != SELECTOR_CONTEXT_CUTOFF_LOCAL
+    ):
+        raise ContractError("direct-launch design schedule differs from the accepted 30-pair contract")
+    if (
+        payload["modeled_joint_advance_power"] != MODELED_JOINT_ADVANCE_POWER
+        or payload["accepted_underpowered_design"] is not True
+    ):
+        raise ContractError("direct-launch design must truthfully retain the accepted 0.13776 power waiver")
+    if payload["generalized_vector_mode"] != "off":
+        raise ContractError("generalized vector mode must remain off")
+    start = _exact_local_date(payload["study_start_local_date"])
+    if not _window_has_one_utc_offset(start):
+        raise ContractError("direct-launch 60-day window crosses a UTC-offset transition")
+    today = date.today() if now_local_date is None else now_local_date
+    if type(today) is not date or date.fromisoformat(start) <= today:
+        raise ContractError("direct-launch start must remain future; missed starts require a new preregistration")
+    if not isinstance(payload["source_git_sha"], str) or not re.fullmatch(r"[0-9a-f]{40}", payload["source_git_sha"]):
+        raise ContractError("source_git_sha must be exact lowercase 40-hex")
+    for field in _SHA_FIELDS:
+        require_sha256(payload[field], field)
+    lock_hash = require_sha256(payload["design_lock_sha256"], "design_lock_sha256")
+    preimage = {key: value for key, value in payload.items() if key != "design_lock_sha256"}
+    if hashlib.sha256(canonical_json_bytes(preimage, reject_forbidden_fields=False)).hexdigest() != lock_hash:
+        raise ContractError("direct-launch immutable design hash mismatch")
+    return DirectLaunchDesign(payload, raw, lock_hash)
+
+
+def build_direct_launch_design(**fields: object) -> DirectLaunchDesign:
+    payload: dict[str, object] = {
+        "accepted_underpowered_design": True,
+        "experiment_id": EXPERIMENT_ID,
+        "generalized_vector_mode": "off",
+        "modeled_joint_advance_power": MODELED_JOINT_ADVANCE_POWER,
+        "randomized_pair_count": PAIR_COUNT,
+        "schema": DESIGN_SCHEMA,
+        "selector_context_cutoff_local": SELECTOR_CONTEXT_CUTOFF_LOCAL,
+        "study_id": STUDY_ID,
+        "timezone": TIMEZONE,
+        "window_days": WINDOW_DAYS,
+        **fields,
+    }
+    if "design_lock_sha256" in payload:
+        raise ContractError("design_lock_sha256 is computed internally")
+    payload["design_lock_sha256"] = hashlib.sha256(
+        canonical_json_bytes(payload, reject_forbidden_fields=False)
+    ).hexdigest()
+    raw = canonical_json_bytes(payload, reject_forbidden_fields=False)
+    return parse_direct_launch_design(raw, now_local_date=date.min)

--- a/experiment_orchestrator/launch_control.py
+++ b/experiment_orchestrator/launch_control.py
@@ -1,6 +1,6 @@
 """Audited API-only commands used by dormant M8 GitOps components.
 
-There is no database client or device client in this module.  Kubernetes Jobs
+There is no database client or equipment endpoint integration in this module.  Kubernetes Jobs
 invoke exactly one lifecycle action through the authenticated component API;
 the manifests are not referenced by a production overlay until an operator
 deliberately selects the matching stage.

--- a/experiment_orchestrator/launch_control.py
+++ b/experiment_orchestrator/launch_control.py
@@ -1,0 +1,213 @@
+"""Audited API-only commands used by dormant M8 GitOps components.
+
+There is no database client or device client in this module.  Kubernetes Jobs
+invoke exactly one lifecycle action through the authenticated component API;
+the manifests are not referenced by a production overlay until an operator
+deliberately selects the matching stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from .contracts import ContractError, canonical_json_bytes
+from .launch_artifacts import TIMEZONE, DirectLaunchDesign, parse_direct_launch_design
+
+
+def _api_root(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != "verdify-api"
+        or parsed.port != 8000
+        or parsed.path.rstrip("/")
+        or parsed.query
+        or parsed.fragment
+        or parsed.username
+        or parsed.password
+    ):
+        raise ContractError("launch control API must be exact in-cluster http://verdify-api:8000")
+    return "http://verdify-api:8000"
+
+
+def _state_precondition(status: dict[str, object]) -> dict[str, object]:
+    return {
+        "expected_admission_state": status["admission_state"],
+        "expected_component_enabled": status["db_component_enabled"],
+        "expected_execution_phase": status["execution_phase"],
+        "expected_lease_generation": status["lease_generation"],
+        "expected_lifecycle_status": status["lifecycle_status"],
+        "expected_revision_bundle_sha256": status["revision_bundle_sha256"],
+    }
+
+
+async def _request(
+    client: httpx.AsyncClient,
+    *,
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    response = await client.request(
+        method,
+        url,
+        headers={"X-Verdify-Experiment-Token": token, "accept": "application/json"},
+        json=payload,
+    )
+    if response.status_code != 200:
+        raise ContractError(f"audited lifecycle API rejected {method} with status {response.status_code}")
+    if response.headers.get("content-type", "").split(";", 1)[0].strip().lower() != "application/json":
+        raise ContractError("audited lifecycle API returned a non-JSON receipt")
+    try:
+        result = response.json()
+    except json.JSONDecodeError as exc:
+        raise ContractError("audited lifecycle API receipt is malformed") from exc
+    if not isinstance(result, dict):
+        raise ContractError("audited lifecycle API receipt must be an object")
+    return result
+
+
+async def execute_control(
+    *,
+    action: str,
+    api_root: str,
+    token: str,
+    audit_ref: str,
+    design: DirectLaunchDesign | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> bytes:
+    if not token or any(character.isspace() for character in token):
+        raise ContractError("experiment API credential is unavailable or malformed")
+    root = _api_root(api_root)
+    if action not in {"lock-design", "approve-day1", "emergency-hold"}:
+        raise ContractError("launch control action is unknown")
+    experiment_id = design.experiment_id if design is not None else os.environ.get("VERDIFY_ACTIVE_EXPERIMENT_ID", "")
+    if not experiment_id:
+        raise ContractError("launch control experiment identity is unavailable")
+    base = f"{root}/api/v1/experiments/{experiment_id}"
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(15.0),
+        follow_redirects=False,
+        trust_env=False,
+        transport=transport,
+    ) as client:
+        status = await _request(
+            client,
+            method="GET",
+            url=f"{base}/component-status",
+            token=token,
+        )
+        if action != "emergency-hold" and status.get("open_exposures") != 0:
+            raise ContractError("launch control requires an explicit zero-open-exposure status")
+        command: dict[str, object] = {
+            "audit_ref": audit_ref,
+            **_state_precondition(status),
+        }
+        if action == "lock-design":
+            if design is None:
+                raise ContractError("lock-design requires one canonical design")
+            if (
+                status.get("lifecycle_status"),
+                status.get("execution_phase"),
+                status.get("admission_state"),
+                status.get("db_component_enabled"),
+            ) != ("draft", "shadow", "closed", False):
+                raise ContractError("design lock requires the exact feature-off draft state")
+            command.update({"action": "direct_launch_commit", **design.api_lock_fields()})
+        elif action == "approve-day1":
+            if (
+                status.get("lifecycle_status"),
+                status.get("execution_phase"),
+                status.get("admission_state"),
+                status.get("db_component_enabled"),
+            ) != ("armed", "randomized", "closed", True):
+                raise ContractError("day-1 approval requires finalized armed closed state")
+            approvals = status.get("approvals")
+            if not isinstance(approvals, dict) or approvals.get("randomized_day_1") is not False:
+                raise ContractError("day-1 approval must be absent before the separate command")
+            command["action"] = "direct_launch_approve_day1"
+        else:
+            if status.get("admission_state") == "emergency_hold":
+                return canonical_json_bytes(
+                    {
+                        "action": "emergency-hold",
+                        "audit_ref": audit_ref,
+                        "experiment_id": experiment_id,
+                        "idempotent": True,
+                        "status": "already_held",
+                    },
+                    reject_forbidden_fields=False,
+                )
+            command.update(
+                {
+                    "action": "set_admission",
+                    "reason": "exposure-close-first GitOps rollback; facility authority yielded",
+                    "target_admission_state": "emergency_hold",
+                }
+            )
+        result = await _request(
+            client,
+            method="POST",
+            url=f"{base}/component-control/commands",
+            token=token,
+            payload=command,
+        )
+    state = result.get("state")
+    if not isinstance(state, dict):
+        raise ContractError("lifecycle command receipt omitted the resulting state")
+    return canonical_json_bytes(
+        {
+            "action": action,
+            "audit_ref": audit_ref,
+            "experiment_id": experiment_id,
+            "receipt_sha256": hashlib.sha256(canonical_json_bytes(result)).hexdigest(),
+            "resulting_admission_state": state.get("admission_state"),
+            "resulting_execution_phase": state.get("execution_phase"),
+            "resulting_lifecycle_status": state.get("lifecycle_status"),
+            "status": "pass",
+        },
+        reject_forbidden_fields=False,
+    )
+
+
+async def _main(args: argparse.Namespace) -> int:
+    design = None
+    if args.design is not None:
+        design = parse_direct_launch_design(
+            args.design.read_bytes(),
+            now_local_date=datetime.now(ZoneInfo(TIMEZONE)).date(),
+        )
+    raw = await execute_control(
+        action=args.action,
+        api_root=os.environ.get("VERDIFY_EXPERIMENT_API_BASE_URL", ""),
+        token=os.environ.get("VERDIFY_EXPERIMENT_API_TOKEN", ""),
+        audit_ref=args.audit_ref,
+        design=design,
+    )
+    args.receipt.write_bytes(raw + b"\n")
+    print(json.dumps({"receipt_sha256": hashlib.sha256(raw).hexdigest(), "status": "pass"}, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one audited experiment-v2 lifecycle command")
+    parser.add_argument("action", choices=("lock-design", "approve-day1", "emergency-hold"))
+    parser.add_argument("--audit-ref", required=True)
+    parser.add_argument("--design", type=Path)
+    parser.add_argument("--receipt", type=Path, default=Path("/dev/termination-log"))
+    return asyncio.run(_main(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiment_orchestrator/preflight.py
+++ b/experiment_orchestrator/preflight.py
@@ -1,7 +1,7 @@
 """Non-actuating strict OpenAI selector-profile preflight.
 
 The preflight has provider-network authority only.  It has no database,
-Kubernetes, or device client, and its persisted receipt intentionally omits the
+Kubernetes, or equipment endpoint, and its persisted receipt intentionally omits the
 selected profile and complete provider response.
 """
 

--- a/experiment_orchestrator/preflight.py
+++ b/experiment_orchestrator/preflight.py
@@ -1,0 +1,185 @@
+"""Non-actuating strict OpenAI selector-profile preflight.
+
+The preflight has provider-network authority only.  It has no database,
+Kubernetes, or device client, and its persisted receipt intentionally omits the
+selected profile and complete provider response.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import ipaddress
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from .contracts import (
+    CLIMATE_SOURCE_SCHEMA,
+    CLIMATE_VALUE_FIELDS,
+    CONTEXT_SCHEMA,
+    ContractError,
+    SelectorContext,
+    SelectorIdentity,
+    canonical_json_bytes,
+    canonical_sha256,
+    format_utc_timestamp,
+)
+from .provider import SelectorProviderAdapter
+from .settings import ProviderSettings
+
+PREFLIGHT_SCHEMA = "verdify-experiment-v2-openai-preflight-receipt-v1"
+
+
+@dataclass(frozen=True)
+class PreflightReceipt:
+    schema: str
+    status: str
+    purpose: str
+    provider: str
+    model_identifier: str
+    model_revision: str
+    selector_identity_sha256: str
+    context_sha256: str
+    raw_request_sha256: str
+    raw_response_sha256: str
+    attempt_receipt_sha256: tuple[str, ...]
+    response_schema_revision: str
+    strict_profile_only: bool
+    tools_allowed: bool
+    database_authority: bool
+    device_authority: bool
+    kubernetes_authority: bool
+    recorded_at: str
+
+    def canonical_bytes(self) -> bytes:
+        payload = asdict(self)
+        payload["attempt_receipt_sha256"] = list(self.attempt_receipt_sha256)
+        return canonical_json_bytes(payload, reject_forbidden_fields=False)
+
+
+def _preflight_context(now: datetime) -> SelectorContext:
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ContractError("preflight clock must be timezone-aware")
+    now = now.astimezone(UTC)
+    observed = now - timedelta(seconds=30)
+    cutoff = now - timedelta(seconds=1)
+    boundary = now + timedelta(minutes=5)
+    values = dict.fromkeys(CLIMATE_VALUE_FIELDS)
+    values["temp_avg_f"] = 75.0
+    values["vpd_avg_kpa"] = 1.2
+    source = {
+        "schema": CLIMATE_SOURCE_SCHEMA,
+        "observed_at": format_utc_timestamp(observed),
+        "values": values,
+    }
+    source["source_row_sha256"] = canonical_sha256(
+        source,
+        domain="verdify-experiment-v2-selector-source-v1",
+    )
+    payload = {
+        "boundary_at": format_utc_timestamp(boundary),
+        "climate_observations": [source],
+        "context_cutoff_at": format_utc_timestamp(cutoff),
+        "forecast_vintage": [],
+        "local_date": (now + timedelta(days=1)).date().isoformat(),
+        "schema": CONTEXT_SCHEMA,
+    }
+    raw = canonical_json_bytes(payload)
+    return SelectorContext.parse(raw, hashlib.sha256(raw).hexdigest())
+
+
+async def run_preflight(
+    *,
+    identity: SelectorIdentity,
+    provider: SelectorProviderAdapter,
+    clock=lambda: datetime.now(UTC),
+) -> PreflightReceipt:
+    started = clock().astimezone(UTC)
+    if (
+        identity.provider != "openai"
+        or identity.model_identifier != "gpt-5.6-sol"
+        or identity.model_revision != "gpt-5.6-sol"
+        or identity.tool_contract_revision != "none-v1"
+        or identity.transport_protocol != "openai_chat_completions"
+    ):
+        raise ContractError("preflight identity is not the strict tool-free GPT-5.6 Sol contract")
+    context = _preflight_context(started)
+    invocation = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"verdify-openai-preflight:{identity.canonical_sha256}:{started.date().isoformat()}",
+        )
+    )
+    result = await provider.select(
+        study_id="verdify-experiment-v2-non-actuating-preflight",
+        local_date=context.local_date,
+        invocation_key=invocation,
+        context=context,
+        identity=identity,
+    )
+    if result.fallback_reason is not None or result.raw_response_sha256 is None:
+        raise ContractError("OpenAI preflight did not return one contract-valid strict profile response")
+    return PreflightReceipt(
+        schema=PREFLIGHT_SCHEMA,
+        status="pass",
+        purpose="non-actuating-profile-contract-preflight",
+        provider=identity.provider,
+        model_identifier=identity.model_identifier,
+        model_revision=identity.model_revision,
+        selector_identity_sha256=identity.canonical_sha256,
+        context_sha256=context.canonical_sha256,
+        raw_request_sha256=result.raw_request_sha256,
+        raw_response_sha256=result.raw_response_sha256,
+        attempt_receipt_sha256=result.attempt_receipt_sha256,
+        response_schema_revision=identity.response_schema_revision,
+        strict_profile_only=True,
+        tools_allowed=False,
+        database_authority=False,
+        device_authority=False,
+        kubernetes_authority=False,
+        recorded_at=format_utc_timestamp(started),
+    )
+
+
+def _load_identity(path: Path) -> SelectorIdentity:
+    raw = path.read_bytes()
+    return SelectorIdentity.parse(raw, hashlib.sha256(raw).hexdigest())
+
+
+async def _main(args: argparse.Namespace) -> int:
+    identity = _load_identity(args.identity)
+    key = os.environ.get("VERDIFY_EXPERIMENT_SELECTOR_API_KEY", "")
+    if not key:
+        raise ContractError("OpenAI preflight credential is unavailable")
+    provider = SelectorProviderAdapter(
+        ProviderSettings(
+            endpoint="https://api.openai.com/v1",
+            endpoint_host="api.openai.com",
+            endpoint_port=443,
+            egress_network=ipaddress.ip_network("0.0.0.0/0"),
+            api_key=key,
+            maximum_response_bytes=16_384,
+        )
+    )
+    receipt = await run_preflight(identity=identity, provider=provider)
+    raw = receipt.canonical_bytes()
+    args.receipt.write_bytes(raw + b"\n")
+    print(json.dumps({"receipt_sha256": hashlib.sha256(raw).hexdigest(), "status": "pass"}, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the non-actuating strict OpenAI profile preflight")
+    parser.add_argument("--identity", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path, default=Path("/dev/termination-log"))
+    args = parser.parse_args()
+    return asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/grafana/provisioning/dashboards/json/confirmed-component-experiment-v2.json
+++ b/grafana/provisioning/dashboards/json/confirmed-component-experiment-v2.json
@@ -157,9 +157,31 @@
           }
         }
       ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Launch authorization and exposure-close-first rollback",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "targets": [
+        {
+          "rawSql": "SELECT experiment_id AS \"Experiment\", lifecycle_status AS \"Lifecycle\", execution_phase AS \"Phase\", admission_state AS \"Admission\", design_locked AS \"Design locked\", randomization_finalized AS \"Finalized once\", randomized_day_1_approved AS \"Day-1 approved\", launch_gate AS \"Launch gate\", open_exposure_count AS \"Open exposures\", kill_action AS \"Kill action\", rollback_action AS \"Rollback action\", rollback_ready AS \"Rollback ready\" FROM public.fn_experiment_v2_launch_gate_status() ORDER BY experiment_id",
+          "refId": "A",
+          "format": "table",
+          "datasource": {
+            "uid": "verdify-tsdb",
+            "type": "grafana-postgresql-datasource"
+          }
+        }
+      ]
     }
   ],
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "style": "light"
 }

--- a/ingestor/esp32_push.py
+++ b/ingestor/esp32_push.py
@@ -545,8 +545,6 @@ async def _execute_one(request: _WriteRequest, index: int) -> DeviceCommandOutco
         return _outcome(request, index, "failed", f"command_error:{type(exc).__name__}")
 
     parameter = _parameter_for(obj_id, entity_type)
-    shared.recently_pushed[parameter] = time.time()
-    shared.recently_pushed_values[parameter] = float(value)
     outcome = _outcome(request, index, "sent", "api_command_returned")
     log.info(
         "writer_delivery phase=transport status=sent reason=api_command_returned param=%s generation=%d attempt=%d",
@@ -555,6 +553,16 @@ async def _execute_one(request: _WriteRequest, index: int) -> DeviceCommandOutco
         request.attempt,
     )
     return outcome
+
+
+def _commit_sent_cache(outcomes: Sequence[DeviceCommandOutcome]) -> None:
+    """Advance echo suppression only after the sent milestone is durable."""
+    committed_at = time.time()
+    for outcome in outcomes:
+        if outcome.status != "sent":
+            continue
+        shared.recently_pushed[outcome.parameter] = committed_at
+        shared.recently_pushed_values[outcome.parameter] = outcome.value
 
 
 def _pop_ready_request(now: float) -> tuple[_WriteRequest | None, float | None]:
@@ -671,6 +679,7 @@ async def _writer_worker() -> None:
             except LifecyclePersistenceError:
                 _abort_all_requests("lifecycle_persistence_unavailable")
                 return
+            _commit_sent_cache(quantum_outcomes)
 
         if request.next_index >= len(request.changes):
             if not await _finish_request(request, ()):
@@ -709,6 +718,7 @@ async def _immediate_result(
     reason: str,
     attempt: int,
     on_state: StateCallback | None,
+    accepted_generation: int | None = None,
 ) -> PushBatchResult:
     loop = asyncio.get_running_loop()
     placeholder = _WriteRequest(
@@ -717,7 +727,9 @@ async def _immediate_result(
         ready=asyncio.Event(),
         on_state=on_state,
         attempt=attempt,
-        accepted_generation=int(shared.transport_generation),
+        accepted_generation=(
+            int(shared.transport_generation) if accepted_generation is None else int(accepted_generation)
+        ),
         accepted_client=shared.esp32.get("client"),
         command_versions=tuple(0.0 for _ in changes),
     )
@@ -792,6 +804,7 @@ async def push_to_esp32_detailed(
     attempt: int = 1,
     on_state: StateCallback | None = None,
     command_versions: Sequence[float] | None = None,
+    expected_connection_generation: int | None = None,
 ) -> PushBatchResult:
     """Queue a bounded batch and return a truthful terminal result per command.
 
@@ -805,6 +818,16 @@ async def push_to_esp32_detailed(
     batch = tuple((obj_id, float(value), entity_type) for obj_id, value, entity_type in changes)
     if not batch:
         return PushBatchResult(())
+    accepted_generation = int(shared.transport_generation)
+    if expected_connection_generation is not None and expected_connection_generation != accepted_generation:
+        return await _immediate_result(
+            batch,
+            "failed",
+            "transport_generation_changed",
+            attempt,
+            on_state,
+            accepted_generation=expected_connection_generation,
+        )
     if len(batch) > _MAX_BATCH_COMMANDS:
         return await _immediate_result(batch, "failed", "batch_limit_exceeded", attempt, on_state)
     if failure := _preflight_failure():
@@ -822,7 +845,7 @@ async def push_to_esp32_detailed(
         ready=asyncio.Event(),
         on_state=on_state,
         attempt=attempt,
-        accepted_generation=int(shared.transport_generation),
+        accepted_generation=accepted_generation,
         accepted_client=shared.esp32.get("client"),
         command_versions=versions,
     )
@@ -1166,8 +1189,6 @@ async def push_component_bundle(
                             reason = f"command_error:{type(exc).__name__}"
 
                 if reason is None:
-                    shared.recently_pushed[call.parameter] = time.time()
-                    shared.recently_pushed_values[call.parameter] = float(call.value)
                     outcome = _component_outcome(
                         call, index, "sent", "api_command_returned", expected_writer_generation, accepted_generation
                     )
@@ -1177,6 +1198,9 @@ async def push_component_bundle(
                     )
                 terminal.append(outcome)
                 await _emit_component_state(on_state, (outcome,))
+                if outcome.status == "sent":
+                    shared.recently_pushed[call.parameter] = time.time()
+                    shared.recently_pushed_values[call.parameter] = float(call.value)
 
                 if outcome.status == "failed":
                     cancelled = tuple(

--- a/ingestor/ingestor.py
+++ b/ingestor/ingestor.py
@@ -78,7 +78,6 @@ from occupancy import refresh_latest_occupancy_state, sync_occupancy_state
 from pydantic import ValidationError
 from tasks import (
     BAND_DRIVEN_PARAMS,
-    IRRIGATION_SCHEDULE_PARAMS,
     alert_monitor,
     attest_component_safe_startup,
     clear_component_entity_inventory,
@@ -2928,9 +2927,18 @@ def _record_cfg_readback(obj_id: str, value: Any) -> bool:
             )
             return True
 
+    generation = int(shared.transport_generation)
     prev = shared.cfg_readback.get(cfg_param)
+    prev_generation = shared.cfg_readback_generation.get(cfg_param)
+    replay_was_ready = shared.transport_readbacks_ready(generation)
     state.cfg_readback[cfg_param] = val
-    shared.cfg_readback[cfg_param] = val
+    replay_completed = shared.note_cfg_readback_observed(cfg_param, val, generation)
+    if replay_completed:
+        log.info(
+            "writer_reconcile reason=transport_reconnect generation=%d action=readbacks_complete readback_count=%d",
+            generation,
+            len(shared.transport_observed_cfg_readbacks),
+        )
     # #433/#639: capture the original ESPHome callback timestamp.  The
     # component source collector freezes an epoch only after all 48 callbacks
     # advance; periodic cached setpoint_snapshot flushes never call this hook.
@@ -2938,6 +2946,8 @@ def _record_cfg_readback(obj_id: str, value: Any) -> bool:
     drift_version: int | None = None
     if (
         cfg_param in _RECONCILABLE_CFG_PARAMS
+        and replay_was_ready
+        and prev_generation == generation
         and prev is not None
         and not math.isclose(prev, val, rel_tol=0.01, abs_tol=0.001)
     ):
@@ -2948,7 +2958,7 @@ def _record_cfg_readback(obj_id: str, value: Any) -> bool:
             shared.transport_generation,
             drift_version,
         )
-    if cfg_param in FORCED_ON_SWITCH_PARAMS and val < 0.5:
+    if cfg_param in FORCED_ON_SWITCH_PARAMS and val < 0.5 and replay_was_ready:
         if drift_version is None:
             drift_version = shared.note_cfg_drift(cfg_param)
         log.warning(
@@ -2961,26 +2971,35 @@ def _record_cfg_readback(obj_id: str, value: Any) -> bool:
 
 
 def _mirror_irrigation_number_readback(param: str, value: Any) -> None:
-    """Treat ESP32 irrigation number-state reports as cfg readbacks.
+    """Treat ESP32 writable-entity state reports as current device truth.
 
-    The irrigation schedule knobs are persisted firmware globals exposed both
-    as writable Number entities and cfg_* diagnostic template sensors. Mirroring
-    the ESP32 Number state keeps setpoint_snapshot fresh when a cfg_* template
-    sensor fails to republish after a reconnect.
+    Most writable fields also expose cfg_* diagnostic sensors, but a small
+    legacy set only has its native Number/Switch state. Mirroring every mapped
+    writable entity closes that gap so reconnect never needs a blind restore.
+    The historical helper name is retained for compatibility with source
+    contract tests and callers.
     """
-    if param not in IRRIGATION_SCHEDULE_PARAMS:
+    if param not in _RECONCILABLE_CFG_PARAMS:
         return
     try:
         val = float(value)
     except (TypeError, ValueError):
-        log.warning("irrigation number readback rejected non-numeric: %s=%r", param, value)
+        log.warning("writable entity readback rejected non-numeric: %s=%r", param, value)
         return
     if math.isnan(val):
         return
+    generation = int(shared.transport_generation)
     prev = shared.cfg_readback.get(param)
+    prev_generation = shared.cfg_readback_generation.get(param)
+    replay_was_ready = shared.transport_readbacks_ready(generation)
     state.cfg_readback[param] = val
-    shared.cfg_readback[param] = val
-    if prev is not None and not math.isclose(prev, val, rel_tol=0.01, abs_tol=0.001):
+    shared.note_cfg_readback_observed(param, val, generation)
+    if (
+        replay_was_ready
+        and prev_generation == generation
+        and prev is not None
+        and not math.isclose(prev, val, rel_tol=0.01, abs_tol=0.001)
+    ):
         drift_version = shared.note_cfg_drift(param)
         log.info(
             "writer_reconcile reason=cfg_drift param=%s generation=%d drift_version=%d source=number_mirror",
@@ -3123,6 +3142,10 @@ def on_state_change(entity_state) -> None:
         val = entity_state.state
         if _record_cfg_readback(obj_id, 1.0 if val else 0.0):
             return
+
+        param = SETPOINT_MAP.get(obj_id)
+        if param:
+            _mirror_irrigation_number_readback(param, 1.0 if val else 0.0)
 
         equip = EQUIPMENT_SWITCH_MAP.get(obj_id)
         if equip:
@@ -3523,19 +3546,26 @@ async def esp32_loop(pool: asyncpg.Pool = None) -> None:
             )
 
             # Advance the transport generation exactly once for this successful
-            # API connect.  cfg drift has a separate targeted wakeup and can
-            # never reach this generation counter.
+            # API connect. Reconciliation remains blocked until the native API
+            # replays every writable field enumerated on this socket.
+            # This prevents a replacement writer from comparing desired state
+            # against the preceding generation's in-memory cache.
             import time as _time_mod
 
-            connection_generation = shared.note_transport_connected()
-            # Compatibility event is set inside note_transport_connected(); it
-            # remains reconnect-only and is consumed after this generation is
-            # reconciled.
-            shared.force_setpoint_push.set()
+            expected_cfg_readbacks = frozenset(
+                readback_param
+                for entity in entities
+                if (readback_param := SETPOINT_MAP.get(entity.object_id) or CFG_READBACK_MAP.get(entity.object_id))
+                in _RECONCILABLE_CFG_PARAMS
+            )
+            connection_generation = shared.note_transport_connected(expected_cfg_readbacks)
+            state.cfg_readback.clear()
             shared.esp32_connected_at = _time_mod.time()
             log.info(
-                "writer_reconcile reason=transport_reconnect generation=%d action=reconcile_requested",
+                "writer_reconcile reason=transport_reconnect generation=%d "
+                "action=awaiting_readbacks expected_readback_count=%d",
                 connection_generation,
+                len(expected_cfg_readbacks),
             )
             record_component_entity_inventory(
                 tuple(

--- a/ingestor/shared.py
+++ b/ingestor/shared.py
@@ -219,10 +219,12 @@ esp32 = {
 recently_pushed: dict[str, float] = {}
 recently_pushed_values: dict[str, float] = {}
 
-# param -> latest cfg_* readback from ESP32. Used by reconnect dispatch to
-# reconcile desired setpoints against device state instead of force-pushing
-# values the firmware has already confirmed.
+# param -> latest writable-field readback from ESP32 (cfg_* diagnostics or the
+# native Number/Switch state when no cfg_* sensor exists). Used by reconnect
+# dispatch to compare desired state against device truth. The parallel
+# generation map is authoritative: an earlier socket is never current truth.
 cfg_readback: dict[str, float] = {}
+cfg_readback_generation: dict[str, int] = {}
 
 # Lane C (#584) / contract v2 (#586): latest device-echoed policy identity,
 # keyed by verdify_schemas.policy_transport.POLICY_IDENTITY_SENSOR — the ONE
@@ -238,6 +240,15 @@ policy_readback: dict[str, str] = {}
 transport_generation = 0
 reconciled_transport_generation = 0
 
+# A reconnect is not eligible for reconciliation until the native API has
+# replayed every writable field enumerated on that exact connection.
+# ESPHome sends the initial states asynchronously after subscribe_states(); a
+# fixed sleep races that replay and caused broad startup restore batches to be
+# computed from the preceding connection's cache (#433/#641).
+transport_expected_cfg_readbacks: frozenset[str] = frozenset()
+transport_observed_cfg_readbacks: set[str] = set()
+transport_readbacks_generation = 0
+
 # cfg parameter -> monotonic drift version.  Versioning lets a dispatcher clear
 # only the drift it actually observed; a newer readback arriving mid-dispatch
 # remains pending for the next targeted pass.
@@ -247,23 +258,85 @@ _cfg_drift_version = 0
 # Wake the scheduler for targeted cfg drift without advancing transport state.
 setpoint_dispatch_requested = asyncio.Event()
 
-# Compatibility reconnect event.  This event is now set ONLY by
-# note_transport_connected(); generic cfg drift must never set it.
+# Compatibility reconnect event. This event is set only when the exact current
+# generation finishes its initial replay; generic cfg drift must never set it.
 force_setpoint_push = asyncio.Event()
 
 
-def note_transport_connected() -> int:
-    """Advance and return the one monotonic generation for a real API connect."""
-    global transport_generation
+def note_transport_connected(expected_cfg_readbacks: frozenset[str] = frozenset()) -> int:
+    """Start one transport generation whose readback replay is not yet ready.
+
+    The caller supplies only writable parameters actually enumerated on this
+    connection.  An empty inventory stays unready: blindly restoring against a
+    socket that exposed no device truth is less safe than waiting.
+    """
+    global transport_generation, transport_expected_cfg_readbacks
+    global transport_observed_cfg_readbacks, transport_readbacks_generation
     transport_generation += 1
-    force_setpoint_push.set()
-    setpoint_dispatch_requested.set()
+    transport_expected_cfg_readbacks = frozenset(expected_cfg_readbacks)
+    transport_observed_cfg_readbacks = set()
+    transport_readbacks_generation = 0
+    cfg_readback.clear()
+    cfg_readback_generation.clear()
+    force_setpoint_push.clear()
+    setpoint_dispatch_requested.clear()
     return transport_generation
+
+
+def note_cfg_readback_observed(param: str, value: float, generation: int) -> bool:
+    """Record one writable value only inside the exact current replay.
+
+    Returns true exactly once when the last expected parameter for this
+    generation arrives.  Late callbacks are fenced by the connection callback,
+    but the explicit generation check keeps this helper safe in isolation too.
+    """
+    global transport_readbacks_generation
+    if generation != transport_generation:
+        return False
+    cfg_readback[param] = float(value)
+    cfg_readback_generation[param] = generation
+    if param in transport_expected_cfg_readbacks:
+        transport_observed_cfg_readbacks.add(param)
+    if (
+        transport_expected_cfg_readbacks
+        and transport_expected_cfg_readbacks <= transport_observed_cfg_readbacks
+        and transport_readbacks_generation != generation
+    ):
+        transport_readbacks_generation = generation
+        force_setpoint_push.set()
+        setpoint_dispatch_requested.set()
+        return True
+    return False
+
+
+def transport_readbacks_ready(generation: int) -> bool:
+    """Return true only for a complete replay from the exact live generation."""
+    return (
+        generation == transport_generation
+        and generation == transport_readbacks_generation
+        and bool(transport_expected_cfg_readbacks)
+        and transport_expected_cfg_readbacks <= transport_observed_cfg_readbacks
+    )
+
+
+def current_cfg_readbacks(generation: int | None = None) -> dict[str, float]:
+    """Copy only writable values observed on the requested/current socket."""
+    current = transport_generation if generation is None else generation
+    return {param: value for param, value in cfg_readback.items() if cfg_readback_generation.get(param) == current}
+
+
+def missing_transport_cfg_readbacks(generation: int) -> frozenset[str]:
+    """Report the exact current-generation replay gap for bounded logging."""
+    if generation != transport_generation:
+        return transport_expected_cfg_readbacks
+    return transport_expected_cfg_readbacks - transport_observed_cfg_readbacks
 
 
 def mark_transport_reconciled(generation: int) -> None:
     """Mark one completed generation without erasing a newer reconnect."""
     global reconciled_transport_generation
+    if not transport_readbacks_ready(generation):
+        return
     reconciled_transport_generation = max(reconciled_transport_generation, generation)
     if transport_generation <= reconciled_transport_generation:
         force_setpoint_push.clear()

--- a/ingestor/tasks/dispatcher.py
+++ b/ingestor/tasks/dispatcher.py
@@ -5,6 +5,7 @@ original module. The tasks package __init__ re-exports the public
 surface so every `from tasks import X` still resolves.
 """
 
+from entity_map import CFG_READBACK_MAP, SETPOINT_MAP
 from esp32_push import (
     DeviceCommandOutcome,
     LifecyclePersistenceError,
@@ -76,6 +77,21 @@ from ._common import (
     registry_value_error,
     shared,
 )
+
+# Reconnect restoration is intentionally small and explicit.  These are the
+# only legacy safety controls in the old force-reconcile set. Every field has
+# either a cfg_* diagnostic or native Number/Switch readback route, so this set
+# is intentionally empty today. A future genuinely unobserved field is bounded
+# here and by MAX_RECONNECT_COMMANDS instead of reopening a broad blind restore.
+_RECONNECT_SAFETY_CANDIDATES = (
+    LIGHTING_POLICY_PARAMS
+    | LIGHTING_CIRCUIT_LUX_PARAMS
+    | HOUSE_BAND_PARAMS
+    | frozenset(p for p in CROP_BAND_REG if p.startswith("vpd_target_"))
+)
+_CURRENT_READBACK_PARAMS = frozenset(CFG_READBACK_MAP.values()) | frozenset(SETPOINT_MAP.values())
+RECONNECT_UNOBSERVED_RESTORE_PARAMS = frozenset(_RECONNECT_SAFETY_CANDIDATES - _CURRENT_READBACK_PARAMS)
+MAX_RECONNECT_COMMANDS = 12
 
 
 def _upsert_change(changes: list[tuple[str, float]], param: str, value: float) -> None:
@@ -330,7 +346,7 @@ def _heap_push_defer_active(
 
 def _readback_drift(param: str, desired: float) -> bool:
     """True when ESP32 cfg_* readback disagrees with the desired value."""
-    readback = shared.cfg_readback.get(param)
+    readback = shared.current_cfg_readbacks().get(param)
     if readback is None:
         return False
     return not readback_values_equivalent(param, readback, desired)
@@ -338,10 +354,11 @@ def _readback_drift(param: str, desired: float) -> bool:
 
 def _unchanged_anchor_dispatch_count(changes: list[tuple[str, float, str]]) -> int:
     """Count anchor commands whose canonical cfg readback already matches."""
+    current_readbacks = shared.current_cfg_readbacks()
     return sum(
         param in band_anchors.ANCHOR_SYNC_PARAMS
-        and param in shared.cfg_readback
-        and readback_values_equivalent(param, shared.cfg_readback[param], value)
+        and param in current_readbacks
+        and readback_values_equivalent(param, current_readbacks[param], value)
         for param, value, _source in changes
     )
 
@@ -602,61 +619,35 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
     else:
         dispatch_reason = "desired_change"
 
+    if reconnect_pending and not shared.transport_readbacks_ready(reconnect_generation):
+        missing = shared.missing_transport_cfg_readbacks(reconnect_generation)
+        log.warning(
+            "writer_reconcile reason=transport_reconnect generation=%d "
+            "action=blocked_readbacks_incomplete expected=%d missing=%d",
+            reconnect_generation,
+            len(shared.transport_expected_cfg_readbacks),
+            len(missing),
+        )
+        return
+
     def complete_dispatch_trigger() -> None:
         if reconnect_pending:
             shared.mark_transport_reconciled(reconnect_generation)
         shared.clear_cfg_drift(drift_versions)
 
-    # On a REAL ESP32 transport generation, rebuild the cache from firmware
-    # cfg_* readbacks. Generic cfg drift never enters this block or clears the
-    # sent-value cache.
-    # Values already confirmed by the device do not need to be pushed again;
-    # params without a readback still flow through as a conservative fallback.
-    #
-    # NVS-persisted band params (CROP_BAND_REG — temp/vpd anchors, zone targets,
-    # priorities, boosts, taper) are seeded here too (#430 Tier 1). They were
-    # formerly force-re-pushed on every reconnect; but they are restore_value:yes
-    # (survive reboot), so seeding from cfg_readback is safe and their per-param
-    # `_readback_drift` gate still re-pushes any value that actually differs from
-    # authoritative (a changed band, or a device echoing a wrong value). The old
-    # blanket exclusion re-asserted all ~74 BAND_DRIVEN_PARAMS with UNCHANGED
-    # values every reconnect (~7,400 constant pushes/day, ~100 reconnects/day) —
-    # the churn the recently_pushed comment below names as driving ESP32 heap into
-    # critical-pressure transients (#428).
-    #
-    # EXCEPTION (must stay force-reconciled): band params that REVERT to cold
-    # defaults on a reboot/OTA (restore_value:no). Seeding these from the device's
-    # possibly-reverted — or silently-not-republished — cfg_readback could mask a
-    # reverted device and strand the greenhouse on a stale value, and
-    # `_readback_drift` reads the same stale cache so it can't catch it (Case D).
-    # They are left UNSEEDED so the next dispatch re-asserts the authoritative
-    # value unconditionally. Two groups:
-    #   • lighting lux/policy — the 2026-06-16 grow-light-strand incident
-    #     (_common.py:111); force-reconciled before and after this change.
-    #   • served-band edges + per-zone vpd_target (HOUSE_BAND_PARAMS + vpd_target_*)
-    #     back onto restore_value:no globals. Harmless in the live anchors regime —
-    #     recomputed on-chip every cycle from the restore_value:yes anchors and NOT
-    #     pushed while anchors_live — so force-reconciling them costs ~0 churn there;
-    #     included as defense-in-depth against a legacy on-chip-band-disabled fallback.
-    # The delta-seeded remainder (crop-band anchors/priorities/boosts/taper) is all
-    # restore_value:yes; a test pins that no reverting param slips into the seed.
-    RECONNECT_FORCE_RECONCILE = (
-        LIGHTING_POLICY_PARAMS
-        | LIGHTING_CIRCUIT_LUX_PARAMS
-        | HOUSE_BAND_PARAMS
-        | frozenset(p for p in CROP_BAND_REG if p.startswith("vpd_target_"))
-    )
+    # Rebuild the comparison cache only from callbacks belonging to this exact
+    # connection. Readback-routed controls, including restore_value:no fields,
+    # are delta-repaired from live truth. Any future control with no observable
+    # route is deliberately forgotten and conservatively restored below.
     reconnect_event_set = False
     if shared.force_setpoint_push.is_set():
         reconnect_event_set = True
     if reconnect_event_set and reconnect_pending:
-        _last_pushed.clear()
+        current_readbacks = shared.current_cfg_readbacks(reconnect_generation)
+        for param in RECONNECT_UNOBSERVED_RESTORE_PARAMS:
+            _last_pushed.pop(param, None)
         seeded = 0
-        force_reconciled = 0
-        for param, val in shared.cfg_readback.items():
-            if param in RECONNECT_FORCE_RECONCILE:
-                force_reconciled += 1
-                continue
+        for param, val in current_readbacks.items():
             _last_pushed[param] = float(val)
             seeded += 1
         if SWITCH_CONFIRM_EQUIPMENT:
@@ -672,17 +663,17 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
                 )
             equipment_state = {row["equipment"]: bool(row["state"]) for row in equipment_rows}
             for param, equipment in SWITCH_CONFIRM_EQUIPMENT.items():
-                if param in shared.cfg_readback:
+                if param in current_readbacks:
                     continue
                 if equipment in equipment_state:
                     _last_pushed[param] = 1.0 if equipment_state[equipment] else 0.0
                     seeded += 1
         log.info(
             "writer_reconcile reason=transport_reconnect generation=%d seeded=%d "
-            "force_reconciled=%d comparison=desired_vs_observed",
+            "unobserved_restore_limit=%d comparison=current_generation_readbacks",
             reconnect_generation,
             seeded,
-            force_reconciled,
+            len(RECONNECT_UNOBSERVED_RESTORE_PARAMS),
         )
     async with pool.acquire() as conn:
         # Compute crop-science band, per-zone VPD targets, the DB-owned house
@@ -1073,7 +1064,7 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
                 changes.append((param, planned_val))
 
         for param in FORCED_ON_SWITCH_PARAMS:
-            readback = shared.cfg_readback.get(param)
+            readback = shared.current_cfg_readbacks().get(param)
             if readback is not None and readback < 0.5:
                 if not any(existing_param == param for existing_param, _ in changes):
                     log.warning(
@@ -1098,6 +1089,22 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
         for param, value in changes:
             deduped_changes[param] = float(value)
         changes = list(deduped_changes.items())
+
+        if reconnect_pending and len(changes) > MAX_RECONNECT_COMMANDS:
+            # A reconnect is recovery work, not authority to enqueue another
+            # historical 40+ command restore storm.  Leave the generation
+            # unreconciled and retry on the ordinary cadence after operators
+            # can inspect the current-generation comparison evidence.
+            shared.defer_failed_dispatch(reconnect_generation, drift_versions)
+            log.error(
+                "writer_reconcile reason=transport_reconnect generation=%d "
+                "action=blocked_broad_restore command_count=%d limit=%d",
+                reconnect_generation,
+                len(changes),
+                MAX_RECONNECT_COMMANDS,
+            )
+            (STATE_DIR / "setpoint-dispatcher.log").touch()
+            return
 
         if not changes:
             clamp_rows_written = await _write_clamp_audit_rows(conn, clamps_to_log, set())
@@ -1334,14 +1341,6 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
             param = str(record["parameter"])
             value = float(record["value"])
             status = _persisted_delivery_status(outcome, final_attempt)
-            if outcome.status == "sent":
-                # Physical API return is the first point at which sent caches
-                # may advance.  Confirmation still waits for cfg/equipment
-                # readback in the independent confirmation path.
-                _last_pushed[param] = value
-                # Compatibility invariant text: the physical helper performs
-                # shared.recently_pushed[param] = time.time() only after the API
-                # command returns; the dispatcher deliberately never pre-marks.
             allowed = list(delivery_transition_prior_statuses(status))
             async with pool.acquire() as state_conn:
                 persisted = await state_conn.fetchval(
@@ -1375,6 +1374,11 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
                         if preserved is None:
                             raise RuntimeError(f"illegal delivery transition {current!r} -> {status!r} for {param}")
                         status = preserved
+            if outcome.status == "sent":
+                # Advance the desired/sent cache only after the corresponding
+                # durable terminal callback succeeded. Confirmation remains an
+                # independent cfg/equipment readback transition.
+                _last_pushed[param] = value
             log.info(
                 "writer_delivery phase=persisted status=%s reason=%s param=%s generation=%d attempt=%d",
                 status,
@@ -1446,6 +1450,7 @@ async def setpoint_dispatcher(pool: asyncpg.Pool) -> None:
             attempt=attempt,
             on_state=on_state,
             command_versions=[record["requested_at"].timestamp() for record in pending_records],
+            expected_connection_generation=reconnect_generation,
         )
         if result.fatal_error:
             raise LifecyclePersistenceError(result.fatal_error)

--- a/research/planner-efficacy/protocols/assigned-day-itt-v2.fixtures.json
+++ b/research/planner-efficacy/protocols/assigned-day-itt-v2.fixtures.json
@@ -1,0 +1,86 @@
+{
+  "cases": [
+    {
+      "canonical_export": {
+        "rows": [
+          {
+            "assignment_id": "11111111-1111-4111-8111-111111111111",
+            "blinded_label": "X",
+            "execution_phase": "randomized",
+            "fallback_or_rescue": false,
+            "fidelity": {
+              "exposure_seconds": 64800,
+              "per_protocol_exposure_complete": true
+            },
+            "fixed_window_utc_end": "2026-11-03T07:00:00Z",
+            "fixed_window_utc_start": "2026-11-02T13:00:00Z",
+            "local_date": "2026-11-02",
+            "missing_reason": null,
+            "nine_control_state_minutes": 90.0,
+            "outcome_complete": true,
+            "temperature_corridor_distance_f": 0.0,
+            "vpd_corridor_distance_kpa": 0.0
+          }
+        ],
+        "schema": "verdify-experiment-v2-blinded-day-export-v1"
+      },
+      "export_sha256": "7300da5156713478ac69345795706235e66bc2ea85546360bf1b035119ac44fa",
+      "name": "complete_full_fidelity"
+    },
+    {
+      "canonical_export": {
+        "rows": [
+          {
+            "assignment_id": "22222222-2222-4222-8222-222222222222",
+            "blinded_label": "Y",
+            "execution_phase": "randomized",
+            "fallback_or_rescue": true,
+            "fidelity": {
+              "exposure_seconds": 0,
+              "per_protocol_exposure_complete": false
+            },
+            "fixed_window_utc_end": "2026-11-03T07:00:00Z",
+            "fixed_window_utc_start": "2026-11-02T13:00:00Z",
+            "local_date": "2026-11-02",
+            "missing_reason": null,
+            "nine_control_state_minutes": 0.0,
+            "outcome_complete": true,
+            "temperature_corridor_distance_f": 0.25,
+            "vpd_corridor_distance_kpa": 0.05
+          }
+        ],
+        "schema": "verdify-experiment-v2-blinded-day-export-v1"
+      },
+      "export_sha256": "0f5053d24b76a9a27db48ee6194a1f5bdd9fb3eec24ad2ad28621c76e9606946",
+      "name": "fallback_zero_exposure"
+    },
+    {
+      "canonical_export": {
+        "rows": [
+          {
+            "assignment_id": "33333333-3333-4333-8333-333333333333",
+            "blinded_label": "X",
+            "execution_phase": "randomized",
+            "fallback_or_rescue": true,
+            "fidelity": {
+              "exposure_seconds": 1200,
+              "per_protocol_exposure_complete": false
+            },
+            "fixed_window_utc_end": "2026-11-03T07:00:00Z",
+            "fixed_window_utc_start": "2026-11-02T13:00:00Z",
+            "local_date": "2026-11-02",
+            "missing_reason": "climate_completeness",
+            "nine_control_state_minutes": null,
+            "outcome_complete": false,
+            "temperature_corridor_distance_f": null,
+            "vpd_corridor_distance_kpa": null
+          }
+        ],
+        "schema": "verdify-experiment-v2-blinded-day-export-v1"
+      },
+      "export_sha256": "61dc111db2691341af7202882931f3a89c8fda61eb9afc3397a936eba0cbcb6a",
+      "name": "rescue_null_outcome"
+    }
+  ],
+  "schema": "verdify-experiment-v2-day1-export-fixtures-v1"
+}

--- a/research/planner-efficacy/protocols/direct-launch-basis-v1.json
+++ b/research/planner-efficacy/protocols/direct-launch-basis-v1.json
@@ -1,0 +1,27 @@
+{
+  "accepted_underpowered_design": true,
+  "candidate_start_local_date": "2026-11-02",
+  "experiment_id": "45039c86-c1d9-52f6-a0a9-d94a17bc4b14",
+  "generalized_vector_mode": "off",
+  "missed_start_policy": "new_preregistration_and_new_design_lock",
+  "modeled_joint_advance_power": "0.13776",
+  "provider_contract": {
+    "model": "gpt-5.6-sol",
+    "profile_only": true,
+    "reasoning_effort": "medium",
+    "strict_structured_output": true,
+    "tools": false
+  },
+  "randomization_contract": {
+    "caller_supplied_randomness": false,
+    "draws": 1,
+    "no_redraw": true,
+    "source": "internal_os_csprng"
+  },
+  "randomized_pair_count": 30,
+  "schema": "verdify-experiment-v2-direct-launch-basis-v1",
+  "selection_policy": "earliest_unused_future_offset_stable_60_day_window_at_lock_time",
+  "study_id": "verdify-confirmed-component-switchback-v2-2026-08",
+  "timezone": "America/Denver",
+  "window_days": 60
+}

--- a/research/planner-efficacy/switchback/v2_day1_export.py
+++ b/research/planner-efficacy/switchback/v2_day1_export.py
@@ -1,0 +1,156 @@
+"""Deterministic blinded assigned-day ITT export and replay contract.
+
+Every immutable assignment produces exactly one row.  Exposure is nested under
+fidelity and cannot select, truncate, weight, or remove the primary fixed-window
+outcome.  The module contains no database, provider, randomization, or reveal
+client and rejects mapping/secret/physical-arm fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from datetime import UTC
+from typing import Any
+
+from .v2_outcomes import ANALYZED_SECONDS, RandomizedIttRow, _local_window, make_randomized_itt_row
+
+DAY1_EXPORT_SCHEMA = "verdify-experiment-v2-blinded-day-export-v1"
+DAY1_EXPORT_DOMAIN = b"verdify-experiment-v2-blinded-day-export-v1\x00"
+
+_TOP_FIELDS = {"rows", "schema"}
+_ROW_FIELDS = {
+    "assignment_id",
+    "blinded_label",
+    "execution_phase",
+    "fallback_or_rescue",
+    "fidelity",
+    "fixed_window_utc_end",
+    "fixed_window_utc_start",
+    "local_date",
+    "missing_reason",
+    "nine_control_state_minutes",
+    "outcome_complete",
+    "temperature_corridor_distance_f",
+    "vpd_corridor_distance_kpa",
+}
+_FIDELITY_FIELDS = {"exposure_seconds", "per_protocol_exposure_complete"}
+_FORBIDDEN = {
+    "mapping",
+    "physical_arm",
+    "randomization_secret",
+    "secret",
+    "x_physical_arm",
+    "y_physical_arm",
+}
+
+
+def _canonical(value: dict[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _row_payload(row: RandomizedIttRow, *, timezone: str) -> dict[str, Any]:
+    start, end = _local_window(row.local_date, timezone)
+    values = asdict(row)
+    exposure_seconds = values.pop("exposure_seconds")
+    per_protocol = values.pop("per_protocol_exposure_complete")
+    values.update(
+        {
+            "fidelity": {
+                "exposure_seconds": exposure_seconds,
+                "per_protocol_exposure_complete": per_protocol,
+            },
+            "fixed_window_utc_end": end.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "fixed_window_utc_start": start.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+    )
+    return values
+
+
+def freeze_blinded_day_export(
+    rows: list[RandomizedIttRow],
+    *,
+    timezone: str = "America/Denver",
+) -> tuple[bytes, str]:
+    if not rows:
+        raise ValueError("blinded day export requires at least one immutable assignment")
+    ordered = sorted(rows, key=lambda row: (row.local_date, row.assignment_id))
+    identities = [(row.local_date, row.assignment_id) for row in ordered]
+    if len(set(identities)) != len(identities):
+        raise ValueError("blinded day export contains a duplicate assignment row")
+    payload = {"rows": [_row_payload(row, timezone=timezone) for row in ordered], "schema": DAY1_EXPORT_SCHEMA}
+    raw = _canonical(payload)
+    lowered = raw.decode().lower()
+    if any(f'"{field}"' in lowered for field in _FORBIDDEN):
+        raise ValueError("blinded day export contains restricted randomization material")
+    return raw, hashlib.sha256(DAY1_EXPORT_DOMAIN + raw).hexdigest()
+
+
+def replay_blinded_day_export(
+    raw: bytes,
+    expected_sha256: str,
+    *,
+    timezone: str = "America/Denver",
+) -> tuple[RandomizedIttRow, ...]:
+    if type(raw) is not bytes or hashlib.sha256(DAY1_EXPORT_DOMAIN + raw).hexdigest() != expected_sha256:
+        raise ValueError("blinded day export byte/hash binding mismatch")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("blinded day export is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict) or set(payload) != _TOP_FIELDS or payload["schema"] != DAY1_EXPORT_SCHEMA:
+        raise ValueError("blinded day export schema mismatch")
+    if _canonical(payload) != raw or not isinstance(payload["rows"], list) or not payload["rows"]:
+        raise ValueError("blinded day export is not canonical or has no rows")
+    replayed: list[RandomizedIttRow] = []
+    for item in payload["rows"]:
+        if not isinstance(item, dict) or set(item) != _ROW_FIELDS:
+            raise ValueError("blinded day row shape mismatch")
+        fidelity = item["fidelity"]
+        if not isinstance(fidelity, dict) or set(fidelity) != _FIDELITY_FIELDS:
+            raise ValueError("blinded day fidelity shape mismatch")
+        start, end = _local_window(item["local_date"], timezone)
+        if item["fixed_window_utc_start"] != start.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ") or item[
+            "fixed_window_utc_end"
+        ] != end.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"):
+            raise ValueError("blinded day export changed the fixed [06:00,24:00) window")
+        climate_missing = item["temperature_corridor_distance_f"] is None or item["vpd_corridor_distance_kpa"] is None
+        equipment_missing = item["nine_control_state_minutes"] is None
+        row = make_randomized_itt_row(
+            assignment_id=item["assignment_id"],
+            local_date=item["local_date"],
+            blinded_label=item["blinded_label"],
+            climate=(
+                item["temperature_corridor_distance_f"],
+                item["vpd_corridor_distance_kpa"],
+                item["missing_reason"] if climate_missing else None,
+            ),
+            equipment=(
+                item["nine_control_state_minutes"],
+                item["missing_reason"] if equipment_missing and not climate_missing else None,
+            ),
+            fallback_or_rescue=item["fallback_or_rescue"],
+            exposure_seconds=fidelity["exposure_seconds"],
+        )
+        if asdict(row)["outcome_complete"] is not item["outcome_complete"] or (
+            fidelity["per_protocol_exposure_complete"] is not row.per_protocol_exposure_complete
+        ):
+            raise ValueError("blinded day derived completeness fields are inconsistent")
+        replayed.append(row)
+    if [(row.local_date, row.assignment_id) for row in replayed] != sorted(
+        (row.local_date, row.assignment_id) for row in replayed
+    ):
+        raise ValueError("blinded day rows are not in deterministic assignment order")
+    if any(not 0 <= row.exposure_seconds <= ANALYZED_SECONDS for row in replayed):
+        raise ValueError("blinded day fidelity exposure is outside the fixed window")
+    reproduced, reproduced_sha = freeze_blinded_day_export(list(replayed), timezone=timezone)
+    if reproduced != raw or reproduced_sha != expected_sha256:
+        raise ValueError("blinded day replay did not reproduce identical bytes and hash")
+    return tuple(replayed)

--- a/research/planner-efficacy/tests/test_switchback_v2_day1_export.py
+++ b/research/planner-efficacy/tests/test_switchback_v2_day1_export.py
@@ -32,14 +32,14 @@ def test_every_checked_in_day1_case_replays_to_identical_bytes_and_hash() -> Non
 
 
 def test_exposure_is_fidelity_only_and_never_selects_the_primary_itt_row() -> None:
-    common = dict(
-        assignment_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        local_date="2026-11-02",
-        blinded_label="X",
-        climate=(0.1, 0.2, None),
-        equipment=(30.0, None),
-        fallback_or_rescue=False,
-    )
+    common = {
+        "assignment_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "local_date": "2026-11-02",
+        "blinded_label": "X",
+        "climate": (0.1, 0.2, None),
+        "equipment": (30.0, None),
+        "fallback_or_rescue": False,
+    }
     zero = make_randomized_itt_row(**common, exposure_seconds=0)
     full = make_randomized_itt_row(**common, exposure_seconds=64_800)
     zero_payload = json.loads(freeze_blinded_day_export([zero])[0])["rows"][0]

--- a/research/planner-efficacy/tests/test_switchback_v2_day1_export.py
+++ b/research/planner-efficacy/tests/test_switchback_v2_day1_export.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from switchback.v2_day1_export import freeze_blinded_day_export, replay_blinded_day_export
+from switchback.v2_outcomes import make_randomized_itt_row
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "protocols/assigned-day-itt-v2.fixtures.json"
+
+
+def _canonical(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def test_every_checked_in_day1_case_replays_to_identical_bytes_and_hash() -> None:
+    fixture = json.loads(FIXTURE.read_text())
+    assert fixture["schema"] == "verdify-experiment-v2-day1-export-fixtures-v1"
+    assert {case["name"] for case in fixture["cases"]} == {
+        "complete_full_fidelity",
+        "fallback_zero_exposure",
+        "rescue_null_outcome",
+    }
+    for case in fixture["cases"]:
+        raw = _canonical(case["canonical_export"])
+        rows = replay_blinded_day_export(raw, case["export_sha256"])
+        repeated, repeated_sha = freeze_blinded_day_export(list(rows))
+        assert repeated == raw
+        assert repeated_sha == case["export_sha256"]
+        assert len(rows) == 1
+
+
+def test_exposure_is_fidelity_only_and_never_selects_the_primary_itt_row() -> None:
+    common = dict(
+        assignment_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        local_date="2026-11-02",
+        blinded_label="X",
+        climate=(0.1, 0.2, None),
+        equipment=(30.0, None),
+        fallback_or_rescue=False,
+    )
+    zero = make_randomized_itt_row(**common, exposure_seconds=0)
+    full = make_randomized_itt_row(**common, exposure_seconds=64_800)
+    zero_payload = json.loads(freeze_blinded_day_export([zero])[0])["rows"][0]
+    full_payload = json.loads(freeze_blinded_day_export([full])[0])["rows"][0]
+    zero_fidelity = zero_payload.pop("fidelity")
+    full_fidelity = full_payload.pop("fidelity")
+    assert zero_payload == full_payload
+    assert zero_fidelity != full_fidelity
+    assert zero_payload["fixed_window_utc_start"] == "2026-11-02T13:00:00Z"
+    assert zero_payload["fixed_window_utc_end"] == "2026-11-03T07:00:00Z"
+
+
+def test_blinded_export_never_contains_mapping_secret_or_physical_arm() -> None:
+    lowered = FIXTURE.read_text().lower()
+    for forbidden in (
+        '"mapping"',
+        '"secret"',
+        '"physical_arm"',
+        '"x_physical_arm"',
+        '"y_physical_arm"',
+        '"efficacy"',
+    ):
+        assert forbidden not in lowered

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -52,6 +52,7 @@ $PY -m pytest -q \
   tests/test_03_ingestor.py \
   research/planner-efficacy/tests/test_protocol_template_contract.py \
   research/planner-efficacy/tests/test_switchback_v2_design.py \
+  research/planner-efficacy/tests/test_switchback_v2_day1_export.py \
   research/planner-efficacy/tests/test_switchback_v2_randomization.py \
   research/planner-efficacy/tests/test_switchback_v2_selector.py
 $PY research/planner-efficacy/generate_v2_artifacts.py --check
@@ -107,7 +108,9 @@ $PY -m pytest -q \
   tests/test_experiment_v2_restore_rehearsal.py \
   tests/test_experiment_v2_shadow_source_lock.py \
   tests/test_experiment_v2_data_contract.py \
+  tests/test_experiment_v2_day1_authorization.py \
   tests/test_experiment_v2_direct_launch_runtime.py \
+  tests/test_experiment_v2_launch_artifacts.py \
   tests/test_experiment_v2_direct_proof_activation.py \
   tests/test_experiment_v2_direct_proof_attempt_status.py \
   tests/test_experiment_v2_direct_proof_recovery_range_rollover.py \

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -61,11 +61,13 @@ $PY -m pytest -q tests/test_device_write_gate.py
 
 step "pure-logic / contract tests"
 $PY -m pytest -q \
+  tests/test_05_dispatcher.py \
   tests/test_10_planner_routing.py \
   tests/test_11_planner_milestones.py \
   tests/test_13_grafana_band_traceability.py \
   tests/test_14_shadow_mode.py \
   tests/test_14_site_doctor.py \
+  tests/test_16_writer_lifecycle.py \
   tests/test_17_planner_health_surface.py \
   tests/test_18_twin_divergence_dashboard.py \
   tests/test_20_vision_src_sync.py \
@@ -108,6 +110,7 @@ $PY -m pytest -q \
   tests/test_experiment_v2_direct_launch_runtime.py \
   tests/test_experiment_v2_direct_proof_activation.py \
   tests/test_experiment_v2_direct_proof_attempt_status.py \
+  tests/test_experiment_v2_direct_proof_recovery_range_rollover.py \
   tests/test_experiment_v2_direct_proof_retry.py \
   tests/test_experiment_v2_emergency_recovery_retry.py \
   tests/test_experiment_v2_recovery_generation_guard.py \
@@ -157,6 +160,7 @@ $PY -m pytest -q \
   tests/test_twin_asof_migration.py \
   tests/test_twin_live_driver.py \
   tests/test_verdify_traefik_placement.py \
+  tests/test_verify_component_proof_packet.py \
   tests/test_writer_lease_fence.py
 
 step "migration rollback safety classification"

--- a/scripts/mcp-security-acceptance.py
+++ b/scripts/mcp-security-acceptance.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Fail-closed, metadata-only acceptance for Verdify's stateless MCP surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_HERMES_CONFIG = REPO_ROOT / "deploy/k8s/components/hermes-iris/hermes-config.yaml"
+PROTOCOL_VERSION = "2025-11-25"
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+
+class AcceptanceError(RuntimeError):
+    """A safe acceptance failure that never contains a credential or response body."""
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    label: str
+    url: str
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, _req, _fp, _code, _msg, _headers, _newurl):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _read_bounded(response) -> bytes:
+    body = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(body) > MAX_RESPONSE_BYTES:
+        raise AcceptanceError("response exceeded the bounded acceptance size")
+    return body
+
+
+def _request(
+    url: str, *, method: str, payload: dict | None = None, bearer: str | None = None, timeout: float
+) -> Response:
+    headers = {"accept": "application/json, text/event-stream", "user-agent": "verdify-mcp-acceptance/1"}
+    data = None
+    if payload is not None:
+        headers["content-type"] = "application/json"
+        data = json.dumps(payload, separators=(",", ":")).encode()
+        if payload.get("method") != "initialize":
+            headers["mcp-protocol-version"] = PROTOCOL_VERSION
+    if bearer is not None:
+        headers["authorization"] = f"Bearer {bearer}"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _OPENER.open(request, timeout=timeout) as response:
+            return Response(
+                response.status,
+                {key.lower(): value for key, value in response.headers.items()},
+                _read_bounded(response),
+            )
+    except urllib.error.HTTPError as exc:
+        return Response(exc.code, {key.lower(): value for key, value in exc.headers.items()}, _read_bounded(exc))
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        raise AcceptanceError(f"request failed before an HTTP response: {type(exc).__name__}")
+
+
+def _rpc(method: str, request_id: int, params: dict | None = None) -> dict:
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+
+
+def _initialize(request_id: int) -> dict:
+    return _rpc(
+        "initialize",
+        request_id,
+        {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "verdify-security-acceptance", "version": "1"},
+        },
+    )
+
+
+def _protocol_payload(response: Response, *, check: str) -> dict:
+    try:
+        if response.headers.get("content-type", "").lower().startswith("text/event-stream"):
+            lines = response.body.decode().splitlines()
+            encoded = next(line.removeprefix("data: ") for line in lines if line.startswith("data: "))
+            payload = json.loads(encoded)
+        else:
+            payload = json.loads(response.body)
+    except (StopIteration, UnicodeDecodeError, json.JSONDecodeError):
+        raise AcceptanceError(f"{check} did not return one parseable protocol payload")
+    if not isinstance(payload, dict):
+        raise AcceptanceError(f"{check} returned a non-object protocol payload")
+    return payload
+
+
+def _assert_no_session(response: Response, *, check: str) -> None:
+    if "mcp-session-id" in response.headers:
+        raise AcceptanceError(f"{check} exposed a stateful MCP session identifier")
+
+
+def _assert_unauthorized(response: Response, *, check: str) -> None:
+    _assert_no_session(response, check=check)
+    if response.status != 401:
+        raise AcceptanceError(f"{check} returned HTTP {response.status}, expected generic 401")
+    if response.headers.get("www-authenticate") != "Bearer":
+        raise AcceptanceError(f"{check} omitted the generic Bearer challenge")
+    try:
+        body = json.loads(response.body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise AcceptanceError(f"{check} returned a non-JSON denial")
+    if body != {"error": "unauthorized"}:
+        raise AcceptanceError(f"{check} returned a non-generic denial body")
+
+
+def expected_iris_tools(config_path: Path = DEFAULT_HERMES_CONFIG) -> frozenset[str]:
+    config_map = yaml.safe_load(config_path.read_text())
+    profile = yaml.safe_load(config_map["data"]["config.yaml"])
+    include = profile["mcp_servers"]["verdify_greenhouse"]["tools"]["include"]
+    tools = frozenset(str(name) for name in include)
+    if not tools or "query" in tools or "climate" not in tools:
+        raise AcceptanceError("canonical Iris tool inventory is absent or unsafe")
+    return tools
+
+
+def _unauthenticated_checks(endpoint: Endpoint, *, repeats: int, timeout: float) -> int:
+    checks = (
+        ("initialize", _initialize(1)),
+        ("tools-list", _rpc("tools/list", 2)),
+        ("admin-query", _rpc("tools/call", 3, {"name": "query", "arguments": {"sql": "SELECT 1"}})),
+    )
+    completed = 0
+    for _round in range(repeats):
+        for name, payload in checks:
+            response = _request(endpoint.url, method="POST", payload=payload, timeout=timeout)
+            _assert_unauthorized(response, check=f"{endpoint.label}:{name}:missing-bearer")
+            completed += 1
+
+    unknown = secrets.token_urlsafe(32)
+    for name, payload in checks:
+        response = _request(endpoint.url, method="POST", payload=payload, bearer=unknown, timeout=timeout)
+        _assert_unauthorized(response, check=f"{endpoint.label}:{name}:unknown-bearer")
+        completed += 1
+    return completed
+
+
+def _authenticated_checks(
+    endpoint: Endpoint,
+    *,
+    bearer: str,
+    expected_tools: frozenset[str],
+    safe_tool: str,
+    repeats: int,
+    timeout: float,
+) -> int:
+    if safe_tool not in expected_tools:
+        raise AcceptanceError("selected safe tool is outside the canonical Iris audience")
+    completed = 0
+    for round_number in range(repeats):
+        initialized = _request(
+            endpoint.url,
+            method="POST",
+            payload=_initialize(100 + round_number),
+            bearer=bearer,
+            timeout=timeout,
+        )
+        _assert_no_session(initialized, check=f"{endpoint.label}:authenticated-initialize")
+        if initialized.status != 200:
+            raise AcceptanceError(
+                f"{endpoint.label}:authenticated-initialize returned HTTP {initialized.status}, expected 200"
+            )
+        initialized_payload = _protocol_payload(initialized, check=f"{endpoint.label}:authenticated-initialize")
+        if "result" not in initialized_payload:
+            raise AcceptanceError(f"{endpoint.label}:authenticated-initialize returned no result")
+        completed += 1
+
+        listed = _request(
+            endpoint.url,
+            method="POST",
+            payload=_rpc("tools/list", 200 + round_number),
+            bearer=bearer,
+            timeout=timeout,
+        )
+        _assert_no_session(listed, check=f"{endpoint.label}:authenticated-tools-list")
+        if listed.status != 200:
+            raise AcceptanceError(
+                f"{endpoint.label}:authenticated-tools-list returned HTTP {listed.status}, expected 200"
+            )
+        list_payload = _protocol_payload(listed, check=f"{endpoint.label}:authenticated-tools-list")
+        try:
+            actual_tools = frozenset(tool["name"] for tool in list_payload["result"]["tools"])
+        except (KeyError, TypeError):
+            raise AcceptanceError(f"{endpoint.label}:authenticated-tools-list returned no inventory")
+        if actual_tools != expected_tools:
+            raise AcceptanceError(f"{endpoint.label}:authenticated-tools-list differs from the bounded Iris audience")
+        completed += 1
+
+        denied_query = _request(
+            endpoint.url,
+            method="POST",
+            payload=_rpc("tools/call", 300 + round_number, {"name": "query", "arguments": {"sql": "SELECT 1"}}),
+            bearer=bearer,
+            timeout=timeout,
+        )
+        _assert_no_session(denied_query, check=f"{endpoint.label}:iris-admin-query")
+        if denied_query.status != 200:
+            raise AcceptanceError(
+                f"{endpoint.label}:iris-admin-query returned HTTP {denied_query.status}, expected tool denial"
+            )
+        query_payload = _protocol_payload(denied_query, check=f"{endpoint.label}:iris-admin-query")
+        try:
+            query_denied = query_payload["result"]["isError"] is True
+        except (KeyError, TypeError):
+            query_denied = False
+        if not query_denied:
+            raise AcceptanceError(f"{endpoint.label}:Iris obtained the admin query tool")
+        completed += 1
+
+        safe_call = _request(
+            endpoint.url,
+            method="POST",
+            payload=_rpc("tools/call", 400 + round_number, {"name": safe_tool, "arguments": {}}),
+            bearer=bearer,
+            timeout=timeout,
+        )
+        _assert_no_session(safe_call, check=f"{endpoint.label}:safe-tool")
+        if safe_call.status != 200:
+            raise AcceptanceError(f"{endpoint.label}:safe-tool returned HTTP {safe_call.status}, expected 200")
+        safe_payload = _protocol_payload(safe_call, check=f"{endpoint.label}:safe-tool")
+        try:
+            safe_succeeded = safe_payload["result"].get("isError", False) is False
+        except (KeyError, TypeError, AttributeError):
+            safe_succeeded = False
+        if not safe_succeeded:
+            raise AcceptanceError(f"{endpoint.label}:safe-tool did not complete successfully")
+        completed += 1
+    return completed
+
+
+def _readiness_check(endpoint: Endpoint, *, timeout: float) -> None:
+    response = _request(endpoint.url, method="GET", timeout=timeout)
+    if response.status != 200:
+        raise AcceptanceError(f"{endpoint.label}:readiness returned HTTP {response.status}, expected 200")
+    payload = _protocol_payload(response, check=f"{endpoint.label}:readiness")
+    expected = {
+        "ready": True,
+        "auth_mode": "enforce",
+        "db": "ok",
+        "auth_misconfigured": False,
+        "missing_tools": [],
+    }
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise AcceptanceError(f"{endpoint.label}:readiness did not prove auth enforcement and healthy dependencies")
+    if "iris" not in payload.get("auth_audiences_configured", []):
+        raise AcceptanceError(f"{endpoint.label}:readiness did not report the Iris audience")
+
+
+def _endpoint(value: str) -> Endpoint:
+    label, separator, url = value.partition("=")
+    if not separator or not label or not url:
+        raise argparse.ArgumentTypeError("endpoint must be LABEL=URL")
+    parsed = urllib.parse.urlsplit(url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise argparse.ArgumentTypeError("endpoint URL must be an http(s) URL without userinfo or a fragment")
+    return Endpoint(label, url)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", action="append", required=True, type=_endpoint, help="MCP endpoint as LABEL=URL")
+    parser.add_argument(
+        "--readiness-url", action="append", default=[], type=_endpoint, help="internal readiness endpoint as LABEL=URL"
+    )
+    parser.add_argument("--token-env", default="VERDIFY_MCP_TOKEN", help="environment variable containing Iris bearer")
+    parser.add_argument("--unauthenticated-only", action="store_true", help="run only missing/unknown bearer checks")
+    parser.add_argument("--expected-tools-config", type=Path, default=DEFAULT_HERMES_CONFIG)
+    parser.add_argument("--safe-tool", default="climate")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.repeats < 1 or args.repeats > 20:
+        raise AcceptanceError("repeats must be between 1 and 20")
+    expected_tools = expected_iris_tools(args.expected_tools_config)
+    bearer = None if args.unauthenticated_only else os.environ.get(args.token_env)
+    if not args.unauthenticated_only and not bearer:
+        raise AcceptanceError(f"Iris bearer environment variable is absent: {args.token_env}")
+
+    endpoint_receipts = []
+    for endpoint in args.endpoint:
+        unauthenticated_checks = _unauthenticated_checks(endpoint, repeats=args.repeats, timeout=args.timeout)
+        authenticated_checks = 0
+        if bearer is not None:
+            authenticated_checks = _authenticated_checks(
+                endpoint,
+                bearer=bearer,
+                expected_tools=expected_tools,
+                safe_tool=args.safe_tool,
+                repeats=args.repeats,
+                timeout=args.timeout,
+            )
+        endpoint_receipts.append(
+            {
+                "label": endpoint.label,
+                "unauthenticated_checks": unauthenticated_checks,
+                "authenticated_checks": authenticated_checks,
+            }
+        )
+    for endpoint in args.readiness_url:
+        _readiness_check(endpoint, timeout=args.timeout)
+
+    print(
+        json.dumps(
+            {
+                "schema": "verdify.mcp-security-acceptance/v1",
+                "checked_at": datetime.now(UTC).isoformat(),
+                "status": "pass",
+                "stateless": True,
+                "expected_iris_tool_count": len(expected_tools),
+                "safe_tool": args.safe_tool if bearer is not None else None,
+                "endpoints": endpoint_receipts,
+                "readiness_labels": [endpoint.label for endpoint in args.readiness_url],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AcceptanceError as exc:
+        print(
+            json.dumps({"schema": "verdify.mcp-security-acceptance/v1", "status": "fail", "error": str(exc)}),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)

--- a/scripts/sops-secret-metadata-receipt.py
+++ b/scripts/sops-secret-metadata-receipt.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Emit a SOPS Secret receipt without decrypting or exposing ciphertext values."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+MAX_SOURCE_BYTES = 4 * 1024 * 1024
+SOPS_ENCRYPTED_REGEX = "^(data|stringData)$"
+ENC_PREFIX = "ENC[AES256_GCM,"
+
+
+class ReceiptError(RuntimeError):
+    """Metadata-only receipt failure; messages never contain document values."""
+
+
+@dataclass(frozen=True)
+class GitSource:
+    repo_root: Path
+    relative_path: Path
+    revision: str
+    last_changed_revision: str
+    commit_time: str
+    contents: bytes
+
+
+def _git(repo: Path, *args: str, text: bool = True):
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=text,
+    )
+    if result.returncode != 0:
+        raise ReceiptError(f"git metadata lookup failed: {args[0]}")
+    return result.stdout
+
+
+def git_source(path: Path, *, repo: Path, revision: str) -> GitSource:
+    repo_root = Path(_git(repo, "rev-parse", "--show-toplevel").strip()).resolve()
+    candidate = path if path.is_absolute() else repo_root / path
+    try:
+        relative_path = candidate.resolve().relative_to(repo_root)
+    except ValueError:
+        raise ReceiptError("encrypted source path is outside the selected repository")
+    resolved_revision = _git(repo_root, "rev-parse", f"{revision}^{{commit}}").strip()
+    last_changed = _git(repo_root, "log", "-1", "--format=%H", resolved_revision, "--", str(relative_path)).strip()
+    if not last_changed:
+        raise ReceiptError("encrypted source has no commit at the selected revision")
+    commit_time = _git(repo_root, "show", "-s", "--format=%cI", resolved_revision).strip()
+    contents = _git(repo_root, "show", f"{resolved_revision}:{relative_path.as_posix()}", text=False)
+    if not contents or len(contents) > MAX_SOURCE_BYTES:
+        raise ReceiptError("encrypted source is empty or exceeds the receipt size bound")
+    return GitSource(repo_root, relative_path, resolved_revision, last_changed, commit_time, contents)
+
+
+def _encrypted_key_names(document: dict) -> list[str]:
+    names: set[str] = set()
+    for field in ("data", "stringData"):
+        values = document.get(field)
+        if values is None:
+            continue
+        if not isinstance(values, dict):
+            raise ReceiptError(f"Secret {field} must be a mapping")
+        for key, value in values.items():
+            if not isinstance(key, str) or not key:
+                raise ReceiptError(f"Secret {field} contains an invalid key name")
+            if not isinstance(value, str) or not value.startswith(ENC_PREFIX):
+                raise ReceiptError(f"Secret {field} contains an unencrypted value")
+            names.add(key)
+    if not names:
+        raise ReceiptError("Secret contains no encrypted data or stringData keys")
+    return sorted(names)
+
+
+def _age_recipient_count(sops: dict) -> int:
+    recipients: list[str] = []
+    direct = sops.get("age", [])
+    if isinstance(direct, list):
+        recipients.extend(row.get("recipient") for row in direct if isinstance(row, dict))
+    groups = sops.get("key_groups", [])
+    if isinstance(groups, list):
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("age"), list):
+                continue
+            recipients.extend(row.get("recipient") for row in group["age"] if isinstance(row, dict))
+    return len({recipient for recipient in recipients if isinstance(recipient, str) and recipient.startswith("age1")})
+
+
+def secret_metadata(source: GitSource, *, expected_name: str, expected_namespace: str, required_keys: set[str]) -> dict:
+    try:
+        document = yaml.safe_load(source.contents)
+    except yaml.YAMLError:
+        raise ReceiptError("encrypted source is not valid YAML")
+    if not isinstance(document, dict) or document.get("apiVersion") != "v1" or document.get("kind") != "Secret":
+        raise ReceiptError("encrypted source is not a Kubernetes v1 Secret")
+    metadata = document.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ReceiptError("encrypted Secret metadata is absent")
+    name = metadata.get("name")
+    namespace = metadata.get("namespace")
+    if name != expected_name or namespace != expected_namespace:
+        raise ReceiptError("encrypted Secret target does not match the expected namespace/name")
+
+    key_names = _encrypted_key_names(document)
+    missing = sorted(required_keys - set(key_names))
+    if missing:
+        raise ReceiptError("encrypted Secret is missing one or more required key names")
+
+    sops = document.get("sops")
+    if not isinstance(sops, dict):
+        raise ReceiptError("SOPS metadata is absent")
+    if sops.get("encrypted_regex") != SOPS_ENCRYPTED_REGEX:
+        raise ReceiptError("SOPS encrypted_regex does not protect data and stringData exactly")
+    if not isinstance(sops.get("mac"), str) or not sops["mac"].startswith("ENC["):
+        raise ReceiptError("SOPS encrypted MAC metadata is absent")
+    age_recipients = _age_recipient_count(sops)
+    if age_recipients < 1:
+        raise ReceiptError("SOPS age recipient metadata is absent")
+    version = sops.get("version")
+    lastmodified = sops.get("lastmodified")
+    if not isinstance(version, str) or not version:
+        raise ReceiptError("SOPS version metadata is absent")
+    if not isinstance(lastmodified, str) or not lastmodified:
+        raise ReceiptError("SOPS lastmodified metadata is absent")
+
+    return {
+        "schema": "verdify.sops-secret-metadata-receipt/v1",
+        "checked_at": datetime.now(UTC).isoformat(),
+        "status": "pass",
+        "source": {
+            "repository": source.repo_root.name,
+            "path": source.relative_path.as_posix(),
+            "revision": source.revision,
+            "revision_committed_at": source.commit_time,
+            "last_changed_revision": source.last_changed_revision,
+            "encrypted_file_sha256": hashlib.sha256(source.contents).hexdigest(),
+        },
+        "secret": {
+            "namespace": namespace,
+            "name": name,
+            "type": document.get("type", "Opaque"),
+            "key_names": key_names,
+            "required_key_names": sorted(required_keys),
+            "required_keys_present": True,
+        },
+        "sops": {
+            "version": version,
+            "lastmodified": lastmodified,
+            "encrypted_regex": sops["encrypted_regex"],
+            "encrypted_mac_present": True,
+            "age_recipient_count": age_recipients,
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="path to the encrypted Secret inside its Git repository")
+    parser.add_argument(
+        "--repo", type=Path, required=True, help="owning Git repository (no remote credentials emitted)"
+    )
+    parser.add_argument("--revision", default="HEAD", help="commit/ref whose encrypted bytes are authoritative")
+    parser.add_argument("--expected-name", required=True)
+    parser.add_argument("--expected-namespace", required=True)
+    parser.add_argument("--required-key", action="append", default=[])
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    source = git_source(args.source, repo=args.repo, revision=args.revision)
+    receipt = secret_metadata(
+        source,
+        expected_name=args.expected_name,
+        expected_namespace=args.expected_namespace,
+        required_keys=set(args.required_key),
+    )
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ReceiptError as exc:
+        print(
+            json.dumps({"schema": "verdify.sops-secret-metadata-receipt/v1", "status": "fail", "error": str(exc)}),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)

--- a/scripts/verify_component_proof_packet.py
+++ b/scripts/verify_component_proof_packet.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Validate and seal an exported baseline/aggressive/baseline proof packet.
+
+This tool is deliberately offline and non-actuating.  It consumes evidence
+already exported from the immutable v2 ledgers, verifies the full-48 freshness,
+lineage, generation, and final fail-closed invariants, then optionally writes a
+canonical metadata packet using exclusive creation.  Its SHA is a packet seal,
+not a replacement for the database-owned physical proof receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+SCHEMA = "verdify-component-physical-proof-packet-v1"
+WIRE_IDS = frozenset((*range(1, 6), *range(7, 50)))
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+BOUNDARY_CONTRACT = (
+    ("baseline_before", "baseline"),
+    ("aggressive", "aggressive"),
+    ("baseline_after", "baseline"),
+)
+FORBIDDEN_KEY_FRAGMENTS = (
+    "secret",
+    "mapping",
+    "physical_arm",
+    "blinded_label",
+    "authorization_token",
+)
+
+
+class ProofPacketError(ValueError):
+    """The supplied packet cannot prove the physical sequence."""
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def _exact_keys(value: object, expected: set[str], label: str, optional: set[str] | None = None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProofPacketError(f"{label} must be an object")
+    optional = optional or set()
+    actual = set(value)
+    missing = expected - actual
+    extra = actual - expected - optional
+    if missing or extra:
+        raise ProofPacketError(f"{label} keys differ: missing={sorted(missing)} extra={sorted(extra)}")
+    return value
+
+
+def _uuid(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise ProofPacketError(f"{label} must be a UUID string")
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise ProofPacketError(f"{label} is not a UUID") from exc
+    if str(parsed) != value.lower():
+        raise ProofPacketError(f"{label} is not canonical UUID text")
+    return value
+
+
+def _sha(value: object, label: str) -> str:
+    if not isinstance(value, str) or SHA256.fullmatch(value) is None:
+        raise ProofPacketError(f"{label} must be lowercase SHA-256 hex")
+    return value
+
+
+def _positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ProofPacketError(f"{label} must be a positive integer")
+    return value
+
+
+def _timestamp(value: object, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ProofPacketError(f"{label} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ProofPacketError(f"{label} is not an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ProofPacketError(f"{label} must carry a UTC offset")
+    return parsed.astimezone(UTC)
+
+
+def _reject_forbidden_keys(value: object, path: str = "packet") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(fragment in lowered for fragment in FORBIDDEN_KEY_FRAGMENTS):
+                raise ProofPacketError(f"{path}.{key} is forbidden in a blinded proof packet")
+            _reject_forbidden_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_keys(child, f"{path}[{index}]")
+
+
+def validate_packet(packet: object) -> None:
+    top = _exact_keys(
+        packet,
+        {
+            "schema",
+            "experiment_id",
+            "authorization_id",
+            "attempt_number",
+            "authorized_from",
+            "authorized_to",
+            "revision_bundle_sha256",
+            "lease_generation",
+            "writer_generation",
+            "connection_generation",
+            "proof_receipt_id",
+            "proof_receipt_sha256",
+            "proof_receipt_recorded_at",
+            "boundaries",
+            "final_status",
+        },
+        "packet",
+        {"packet_sha256"},
+    )
+    _reject_forbidden_keys(top)
+    if top["schema"] != SCHEMA:
+        raise ProofPacketError("packet schema is not current")
+    _uuid(top["experiment_id"], "experiment_id")
+    _uuid(top["authorization_id"], "authorization_id")
+    _positive_int(top["attempt_number"], "attempt_number")
+    revision = _sha(top["revision_bundle_sha256"], "revision_bundle_sha256")
+    lease = _positive_int(top["lease_generation"], "lease_generation")
+    writer = _positive_int(top["writer_generation"], "writer_generation")
+    connection = _positive_int(top["connection_generation"], "connection_generation")
+    _uuid(top["proof_receipt_id"], "proof_receipt_id")
+    _sha(top["proof_receipt_sha256"], "proof_receipt_sha256")
+    authorized_from = _timestamp(top["authorized_from"], "authorized_from")
+    authorized_to = _timestamp(top["authorized_to"], "authorized_to")
+    proof_recorded = _timestamp(top["proof_receipt_recorded_at"], "proof_receipt_recorded_at")
+    if authorized_from >= authorized_to:
+        raise ProofPacketError("authorization range is empty or reversed")
+
+    boundaries = top["boundaries"]
+    if not isinstance(boundaries, list) or len(boundaries) != len(BOUNDARY_CONTRACT):
+        raise ProofPacketError("packet must contain exactly three ordered boundaries")
+    all_boundary_ids: set[str] = set()
+    all_epoch_ids: set[str] = set()
+    all_receipt_hashes: set[str] = set()
+    boundary_completed_at: list[datetime] = []
+    state_hashes: list[str] = []
+
+    for boundary_index, ((expected_stage, expected_profile), raw_boundary) in enumerate(
+        zip(BOUNDARY_CONTRACT, boundaries, strict=True)
+    ):
+        label = f"boundaries[{boundary_index}]"
+        boundary = _exact_keys(
+            raw_boundary,
+            {
+                "stage",
+                "profile",
+                "work_id",
+                "bundle_id",
+                "bundle_finished_at",
+                "expected_state_content_sha256",
+                "epochs",
+            },
+            label,
+        )
+        if (boundary["stage"], boundary["profile"]) != (expected_stage, expected_profile):
+            raise ProofPacketError(f"{label} stage/profile is out of order")
+        work_id = _uuid(boundary["work_id"], f"{label}.work_id")
+        bundle_id = _uuid(boundary["bundle_id"], f"{label}.bundle_id")
+        if work_id in all_boundary_ids or bundle_id in all_boundary_ids or work_id == bundle_id:
+            raise ProofPacketError("boundary work and bundle identities must be distinct")
+        all_boundary_ids.update((work_id, bundle_id))
+        bundle_finished = _timestamp(boundary["bundle_finished_at"], f"{label}.bundle_finished_at")
+        expected_hash = _sha(boundary["expected_state_content_sha256"], f"{label}.expected_state_content_sha256")
+        state_hashes.append(expected_hash)
+        epochs = boundary["epochs"]
+        if not isinstance(epochs, list) or len(epochs) != 2:
+            raise ProofPacketError(f"{label} must contain exactly two receipt-bound epochs")
+        epoch_components: list[dict[int, datetime]] = []
+        epoch_completed_at: list[datetime] = []
+
+        for epoch_index, raw_epoch in enumerate(epochs):
+            epoch_label = f"{label}.epochs[{epoch_index}]"
+            epoch = _exact_keys(
+                raw_epoch,
+                {
+                    "source_epoch_id",
+                    "work_id",
+                    "bundle_id",
+                    "observation_receipt_sha256",
+                    "policy_state_content_sha256",
+                    "persisted_at",
+                    "revision_bundle_sha256",
+                    "lease_generation",
+                    "writer_generation",
+                    "connection_generation",
+                    "components",
+                },
+                epoch_label,
+            )
+            epoch_id = _uuid(epoch["source_epoch_id"], f"{epoch_label}.source_epoch_id")
+            receipt_hash = _sha(epoch["observation_receipt_sha256"], f"{epoch_label}.observation_receipt_sha256")
+            if epoch_id in all_epoch_ids or receipt_hash in all_receipt_hashes:
+                raise ProofPacketError("source epochs and observation receipts must be globally distinct")
+            all_epoch_ids.add(epoch_id)
+            all_receipt_hashes.add(receipt_hash)
+            if epoch["work_id"] != work_id or epoch["bundle_id"] != bundle_id:
+                raise ProofPacketError(f"{epoch_label} is not bound to its exact work/bundle")
+            if (
+                _sha(epoch["policy_state_content_sha256"], f"{epoch_label}.policy_state_content_sha256")
+                != expected_hash
+            ):
+                raise ProofPacketError(f"{epoch_label} does not match its expected state")
+            if _sha(epoch["revision_bundle_sha256"], f"{epoch_label}.revision_bundle_sha256") != revision:
+                raise ProofPacketError(f"{epoch_label} revision changed")
+            if (
+                _positive_int(epoch["lease_generation"], f"{epoch_label}.lease_generation") != lease
+                or _positive_int(epoch["writer_generation"], f"{epoch_label}.writer_generation") != writer
+                or _positive_int(epoch["connection_generation"], f"{epoch_label}.connection_generation") != connection
+            ):
+                raise ProofPacketError(f"{epoch_label} generation changed")
+            persisted_at = _timestamp(epoch["persisted_at"], f"{epoch_label}.persisted_at")
+            components = epoch["components"]
+            if not isinstance(components, list) or len(components) != 48:
+                raise ProofPacketError(f"{epoch_label} must contain exactly 48 components")
+            observed: dict[int, datetime] = {}
+            ordered_wire_ids: list[int] = []
+            for component_index, raw_component in enumerate(components):
+                component_label = f"{epoch_label}.components[{component_index}]"
+                component = _exact_keys(raw_component, {"wire_id", "observed_at"}, component_label)
+                wire_id = component["wire_id"]
+                if isinstance(wire_id, bool) or not isinstance(wire_id, int) or wire_id not in WIRE_IDS:
+                    raise ProofPacketError(f"{component_label}.wire_id is outside the exact manifest")
+                if wire_id in observed:
+                    raise ProofPacketError(f"{epoch_label} repeats wire_id {wire_id}")
+                observed[wire_id] = _timestamp(component["observed_at"], f"{component_label}.observed_at")
+                ordered_wire_ids.append(wire_id)
+            if frozenset(observed) != WIRE_IDS:
+                raise ProofPacketError(f"{epoch_label} is not the exact 48-field manifest")
+            if ordered_wire_ids != sorted(WIRE_IDS):
+                raise ProofPacketError(f"{epoch_label} is not in canonical wire order")
+            first_observed, last_observed = min(observed.values()), max(observed.values())
+            if first_observed <= bundle_finished:
+                raise ProofPacketError(f"{epoch_label} includes a pre-completion/cached observation")
+            if (last_observed - first_observed).total_seconds() > 60:
+                raise ProofPacketError(f"{epoch_label} exceeds bounded component skew")
+            if persisted_at < last_observed or (persisted_at - last_observed).total_seconds() > 90:
+                raise ProofPacketError(f"{epoch_label} is stale or persisted before observation")
+            if (
+                not authorized_from <= first_observed < authorized_to
+                or not authorized_from < persisted_at <= authorized_to
+            ):
+                raise ProofPacketError(f"{epoch_label} falls outside the attended authorization")
+            epoch_components.append(observed)
+            epoch_completed_at.append(last_observed)
+
+        if (epoch_completed_at[1] - epoch_completed_at[0]).total_seconds() < 30:
+            raise ProofPacketError(f"{label} epochs are less than 30 seconds apart")
+        if any(epoch_components[1][wire_id] <= epoch_components[0][wire_id] for wire_id in WIRE_IDS):
+            raise ProofPacketError(f"{label} second epoch does not advance every component")
+        boundary_completed_at.append(epoch_completed_at[1])
+
+    if not boundary_completed_at[0] < boundary_completed_at[1] < boundary_completed_at[2]:
+        raise ProofPacketError("proof boundaries are not strictly ordered")
+    if state_hashes[0] != state_hashes[2] or state_hashes[1] == state_hashes[0]:
+        raise ProofPacketError("proof states are not baseline/aggressive/baseline")
+    if proof_recorded < boundary_completed_at[2] or proof_recorded > authorized_to:
+        raise ProofPacketError("proof receipt was not sealed after recovery inside authorization")
+
+    final_status = _exact_keys(
+        top["final_status"],
+        {
+            "lifecycle_status",
+            "execution_phase",
+            "admission_state",
+            "component_enabled",
+            "open_exposure_count",
+            "baseline_confirmed",
+        },
+        "final_status",
+    )
+    if final_status != {
+        "lifecycle_status": "draft",
+        "execution_phase": "shadow",
+        "admission_state": "closed",
+        "component_enabled": False,
+        "open_exposure_count": 0,
+        "baseline_confirmed": True,
+    }:
+        raise ProofPacketError("final status is not baseline-confirmed, shadow, closed, and exposure-free")
+
+    if "packet_sha256" in top:
+        supplied = _sha(top["packet_sha256"], "packet_sha256")
+        unsigned = deepcopy(top)
+        unsigned.pop("packet_sha256")
+        actual = hashlib.sha256(canonical_json_bytes(unsigned)).hexdigest()
+        if supplied != actual:
+            raise ProofPacketError("packet_sha256 does not match canonical packet bytes")
+
+
+def seal_packet(packet: object) -> dict[str, Any]:
+    validate_packet(packet)
+    sealed = deepcopy(packet)
+    assert isinstance(sealed, dict)
+    sealed.pop("packet_sha256", None)
+    sealed["packet_sha256"] = hashlib.sha256(canonical_json_bytes(sealed)).hexdigest()
+    validate_packet(sealed)
+    return sealed
+
+
+def write_exclusive(packet: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if output.is_symlink():
+        raise ProofPacketError("output path must not be a symlink")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(output, flags, stat.S_IRUSR | stat.S_IWUSR)
+    except FileExistsError as exc:
+        raise ProofPacketError("output already exists; proof packets are immutable") from exc
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(canonical_json_bytes(packet))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="exported JSON evidence packet")
+    parser.add_argument("--output", type=Path, help="exclusive-create path for the sealed canonical packet")
+    args = parser.parse_args(argv)
+    try:
+        packet = json.loads(args.input.read_text())
+        sealed = seal_packet(packet)
+        if args.output is not None:
+            write_exclusive(sealed, args.output)
+        print(
+            f"status=pass schema={SCHEMA} packet_sha256={sealed['packet_sha256']} "
+            f"proof_receipt_id={sealed['proof_receipt_id']}"
+        )
+    except (OSError, json.JSONDecodeError, ProofPacketError) as exc:
+        print(f"status=fail reason={type(exc).__name__}:{exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_03_ingestor.py
+++ b/tests/test_03_ingestor.py
@@ -84,6 +84,10 @@ def _reset_reconcile_state(monkeypatch):
     monkeypatch.setattr(shared, "reconciled_transport_generation", 0)
     monkeypatch.setattr(shared, "cfg_drift_versions", {})
     monkeypatch.setattr(shared, "_cfg_drift_version", 0)
+    monkeypatch.setattr(shared, "cfg_readback_generation", {})
+    monkeypatch.setattr(shared, "transport_expected_cfg_readbacks", frozenset())
+    monkeypatch.setattr(shared, "transport_observed_cfg_readbacks", set())
+    monkeypatch.setattr(shared, "transport_readbacks_generation", 0)
     monkeypatch.setattr(shared, "force_setpoint_push", asyncio.Event())
     monkeypatch.setattr(shared, "setpoint_dispatch_requested", asyncio.Event())
     monkeypatch.setattr(shared, "setpoint_dispatch_lock", asyncio.Lock())
@@ -94,16 +98,16 @@ def _reset_reconcile_state(monkeypatch):
 
 
 def test_cfg_drift_never_advances_transport_generation(caplog):
-    shared.transport_generation = 7
-    shared.reconciled_transport_generation = 7
     wire_id = "cfg___mister_vpd_weight"
+    generation = shared.note_transport_connected(frozenset({"mister_vpd_weight"}))
 
     assert ingestor._record_cfg_readback(wire_id, 42.0) is True
+    shared.mark_transport_reconciled(generation)
     with caplog.at_level(logging.INFO, logger="ingestor"):
         assert ingestor._record_cfg_readback(wire_id, 43.0) is True
 
-    assert shared.transport_generation == 7
-    assert shared.reconciled_transport_generation == 7
+    assert shared.transport_generation == generation
+    assert shared.reconciled_transport_generation == generation
     assert not shared.force_setpoint_push.is_set()
     assert shared.setpoint_dispatch_requested.is_set()
     assert shared.cfg_drift_versions == {"mister_vpd_weight": 1}
@@ -358,16 +362,21 @@ async def test_writer_fatal_monitor_forces_supervised_process_failure():
 
 
 def test_real_connect_generation_is_monotonic_and_never_erases_newer_reconnect():
-    first = shared.note_transport_connected()
-    second = shared.note_transport_connected()
+    first = shared.note_transport_connected(frozenset({"first"}))
+    assert not shared.force_setpoint_push.is_set()
+    assert not shared.setpoint_dispatch_requested.is_set()
+    assert shared.note_cfg_readback_observed("first", 1.0, first)
+    shared.mark_transport_reconciled(first)
+    second = shared.note_transport_connected(frozenset({"second"}))
 
     assert (first, second) == (1, 2)
-    assert shared.force_setpoint_push.is_set()
-    assert shared.setpoint_dispatch_requested.is_set()
+    assert not shared.force_setpoint_push.is_set()
+    assert not shared.setpoint_dispatch_requested.is_set()
 
     shared.mark_transport_reconciled(first)
     assert shared.reconciled_transport_generation == 1
-    assert shared.force_setpoint_push.is_set(), "generation 1 must not erase pending generation 2"
+    assert shared.note_cfg_readback_observed("second", 2.0, second)
+    assert shared.force_setpoint_push.is_set()
 
     shared.mark_transport_reconciled(second)
     assert shared.reconciled_transport_generation == 2
@@ -386,9 +395,11 @@ def test_cfg_drift_clear_is_version_safe():
 
 def test_old_drift_completion_cannot_erase_newer_reconnect_wake():
     observed = {"mister_vpd_weight": shared.note_cfg_drift("mister_vpd_weight")}
-    first_generation = shared.note_transport_connected()
+    first_generation = shared.note_transport_connected(frozenset({"first"}))
+    assert shared.note_cfg_readback_observed("first", 1.0, first_generation)
     shared.mark_transport_reconciled(first_generation)
-    newer_generation = shared.note_transport_connected()
+    newer_generation = shared.note_transport_connected(frozenset({"newer"}))
+    assert shared.note_cfg_readback_observed("newer", 2.0, newer_generation)
 
     shared.clear_cfg_drift(observed)
 
@@ -399,7 +410,8 @@ def test_old_drift_completion_cannot_erase_newer_reconnect_wake():
 
 
 def test_failed_dispatch_consumes_only_its_immediate_wake_without_claiming_reconcile():
-    generation = shared.note_transport_connected()
+    generation = shared.note_transport_connected(frozenset({"current"}))
+    assert shared.note_cfg_readback_observed("current", 1.0, generation)
     observed = {"mister_vpd_weight": shared.note_cfg_drift("mister_vpd_weight")}
 
     shared.defer_failed_dispatch(generation, observed)
@@ -410,10 +422,46 @@ def test_failed_dispatch_consumes_only_its_immediate_wake_without_claiming_recon
     assert not shared.setpoint_dispatch_requested.is_set()
 
     shared.setpoint_dispatch_requested.set()
-    newer_generation = shared.note_transport_connected()
+    newer_generation = shared.note_transport_connected(frozenset({"newer"}))
+    assert shared.note_cfg_readback_observed("newer", 2.0, newer_generation)
     shared.defer_failed_dispatch(generation, observed)
     assert newer_generation == 2
     assert shared.setpoint_dispatch_requested.is_set()
+
+
+def test_reconnect_readback_barrier_clears_stale_cache_and_opens_once_complete():
+    shared.cfg_readback.update({"stale": 1.0})
+    shared.cfg_readback_generation.update({"stale": 9})
+
+    generation = shared.note_transport_connected(frozenset({"a", "b"}))
+
+    assert shared.cfg_readback == {}
+    assert shared.current_cfg_readbacks() == {}
+    assert not shared.transport_readbacks_ready(generation)
+    assert not shared.note_cfg_readback_observed("a", 1.0, generation)
+    assert not shared.transport_readbacks_ready(generation)
+    assert shared.note_cfg_readback_observed("b", 2.0, generation)
+    assert shared.transport_readbacks_ready(generation)
+    assert shared.current_cfg_readbacks() == {"a": 1.0, "b": 2.0}
+
+
+def test_late_readback_cannot_complete_or_pollute_newer_generation():
+    first = shared.note_transport_connected(frozenset({"a"}))
+    second = shared.note_transport_connected(frozenset({"b"}))
+
+    assert not shared.note_cfg_readback_observed("a", 1.0, first)
+    assert shared.current_cfg_readbacks() == {}
+    assert shared.note_cfg_readback_observed("b", 2.0, second)
+    assert shared.transport_readbacks_ready(second)
+
+
+def test_native_number_readback_completes_replay_for_field_without_cfg_sensor():
+    generation = shared.note_transport_connected(frozenset({"mister_on_s"}))
+
+    ingestor._mirror_irrigation_number_readback("mister_on_s", 300.0)
+
+    assert shared.transport_readbacks_ready(generation)
+    assert shared.current_cfg_readbacks() == {"mister_on_s": 300.0}
 
 
 @pytest.mark.asyncio

--- a/tests/test_05_dispatcher.py
+++ b/tests/test_05_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -33,6 +34,7 @@ def test_normalized_desired_observed_comparison(parameter, observed, desired, eq
 
 def test_targeted_readback_drift_does_not_depend_on_reconnect_event(monkeypatch):
     monkeypatch.setattr(shared, "cfg_readback", {"mister_vpd_weight": 0.4})
+    monkeypatch.setattr(shared, "cfg_readback_generation", {"mister_vpd_weight": 11})
     monkeypatch.setattr(shared, "transport_generation", 11)
     monkeypatch.setattr(shared, "reconciled_transport_generation", 11)
 
@@ -75,6 +77,9 @@ def test_reconnect_reconcile_is_generation_gated_and_cfg_drift_is_separate():
     assert "if reconnect_event_set and reconnect_pending:" in source
     assert "shared.clear_cfg_drift(drift_versions)" in source
     assert "shared.mark_transport_reconciled(reconnect_generation)" in source
+    assert "shared.transport_readbacks_ready(reconnect_generation)" in source
+    assert "action=blocked_readbacks_incomplete" in source
+    assert "expected_connection_generation=reconnect_generation" in source
 
 
 def test_runtime_probe_classifies_reconnect_drift_retry_and_broad_batches():
@@ -107,9 +112,30 @@ def test_runtime_probe_classifies_reconnect_drift_retry_and_broad_batches():
 def test_unchanged_anchor_probe_uses_observed_readback_not_constant(monkeypatch):
     anchor = next(iter(dispatcher.band_anchors.ANCHOR_SYNC_PARAMS))
     monkeypatch.setattr(shared, "cfg_readback", {anchor: 1.25})
+    monkeypatch.setattr(shared, "cfg_readback_generation", {anchor: shared.transport_generation})
 
     assert dispatcher._unchanged_anchor_dispatch_count([(anchor, 1.25, "band")]) == 1
     assert dispatcher._unchanged_anchor_dispatch_count([(anchor, 1.5, "band")]) == 0
+
+
+@pytest.mark.asyncio
+async def test_reconnect_dispatch_never_queries_or_writes_before_current_readbacks(monkeypatch):
+    monkeypatch.setattr(shared, "transport_generation", 12)
+    monkeypatch.setattr(shared, "reconciled_transport_generation", 11)
+    monkeypatch.setattr(shared, "transport_expected_cfg_readbacks", frozenset({"a", "b"}))
+    monkeypatch.setattr(shared, "transport_observed_cfg_readbacks", {"a"})
+    monkeypatch.setattr(shared, "transport_readbacks_generation", 0)
+    pool = MagicMock()
+
+    await dispatcher.setpoint_dispatcher(pool)
+
+    pool.acquire.assert_not_called()
+    assert shared.reconciled_transport_generation == 11
+
+
+def test_reconnect_blind_restore_set_is_empty_while_all_candidates_have_readbacks():
+    assert dispatcher.RECONNECT_UNOBSERVED_RESTORE_PARAMS == frozenset()
+    assert dispatcher.MAX_RECONNECT_COMMANDS < 40
 
 
 def test_durable_lifecycle_mapping_keeps_retry_nonterminal_and_other_states_exact():

--- a/tests/test_08_observability.py
+++ b/tests/test_08_observability.py
@@ -160,13 +160,17 @@ class TestDispatcherWiring:
         ingestor = (REPO_ROOT / "ingestor" / "ingestor.py").read_text()
         shared_source = (REPO_ROOT / "ingestor" / "shared.py").read_text()
         push_helper = (REPO_ROOT / "ingestor" / "esp32_push.py").read_text()
-        assert "shared.recently_pushed[param] = time.time()" in body
+        assert "def _commit_sent_cache(" in push_helper
+        assert "_commit_sent_cache(quantum_outcomes)" in push_helper
+        assert push_helper.index("await _emit_state_until_recorded(request, quantum_outcomes)") < push_helper.index(
+            "_commit_sent_cache(quantum_outcomes)"
+        )
         assert "LISTEN/NOTIFY real-time listener" in body
         assert "reconnect reconcile" in body
         assert "shared.cfg_readback" in body
         assert "cfg_readback: dict[str, float]" in shared_source
-        assert "shared.cfg_readback[cfg_param]" in ingestor
-        assert "await asyncio.sleep(2)" in ingestor
+        assert "shared.note_cfg_readback_observed(cfg_param, val, generation)" in ingestor
+        assert "action=awaiting_readbacks" in ingestor
         assert "_BATCH_PAUSE_EVERY" in push_helper
         assert "_MIN_COMMAND_INTERVAL_S" in push_helper
         assert "async with _PUSH_LOCK" in push_helper
@@ -198,79 +202,32 @@ class TestDispatcherWiring:
         assert "shared.recently_pushed.pop(param, None)" not in body
         assert "shared.recently_pushed_values.pop(param, None)" not in body
 
-    def test_reconnect_seeds_persisted_band_but_force_reconciles_reverting_lighting(self):
-        # #430 Tier 1: the reconnect seed no longer BLANKET-excludes all
-        # BAND_DRIVEN_PARAMS (which force-re-pushed ~74 constants/reconnect ≈
-        # 7,400/day of ESP32 heap churn, #428). NVS-persisted crop-band params
-        # (restore_value:yes) are now seeded from cfg_readback; corrective re-sync
-        # is provided per-param by _readback_drift. BUT the reboot-reverting
-        # lighting params (LIGHTING_POLICY_PARAMS | LIGHTING_CIRCUIT_LUX_PARAMS,
-        # restore_value:no) MUST stay force-reconciled so a reverted/non-republished
-        # device cannot strand the grow lights (the 2026-06-16 incident).
+    def test_reconnect_waits_for_current_readbacks_and_limits_unobserved_restore(self):
+        # #433 startup correctness: every routed field is compared against the
+        # exact current socket generation. Native Number/Switch state covers
+        # legacy fields without cfg_* diagnostics, and a hard ceiling prevents
+        # a broad reconnect wave from escaping if that contract ever drifts.
         body = self._read()
         ingestor = (REPO_ROOT / "ingestor" / "ingestor.py").read_text()
-        # The old blanket force-push log/behavior is gone.
         assert "forcing %d band setpoint(s)" not in body
-        # Reboot-reverting params (lighting + served-band edges + zone vpd_target)
-        # are force-reconciled (unseeded), not delta-seeded.
-        assert "RECONNECT_FORCE_RECONCILE = (" in body
-        assert "LIGHTING_POLICY_PARAMS" in body and "LIGHTING_CIRCUIT_LUX_PARAMS" in body
-        assert "HOUSE_BAND_PARAMS" in body
-        assert 'p for p in CROP_BAND_REG if p.startswith("vpd_target_")' in body
-        assert "if param in RECONNECT_FORCE_RECONCILE:" in body
-        # The 2026-06-16 grow-light-strand rationale is preserved in the seed comment.
-        assert "2026-06-16" in body
-        # readback_drift remains the authoritative re-sync gate at every push site.
+        assert "RECONNECT_UNOBSERVED_RESTORE_PARAMS" in body
+        assert "MAX_RECONNECT_COMMANDS = 12" in body
+        assert "action=blocked_broad_restore" in body
+        assert "shared.current_cfg_readbacks(reconnect_generation)" in body
+        assert "shared.transport_readbacks_ready(reconnect_generation)" in body
+        assert "action=awaiting_readbacks" in ingestor
+        assert "action=readbacks_complete" in ingestor
         assert "and not _readback_drift(param, val)" in body
-        # The dispatcher-owned ESP32 echo-ignore (ingestor side) is unchanged.
         assert "setpoint_changes ignored dispatcher-owned ESP32 echo" in ingestor
         assert "BAND_DRIVEN_PARAMS" in ingestor
 
-    def test_no_reboot_reverting_band_param_is_delta_seeded(self):
-        # ENFORCED INVARIANT (#430 Tier 1, validation case D): every band param that
-        # the reconnect delta-seed keeps (BAND_DRIVEN_PARAMS minus the force-
-        # reconcile set) must be restore_value:yes in firmware globals, so a
-        # reverted/non-republished device can never be masked by a stale
-        # cfg_readback and stranded. A future restore_value:no addition that slips
-        # into the delta-seed fails here.
-        import re as _re
+    def test_reconnect_unobserved_restore_params_have_no_current_readback_route(self):
+        from entity_map import CFG_READBACK_MAP, SETPOINT_MAP
+        from tasks.dispatcher import _RECONNECT_SAFETY_CANDIDATES, RECONNECT_UNOBSERVED_RESTORE_PARAMS
 
-        from tasks._common import (
-            BAND_DRIVEN_PARAMS,
-            CROP_BAND_REG,
-            HOUSE_BAND_PARAMS,
-            LIGHTING_CIRCUIT_LUX_PARAMS,
-            LIGHTING_POLICY_PARAMS,
-        )
-
-        force_reconcile = (
-            LIGHTING_POLICY_PARAMS
-            | LIGHTING_CIRCUIT_LUX_PARAMS
-            | HOUSE_BAND_PARAMS
-            | frozenset(p for p in CROP_BAND_REG if p.startswith("vpd_target_"))
-        )
-        delta_seeded = BAND_DRIVEN_PARAMS - force_reconcile
-
-        gl = (REPO_ROOT / "firmware" / "greenhouse" / "globals.yaml").read_text()
-        restore = {}
-        for blk in _re.split(r"\n  - id: ", gl)[1:]:
-            gid = blk.splitlines()[0].strip()
-            m = _re.search(r"restore_value:\s*(yes|no)", blk)
-            restore[gid] = m.group(1) if m else None
-
-        def reverts(param: str) -> bool:
-            # Direct-name / common-prefix mapping to a firmware global. Params with
-            # no direct global are on-chip-derived from persisted anchors (safe).
-            for gid in (param, f"band_{param}", f"num_{param}"):
-                if gid in restore:
-                    return restore[gid] == "no"
-            return False
-
-        offenders = sorted(p for p in delta_seeded if reverts(p))
-        assert not offenders, (
-            f"restore_value:no band params in the delta-seed (Case D exposure): {offenders} "
-            "— add them to RECONNECT_FORCE_RECONCILE in dispatcher.py"
-        )
+        readback_params = frozenset(CFG_READBACK_MAP.values()) | frozenset(SETPOINT_MAP.values())
+        assert _RECONNECT_SAFETY_CANDIDATES <= readback_params
+        assert RECONNECT_UNOBSERVED_RESTORE_PARAMS.isdisjoint(readback_params)
 
     def test_dispatcher_repushes_active_plan_when_cfg_readback_drifts(self):
         body = self._read()
@@ -652,10 +609,13 @@ class TestContractDriftGuardrails:
     def test_post_boot_readback_repair_covers_static_and_planner_paths(self):
         ingestor_source = (REPO_ROOT / "ingestor" / "ingestor.py").read_text()
         tasks_source = _tasks_source()
-        assert "shared.force_setpoint_push.set()" in ingestor_source
-        assert "prev is not None and not math.isclose" in ingestor_source
+        shared_source = (REPO_ROOT / "ingestor" / "shared.py").read_text()
+        assert "force_setpoint_push.set()" in shared_source
+        assert "transport_expected_cfg_readbacks <= transport_observed_cfg_readbacks" in shared_source
+        assert "shared.force_setpoint_push.set()" not in ingestor_source
+        assert "prev_generation == generation" in ingestor_source
         assert "if shared.force_setpoint_push.is_set():" in tasks_source
-        assert "_last_pushed.clear()" in tasks_source
+        assert "for param in RECONNECT_UNOBSERVED_RESTORE_PARAMS:" in tasks_source
         assert "def _readback_drift(param: str, desired: float) -> bool:" in tasks_source
         assert 'for param in ("temp_low", "temp_high", "vpd_low", "vpd_high"):' in tasks_source
         assert (

--- a/tests/test_12_fidelity.py
+++ b/tests/test_12_fidelity.py
@@ -3307,14 +3307,15 @@ def test_irrigation_feedback_alias_sets_stay_aligned():
         assert not any("tds" in key for key in container)
 
 
-def test_irrigation_number_states_refresh_cfg_snapshot_path():
+def test_writable_entity_states_refresh_generation_fenced_cfg_snapshot_path():
     ingestor_src = Path("ingestor/ingestor.py").read_text()
 
     assert "def _mirror_irrigation_number_readback" in ingestor_src
-    assert "param not in IRRIGATION_SCHEDULE_PARAMS" in ingestor_src
+    assert "param not in _RECONCILABLE_CFG_PARAMS" in ingestor_src
     assert "state.cfg_readback[param] = val" in ingestor_src
-    assert "shared.cfg_readback[param] = val" in ingestor_src
+    assert "shared.note_cfg_readback_observed(param, val, generation)" in ingestor_src
     assert ingestor_src.count("_mirror_irrigation_number_readback(param, val)") >= 2
+    assert "_mirror_irrigation_number_readback(param, 1.0 if val else 0.0)" in ingestor_src
 
 
 def test_ingestor_accepts_live_mqtt_feedback_without_retained_state():

--- a/tests/test_16_writer_lifecycle.py
+++ b/tests/test_16_writer_lifecycle.py
@@ -161,6 +161,8 @@ async def test_terminal_lifecycle_failure_is_bounded_and_fail_closes_writer(monk
     assert blocked.failed_count == 1
     assert blocked.outcomes[0].reason == "lifecycle_persistence_unavailable"
     assert calls == [1]
+    assert shared.recently_pushed == {}
+    assert shared.recently_pushed_values == {}
     assert shared.writer_fatal_event.is_set()
 
 
@@ -353,6 +355,25 @@ async def test_queued_request_cannot_cross_transport_generation():
     assert [outcome.status for outcome in result.outcomes] == ["sent", "failed"]
     assert result.outcomes[1].reason == "transport_generation_changed"
     assert all(outcome.connection_generation == 4 for outcome in result.outcomes)
+
+
+@pytest.mark.asyncio
+async def test_stale_dispatch_generation_is_rejected_before_queue_or_send():
+    calls: list[int] = []
+
+    async def command(key, _value):
+        calls.append(key)
+
+    _install_number_client(command)
+    result = await esp32_push.push_to_esp32_detailed(
+        [("cmd_1", 1.0, "number")],
+        expected_connection_generation=3,
+    )
+
+    assert calls == []
+    assert result.failed_count == 1
+    assert result.outcomes[0].reason == "transport_generation_changed"
+    assert result.outcomes[0].connection_generation == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_component_experiment_observability.py
+++ b/tests/test_component_experiment_observability.py
@@ -311,7 +311,12 @@ def test_dashboard_uses_only_the_blinded_safe_function():
     assert dashboard["uid"] == "confirmed-component-experiment-v2"
     sql_targets = [target["rawSql"] for panel in dashboard["panels"] for target in panel.get("targets", [])]
     assert len(sql_targets) >= 5
-    assert all("fn_experiment_v2_ops_status()" in query for query in sql_targets)
+    allowed = (
+        "fn_experiment_v2_ops_status()",
+        "fn_experiment_v2_launch_gate_status()",
+    )
+    assert all(any(function in query for function in allowed) for query in sql_targets)
+    assert any("fn_experiment_v2_launch_gate_status()" in query for query in sql_targets)
     combined = "\n".join(sql_targets).lower()
     for forbidden in (
         "control_arm_resolutions",

--- a/tests/test_component_experiment_observability.py
+++ b/tests/test_component_experiment_observability.py
@@ -12,7 +12,11 @@ from typing import get_args
 
 import pytest
 
-from verdify_schemas.alerts import AlertEnvelope, ComponentExperimentIntegrityReason
+from verdify_schemas.alerts import (
+    AlertEnvelope,
+    ComponentExperimentIntegrityReason,
+    ComponentExperimentObservationTruth,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 MIGRATION = ROOT / "db/migrations/215-experiment-v2-ops-observability.sql"
@@ -29,6 +33,12 @@ _ALERT_CASES = re.compile(
 )
 _CASE_BRANCH = re.compile(
     r"\bWHEN\s+(?P<condition>.*?)\s+THEN\s+'(?P<value>[a-z0-9_]+)'",
+    re.DOTALL,
+)
+_OBSERVATION_TRUTH_CASE = re.compile(
+    r"(?P<truth_case>CASE\s+WHEN\s+selected\.future_masked\s+THEN\s+"
+    r"'future_identity_masked'.*?ELSE\s+'exact'\s+END),\s*"
+    r"coalesce\(exposures\.open_count",
     re.DOTALL,
 )
 
@@ -138,6 +148,14 @@ def _db_integrity_branches(function_body: str) -> tuple[tuple[str, str], ...]:
         )
         emitted.append((reason.value, matching_severities[0]))
     return tuple(emitted)
+
+
+def _db_observation_truth_values(function_body: str) -> tuple[str, ...]:
+    match = _OBSERVATION_TRUTH_CASE.search(function_body)
+    assert match is not None, "observation-truth CASE expression not found"
+    branches = tuple(branch.value for branch in _case_branches(match.group("truth_case")))
+    assert "ELSE 'exact'" in match.group("truth_case")
+    return (*branches, "exact")
 
 
 EFFECTIVE_OPS_MIGRATION, EFFECTIVE_OPS_BODY = _latest_ops_status_definition()
@@ -251,6 +269,18 @@ def test_migration_alert_reasons_and_typed_schema_stay_reconciled():
         "expired_work_not_terminal",
         "confirmed_baseline_recovery_missing",
     } <= set(schema_reasons)
+
+
+def test_migration_observation_truth_and_typed_producer_stay_reconciled():
+    assert get_args(ComponentExperimentObservationTruth) == _db_observation_truth_values(EFFECTIVE_OPS_BODY)
+
+
+@pytest.mark.parametrize("observation_truth", get_args(ComponentExperimentObservationTruth))
+def test_every_db_observation_truth_round_trips_the_typed_alert(observation_truth: str):
+    payload = _load_alert_helper()(_ops_row(observation_truth=observation_truth))
+    assert payload is not None
+    envelope = AlertEnvelope.model_validate(payload)
+    assert envelope.details["observation_truth"] == observation_truth
 
 
 def test_alert_contract_comes_from_the_latest_ordered_migration_definition():

--- a/tests/test_component_experiment_writer.py
+++ b/tests/test_component_experiment_writer.py
@@ -60,6 +60,8 @@ def writer_state(monkeypatch):
     monkeypatch.setattr(shared, "writer_lease_strictly_held", lambda minimum_remaining_s=0: True)
     monkeypatch.setattr(shared, "transport_generation", 7)
     monkeypatch.setattr(shared, "esp32", {"client": FakeClient(), "keys": {}, "services": {}})
+    monkeypatch.setattr(shared, "recently_pushed", {})
+    monkeypatch.setattr(shared, "recently_pushed_values", {})
     monkeypatch.setattr(esp32_push, "_pace_command", lambda: asyncio.sleep(0))
     monkeypatch.setattr(esp32_push, "_LIFECYCLE_RETRY_S", 0.0)
     set_component_authority_hold(False)
@@ -347,6 +349,8 @@ async def test_callback_db_failure_self_fences_and_does_not_starve_queued_writer
     ordinary = await asyncio.wait_for(ordinary_task, timeout=1)
     assert ordinary.fatal_error == "component_lifecycle_persistence_unavailable"
     assert client.calls == [("component", 1.0)]
+    assert shared.recently_pushed == {}
+    assert shared.recently_pushed_values == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_experiment_schema_migration.py
+++ b/tests/test_experiment_schema_migration.py
@@ -264,6 +264,7 @@ def test_backfill_covers_repo_migrations_except_unapplied_with_correct_shas():
         "235-experiment-v2-direct-proof-raw-reset-rollover.sql",  # seal pre-claim raw-reset recovery
         "236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql",  # order pre-claim reset from work creation
         "237-experiment-v2-direct-proof-recovery-range-rollover.sql",  # bind rollover to current recovery range
+        "238-experiment-v2-separate-day1-authorization.sql",  # separate finalization from audited day-1 approval
     }
     sql = BACKFILL_SQL.read_text()
     stamped = dict(

--- a/tests/test_experiment_v2_day1_authorization.py
+++ b/tests/test_experiment_v2_day1_authorization.py
@@ -1,0 +1,93 @@
+"""Forward contract for separate #642 authorization and blinded launch status."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/238-experiment-v2-separate-day1-authorization.sql"
+
+
+def _classifier():
+    name = "check_migration_rollback_safety_day1_authorization"
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts/check_migration_rollback_safety.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _body(name: str) -> str:
+    sql = MIGRATION.read_text()
+    marker = f"CREATE OR REPLACE FUNCTION public.{name}("
+    start = sql.index(marker)
+    body = sql.index("AS $body$", start)
+    return sql[body : sql.index("$body$;", body)]
+
+
+def test_forward_migration_is_table_preserving_and_rollback_wrap_safe() -> None:
+    result = _classifier().classify(MIGRATION)
+    assert result.self_committing is False, result.reasons
+    sql = MIGRATION.read_text()
+    assert not re.search(r"\b(DROP|TRUNCATE)\s+TABLE\b", sql, re.IGNORECASE)
+    assert "DELETE FROM" not in sql
+    assert "UPDATE public.experiment_v2_randomization" not in sql
+
+
+def test_scheduler_finalizes_once_then_waits_for_separate_api_approval() -> None:
+    body = _body("fn_experiment_v2_direct_launch_cycle")
+    assert "fn_experiment_v2_finalize_randomization" in body
+    assert "awaiting_separate_day1_approval" in body
+    assert "approval.approved_by LIKE 'verdify-api:%'" in body
+    assert "fn_experiment_v2_direct_launch_approve_day1" not in body
+    for forbidden_input in ("p_secret", "p_rng", "p_random_source", "p_redraw", "p_replace"):
+        assert forbidden_input not in body
+    sql = MIGRATION.read_text()
+    assert "fn_experiment_v2_direct_launch_cycle_pre238" in sql
+    assert "FROM verdify_experiment_shadow_scheduler CASCADE" in sql
+
+
+def test_no_randomized_context_choice_or_work_can_bypass_day1_gate() -> None:
+    sql = MIGRATION.read_text()
+    for relation in (
+        "public.experiment_v2_selector_contexts",
+        "public.experiment_v2_selector_choices",
+        "public.experiment_v2_work",
+    ):
+        assert f"ON {relation}" in sql
+    assert "WHEN (NEW.operation_kind = 'randomized_assignment')" in sql
+    approval_gate = _body("fn_experiment_v2_require_day1_approval")
+    assert "approval.approval_kind = 'randomized_day_1'" in approval_gate
+    assert "approval.issue_number = 642" in approval_gate
+    audit_gate = _body("fn_experiment_v2_day1_approval_audit_binding")
+    assert "^verdify-api:" in audit_gate
+
+
+def test_launch_status_is_blinded_and_names_actionable_kill_rollback_steps() -> None:
+    body = _body("fn_experiment_v2_launch_gate_status")
+    for required in (
+        "awaiting_design_lock",
+        "awaiting_internal_finalization",
+        "awaiting_separate_day1_approval",
+        "set_admission:emergency_hold",
+        "exposure_close_first",
+        "facility_authorized_baseline_recovery",
+        "coarse_disable_after_baseline",
+    ):
+        assert required in body
+    for forbidden in (
+        "secret_bytes",
+        "x_physical_arm",
+        "y_physical_arm",
+        "mapping_payload",
+        "physical_arm",
+        "comparative",
+        "efficacy",
+    ):
+        assert forbidden not in body
+    sql = MIGRATION.read_text()
+    assert "GRANT EXECUTE ON FUNCTION\n    public.fn_experiment_v2_launch_gate_status()\n    TO verdify" in sql

--- a/tests/test_experiment_v2_direct_proof_activation.py
+++ b/tests/test_experiment_v2_direct_proof_activation.py
@@ -1,9 +1,8 @@
-"""Contract gates for the one-sync attended direct physical proof."""
+"""Contract gates for the dormant, one-sync attended physical-proof surface."""
 
 from __future__ import annotations
 
 import subprocess
-from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
@@ -11,12 +10,12 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "deploy/k8s/components/experiment-v2-direct-proof"
 PROD = ROOT / "deploy/k8s/overlays/prod/kustomization.yaml"
-EXPERIMENT_ID = "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+ACTIVATION = ROOT / "deploy/k8s/activations/experiment-v2-direct-proof"
 
 
-def _render() -> list[dict]:
+def _render(path: Path) -> list[dict]:
     result = subprocess.run(
-        ["kustomize", "build", "deploy/k8s/overlays/prod"],
+        ["kustomize", "build", str(path)],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -31,20 +30,51 @@ def _document(rendered: list[dict], kind: str, name: str) -> dict:
     )
 
 
-def test_activation_is_explicitly_included_as_one_attended_component() -> None:
+def test_ordinary_production_excludes_all_direct_proof_activation_resources() -> None:
     prod = yaml.safe_load(PROD.read_text())
-    assert "../../components/experiment-v2-direct-proof" in prod["components"]
+    assert "../../components/experiment-v2-direct-proof" not in prod["components"]
+    rendered = _render(PROD.parent)
+    names = {(document.get("kind"), document.get("metadata", {}).get("name")) for document in rendered}
+    assert ("Job", "verdify-experiment-v2-direct-proof") not in names
+    assert ("ConfigMap", "experiment-v2-direct-proof") not in names
+    assert ("ConfigMap", "experiment-v2-direct-proof-activation") not in names
+
+    ingestor = _document(rendered, "Deployment", "verdify-ingestor")
+    annotations = ingestor["spec"]["template"]["metadata"].get("annotations", {})
+    assert "verdify.io/direct-proof-activation" not in annotations
+    container = next(row for row in ingestor["spec"]["template"]["spec"]["containers"] if row["name"] == "ingestor")
+    explicit_env = {row["name"] for row in container["env"]}
+    assert (
+        not {
+            "VERDIFY_POLICY_VECTOR_MODE",
+            "VERDIFY_COMPONENT_EXPERIMENT_ENABLED",
+            "VERDIFY_ACTIVE_EXPERIMENT_ID",
+        }
+        & explicit_env
+    )
+    config = _document(rendered, "ConfigMap", "verdify-config")["data"]
+    assert config["VERDIFY_POLICY_VECTOR_MODE"] == "off"
+    assert config["VERDIFY_COMPONENT_EXPERIMENT_ENABLED"] == "off"
+    assert config["VERDIFY_ACTIVE_EXPERIMENT_ID"] == ""
+
+
+def test_dormant_activation_is_explicit_and_self_contained() -> None:
+    activation = yaml.safe_load((ACTIVATION / "kustomization.yaml").read_text())
+    assert activation["resources"] == ["../../overlays/prod"]
+    assert activation["components"] == ["../../components/experiment-v2-direct-proof"]
+    assert activation["patches"] == [{"path": "activation-values.patch.yaml"}]
     assert set(yaml.safe_load((COMPONENT / "kustomization.yaml").read_text())["resources"]) == {
+        "activation-configmap.yaml",
         "direct-proof-configmap.yaml",
         "direct-proof-job.yaml",
     }
 
 
-def test_only_the_single_ingestor_gets_the_coarse_capability_override() -> None:
-    rendered = _render()
+def test_dormant_render_grants_no_ingestor_capability() -> None:
+    rendered = _render(ACTIVATION)
     ingestor = _document(rendered, "Deployment", "verdify-ingestor")
     pod = ingestor["spec"]["template"]
-    assert pod["metadata"]["annotations"]["verdify.io/direct-proof-activation"] == ("2026-08-28-jason-vallery-retry-2")
+    assert pod["metadata"]["annotations"]["verdify.io/direct-proof-activation"] == "dormant-no-authority"
     container = next(row for row in pod["spec"]["containers"] if row["name"] == "ingestor")
     env = {row["name"]: row for row in container["env"]}
     assert env["VERDIFY_POLICY_VECTOR_MODE"] == {
@@ -53,11 +83,11 @@ def test_only_the_single_ingestor_gets_the_coarse_capability_override() -> None:
     }
     assert env["VERDIFY_COMPONENT_EXPERIMENT_ENABLED"] == {
         "name": "VERDIFY_COMPONENT_EXPERIMENT_ENABLED",
-        "value": "enabled",
+        "value": "off",
     }
     assert env["VERDIFY_ACTIVE_EXPERIMENT_ID"] == {
         "name": "VERDIFY_ACTIVE_EXPERIMENT_ID",
-        "value": EXPERIMENT_ID,
+        "value": "",
     }
     for deployment in (
         document
@@ -69,13 +99,14 @@ def test_only_the_single_ingestor_gets_the_coarse_capability_override() -> None:
         )
 
 
-def test_proof_job_is_bounded_postsync_nonprivileged_and_avoids_broken_nodes() -> None:
-    rendered = _render()
+def test_proof_job_is_suspended_bounded_postsync_and_nonprivileged() -> None:
+    rendered = _render(ACTIVATION)
     job = _document(rendered, "Job", "verdify-experiment-v2-direct-proof")
     annotations = job["metadata"]["annotations"]
     assert annotations["argocd.argoproj.io/hook"] == "PostSync"
     assert annotations["argocd.argoproj.io/hook-delete-policy"] == "BeforeHookCreation"
     assert annotations["argocd.argoproj.io/sync-wave"] == "1"
+    assert job["spec"]["suspend"] is True
     assert job["spec"]["backoffLimit"] == 0
     assert job["spec"]["activeDeadlineSeconds"] == 6600
     pod = job["spec"]["template"]["spec"]
@@ -89,19 +120,10 @@ def test_proof_job_is_bounded_postsync_nonprivileged_and_avoids_broken_nodes() -
         "seccompProfile": {"type": "RuntimeDefault"},
     }
     assert "serviceAccountName" not in pod
-    assert pod["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"] == [
-        {
-            "matchExpressions": [
-                {
-                    "key": "kubernetes.io/hostname",
-                    "operator": "NotIn",
-                    "values": ["vm-k3s-node4", "vm-k3s-node6"],
-                }
-            ]
-        }
-    ]
+    assert "affinity" not in pod
+    assert "operations.vallery.net/temporary-node-exclusion" not in annotations
     container = pod["containers"][0]
-    assert container["image"].startswith("registry.vallery.net/verdifyconsultancy/verdify-api@sha256:")
+    assert container["image"] == "invalid.local/replace-before-activation:never"
     assert container["securityContext"] == {
         "allowPrivilegeEscalation": False,
         "readOnlyRootFilesystem": True,
@@ -118,18 +140,37 @@ def test_proof_job_is_bounded_postsync_nonprivileged_and_avoids_broken_nodes() -
             "key": "VERDIFY_EXPERIMENT_LIFECYCLE_DB_PASSWORD",
         },
     }
+    assert {row["configMapRef"]["name"] for row in container["envFrom"]} == {
+        "verdify-config",
+        "experiment-v2-direct-proof-activation",
+    }
 
 
-def test_proof_script_is_syntax_valid_exact_role_bound_and_non_provider() -> None:
-    rendered = _render()
+def test_proof_script_is_syntax_valid_runtime_bound_and_non_provider() -> None:
+    rendered = _render(ACTIVATION)
     config = _document(rendered, "ConfigMap", "experiment-v2-direct-proof")
     script = config["data"]["proof.py"]
     compile(script, "proof.py", "exec")
-    assert 'EXPERIMENT_ID = "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"' in script
-    assert "datetime(2026, 8, 28, 17, 45, tzinfo=UTC)" in script
-    assert "datetime(2026, 8, 29, 5, 0, tzinfo=UTC)" in script
-    assert datetime(2026, 8, 28, 17, 45, tzinfo=UTC) < datetime(2026, 8, 29, 5, tzinfo=UTC)
-    assert script.count('"Jason Vallery"') == 2
+    for variable in (
+        "VERDIFY_DIRECT_PROOF_EXPERIMENT_ID",
+        "VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF",
+        "VERDIFY_DIRECT_PROOF_FACILITY_AUTHORIZATION_REF",
+        "VERDIFY_DIRECT_PROOF_AUTHORIZED_FROM",
+        "VERDIFY_DIRECT_PROOF_AUTHORIZED_TO",
+        "VERDIFY_DIRECT_PROOF_SUPERVISOR_ROLE",
+        "VERDIFY_DIRECT_PROOF_RESCUE_OWNER_ROLE",
+        "VERDIFY_DIRECT_PROOF_ACTOR",
+        "VERDIFY_DIRECT_PROOF_CONFIG_REVISION",
+    ):
+        assert variable in script
+    assert "required_activation_value" in script
+    assert "activation_time" in script
+    assert "activation window must be between 3 minutes and 12 hours" in script
+    assert "SUPERVISOR_ROLE" in script and "RESCUE_OWNER_ROLE" in script
+    assert "2026-08-28" not in script
+    assert "2026-08-29" not in script
+    assert "extended-through-23:00-MT" not in script
+    assert "4dbb2e691d91" not in script
     for function in (
         "fn_experiment_v2_direct_proof_begin(",
         "fn_experiment_v2_direct_proof_open_aggressive(",
@@ -186,3 +227,10 @@ def test_default_config_remains_coarse_off_for_the_removal_rollback() -> None:
     assert base["VERDIFY_POLICY_VECTOR_MODE"] == "off"
     assert base["VERDIFY_COMPONENT_EXPERIMENT_ENABLED"] == "off"
     assert base["VERDIFY_ACTIVE_EXPERIMENT_ID"] == ""
+
+
+def test_dormant_activation_values_are_invalid_placeholders() -> None:
+    rendered = _render(ACTIVATION)
+    activation = _document(rendered, "ConfigMap", "experiment-v2-direct-proof-activation")
+    assert activation["data"]
+    assert set(activation["data"].values()) == {"REPLACE_BEFORE_ACTIVATION"}

--- a/tests/test_experiment_v2_direct_proof_recovery_range_rollover.py
+++ b/tests/test_experiment_v2_direct_proof_recovery_range_rollover.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MIGRATION = ROOT / "db/migrations/237-experiment-v2-direct-proof-recovery-range-rollover.sql"
 PREVIOUS = ROOT / "db/migrations/236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql"
+FIXTURE = ROOT / "db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql"
 
 
 def test_rollover_binds_fault_and_receipts_to_exact_recovery_range() -> None:
@@ -48,3 +49,24 @@ def test_applied_migration_236_is_not_rewritten() -> None:
     assert "fault.recorded_at <@ v_auth.proof_valid_range" in sql
     assert "recovered.recorded_at <@ v_auth.proof_valid_range" in sql
     assert "verdify-direct-proof-startup-raw-reset-v2|" in sql
+
+
+def test_restored_fixture_reproduces_the_live_range_failure_and_exact_receipt() -> None:
+    sql = FIXTURE.read_text()
+    for required in (
+        "fault.recorded_at <@ recovery.valid_range",
+        "recovered.recorded_at <@ recovery.valid_range",
+        "upper(recovery.valid_range) - lower(recovery.valid_range) =",
+        "NOT (",
+        "fault_at <@ proof_valid_range",
+        "recovered_at <@ proof_valid_range",
+        "receipt_count >= 2",
+        "sealed.recovery_evidence_sha256 =",
+        "candidates.evidence_sha256",
+        "restored production-shaped migration 237 recovery lineage",
+    ):
+        assert required in sql
+    assert "INSERT INTO" not in sql
+    assert "UPDATE " not in sql
+    assert "DELETE FROM" not in sql
+    assert sql.rstrip().endswith("ROLLBACK;")

--- a/tests/test_experiment_v2_direct_proof_startup_rollover.py
+++ b/tests/test_experiment_v2_direct_proof_startup_rollover.py
@@ -38,8 +38,8 @@ def test_proof_seals_rollover_before_waiting_for_stable_successor() -> None:
     begin = script.index("aggressive_work_id = await connection.fetchval(", settle)
     assert resolve < settle < begin
     assert "RUNTIME_REGISTRATION_SETTLE_SECONDS = 5 * 60" in script
-    assert "datetime(2026, 8, 29, 5, 0, tzinfo=UTC)" in script
-    assert "extended-through-23:00-MT" in script
+    assert 'activation_time("VERDIFY_DIRECT_PROOF_AUTHORIZED_TO")' in script
+    assert 'required_activation_value("VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF")' in script
 
 
 def test_rollover_resolution_is_function_only_and_append_only() -> None:

--- a/tests/test_experiment_v2_launch_artifacts.py
+++ b/tests/test_experiment_v2_launch_artifacts.py
@@ -1,0 +1,282 @@
+"""Dormant M8 design/preflight/activation source contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from experiment_orchestrator.contracts import (
+    OPENAI_SELECTOR_IDENTITY_SCHEMA,
+    OPENAI_SELECTOR_RESPONSE_FORMAT,
+    OPENAI_SELECTOR_RESPONSE_SCHEMA,
+    SelectorIdentity,
+    canonical_json_bytes,
+    openai_messages_template_bytes,
+)
+from experiment_orchestrator.launch_artifacts import (
+    MODELED_JOINT_ADVANCE_POWER,
+    build_direct_launch_design,
+    earliest_offset_stable_start,
+    parse_direct_launch_design,
+)
+from experiment_orchestrator.launch_control import execute_control
+from experiment_orchestrator.preflight import run_preflight
+from experiment_orchestrator.provider import SelectorAttemptResult
+
+ROOT = Path(__file__).resolve().parents[1]
+DESIGN_COMPONENT = ROOT / "deploy/k8s/components/experiment-v2-design-lock"
+AUTHORIZATION_COMPONENT = ROOT / "deploy/k8s/components/experiment-v2-randomized-day1-authorization"
+ACTIVATION_COMPONENT = ROOT / "deploy/k8s/components/experiment-v2-randomized-day1-activation"
+ROLLBACK_COMPONENT = ROOT / "deploy/k8s/components/experiment-v2-randomized-day1-rollback"
+PROD = ROOT / "deploy/k8s/overlays/prod/kustomization.yaml"
+
+
+def _design():
+    return build_direct_launch_design(
+        analyzer_environment_sha256="1" * 64,
+        context_schema_sha256="2" * 64,
+        endpoint_artifact_sha256="3" * 64,
+        outcome_schema_sha256="4" * 64,
+        power_artifact_sha256="4d751a76465d03dc2e75034dcb398d25dc39b375d9976671bd8fffb018d237a2",
+        rollback_artifact_sha256="6" * 64,
+        schedule_schema_sha256="fc73d212f58db91bd55bb70e3faa1431172b4339ae3b22a11d404ba95147b794",
+        selector_artifact_sha256="8" * 64,
+        selector_identity_sha256="9" * 64,
+        source_git_sha="a" * 40,
+        study_start_local_date="2026-11-02",
+    )
+
+
+def _identity() -> SelectorIdentity:
+    system = "Choose one approved profile. Return only the strict schema object."
+    prompt = "Use only this preflight context and select the safest approved profile."
+    decoding = {
+        "max_completion_tokens": 512,
+        "reasoning_effort": "medium",
+        "response_format": OPENAI_SELECTOR_RESPONSE_FORMAT,
+        "stream": False,
+    }
+    payload = {
+        "schema": OPENAI_SELECTOR_IDENTITY_SCHEMA,
+        "provider": "openai",
+        "model_identifier": "gpt-5.6-sol",
+        "model_revision": "gpt-5.6-sol",
+        "expected_system_fingerprint": "openai-managed",
+        "prompt": prompt,
+        "system_message": system,
+        "decoding_parameters": decoding,
+        "prompt_sha256": hashlib.sha256(prompt.encode()).hexdigest(),
+        "system_message_sha256": hashlib.sha256(system.encode()).hexdigest(),
+        "messages_sha256": hashlib.sha256(openai_messages_template_bytes(system, prompt)).hexdigest(),
+        "decoding_parameters_sha256": hashlib.sha256(canonical_json_bytes(decoding)).hexdigest(),
+        "tool_contract_revision": "none-v1",
+        "response_schema_revision": OPENAI_SELECTOR_RESPONSE_SCHEMA,
+        "context_schema_sha256": "b" * 64,
+        "lesson_snapshot_sha256": "c" * 64,
+        "runtime_environment_sha256": "d" * 64,
+        "timeout_milliseconds": 60_000,
+        "max_attempts": 1,
+    }
+    raw = canonical_json_bytes(payload)
+    return SelectorIdentity.parse(raw, hashlib.sha256(raw).hexdigest())
+
+
+def test_future_design_hash_is_immutable_complete_and_offset_stable() -> None:
+    design = _design()
+    replay = parse_direct_launch_design(design.canonical_bytes, now_local_date=date(2026, 8, 29))
+    assert replay == design
+    assert design.payload["modeled_joint_advance_power"] == MODELED_JOINT_ADVANCE_POWER
+    assert design.payload["accepted_underpowered_design"] is True
+    assert design.payload["generalized_vector_mode"] == "off"
+    assert design.payload["study_start_local_date"] == "2026-11-02"
+    assert earliest_offset_stable_start(not_before=date(2026, 8, 30)) == date(2026, 8, 30)
+    changed = json.loads(design.canonical_bytes)
+    changed["randomized_pair_count"] = 31
+    with pytest.raises(ValueError):
+        parse_direct_launch_design(
+            canonical_json_bytes(changed, reject_forbidden_fields=False), now_local_date=date.min
+        )
+    with pytest.raises(ValueError, match="missed starts"):
+        parse_direct_launch_design(design.canonical_bytes, now_local_date=date(2026, 11, 2))
+
+
+@pytest.mark.asyncio
+async def test_preflight_persists_only_strict_profile_contract_metadata() -> None:
+    class Provider:
+        async def select(self, **kwargs):
+            assert kwargs["identity"].decoding_parameters["response_format"] == OPENAI_SELECTOR_RESPONSE_FORMAT
+            return SelectorAttemptResult("aggressive", None, "e" * 64, "f" * 64, ("1" * 64,))
+
+    receipt = await run_preflight(
+        identity=_identity(),
+        provider=Provider(),
+        clock=lambda: datetime(2026, 8, 29, 12, tzinfo=UTC),
+    )
+    raw = receipt.canonical_bytes()
+    assert receipt.status == "pass"
+    assert receipt.strict_profile_only is True and receipt.tools_allowed is False
+    assert not receipt.database_authority and not receipt.device_authority and not receipt.kubernetes_authority
+    assert b"aggressive" not in raw
+    for forbidden in (b"api_key", b"authorization", b"mapping", b"physical_arm", b"secret"):
+        assert forbidden not in raw.lower()
+
+
+@pytest.mark.asyncio
+async def test_lock_and_day1_approval_are_distinct_audited_api_calls() -> None:
+    requests: list[dict] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                json={
+                    "admission_state": "closed",
+                    "approvals": {"randomized_day_1": False},
+                    "db_component_enabled": False,
+                    "execution_phase": "shadow",
+                    "lease_generation": 7,
+                    "lifecycle_status": "draft",
+                    "open_exposures": 0,
+                    "revision_bundle_sha256": "2" * 64,
+                },
+            )
+        body = json.loads(request.content)
+        requests.append(body)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "state": {
+                    "admission_state": "closed",
+                    "execution_phase": "randomized",
+                    "lifecycle_status": "locked",
+                }
+            },
+        )
+
+    receipt = await execute_control(
+        action="lock-design",
+        api_root="http://verdify-api:8000",
+        token="bounded-test-token",  # noqa: S106 - inert MockTransport credential
+        audit_ref="issue-642-design-lock",
+        design=_design(),
+        transport=httpx.MockTransport(handler),
+    )
+    assert requests[0]["action"] == "direct_launch_commit"
+    assert requests[0]["expected_component_enabled"] is False
+    assert requests[0]["audit_ref"] == "issue-642-design-lock"
+    assert b"secret" not in receipt.lower() and b"mapping" not in receipt.lower()
+
+    requests.clear()
+
+    async def approval_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                json={
+                    "admission_state": "closed",
+                    "approvals": {"randomized_day_1": False},
+                    "db_component_enabled": True,
+                    "execution_phase": "randomized",
+                    "lease_generation": 8,
+                    "lifecycle_status": "armed",
+                    "open_exposures": 0,
+                    "revision_bundle_sha256": "2" * 64,
+                },
+            )
+        body = json.loads(request.content)
+        requests.append(body)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "state": {
+                    "admission_state": "closed",
+                    "execution_phase": "randomized",
+                    "lifecycle_status": "armed",
+                }
+            },
+        )
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("VERDIFY_ACTIVE_EXPERIMENT_ID", _design().experiment_id)
+    try:
+        receipt = await execute_control(
+            action="approve-day1",
+            api_root="http://verdify-api:8000",
+            token="bounded-test-token",  # noqa: S106 - inert MockTransport credential
+            audit_ref="issue-642-randomized-day1-approval",
+            transport=httpx.MockTransport(approval_handler),
+        )
+    finally:
+        monkeypatch.undo()
+    assert requests == [
+        {
+            "action": "direct_launch_approve_day1",
+            "audit_ref": "issue-642-randomized-day1-approval",
+            "expected_admission_state": "closed",
+            "expected_component_enabled": True,
+            "expected_execution_phase": "randomized",
+            "expected_lease_generation": 8,
+            "expected_lifecycle_status": "armed",
+            "expected_revision_bundle_sha256": "2" * 64,
+        }
+    ]
+    assert b"secret" not in receipt.lower() and b"mapping" not in receipt.lower()
+
+
+def _documents(path: Path) -> list[dict]:
+    documents: list[dict] = []
+    for source in path.glob("*.yaml"):
+        documents.extend(item for item in yaml.safe_load_all(source.read_text()) if item)
+    return documents
+
+
+def test_activation_and_rollback_manifests_are_dormant_hardened_and_vector_off() -> None:
+    prod = PROD.read_text()
+    for component in (
+        DESIGN_COMPONENT,
+        AUTHORIZATION_COMPONENT,
+        ACTIVATION_COMPONENT,
+        ROLLBACK_COMPONENT,
+    ):
+        assert component.name not in prod
+
+    design_jobs = [item for item in _documents(DESIGN_COMPONENT) if item["kind"] == "Job"]
+    assert {item["metadata"]["name"] for item in design_jobs} == {
+        "verdify-experiment-v2-openai-preflight",
+        "verdify-experiment-v2-design-lock",
+    }
+    for job in design_jobs:
+        pod = job["spec"]["template"]["spec"]
+        container = pod["containers"][0]
+        assert pod["automountServiceAccountToken"] is False
+        assert container["securityContext"]["readOnlyRootFilesystem"] is True
+        assert container["securityContext"]["capabilities"]["drop"] == ["ALL"]
+        env_names = {item["name"] for item in container.get("env", [])}
+        assert not any(name.endswith("DB_PASSWORD") for name in env_names)
+
+    authorization_jobs = [item for item in _documents(AUTHORIZATION_COMPONENT) if item["kind"] == "Job"]
+    assert [item["metadata"]["name"] for item in authorization_jobs] == ["verdify-experiment-v2-day1-approval"]
+    assert not any(item["kind"] == "Job" for item in _documents(ACTIVATION_COMPONENT))
+    activation_kustomization = (ACTIVATION_COMPONENT / "kustomization.yaml").read_text()
+    assert "day1-approval" not in activation_kustomization
+
+    activation = (ACTIVATION_COMPONENT / "workload-activation.patch.yaml").read_text()
+    assert activation.count('name: VERDIFY_POLICY_VECTOR_MODE\n              value: "off"') == 5
+    assert activation.count('name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED\n              value: "enabled"') == 5
+    rollback = (ROLLBACK_COMPONENT / "workload-disable.patch.yaml").read_text()
+    assert rollback.count('name: VERDIFY_POLICY_VECTOR_MODE\n              value: "off"') == 5
+    assert rollback.count('name: VERDIFY_COMPONENT_EXPERIMENT_ENABLED\n              value: "off"') == 5
+    assert rollback.count('name: VERDIFY_ACTIVE_EXPERIMENT_ID\n              value: ""') == 5
+    rollback_job = next(item for item in _documents(ROLLBACK_COMPONENT) if item["kind"] == "Job")
+    command = rollback_job["spec"]["template"]["spec"]["containers"][0]["command"]
+    assert "emergency-hold" in command

--- a/tests/test_mcp_audience_auth.py
+++ b/tests/test_mcp_audience_auth.py
@@ -858,7 +858,7 @@ def test_production_mcp_enforces_iris_audience_with_the_existing_hermes_credenti
     assert "VERDIFY_MCP_TOKEN_ADMIN" not in env
 
 
-def test_rendered_prod_keeps_affinity_through_first_stateless_image_rollout() -> None:
+def test_rendered_prod_is_stateless_without_client_ip_affinity() -> None:
     rendered = subprocess.run(
         ["kustomize", "build", str(PROD_OVERLAY_PATH)],
         cwd=REPO_ROOT,
@@ -891,10 +891,8 @@ def test_rendered_prod_keeps_affinity_through_first_stateless_image_rollout() ->
     assert deployment["spec"]["replicas"] == 2
     assert deployment["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "10"
     assert hermes["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "20"
-    # Keep compatibility with the previously pinned stateful MCP image during
-    # the first stateless image rollout. Affinity cleanup is a later GitOps PR.
-    assert service["spec"]["sessionAffinity"] == "ClientIP"
-    assert service["spec"]["sessionAffinityConfig"] == {"clientIP": {"timeoutSeconds": 10800}}
+    assert service["spec"]["sessionAffinity"] == "None"
+    assert "sessionAffinityConfig" not in service["spec"]
     # The WAN route exposes only the protocol endpoint; internal Service users
     # and kube probes can still call /readyz directly.
     assert ingress["spec"]["routes"][0]["match"] == "Host(`mcp.verdify.ai`) && PathPrefix(`/mcp`)"

--- a/tests/test_mcp_security_acceptance.py
+++ b/tests/test_mcp_security_acceptance.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/mcp-security-acceptance.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("mcp_security_acceptance_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_canonical_iris_inventory_is_bounded_and_excludes_admin_query() -> None:
+    module = _module()
+    tools = module.expected_iris_tools()
+    assert len(tools) == 23
+    assert "climate" in tools
+    assert "query" not in tools
+
+
+def test_generic_unauthorized_contract_rejects_inventory_and_sessions() -> None:
+    module = _module()
+    accepted = module.Response(
+        401,
+        {"content-type": "application/json", "www-authenticate": "Bearer"},
+        b'{"error":"unauthorized"}',
+    )
+    module._assert_unauthorized(accepted, check="public:initialize")
+
+    with pytest.raises(module.AcceptanceError, match="HTTP 503"):
+        module._assert_unauthorized(module.Response(503, {}, b"no available server"), check="public:initialize")
+    with pytest.raises(module.AcceptanceError, match="stateful MCP session"):
+        module._assert_unauthorized(
+            module.Response(401, {"www-authenticate": "Bearer", "mcp-session-id": "opaque"}, accepted.body),
+            check="public:initialize",
+        )
+    with pytest.raises(module.AcceptanceError, match="non-generic denial body"):
+        module._assert_unauthorized(
+            module.Response(
+                401,
+                {"www-authenticate": "Bearer"},
+                b'{"error":"unauthorized","tools":[{"name":"query"}]}',
+            ),
+            check="public:tools-list",
+        )
+
+
+def test_protocol_payload_accepts_json_and_stateless_sse() -> None:
+    module = _module()
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+    encoded = json.dumps(payload).encode()
+    assert (
+        module._protocol_payload(module.Response(200, {"content-type": "application/json"}, encoded), check="json")
+        == payload
+    )
+    sse = b"event: message\ndata: " + encoded + b"\n\n"
+    assert (
+        module._protocol_payload(module.Response(200, {"content-type": "text/event-stream"}, sse), check="sse")
+        == payload
+    )
+
+
+def test_endpoint_parser_forbids_credentials_and_accepts_labeled_direct_urls() -> None:
+    module = _module()
+    endpoint = module._endpoint("replica-a=http://127.0.0.1:18001/mcp")
+    assert endpoint.label == "replica-a"
+    assert endpoint.url.endswith("/mcp")
+    with pytest.raises(Exception, match="without userinfo"):
+        module._endpoint("unsafe=https://bearer@example.test/mcp")
+
+
+def test_failures_never_include_the_presented_bearer(monkeypatch) -> None:
+    module = _module()
+    bearer = "runtime-test-sensitive-bearer"
+
+    def fake_request(*_args, **_kwargs):
+        return module.Response(503, {}, bearer.encode())
+
+    monkeypatch.setattr(module, "_request", fake_request)
+    with pytest.raises(module.AcceptanceError) as excinfo:
+        module._authenticated_checks(
+            module.Endpoint("replica-a", "http://127.0.0.1:18001/mcp"),
+            bearer=bearer,
+            expected_tools=module.expected_iris_tools(),
+            safe_tool="climate",
+            repeats=1,
+            timeout=1,
+        )
+    assert bearer not in str(excinfo.value)
+
+
+def test_authenticated_helper_checks_exact_inventory_admin_denial_and_safe_read(monkeypatch) -> None:
+    module = _module()
+    tools = module.expected_iris_tools()
+    calls = []
+
+    def fake_request(_url, *, method, payload=None, bearer=None, timeout):
+        assert method == "POST"
+        assert bearer == "test-iris-bearer"
+        assert timeout == 1
+        calls.append(payload["method"])
+        if payload["method"] == "initialize":
+            body = {"jsonrpc": "2.0", "id": payload["id"], "result": {"protocolVersion": module.PROTOCOL_VERSION}}
+        elif payload["method"] == "tools/list":
+            body = {
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {"tools": [{"name": name} for name in sorted(tools)]},
+            }
+        elif payload["params"]["name"] == "query":
+            body = {"jsonrpc": "2.0", "id": payload["id"], "result": {"isError": True, "content": []}}
+        else:
+            body = {"jsonrpc": "2.0", "id": payload["id"], "result": {"isError": False, "content": []}}
+        return module.Response(200, {"content-type": "application/json"}, json.dumps(body).encode())
+
+    monkeypatch.setattr(module, "_request", fake_request)
+    completed = module._authenticated_checks(
+        module.Endpoint("replica-a", "http://127.0.0.1:18001/mcp"),
+        bearer="test-iris-bearer",
+        expected_tools=tools,
+        safe_tool="climate",
+        repeats=2,
+        timeout=1,
+    )
+    assert completed == 8
+    assert calls == ["initialize", "tools/list", "tools/call", "tools/call"] * 2
+
+
+def test_unauthenticated_helper_repeats_missing_and_unknown_bearers(monkeypatch) -> None:
+    module = _module()
+    bearers = []
+
+    def fake_request(_url, *, method, payload=None, bearer=None, timeout):
+        assert method == "POST" and payload and timeout == 1
+        bearers.append(bearer)
+        return module.Response(
+            401,
+            {"content-type": "application/json", "www-authenticate": "Bearer"},
+            b'{"error":"unauthorized"}',
+        )
+
+    monkeypatch.setattr(module, "_request", fake_request)
+    completed = module._unauthenticated_checks(
+        module.Endpoint("public", "https://mcp.example.test/mcp"), repeats=2, timeout=1
+    )
+    assert completed == 9
+    assert bearers[:6] == [None] * 6
+    assert len(set(bearers[6:])) == 1 and bearers[6] is not None
+
+
+def test_cli_exposes_no_literal_token_argument() -> None:
+    module = _module()
+    destinations = {action.dest for action in module.build_parser()._actions}
+    assert "token" not in destinations
+    assert "token_env" in destinations

--- a/tests/test_sops_secret_metadata_receipt.py
+++ b/tests/test_sops_secret_metadata_receipt.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/sops-secret-metadata-receipt.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("sops_secret_metadata_receipt_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _source(module, *, encrypted: bool = True):
+    value = "ENC[AES256_GCM,data:ciphertext,iv:opaque,tag:opaque,type:str]" if encrypted else "plaintext-secret"
+    document = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "verdify-hermes", "namespace": "verdify-prod"},
+        "type": "Opaque",
+        "data": {"OPENAI_API_KEY": value, "VERDIFY_MCP_TOKEN": value},
+        "sops": {
+            "age": [{"recipient": "age1publicmetadataonly", "enc": "opaque"}],
+            "lastmodified": "2026-08-29T00:00:00Z",
+            "mac": "ENC[AES256_GCM,data:mac,iv:opaque,tag:opaque,type:str]",
+            "encrypted_regex": "^(data|stringData)$",
+            "version": "3.10.2",
+        },
+    }
+    return module.GitSource(
+        Path("/work/agents"),
+        Path("platform/gitops/secrets-ksops/verdify-prod/secret-verdify-hermes.enc.yaml"),
+        "a" * 40,
+        "b" * 40,
+        "2026-08-29T00:00:00Z",
+        yaml.safe_dump(document).encode(),
+    )
+
+
+def test_receipt_reports_only_source_target_key_names_and_sops_metadata() -> None:
+    module = _module()
+    source = _source(module)
+    receipt = module.secret_metadata(
+        source,
+        expected_name="verdify-hermes",
+        expected_namespace="verdify-prod",
+        required_keys={"OPENAI_API_KEY", "VERDIFY_MCP_TOKEN"},
+    )
+    encoded = json.dumps(receipt, sort_keys=True)
+    assert receipt["status"] == "pass"
+    assert receipt["secret"]["required_keys_present"] is True
+    assert receipt["secret"]["key_names"] == ["OPENAI_API_KEY", "VERDIFY_MCP_TOKEN"]
+    assert receipt["sops"]["age_recipient_count"] == 1
+    assert "ENC[" not in encoded
+    assert "ciphertext" not in encoded
+    assert "age1publicmetadataonly" not in encoded
+
+
+def test_receipt_rejects_plaintext_without_quoting_it() -> None:
+    module = _module()
+    source = _source(module, encrypted=False)
+    with pytest.raises(module.ReceiptError) as excinfo:
+        module.secret_metadata(
+            source,
+            expected_name="verdify-hermes",
+            expected_namespace="verdify-prod",
+            required_keys={"OPENAI_API_KEY"},
+        )
+    assert "unencrypted value" in str(excinfo.value)
+    assert "plaintext-secret" not in str(excinfo.value)
+
+
+def test_receipt_rejects_wrong_target_or_missing_required_key_without_listing_values() -> None:
+    module = _module()
+    source = _source(module)
+    with pytest.raises(module.ReceiptError, match="target does not match"):
+        module.secret_metadata(
+            source,
+            expected_name="other-secret",
+            expected_namespace="verdify-prod",
+            required_keys=set(),
+        )
+    with pytest.raises(module.ReceiptError, match="missing one or more required key"):
+        module.secret_metadata(
+            source,
+            expected_name="verdify-hermes",
+            expected_namespace="verdify-prod",
+            required_keys={"MISSING_KEY"},
+        )
+
+
+def test_receipt_requires_exact_sops_encryption_boundary() -> None:
+    module = _module()
+    source = _source(module)
+    document = yaml.safe_load(source.contents)
+    document["sops"]["encrypted_regex"] = "^(password)$"
+    source = module.GitSource(
+        source.repo_root,
+        source.relative_path,
+        source.revision,
+        source.last_changed_revision,
+        source.commit_time,
+        yaml.safe_dump(document).encode(),
+    )
+    with pytest.raises(module.ReceiptError, match="encrypted_regex"):
+        module.secret_metadata(
+            source,
+            expected_name="verdify-hermes",
+            expected_namespace="verdify-prod",
+            required_keys={"OPENAI_API_KEY"},
+        )
+
+
+def test_git_source_reads_the_exact_committed_revision(tmp_path) -> None:
+    module = _module()
+    repository = tmp_path / "agents"
+    repository.mkdir()
+    relative = Path("platform/gitops/secrets-ksops/verdify-prod/secret-verdify-hermes.enc.yaml")
+    encrypted = repository / relative
+    encrypted.parent.mkdir(parents=True)
+    encrypted.write_bytes(_source(module).contents)
+    for command in (
+        ("init", "-q"),
+        ("config", "user.name", "Receipt Test"),
+        ("config", "user.email", "receipt@example.invalid"),
+        ("add", relative.as_posix()),
+        ("commit", "-qm", "test encrypted source"),
+    ):
+        subprocess.run(["git", "-C", str(repository), *command], check=True)
+
+    source = module.git_source(relative, repo=repository, revision="HEAD")
+    assert source.contents == encrypted.read_bytes()
+    assert source.relative_path == relative
+    assert len(source.revision) == len(source.last_changed_revision) == 40

--- a/tests/test_verify_component_proof_packet.py
+++ b/tests/test_verify_component_proof_packet.py
@@ -1,0 +1,202 @@
+"""Fresh full-48 physical-proof packet failure fixtures."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/verify_component_proof_packet.py"
+SPEC = importlib.util.spec_from_file_location("verify_component_proof_packet", SCRIPT)
+assert SPEC and SPEC.loader
+proof = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = proof
+SPEC.loader.exec_module(proof)
+
+START = datetime(2026, 8, 29, 18, 0, tzinfo=UTC)
+
+
+def _uuid(value: int) -> str:
+    return str(UUID(int=value))
+
+
+def _ts(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _packet() -> dict[str, object]:
+    boundaries = []
+    stages = (
+        ("baseline_before", "baseline", "1" * 64),
+        ("aggressive", "aggressive", "2" * 64),
+        ("baseline_after", "baseline", "1" * 64),
+    )
+    identity = 100
+    for boundary_index, (stage, profile, state_hash) in enumerate(stages):
+        bundle_finished = START + timedelta(seconds=boundary_index * 120)
+        identity += 1
+        work_id = _uuid(identity)
+        identity += 1
+        bundle_id = _uuid(identity)
+        epochs = []
+        for epoch_index in range(2):
+            observed_at = bundle_finished + timedelta(seconds=5 + 31 * epoch_index)
+            identity += 1
+            epochs.append(
+                {
+                    "source_epoch_id": _uuid(identity),
+                    "work_id": work_id,
+                    "bundle_id": bundle_id,
+                    "observation_receipt_sha256": f"{boundary_index + 3}{epoch_index}" * 32,
+                    "policy_state_content_sha256": state_hash,
+                    "persisted_at": _ts(observed_at + timedelta(seconds=2)),
+                    "revision_bundle_sha256": "a" * 64,
+                    "lease_generation": 4,
+                    "writer_generation": 8,
+                    "connection_generation": 12,
+                    "components": [
+                        {"wire_id": wire_id, "observed_at": _ts(observed_at)} for wire_id in sorted(proof.WIRE_IDS)
+                    ],
+                }
+            )
+        boundaries.append(
+            {
+                "stage": stage,
+                "profile": profile,
+                "work_id": work_id,
+                "bundle_id": bundle_id,
+                "bundle_finished_at": _ts(bundle_finished),
+                "expected_state_content_sha256": state_hash,
+                "epochs": epochs,
+            }
+        )
+    return {
+        "schema": proof.SCHEMA,
+        "experiment_id": "45039c86-c1d9-52f6-a0a9-d94a17bc4b14",
+        "authorization_id": _uuid(1),
+        "attempt_number": 9,
+        "authorized_from": _ts(START - timedelta(minutes=1)),
+        "authorized_to": _ts(START + timedelta(minutes=6)),
+        "revision_bundle_sha256": "a" * 64,
+        "lease_generation": 4,
+        "writer_generation": 8,
+        "connection_generation": 12,
+        "proof_receipt_id": _uuid(2),
+        "proof_receipt_sha256": "f" * 64,
+        "proof_receipt_recorded_at": _ts(START + timedelta(seconds=278)),
+        "boundaries": boundaries,
+        "final_status": {
+            "lifecycle_status": "draft",
+            "execution_phase": "shadow",
+            "admission_state": "closed",
+            "component_enabled": False,
+            "open_exposure_count": 0,
+            "baseline_confirmed": True,
+        },
+    }
+
+
+def test_fresh_full48_packet_seals_deterministically_and_keeps_db_receipt_distinct() -> None:
+    first = proof.seal_packet(_packet())
+    second = proof.seal_packet(_packet())
+
+    assert first == second
+    assert first["packet_sha256"] == second["packet_sha256"]
+    assert first["packet_sha256"] != first["proof_receipt_sha256"]
+    unsigned = deepcopy(first)
+    seal = unsigned.pop("packet_sha256")
+    assert hashlib.sha256(proof.canonical_json_bytes(unsigned)).hexdigest() == seal
+
+
+@pytest.mark.parametrize(
+    ("boundary_index", "epoch_index", "wire_id"),
+    [
+        (boundary_index, epoch_index, wire_id)
+        for boundary_index in range(3)
+        for epoch_index in range(2)
+        for wire_id in sorted(proof.WIRE_IDS)
+    ],
+)
+def test_every_missing_full48_component_fails(boundary_index: int, epoch_index: int, wire_id: int) -> None:
+    packet = _packet()
+    epoch = packet["boundaries"][boundary_index]["epochs"][epoch_index]
+    epoch["components"] = [component for component in epoch["components"] if component["wire_id"] != wire_id]
+
+    with pytest.raises(proof.ProofPacketError, match="exactly 48 components"):
+        proof.validate_packet(packet)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda packet: packet["boundaries"][0]["epochs"][0].update(persisted_at=_ts(START + timedelta(seconds=96))),
+            "stale",
+        ),
+        (
+            lambda packet: packet["boundaries"][1]["epochs"][0].update(connection_generation=13),
+            "generation changed",
+        ),
+        (
+            lambda packet: packet["boundaries"][2]["epochs"][1].update(
+                source_epoch_id=packet["boundaries"][2]["epochs"][0]["source_epoch_id"]
+            ),
+            "globally distinct",
+        ),
+        (
+            lambda packet: packet["boundaries"][0]["epochs"][1]["components"][0].update(
+                observed_at=packet["boundaries"][0]["epochs"][0]["components"][0]["observed_at"]
+            ),
+            "does not advance every component",
+        ),
+        (
+            lambda packet: (
+                packet["boundaries"][1].update(expected_state_content_sha256="1" * 64),
+                [epoch.update(policy_state_content_sha256="1" * 64) for epoch in packet["boundaries"][1]["epochs"]],
+            ),
+            "baseline/aggressive/baseline",
+        ),
+        (
+            lambda packet: packet["final_status"].update(component_enabled=True),
+            "final status",
+        ),
+    ],
+)
+def test_receipt_freshness_lineage_generation_and_final_state_fail_closed(mutate, message: str) -> None:
+    packet = _packet()
+    mutate(packet)
+    with pytest.raises(proof.ProofPacketError, match=message):
+        proof.validate_packet(packet)
+
+
+def test_packet_rejects_secret_or_mapping_material() -> None:
+    packet = _packet()
+    packet["randomization_secret"] = "forbidden"
+    with pytest.raises(proof.ProofPacketError, match="keys differ|forbidden"):
+        proof.validate_packet(packet)
+
+
+def test_packet_rejects_reordered_full48_manifest() -> None:
+    packet = _packet()
+    components = packet["boundaries"][0]["epochs"][0]["components"]
+    components[0], components[1] = components[1], components[0]
+    with pytest.raises(proof.ProofPacketError, match="canonical wire order"):
+        proof.validate_packet(packet)
+
+
+def test_exclusive_output_refuses_overwrite_and_round_trips(tmp_path: Path) -> None:
+    output = tmp_path / "private" / "proof.json"
+    sealed = proof.seal_packet(_packet())
+    proof.write_exclusive(sealed, output)
+    assert json.loads(output.read_text()) == sealed
+    assert output.stat().st_mode & 0o777 == 0o600
+    with pytest.raises(proof.ProofPacketError, match="already exists"):
+        proof.write_exclusive(sealed, output)

--- a/verdify_schemas/alerts.py
+++ b/verdify_schemas/alerts.py
@@ -35,6 +35,15 @@ ComponentExperimentIntegrityReason = Literal[
     "baseline_recovery_in_progress",
     "runtime_fault_requires_recovery",
 ]
+ComponentExperimentObservationTruth = Literal[
+    "future_identity_masked",
+    "no_current_work",
+    "expected_state_missing",
+    "unobserved",
+    "stale",
+    "mismatch",
+    "exact",
+]
 AlertType = Literal[
     "alert_validation_failed",
     "band_anchor_db_read_failed",
@@ -543,7 +552,7 @@ class ComponentExperimentIntegrityDetails(_DetailsBase):
     safety_state: str
     reason: ComponentExperimentIntegrityReason
     operation_kind: str | None = None
-    observation_truth: Literal["future_identity_masked", "unobserved", "stale", "mismatch", "exact"]
+    observation_truth: ComponentExperimentObservationTruth
     observation_age_seconds: int | None = Field(default=None, ge=0)
     open_exposure_count: int = Field(..., ge=0)
     writer_generation: int | None = Field(default=None, ge=0)

--- a/verdify_schemas/climate_intent.py
+++ b/verdify_schemas/climate_intent.py
@@ -266,6 +266,8 @@ CLIMATE_RELAY_FIELD_DENYLIST: frozenset[str] = frozenset(
 # `rh_ceiling`/`temp_low`/`occupancy`) plus the ESPHome manual/safety + interlock
 # path (firmware/greenhouse/controls.yaml → `served`/`vent_interlock`/
 # `irrigation`/`resource_budget`/`time_invalid`/`leak_detected`/`relay_min_off`).
+# `wet_taper` is retained for historical rows written by the pre-curve-only
+# firmware even though the current shared-logic taper is inert.
 # test_climate_intent.test_fog_block_reasons_cover_stored_db_values guards this
 # against the live climate_action_log column.
 FOG_BLOCK_REASONS: tuple[str, ...] = (
@@ -286,6 +288,7 @@ FOG_BLOCK_REASONS: tuple[str, ...] = (
     "leak_detected",  # leak-detect safety lock
     "feed_hold",  # FRT-6 absorption hold after a feed
     "dusk_cutoff",  # SAF-3 VPD-independent dusk cutoff rail
+    "wet_taper",  # historical pre-curve-only firmware observation truth
 )
 
 


### PR DESCRIPTION
## Scope

Delivers the single M8 source path needed for safe feature-off convergence and the later, separately authorized physical-proof/day-one stages.

- retires stale ordinary production proof activation and keeps direct proof dormant behind an explicit invalid-by-default activation component
- enforces authenticated MCP acceptance, no affinity, metadata-only SOPS receipts, and zero token output
- fences reconnect replay on exact-generation readbacks, limits fail-closed recovery to 12 commands, and makes lifecycle proof persistence follow successful sends
- adds migration 238 and dormant no-redraw design-lock, provider preflight, separate approval, emergency hold, and blinded day-one export surfaces
- keeps production experiment execution off, the experiment ID empty, vector execution off, and the ingestor at one Recreate replica in the default render

## Validation

- focused writer/reconnect, fidelity, v2 experiment, MCP/security, SOPS receipt, proof-packet, and changed observability test matrix passed
- Ruff passed for the changed orchestrator modules
- production overlay rendered to 115 objects with zero direct-proof objects and no experiment selector or ID overrides
- a current production dump was restored into an isolated TimescaleDB, migrations 237 and 238 applied, all schema suites passed, and all six materialized views refreshed
- applied migration sources 225 through 237 remain byte-identical; 238 is the only new migration

## Attended-proof boundary

The read-only migration-237 restored-production lineage check is intentionally still red before the new writer path has produced a controlled raw-reset reconnect lineage. W1 remains blocked from operator scheduling until this PR is deployed feature-off, a controlled reconnect is recorded, a fresh dump rehearsal passes that check, and W0 runtime/security/provider/writer gates are green.

Tracks #587, #588, #639, #640, #641, #642, #676, and #686. Broad residual issues #424, #427, and #433 remain open until their complete acceptance criteria are proven.

## Runtime rollout declaration

Post-merge restart: verdify-ingestor. The digest-pinned ingestor rollout is required to load the changed observation-truth and climate-intent schemas; it must occur only through the reviewed GitOps pin and normal Argo deployment path.