### PR TITLE
chore(prod): pin M8.1 proof orchestrator image

### DIFF
--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -252,7 +252,7 @@ images:
   # images; the component remains inert until its explicit GitOps feature gate.
   - name: ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator
     newName: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator
-    digest: sha256:8d1bb4505b17151f78edc6442c796592b396d6a0e96b0e21dd454b4028fbb805
+    digest: sha256:ee1e7b1b2ceb692d144a14a4f77aa844ab1fa1db6fff24a36111d05a2e813386
   # verdify-planner (#117): real published GHCR digest, resolved read-only via
   # `gh api orgs/VerdifyConsultancy/packages/container/verdify-planner/versions`
   # (the `branch-live-platform-main` build of planner_graph/). The planner image is


### PR DESCRIPTION
## Summary
- pin only `verdify-experiment-v2-orchestrator` to the immutable image built from merged M8.1 readiness/proof source
- leave every other image, workload, feature gate, and device-affecting surface unchanged
- keep Gate R and direct proof activation dormant

## Build receipt
- source merge: `caf06844208a2d7780fb118de943fd43fc32b55c`
- Argo Workflow: `agent-fleet-ci/verdify-platform-build-experiment-v2-orchestrator-tpzmh`
- source output: `caf06844208a2d7780fb118de943fd43fc32b55c`
- image: `registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:ee1e7b1b2ceb692d144a14a4f77aa844ab1fa1db6fff24a36111d05a2e813386`
- workflow result: Succeeded

## Validation
- digest-only diff (one line)
- `git diff --check`
- production overlay render
- full rendered production client-side apply dry run
- governed PR CI required before merge
