### PR TITLE
fix(experiment): seal orphaned preclaim recovery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -115,6 +115,7 @@ db/migrations/tests/*
 !db/migrations/tests/test-235-experiment-v2-direct-proof-raw-reset-rollover.sql
 !db/migrations/tests/test-236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql
 !db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql
+!db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql
 !db/ledger
 db/ledger/*
 !db/ledger/*.sql

--- a/db/migrations/239-experiment-v2-orphaned-preclaim-recovery.sql
+++ b/db/migrations/239-experiment-v2-orphaned-preclaim-recovery.sql
@@ -1,0 +1,292 @@
+-- 239-experiment-v2-orphaned-preclaim-recovery.sql
+--
+-- Migration 237 expected a raw-reset runtime-fault receipt that the retained
+-- production lineage does not contain.  The device recovery is real, but its
+-- cause is not proven: the immutable record contains an unclaimed aggressive
+-- work item followed by a distinct, root, five-minute baseline recovery with
+-- two observation receipts and a recovered event.  Resolve that failed proof
+-- attempt without manufacturing a runtime fault and without crediting physical
+-- proof.  The historical recovery may lag current authority by exactly one
+-- lease generation; the caller must still hold attended, current baseline-
+-- recovery authority before this append-only resolution can run.
+
+CREATE OR REPLACE FUNCTION public.fn_experiment_v2_direct_proof_resolve_startup_rollover(
+    p_experiment_id uuid,
+    p_authorization_id uuid,
+    p_facility_authorization_ref text,
+    p_actor text DEFAULT current_user
+) RETURNS public.experiment_v2_direct_proof_emergency_recovery_receipts
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $body$
+DECLARE
+    v_exp public.control_experiments%ROWTYPE;
+    v_auth public.experiment_v2_direct_proof_authorizations%ROWTYPE;
+    v_resolution public.experiment_v2_direct_proof_emergency_resolutions%ROWTYPE;
+    v_existing public.experiment_v2_direct_proof_emergency_recovery_receipts%ROWTYPE;
+    v_receipt public.experiment_v2_direct_proof_emergency_recovery_receipts%ROWTYPE;
+    v_aggressive public.experiment_v2_work%ROWTYPE;
+    v_recovery public.experiment_v2_work%ROWTYPE;
+    v_baseline_before_work_id uuid;
+    v_recovered_at timestamptz;
+    v_receipt_count integer;
+    v_evidence_sha256 text;
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext(
+        'experiment-v2-direct-proof-' || p_experiment_id::text));
+
+    SELECT receipt.* INTO v_existing
+      FROM public.experiment_v2_direct_proof_emergency_recovery_receipts receipt
+     WHERE receipt.authorization_id = p_authorization_id;
+    IF v_existing.resolution_id IS NOT NULL THEN
+        IF v_existing.experiment_id <> p_experiment_id OR
+           v_existing.recorded_by <> p_actor THEN
+            RAISE EXCEPTION
+                'direct-proof orphaned recovery resolution is immutable and exact replay differs';
+        END IF;
+        RETURN v_existing;
+    END IF;
+
+    SELECT * INTO v_exp
+      FROM public.control_experiments
+     WHERE experiment_id = p_experiment_id
+     FOR UPDATE;
+    SELECT * INTO v_auth
+      FROM public.experiment_v2_direct_proof_authorizations
+     WHERE authorization_id = p_authorization_id
+       AND experiment_id = p_experiment_id;
+    SELECT aggressive.* INTO v_aggressive
+      FROM public.experiment_v2_direct_proof_attempt_work mapped
+      JOIN public.experiment_v2_work aggressive
+        ON aggressive.experiment_id = p_experiment_id
+       AND aggressive.work_id = mapped.work_id
+     WHERE mapped.authorization_id = p_authorization_id
+       AND mapped.stage = 'aggressive';
+    SELECT mapped.work_id INTO v_baseline_before_work_id
+      FROM public.experiment_v2_direct_proof_attempt_work mapped
+     WHERE mapped.authorization_id = p_authorization_id
+       AND mapped.stage = 'baseline_before';
+
+    -- Select only the latest recovered root baseline which has no causal
+    -- runtime-fault receipt.  This records an orphaned recovery, not a reboot.
+    SELECT recovery.* INTO v_recovery
+      FROM public.experiment_v2_work recovery
+      JOIN public.experiment_v2_work_events recovered
+        ON recovered.experiment_id = recovery.experiment_id
+       AND recovered.work_id = recovery.work_id
+       AND recovered.event_kind = 'recovered'
+     WHERE recovery.experiment_id = p_experiment_id
+       AND recovery.created_at > v_aggressive.created_at
+       AND recovery.created_at > upper(v_auth.proof_valid_range)
+       AND NOT lower_inf(recovery.valid_range)
+       AND NOT upper_inf(recovery.valid_range)
+       AND lower_inc(recovery.valid_range)
+       AND NOT upper_inc(recovery.valid_range)
+       AND upper(recovery.valid_range) - lower(recovery.valid_range) =
+           interval '5 minutes'
+       AND recovery.expires_at = upper(recovery.valid_range)
+       AND recovery.parent_work_id IS NULL
+       AND recovery.work_id <> v_baseline_before_work_id
+       AND recovery.operation_kind = 'baseline_recovery'
+       AND recovery.target_profile = 'baseline'
+       AND recovery.created_by = 'verdify-component-executor-v2'
+       AND recovery.revision_bundle_sha256 = v_exp.revision_bundle_sha256
+       AND recovery.lease_generation = v_aggressive.lease_generation
+       AND recovery.lease_generation IN
+           (v_exp.lease_generation, v_exp.lease_generation - 1)
+       AND recovered.recorded_at <@ recovery.valid_range
+       AND recovered.worker_ref = 'verdify-component-executor-v2'
+       AND (recovered.detail->>'confirmed_at')::timestamptz <@
+           recovery.valid_range
+       AND NOT EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_runtime_faults fault
+            WHERE fault.experiment_id = recovery.experiment_id
+              AND fault.recovery_work_id = recovery.work_id)
+       AND NOT EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_work_events terminal
+            WHERE terminal.experiment_id = recovery.experiment_id
+              AND terminal.work_id = recovery.work_id
+              AND terminal.event_kind IN
+                  ('failed', 'cancelled', 'superseded'))
+       AND (SELECT count(DISTINCT observation.receipt_id)
+              FROM public.experiment_v2_observation_receipts observation
+             WHERE observation.experiment_id = recovery.experiment_id
+               AND observation.work_id = recovery.work_id) >= 2
+     ORDER BY recovery.created_at DESC, recovered.recorded_at DESC
+     LIMIT 1;
+    SELECT recovered.recorded_at INTO v_recovered_at
+      FROM public.experiment_v2_work_events recovered
+     WHERE recovered.experiment_id = p_experiment_id
+       AND recovered.work_id = v_recovery.work_id
+       AND recovered.event_kind = 'recovered'
+     ORDER BY recovered.recorded_at DESC
+     LIMIT 1;
+
+    IF v_exp.experiment_id IS NULL OR
+       v_exp.experiment_id <>
+           '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid OR
+       v_auth.authorization_id IS NULL OR
+       v_auth.revision_bundle_sha256 <> v_exp.revision_bundle_sha256 OR
+       v_exp.status <> 'draft' OR
+       v_exp.execution_phase <> 'commissioning' OR
+       v_exp.admission_state <> 'baseline_recovery' OR
+       NOT v_exp.component_enabled OR
+       v_aggressive.work_id IS NULL OR
+       v_baseline_before_work_id IS NULL OR
+       v_recovery.work_id IS NULL OR
+       v_recovered_at IS NULL OR
+       p_facility_authorization_ref IS NULL OR
+       length(p_facility_authorization_ref) = 0 OR
+       p_actor IS NULL OR length(p_actor) = 0 OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_direct_proof_authorizations newer
+            WHERE newer.experiment_id = p_experiment_id
+              AND newer.attempt_number > v_auth.attempt_number) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_direct_proof_receipts proof
+            WHERE proof.authorization_id = p_authorization_id) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_direct_proof_attempt_events terminal
+            WHERE terminal.authorization_id = p_authorization_id) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_direct_proof_emergency_resolutions resolution
+            WHERE resolution.authorization_id = p_authorization_id) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_work_events terminal
+            WHERE terminal.experiment_id = p_experiment_id
+              AND terminal.work_id = v_aggressive.work_id
+              AND terminal.event_kind IN
+                  ('completed', 'failed', 'recovered', 'cancelled', 'superseded')) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_exposures exposure
+            WHERE exposure.experiment_id = p_experiment_id
+              AND exposure.work_id = v_aggressive.work_id) OR
+       EXISTS (
+           SELECT 1
+             FROM public.experiment_v2_exposures exposure
+             LEFT JOIN public.experiment_v2_exposure_closures closure
+               USING (exposure_id)
+            WHERE exposure.experiment_id = p_experiment_id
+              AND closure.exposure_id IS NULL) THEN
+        RAISE EXCEPTION
+            'direct-proof startup rollover resolution requires the latest active orphaned-preclaim attempt, its recovered root baseline without a runtime-fault receipt, and zero open exposure';
+    END IF;
+
+    SELECT count(DISTINCT observation.receipt_id)::integer,
+           encode(digest(convert_to(
+               'verdify-direct-proof-orphaned-preclaim-recovery-v1|' ||
+               p_authorization_id::text || '|' ||
+               v_aggressive.work_id::text || '|' ||
+               v_recovery.work_id::text || '|' ||
+               string_agg(observation.observation_receipt_sha256, '|'
+                          ORDER BY observation.persisted_at,
+                                   observation.receipt_id),
+               'UTF8'), 'sha256'), 'hex')
+      INTO v_receipt_count, v_evidence_sha256
+      FROM public.experiment_v2_observation_receipts observation
+     WHERE observation.experiment_id = p_experiment_id
+       AND observation.work_id = v_recovery.work_id;
+    IF v_receipt_count < 2 OR v_evidence_sha256 IS NULL THEN
+        RAISE EXCEPTION
+            'direct-proof orphaned recovery resolution requires two receipt-bound recovered baseline epochs';
+    END IF;
+
+    INSERT INTO public.experiment_v2_direct_proof_emergency_resolutions
+        (authorization_id, experiment_id, resolution_kind,
+         expected_revision_bundle_sha256,
+         expected_emergency_lease_generation, facility_authorization_ref,
+         recovery_work_id, recovery_valid_range, reason,
+         recorded_by, recorded_at)
+    VALUES
+        (p_authorization_id, p_experiment_id, 'bounded_baseline_recovery',
+         v_exp.revision_bundle_sha256, v_exp.lease_generation,
+         p_facility_authorization_ref, v_recovery.work_id,
+         v_recovery.valid_range,
+         'Orphaned preclaim recovery; runtime-fault receipt absent and cause unproven',
+         p_actor, v_now)
+    RETURNING * INTO v_resolution;
+    INSERT INTO public.experiment_v2_work_events
+        (experiment_id, work_id, event_kind, worker_ref,
+         claim_expires_at, detail, recorded_at)
+    SELECT p_experiment_id, v_aggressive.work_id, 'failed', p_actor,
+           NULL,
+           jsonb_build_object(
+               'reason', 'orphaned_preclaim_recovery_cause_unproven',
+               'direct_proof_authorization_id', p_authorization_id,
+               'runtime_fault_receipt', 'absent',
+               'recovery_work_id', v_recovery.work_id),
+           v_now
+     WHERE NOT EXISTS (
+         SELECT 1
+           FROM public.experiment_v2_work_events terminal
+          WHERE terminal.experiment_id = p_experiment_id
+            AND terminal.work_id = v_aggressive.work_id
+            AND terminal.event_kind IN
+                ('completed', 'failed', 'recovered', 'cancelled', 'superseded'));
+    INSERT INTO public.experiment_v2_direct_proof_attempt_events
+        (authorization_id, experiment_id, event_kind,
+         successor_authorization_id, reason, recorded_by, recorded_at)
+    VALUES
+        (p_authorization_id, p_experiment_id, 'failed', NULL,
+         'orphaned preclaim recovery sealed; runtime cause unproven',
+         p_actor, v_now);
+    INSERT INTO public.experiment_v2_direct_proof_emergency_recovery_receipts
+        (resolution_id, authorization_id, experiment_id, recovery_work_id,
+         recovery_evidence_sha256, recorded_by, recorded_at)
+    VALUES
+        (v_resolution.resolution_id, p_authorization_id, p_experiment_id,
+         v_recovery.work_id, v_evidence_sha256, p_actor, v_now)
+    RETURNING * INTO v_receipt;
+
+    -- The retained recovered baseline is deliberately one lease behind current
+    -- authority.  The generic admission helper only closes baseline recovery
+    -- on same-lease evidence, so this exact repair performs the close and
+    -- authority fence atomically after sealing the immutable receipt above.
+    -- Do not manufacture a current recovery merely to satisfy that helper.
+    PERFORM set_config('verdify.experiment_v2_transition', 'on', true);
+    UPDATE public.control_experiments
+       SET execution_phase = 'shadow', admission_state = 'closed',
+           component_enabled = false,
+           lease_generation = lease_generation + 1, updated_at = v_now
+     WHERE experiment_id = p_experiment_id;
+    INSERT INTO public.experiment_events
+        (experiment_id, event_kind, severity, actor, detail, recorded_at)
+    VALUES
+        (p_experiment_id, 'state_transition', 'warning', p_actor,
+         jsonb_build_object(
+             'v2_phase', 'shadow',
+             'v2_admission', 'closed',
+             'v2_event', 'direct_proof_orphaned_preclaim_recovery_sealed',
+             'authorization_id', p_authorization_id,
+             'emergency_resolution_id', v_resolution.resolution_id,
+             'aggressive_work_id', v_aggressive.work_id,
+             'runtime_fault_receipt', 'absent',
+             'recovery_cause', 'unproven',
+             'recovery_work_id', v_recovery.work_id,
+             'recovery_evidence_sha256', v_evidence_sha256),
+         v_now);
+    RETURN v_receipt;
+END;
+$body$;
+
+ALTER FUNCTION public.fn_experiment_v2_direct_proof_resolve_startup_rollover(
+    uuid, uuid, text, text)
+    OWNER TO verdify_experiment_v2_owner;
+REVOKE ALL PRIVILEGES ON FUNCTION
+    public.fn_experiment_v2_direct_proof_resolve_startup_rollover(
+        uuid, uuid, text, text)
+    FROM PUBLIC CASCADE;
+GRANT EXECUTE ON FUNCTION
+    public.fn_experiment_v2_direct_proof_resolve_startup_rollover(
+        uuid, uuid, text, text)
+    TO verdify_experiment_lifecycle;

--- a/db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql
+++ b/db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql
@@ -1,0 +1,303 @@
+-- test-239-experiment-v2-orphaned-preclaim-recovery.sql
+-- Transactionally rolled-back function/ACL and restored production-lineage
+-- fixture.  The final block exercises the exact unsealed production-shaped
+-- attempt, then rolls every append and authority transition back.
+BEGIN;
+
+DO $assertions$
+DECLARE
+    v_definition text;
+BEGIN
+    SELECT pg_get_functiondef(
+               'public.fn_experiment_v2_direct_proof_resolve_startup_rollover(uuid,uuid,text,text)'::regprocedure)
+      INTO v_definition;
+    IF v_definition IS NULL OR
+       position('recovery.created_at > upper(v_auth.proof_valid_range)' in
+                v_definition) = 0 OR
+       position('recovery.lease_generation = v_aggressive.lease_generation' in
+                v_definition) = 0 OR
+       position('v_exp.lease_generation - 1' in v_definition) = 0 OR
+       position('public.experiment_v2_runtime_faults fault' in v_definition) = 0 OR
+       position('fault.recovery_work_id = recovery.work_id' in v_definition) = 0 OR
+       position('verdify-direct-proof-orphaned-preclaim-recovery-v1|' in
+                v_definition) = 0 OR
+       position('runtime_fault_receipt'', ''absent' in v_definition) = 0 OR
+       position('recovery_cause'', ''unproven' in v_definition) = 0 OR
+       position('admission_state = ''closed''' in v_definition) = 0 OR
+       position('fn_experiment_v2_set_admission' in v_definition) <> 0 OR
+       position('verdify-direct-proof-startup-raw-reset-' in v_definition) <> 0 OR
+       has_function_privilege(
+           'public',
+           'public.fn_experiment_v2_direct_proof_resolve_startup_rollover(uuid,uuid,text,text)',
+           'EXECUTE') OR
+       NOT has_function_privilege(
+           'verdify_experiment_lifecycle',
+           'public.fn_experiment_v2_direct_proof_resolve_startup_rollover(uuid,uuid,text,text)',
+           'EXECUTE') THEN
+        RAISE EXCEPTION
+            'migration 239 orphaned-preclaim recovery evidence gate or ACL is not exact';
+    END IF;
+END
+$assertions$;
+
+DO $live_shaped_recovery$
+DECLARE
+    v_candidate_count integer;
+    v_outside_predecessor_count integer;
+    v_missing_fault_receipt_count integer;
+    v_exact_receipt_count integer;
+BEGIN
+    WITH candidates AS (
+        SELECT auth.authorization_id,
+               auth.proof_valid_range,
+               aggressive.work_id AS aggressive_work_id,
+               aggressive.created_at AS aggressive_created_at,
+               aggressive.lease_generation AS aggressive_lease_generation,
+               recovery.work_id AS recovery_work_id,
+               recovery.created_at AS recovery_created_at,
+               recovery.valid_range AS recovery_valid_range,
+               recovery.lease_generation AS recovery_lease_generation,
+               recovered.recorded_at AS recovered_at,
+               (SELECT count(DISTINCT observation.receipt_id)::integer
+                  FROM public.experiment_v2_observation_receipts observation
+                 WHERE observation.experiment_id = auth.experiment_id
+                   AND observation.work_id = recovery.work_id) AS receipt_count,
+               NOT EXISTS (
+                   SELECT 1
+                     FROM public.experiment_v2_runtime_faults fault
+                    WHERE fault.experiment_id = auth.experiment_id
+                      AND fault.recovery_work_id = recovery.work_id) AS fault_receipt_absent,
+               (SELECT encode(digest(convert_to(
+                           'verdify-direct-proof-orphaned-preclaim-recovery-v1|' ||
+                           auth.authorization_id::text || '|' ||
+                           aggressive.work_id::text || '|' ||
+                           recovery.work_id::text || '|' ||
+                           string_agg(observation.observation_receipt_sha256, '|'
+                                      ORDER BY observation.persisted_at,
+                                               observation.receipt_id),
+                           'UTF8'), 'sha256'), 'hex')
+                  FROM public.experiment_v2_observation_receipts observation
+                 WHERE observation.experiment_id = auth.experiment_id
+                   AND observation.work_id = recovery.work_id) AS evidence_sha256
+          FROM public.experiment_v2_direct_proof_authorizations auth
+          JOIN public.experiment_v2_direct_proof_attempt_work mapped
+            ON mapped.authorization_id = auth.authorization_id
+           AND mapped.stage = 'aggressive'
+          JOIN public.experiment_v2_work aggressive
+            ON aggressive.experiment_id = auth.experiment_id
+           AND aggressive.work_id = mapped.work_id
+          JOIN public.experiment_v2_work recovery
+            ON recovery.experiment_id = auth.experiment_id
+           AND recovery.created_at > aggressive.created_at
+           AND recovery.created_at > upper(auth.proof_valid_range)
+           AND recovery.lease_generation = aggressive.lease_generation
+          JOIN public.experiment_v2_work_events recovered
+            ON recovered.experiment_id = recovery.experiment_id
+           AND recovered.work_id = recovery.work_id
+           AND recovered.event_kind = 'recovered'
+         WHERE auth.experiment_id =
+                   '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid
+           AND recovery.parent_work_id IS NULL
+           AND recovery.operation_kind = 'baseline_recovery'
+           AND recovery.target_profile = 'baseline'
+           AND recovery.created_by = 'verdify-component-executor-v2'
+           AND recovery.revision_bundle_sha256 = auth.revision_bundle_sha256
+           AND NOT lower_inf(recovery.valid_range)
+           AND NOT upper_inf(recovery.valid_range)
+           AND lower_inc(recovery.valid_range)
+           AND NOT upper_inc(recovery.valid_range)
+           AND upper(recovery.valid_range) - lower(recovery.valid_range) =
+               interval '5 minutes'
+           AND recovery.expires_at = upper(recovery.valid_range)
+           AND recovered.recorded_at <@ recovery.valid_range
+           AND recovered.worker_ref = 'verdify-component-executor-v2'
+           AND (recovered.detail->>'confirmed_at')::timestamptz <@
+               recovery.valid_range
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_runtime_faults fault
+                WHERE fault.experiment_id = recovery.experiment_id
+                  AND fault.recovery_work_id = recovery.work_id)
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_exposures exposure
+                WHERE exposure.experiment_id = auth.experiment_id
+                  AND exposure.work_id = aggressive.work_id)
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_direct_proof_receipts proof
+                WHERE proof.authorization_id = auth.authorization_id)
+    )
+    SELECT count(*) FILTER (WHERE receipt_count >= 2),
+           count(*) FILTER (
+               WHERE receipt_count >= 2
+                 AND recovery_created_at > upper(proof_valid_range)
+                 AND recovered_at > upper(proof_valid_range)),
+           count(*) FILTER (
+               WHERE receipt_count >= 2 AND fault_receipt_absent),
+           count(*) FILTER (
+               WHERE receipt_count >= 2
+                 AND EXISTS (
+                     SELECT 1
+                       FROM public.experiment_v2_direct_proof_emergency_recovery_receipts sealed
+                      WHERE sealed.authorization_id = candidates.authorization_id
+                        AND sealed.recovery_work_id = candidates.recovery_work_id
+                        AND sealed.recovery_evidence_sha256 =
+                            candidates.evidence_sha256))
+      INTO v_candidate_count, v_outside_predecessor_count,
+           v_missing_fault_receipt_count, v_exact_receipt_count
+      FROM candidates;
+
+    IF v_candidate_count < 1 OR
+       v_outside_predecessor_count < 1 OR
+       v_missing_fault_receipt_count < 1 THEN
+        RAISE EXCEPTION
+            'restored production-shaped migration 239 orphaned-preclaim recovery lineage is absent, causalized without evidence, or still predecessor-range bound';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM public.experiment_v2_direct_proof_emergency_recovery_receipts sealed
+          JOIN public.experiment_v2_direct_proof_authorizations auth
+            USING (authorization_id)
+          JOIN public.experiment_v2_direct_proof_attempt_work mapped
+            ON mapped.authorization_id = auth.authorization_id
+           AND mapped.stage = 'aggressive'
+          JOIN public.experiment_v2_work aggressive
+            ON aggressive.experiment_id = auth.experiment_id
+           AND aggressive.work_id = mapped.work_id
+          JOIN public.experiment_v2_work recovery
+            ON recovery.experiment_id = auth.experiment_id
+           AND recovery.work_id = sealed.recovery_work_id
+           AND recovery.created_at > upper(auth.proof_valid_range)
+           AND recovery.lease_generation = aggressive.lease_generation
+         WHERE auth.experiment_id =
+                   '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM public.experiment_v2_runtime_faults fault
+                WHERE fault.experiment_id = recovery.experiment_id
+                  AND fault.recovery_work_id = recovery.work_id)) AND
+       v_exact_receipt_count < 1 THEN
+        RAISE EXCEPTION
+            'migration 239 sealed orphaned-recovery receipt does not reproduce from its exact observation receipts';
+    END IF;
+END
+$live_shaped_recovery$;
+
+DO $execute_unsealed_recovery$
+DECLARE
+    c_experiment_id constant uuid :=
+        '45039c86-c1d9-52f6-a0a9-d94a17bc4b14'::uuid;
+    c_authorization_id constant uuid :=
+        'd00304d1-74f9-4872-857e-6944de53ac46'::uuid;
+    c_aggressive_work_id constant uuid :=
+        '7aa1f560-a309-4d17-b9ad-57a20574f05d'::uuid;
+    c_recovery_work_id constant uuid :=
+        '7093f8c3-a36e-49f2-8b4b-443d32a9a51b'::uuid;
+    c_evidence_sha256 constant text :=
+        '0fa6d172de87cf2008d5908ff4a3517eeca1d1cd4811e86461fc349c25f41b91';
+    v_before public.control_experiments%ROWTYPE;
+    v_after public.control_experiments%ROWTYPE;
+    v_receipt public.experiment_v2_direct_proof_emergency_recovery_receipts%ROWTYPE;
+    v_reproduced_sha256 text;
+BEGIN
+    -- A later rehearsal of an already-sealed dump is covered by the immutable
+    -- receipt reproduction above.  Exercise the mutation path only while this
+    -- exact production-shaped authorization remains unsealed.
+    IF NOT EXISTS (
+        SELECT 1
+          FROM public.experiment_v2_direct_proof_authorizations auth
+         WHERE auth.authorization_id = c_authorization_id
+           AND auth.experiment_id = c_experiment_id) OR
+       EXISTS (
+        SELECT 1
+          FROM public.experiment_v2_direct_proof_emergency_recovery_receipts sealed
+         WHERE sealed.authorization_id = c_authorization_id) THEN
+        RETURN;
+    END IF;
+
+    SELECT * INTO STRICT v_before
+      FROM public.control_experiments
+     WHERE experiment_id = c_experiment_id;
+    IF v_before.status <> 'draft' OR
+       v_before.execution_phase <> 'commissioning' OR
+       v_before.admission_state NOT IN ('closed', 'emergency_hold',
+                                        'baseline_recovery') OR
+       v_before.component_enabled <> (v_before.admission_state =
+                                      'baseline_recovery') THEN
+        RAISE EXCEPTION
+            'migration 239 execution fixture did not start from an exact fail-closed commissioning state';
+    END IF;
+
+    IF v_before.admission_state <> 'baseline_recovery' THEN
+        PERFORM public.fn_experiment_v2_set_admission(
+            c_experiment_id, 'baseline_recovery',
+            'migration-239-restored-fixture',
+            'fixture://migration-239/orphaned-preclaim-recovery');
+    END IF;
+    SELECT * INTO STRICT v_receipt
+      FROM public.fn_experiment_v2_direct_proof_resolve_startup_rollover(
+          c_experiment_id, c_authorization_id,
+          'fixture://migration-239/orphaned-preclaim-recovery',
+          'migration-239-restored-fixture');
+    SELECT * INTO STRICT v_after
+      FROM public.control_experiments
+     WHERE experiment_id = c_experiment_id;
+
+    SELECT encode(digest(convert_to(
+               'verdify-direct-proof-orphaned-preclaim-recovery-v1|' ||
+               c_authorization_id::text || '|' ||
+               c_aggressive_work_id::text || '|' ||
+               c_recovery_work_id::text || '|' ||
+               string_agg(observation.observation_receipt_sha256, '|'
+                          ORDER BY observation.persisted_at,
+                                   observation.receipt_id),
+               'UTF8'), 'sha256'), 'hex')
+      INTO v_reproduced_sha256
+      FROM public.experiment_v2_observation_receipts observation
+     WHERE observation.experiment_id = c_experiment_id
+       AND observation.work_id = c_recovery_work_id;
+
+    IF v_receipt.recovery_work_id <> c_recovery_work_id OR
+       v_receipt.recovery_evidence_sha256 <> c_evidence_sha256 OR
+       v_reproduced_sha256 <> c_evidence_sha256 OR
+       v_after.execution_phase <> 'shadow' OR
+       v_after.admission_state <> 'closed' OR
+       v_after.component_enabled OR
+       v_after.lease_generation <> v_before.lease_generation + 1 OR
+       (SELECT count(*)
+          FROM public.experiment_v2_direct_proof_emergency_resolutions resolution
+         WHERE resolution.authorization_id = c_authorization_id
+           AND resolution.recovery_work_id = c_recovery_work_id
+           AND resolution.reason =
+               'Orphaned preclaim recovery; runtime-fault receipt absent and cause unproven') <> 1 OR
+       (SELECT count(*)
+          FROM public.experiment_v2_direct_proof_emergency_recovery_receipts receipt
+         WHERE receipt.authorization_id = c_authorization_id
+           AND receipt.recovery_work_id = c_recovery_work_id
+           AND receipt.recovery_evidence_sha256 = c_evidence_sha256) <> 1 OR
+       (SELECT count(*)
+          FROM public.experiment_v2_work_events terminal
+         WHERE terminal.experiment_id = c_experiment_id
+           AND terminal.work_id = c_aggressive_work_id
+           AND terminal.event_kind = 'failed'
+           AND terminal.detail->>'runtime_fault_receipt' = 'absent'
+           AND terminal.detail->>'reason' =
+               'orphaned_preclaim_recovery_cause_unproven') <> 1 OR
+       (SELECT count(*)
+          FROM public.experiment_v2_direct_proof_attempt_events terminal
+         WHERE terminal.authorization_id = c_authorization_id
+           AND terminal.event_kind = 'failed'
+           AND terminal.reason =
+               'orphaned preclaim recovery sealed; runtime cause unproven') <> 1 OR
+       EXISTS (
+          SELECT 1
+            FROM public.experiment_v2_direct_proof_receipts proof
+           WHERE proof.authorization_id = c_authorization_id) THEN
+        RAISE EXCEPTION
+            'migration 239 exact orphaned-preclaim execution did not seal one non-proof receipt and atomically fence authority';
+    END IF;
+END
+$execute_unsealed_recovery$;
+
+ROLLBACK;

--- a/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-configmap.yaml
+++ b/deploy/k8s/components/experiment-v2-direct-proof/direct-proof-configmap.yaml
@@ -588,6 +588,9 @@ data:
                         "reconnect-failed attempt, its recovered linked baseline, and zero open exposure",
                         "direct-proof startup rollover resolution requires the latest active "
                         "raw-reset attempt, its recovered root baseline, and zero open exposure",
+                        "direct-proof startup rollover resolution requires the latest active "
+                        "orphaned-preclaim attempt, its recovered root baseline without a "
+                        "runtime-fault receipt, and zero open exposure",
                         "direct-proof startup rollover resolution requires two receipt-bound "
                         "recovered baseline epochs",
                     ),

--- a/deploy/k8s/components/experiment-v2-restore-rehearsal/restore-rehearsal-script.yaml
+++ b/deploy/k8s/components/experiment-v2-restore-rehearsal/restore-rehearsal-script.yaml
@@ -682,7 +682,9 @@ data:
       234-experiment-v2-direct-proof-startup-rollover.sql \
       235-experiment-v2-direct-proof-raw-reset-rollover.sql \
       236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql \
-      237-experiment-v2-direct-proof-recovery-range-rollover.sql
+      237-experiment-v2-direct-proof-recovery-range-rollover.sql \
+      238-experiment-v2-separate-day1-authorization.sql \
+      239-experiment-v2-orphaned-preclaim-recovery.sql
     do
       expected_sha256="$(sha256sum -- "/work/db/migrations/${migration}" | awk '{print $1}')"
       ledger_sha256="$(psql -X -v ON_ERROR_STOP=1 -At -d "${PGDATABASE}" \
@@ -740,14 +742,11 @@ data:
       -f /work/db/migrations/tests/test-232-experiment-v2-observation-pair-recovery-retry.sql
     psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" \
       -f /work/db/migrations/tests/test-233-experiment-v2-direct-proof-zero-exposure-seal.sql
+    # Migrations 234-237 are immutable predecessor definitions of the same
+    # function.  Their fixtures remain in source history, but only the final
+    # replacement can be asserted after the complete ledger replay.
     psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" \
-      -f /work/db/migrations/tests/test-234-experiment-v2-direct-proof-startup-rollover.sql
-    psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" \
-      -f /work/db/migrations/tests/test-235-experiment-v2-direct-proof-raw-reset-rollover.sql
-    psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" \
-      -f /work/db/migrations/tests/test-236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql
-    psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" \
-      -f /work/db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql
+      -f /work/db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql
     psql -X -v ON_ERROR_STOP=1 -d "${PGDATABASE}" <<'SQL'
     DO $assertions$
     BEGIN
@@ -904,4 +903,4 @@ data:
     END;
     $assertions$;
     SQL
-    echo "[restore-rehearsal] PASS: recent-dump schema/ACL replay and v2 vertical fixtures; exact 214-222 ledger and runtime facade DML verified (non-superuser rehearsal; not proof of production-superuser denial)"
+    echo "[restore-rehearsal] PASS: recent-dump schema/ACL replay and v2 vertical fixtures; exact 214-239 ledger and runtime facade DML verified (non-superuser rehearsal; not proof of production-superuser denial)"

--- a/tests/test_experiment_schema_migration.py
+++ b/tests/test_experiment_schema_migration.py
@@ -265,6 +265,7 @@ def test_backfill_covers_repo_migrations_except_unapplied_with_correct_shas():
         "236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql",  # order pre-claim reset from work creation
         "237-experiment-v2-direct-proof-recovery-range-rollover.sql",  # bind rollover to current recovery range
         "238-experiment-v2-separate-day1-authorization.sql",  # separate finalization from audited day-1 approval
+        "239-experiment-v2-orphaned-preclaim-recovery.sql",  # seal retained noncausal recovery without proof credit
     }
     sql = BACKFILL_SQL.read_text()
     stamped = dict(
@@ -324,6 +325,7 @@ def test_migrate_image_carries_migrations_and_runner():
         "!db/migrations/tests/test-235-experiment-v2-direct-proof-raw-reset-rollover.sql",
         "!db/migrations/tests/test-236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql",
         "!db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql",
+        "!db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql",
         "!db/ledger",
         "db/ledger/*",
         "!db/ledger/*.sql",
@@ -332,8 +334,8 @@ def test_migrate_image_carries_migrations_and_runner():
     assert indexes == sorted(indexes), "Kaniko re-include rules must stay ordered"
 
     # The production migrate image remains free of the broad SQL fixture tree.
-    # Only the seventeen vertical fixtures executed by the one-release restore
-    # rehearsal are admitted into /db/migrations/tests.
+    # Only the eighteen bounded vertical/predecessor fixtures retained by the
+    # one-release restore rehearsal are admitted into /db/migrations/tests.
     test_fixture_reincludes = [line for line in ignore_lines if line.startswith("!db/migrations/tests/")]
     assert test_fixture_reincludes == [
         "!db/migrations/tests/test-214-confirmed-component-experiment-v2.sql",
@@ -353,6 +355,7 @@ def test_migrate_image_carries_migrations_and_runner():
         "!db/migrations/tests/test-235-experiment-v2-direct-proof-raw-reset-rollover.sql",
         "!db/migrations/tests/test-236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql",
         "!db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql",
+        "!db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql",
     ]
 
 

--- a/tests/test_experiment_v2_orphaned_preclaim_recovery.py
+++ b/tests/test_experiment_v2_orphaned_preclaim_recovery.py
@@ -1,0 +1,116 @@
+"""Forward-only contract for the retained orphaned preclaim recovery lineage."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/239-experiment-v2-orphaned-preclaim-recovery.sql"
+PREVIOUS = ROOT / "db/migrations/237-experiment-v2-direct-proof-recovery-range-rollover.sql"
+FIXTURE = ROOT / "db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql"
+PROOF = ROOT / "deploy/k8s/components/experiment-v2-direct-proof/direct-proof-configmap.yaml"
+
+
+def test_orphaned_recovery_requires_exact_retained_noncausal_lineage() -> None:
+    sql = MIGRATION.read_text()
+    for required in (
+        "45039c86-c1d9-52f6-a0a9-d94a17bc4b14",
+        "recovery.created_at > v_aggressive.created_at",
+        "recovery.created_at > upper(v_auth.proof_valid_range)",
+        "recovery.parent_work_id IS NULL",
+        "recovery.operation_kind = 'baseline_recovery'",
+        "recovery.target_profile = 'baseline'",
+        "recovery.created_by = 'verdify-component-executor-v2'",
+        "recovery.revision_bundle_sha256 = v_exp.revision_bundle_sha256",
+        "recovery.lease_generation = v_aggressive.lease_generation",
+        "v_exp.lease_generation - 1",
+        "upper(recovery.valid_range) - lower(recovery.valid_range) =",
+        "interval '5 minutes'",
+        "recovered.recorded_at <@ recovery.valid_range",
+        "(recovered.detail->>'confirmed_at')::timestamptz <@",
+        "fault.recovery_work_id = recovery.work_id",
+        "count(DISTINCT observation.receipt_id)",
+        "ORDER BY recovery.created_at DESC, recovered.recorded_at DESC",
+        "LIMIT 1",
+    ):
+        assert required in sql
+    assert "fault.reported_fault_kind = 'reboot'" not in sql
+    assert "fault.fault_source = 'raw_reset_epoch'" not in sql
+
+
+def test_orphaned_resolution_is_append_only_nonproof_and_truthful() -> None:
+    sql = MIGRATION.read_text()
+    for required in (
+        "INSERT INTO public.experiment_v2_direct_proof_emergency_resolutions",
+        "INSERT INTO public.experiment_v2_work_events",
+        "INSERT INTO public.experiment_v2_direct_proof_attempt_events",
+        "INSERT INTO public.experiment_v2_direct_proof_emergency_recovery_receipts",
+        "verdify-direct-proof-orphaned-preclaim-recovery-v1|",
+        "Orphaned preclaim recovery; runtime-fault receipt absent and cause unproven",
+        "orphaned_preclaim_recovery_cause_unproven",
+        "'runtime_fault_receipt', 'absent'",
+        "'recovery_cause', 'unproven'",
+    ):
+        assert required in sql
+    assert "INSERT INTO public.experiment_v2_direct_proof_receipts" not in sql
+    assert "UPDATE public.experiment_v2_direct_proof_authorizations" not in sql
+    assert "DELETE FROM" not in sql
+    assert "verdify-direct-proof-startup-raw-reset-" not in sql
+
+
+def test_resolution_atomically_closes_and_fences_authority() -> None:
+    sql = MIGRATION.read_text()
+    receipt_insert = sql.index("INSERT INTO public.experiment_v2_direct_proof_emergency_recovery_receipts")
+    authority_update = sql.index("UPDATE public.control_experiments", receipt_insert)
+    assert receipt_insert < authority_update
+    for required in (
+        "execution_phase = 'shadow', admission_state = 'closed'",
+        "component_enabled = false",
+        "lease_generation = lease_generation + 1",
+        "SET execution_phase = 'shadow'",
+    ):
+        assert required in sql
+    assert "fn_experiment_v2_set_admission" not in sql
+
+
+def test_resolution_keeps_exact_function_acl() -> None:
+    sql = MIGRATION.read_text()
+    assert "LANGUAGE plpgsql" in sql
+    assert "SECURITY DEFINER" in sql
+    assert "SET search_path = public, pg_temp" in sql
+    assert "OWNER TO verdify_experiment_v2_owner" in sql
+    assert "FROM PUBLIC CASCADE" in sql
+    assert "TO verdify_experiment_lifecycle" in sql
+
+
+def test_applied_recovery_range_migration_is_not_rewritten() -> None:
+    sql = PREVIOUS.read_text()
+    assert "fault.fault_source = 'raw_reset_epoch'" in sql
+    assert "fault.reported_fault_kind = 'reboot'" in sql
+    assert "verdify-direct-proof-startup-raw-reset-v3|" in sql
+
+
+def test_restored_fixture_executes_exact_lineage_and_rolls_back() -> None:
+    sql = FIXTURE.read_text()
+    for required in (
+        "d00304d1-74f9-4872-857e-6944de53ac46",
+        "7aa1f560-a309-4d17-b9ad-57a20574f05d",
+        "7093f8c3-a36e-49f2-8b4b-443d32a9a51b",
+        "0fa6d172de87cf2008d5908ff4a3517eeca1d1cd4811e86461fc349c25f41b91",
+        "public.fn_experiment_v2_set_admission(",
+        "public.fn_experiment_v2_direct_proof_resolve_startup_rollover(",
+        "v_after.execution_phase <> 'shadow'",
+        "v_after.admission_state <> 'closed'",
+        "v_after.lease_generation <> v_before.lease_generation + 1",
+        "runtime_fault_receipt' = 'absent'",
+        "orphaned_preclaim_recovery_cause_unproven",
+        "FROM public.experiment_v2_direct_proof_receipts proof",
+    ):
+        assert required in sql
+    assert sql.rstrip().endswith("ROLLBACK;")
+
+
+def test_proof_runner_retries_only_the_new_exact_not_ready_contract() -> None:
+    proof = re.sub(r'"\s+"', "", PROOF.read_text())
+    assert (
+        "orphaned-preclaim attempt, its recovered root baseline without a runtime-fault receipt, and zero open exposure"
+    ) in " ".join(proof.split())

--- a/tests/test_experiment_v2_restore_rehearsal.py
+++ b/tests/test_experiment_v2_restore_rehearsal.py
@@ -202,7 +202,7 @@ def test_script_restores_only_the_bounded_latest_dump_and_runs_real_gates():
         "test-218-planner-required-failure-history.sql",
         "migration 217 exact-runtime Timescale facade/ACL fixture passed",
         "migration 218 required-failure-history fixture passed",
-        "exact 214-222 ledger",
+        "exact 214-239 ledger",
         "current_setting('timescaledb.restoring', true) IS DISTINCT FROM 'off'",
         "fn_experiment_v2_ops_status()",
         "fn_record_equipment_counter_sample",
@@ -284,17 +284,8 @@ def test_script_restores_only_the_bounded_latest_dump_and_runs_real_gates():
     fixture_233 = script.index(
         "-f /work/db/migrations/tests/test-233-experiment-v2-direct-proof-zero-exposure-seal.sql"
     )
-    fixture_234 = script.index("-f /work/db/migrations/tests/test-234-experiment-v2-direct-proof-startup-rollover.sql")
-    fixture_235 = script.index(
-        "-f /work/db/migrations/tests/test-235-experiment-v2-direct-proof-raw-reset-rollover.sql"
-    )
-    fixture_236 = script.index(
-        "-f /work/db/migrations/tests/test-236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql"
-    )
-    fixture_237 = script.index(
-        "-f /work/db/migrations/tests/test-237-experiment-v2-direct-proof-recovery-range-rollover.sql"
-    )
-    final_assertions = script.index("DO $assertions$", fixture_237)
+    fixture_239 = script.index("-f /work/db/migrations/tests/test-239-experiment-v2-orphaned-preclaim-recovery.sql")
+    final_assertions = script.index("DO $assertions$", fixture_239)
     assert (
         max(apply_positions)
         < ledger_gate
@@ -309,10 +300,7 @@ def test_script_restores_only_the_bounded_latest_dump_and_runs_real_gates():
         < fixture_231
         < fixture_232
         < fixture_233
-        < fixture_234
-        < fixture_235
-        < fixture_236
-        < fixture_237
+        < fixture_239
         < final_assertions
     )
     for candidate_migration in (
@@ -340,6 +328,8 @@ def test_script_restores_only_the_bounded_latest_dump_and_runs_real_gates():
         "235-experiment-v2-direct-proof-raw-reset-rollover.sql",
         "236-experiment-v2-direct-proof-preclaim-raw-reset-rollover.sql",
         "237-experiment-v2-direct-proof-recovery-range-rollover.sql",
+        "238-experiment-v2-separate-day1-authorization.sql",
+        "239-experiment-v2-orphaned-preclaim-recovery.sql",
     ):
         assert candidate_migration in script
     compact_script = " ".join(script.split())


### PR DESCRIPTION
## Outcome

Adds forward-only migration 239 so the retained failed #641 preclaim lineage can be sealed truthfully without inventing a raw-reset runtime fault or crediting physical proof.

- selects the exact latest root five-minute recovered baseline after the predecessor authorization
- requires matching revision and aggressive lease, current/current-1 authority, two immutable observation receipts, and no linked runtime-fault receipt or exposure
- appends one bounded recovery resolution, failed-attempt event, failed-work event, and reproducible recovery receipt
- atomically returns the exact study to shadow / closed / component off with a new lease fence
- never inserts a direct-proof receipt and never rewrites applied migrations or retained evidence
- updates the dormant proof retry contract and recent-dump restore rehearsal through migrations 238/239

## Production-shaped evidence

A fresh production dump was restored into disposable TimescaleDB. Migration 237 reproduced its exact retained-lineage rejection. The normal migration runner then saw only migration 239 pending, applied it transactionally, and stamped source SHA-256 `625d53bae9ef52bc14cb5690136d9de1d478bbb2cb67b8e1838afe72ea63f601`.

The rolled-back execution fixture selected recovery `7093f8c3-a36e-49f2-8b4b-443d32a9a51b`, reproduced evidence hash `0fa6d172de87cf2008d5908ff4a3517eeca1d1cd4811e86461fc349c25f41b91`, sealed zero proof receipts, and converged to shadow / closed / off at lease 17.

## Validation

- 52 focused cross-layer tests passed
- migration 239 classified wrap-safe
- restored production-shaped migration/ACL/behavior fixture passed with rollback
- exact ledgered runner apply and checksum assertion passed
- local consolidated gate passed lint/format, all schema suites, selector/randomization/design contracts, and device write gates
- Linux Agent Fleet CI is the authoritative full-suite/build gate

No production actuation is included. The direct-proof component remains dormant and ordinary production remains feature-off.
