### PR TITLE
ops(experiment): activate Gate R readiness

### DIFF
--- a/deploy/k8s/activations/experiment-v2-gate-r-readiness/kustomization.yaml
+++ b/deploy/k8s/activations/experiment-v2-gate-r-readiness/kustomization.yaml
@@ -4,10 +4,7 @@ kind: Kustomization
 resources:
   - ../../overlays/prod
 
-namespace: verdify-prod
-
-components:
-  - ../../components/experiment-v2-gate-r-readiness
-
-patches:
-  - path: activation-values.patch.yaml
+# During the attended M8.1 run the exact component and activation patch live in
+# the canonical production overlay so the Argo Application source path remains
+# deploy/k8s/overlays/prod. Restore this standalone dormant wrapper after the
+# one-shot receipt is retained.

--- a/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
+++ b/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: experiment-v2-gate-r-readiness-activation
+data:
+  VERDIFY_GATE_R_READINESS_APPLICATION_SOURCE: "bc8ad7d5fc6ec6330df8a9ab3a20ccd301aea3e4"
+  VERDIFY_GATE_R_READINESS_EXPERIMENT_ID: "45039c86-c1d9-52f6-a0a9-d94a17bc4b14"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verdify-experiment-v2-gate-r-readiness
+  annotations:
+    verdify.io/gate-r-readiness-activation: "m81-20260830-bc8ad7d5"
+spec:
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        verdify.io/gate-r-readiness-activation: "m81-20260830-bc8ad7d5"
+    spec:
+      containers:
+        - name: readiness
+          image: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:b6dd428c5c7d871c6f3f649e175f7cb9d28330832e249d1755f35fe243f5cbec

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -103,6 +103,10 @@ components:
   # capability is off, so this remains an inert, observable Gate-1 runtime.
   # Shadow/randomized operation remains a later GitOps change.
   - ../../components/experiment-v2-orchestrator
+  # M8.1 recovery-only Gate R readiness. This attended PostSync Job is read-only,
+  # carries no lifecycle/provider/device credential, and cannot activate Gate R.
+  # Remove it after retaining the immutable packet/guard receipt.
+  - ../../components/experiment-v2-gate-r-readiness
   # Gate 1 ordinary database-role cutover. The PreSync hook installs and proves
   # the two migration-217 logins before API/ingestor roll, then the pod patches
   # remove the database-owner credential from both ordinary containers. Merge
@@ -172,6 +176,10 @@ patches:
   # Numbered migrations run in the PreSync hook on the same exact revision,
   # before API/ingestor workloads can consume the new schema.
   - path: migration-ledger.patch.yaml
+  # One-shot M8.1 recovery readiness activation. The exact application source
+  # and immutable orchestrator digest are bound here; the collector reads the
+  # operation's exact GitOps revision directly from the Argo Application.
+  - path: experiment-v2-gate-r-readiness.patch.yaml
   # ⚠️ TEMPORARY (#382, 2026-06-20): the ingestor `state` volume is emptyDir, not the
   # iSCSI PVC — defined DIRECTLY in ingestor-state-volume.yaml. (The old
   # TEMP-ingestor-state-emptydir.patch.yaml `$patch: replace` here never overrode the

--- a/tests/test_experiment_v2_gate_r_readiness_activation.py
+++ b/tests/test_experiment_v2_gate_r_readiness_activation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 PROD = ROOT / "deploy/k8s/overlays/prod"
 ACTIVATION = ROOT / "deploy/k8s/activations/experiment-v2-gate-r-readiness"
+ATTENDED_PATCH = PROD / "experiment-v2-gate-r-readiness.patch.yaml"
 
 
 def _render(path: Path) -> list[dict]:
@@ -27,19 +29,52 @@ def _document(rows: list[dict], kind: str, name: str) -> dict:
     return next(row for row in rows if row["kind"] == kind and row["metadata"]["name"] == name)
 
 
-def test_ordinary_production_excludes_gate_r_readiness() -> None:
-    names = {(row["kind"], row["metadata"]["name"]) for row in _render(PROD)}
-    assert ("Job", "verdify-experiment-v2-gate-r-readiness") not in names
-    assert ("ConfigMap", "experiment-v2-gate-r-readiness-activation") not in names
+def test_production_gate_r_readiness_is_absent_or_exactly_attended() -> None:
+    rows = _render(PROD)
+    names = {(row["kind"], row["metadata"]["name"]) for row in rows}
+    job_key = ("Job", "verdify-experiment-v2-gate-r-readiness")
+    activation_key = ("ConfigMap", "experiment-v2-gate-r-readiness-activation")
+    if job_key not in names:
+        assert activation_key not in names
+        assert not ATTENDED_PATCH.exists()
+        return
+
+    assert activation_key in names
+    assert ATTENDED_PATCH.is_file()
+    job = _document(rows, *job_key)
+    activation = _document(rows, *activation_key)
+    assert job["spec"]["suspend"] is False
+    marker = job["metadata"]["annotations"]["verdify.io/gate-r-readiness-activation"]
+    assert re.fullmatch(r"m81-[0-9]{8}-[0-9a-f]{8}", marker)
+    assert job["spec"]["template"]["metadata"]["annotations"] == {"verdify.io/gate-r-readiness-activation": marker}
+    image = job["spec"]["template"]["spec"]["containers"][0]["image"]
+    assert re.fullmatch(
+        r"registry\.vallery\.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:[0-9a-f]{64}",
+        image,
+    )
+    prod = yaml.safe_load((PROD / "kustomization.yaml").read_text())
+    pin = next(
+        row for row in prod["images"] if row["name"] == "ghcr.io/verdifyconsultancy/verdify-experiment-v2-orchestrator"
+    )
+    assert image == f"{pin['newName']}@{pin['digest']}"
+    assert activation["data"]["VERDIFY_GATE_R_READINESS_EXPERIMENT_ID"] == ("45039c86-c1d9-52f6-a0a9-d94a17bc4b14")
+    assert re.fullmatch(r"[0-9a-f]{40}", activation["data"]["VERDIFY_GATE_R_READINESS_APPLICATION_SOURCE"])
 
 
-def test_activation_is_suspended_invalid_and_nonactuating() -> None:
-    rows = _render(ACTIVATION)
+def test_activation_state_is_exact_and_nonactuating() -> None:
+    attended = ATTENDED_PATCH.is_file()
+    rows = _render(PROD if attended else ACTIVATION)
     job = _document(rows, "Job", "verdify-experiment-v2-gate-r-readiness")
     assert job["metadata"]["namespace"] == "verdify-prod"
-    assert job["spec"]["suspend"] is True
+    assert job["spec"]["suspend"] is (not attended)
     container = job["spec"]["template"]["spec"]["containers"][0]
-    assert container["image"] == "invalid.local/replace-before-activation:never"
+    if attended:
+        assert re.fullmatch(
+            r"registry\.vallery\.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:[0-9a-f]{64}",
+            container["image"],
+        )
+    else:
+        assert container["image"] == "invalid.local/replace-before-activation:never"
     command = container["args"][0]
     assert "--mode recovery" in command
     assert "--boundary gate-r" in command
@@ -57,11 +92,14 @@ def test_activation_is_suspended_invalid_and_nonactuating() -> None:
         "VERDIFY_GATE_R_READINESS_APPLICATION_SOURCE",
         "VERDIFY_GATE_R_READINESS_EXPERIMENT_ID",
     }
-    assert set(activation["data"].values()) == {"REPLACE_BEFORE_ACTIVATION"}
+    if attended:
+        assert "REPLACE_BEFORE_ACTIVATION" not in activation["data"].values()
+    else:
+        assert set(activation["data"].values()) == {"REPLACE_BEFORE_ACTIVATION"}
 
 
 def test_read_capability_and_network_are_exact() -> None:
-    rows = _render(ACTIVATION)
+    rows = _render(PROD if ATTENDED_PATCH.is_file() else ACTIVATION)
     role = _document(rows, "Role", "verdify-experiment-v2-gate-r-readiness")
     assert all(set(rule["verbs"]).issubset({"get", "list"}) for rule in role["rules"])
     config_rule = next(rule for rule in role["rules"] if rule["resources"] == ["configmaps"])


### PR DESCRIPTION
## Summary

- add the read-only Gate R readiness component to the canonical production overlay for one attended M8.1 capture
- bind the exact `bc8ad7d5fc6ec6330df8a9ab3a20ccd301aea3e4` application source and canonical orchestrator digest
- keep Gate R itself absent and grant no lifecycle, provider, MCP, or device authority
- keep every activation render valid while the canonical overlay owns the one-shot activation
- retain a fail-closed test contract for both ordinary-absent and exact-attended production states

## Validation

- focused recovery collector/guard/activation suite: pass
- ruff + pre-commit: pass
- prod, Gate R readiness, Gate R, and direct-proof renders: pass
- client-side apply dry-run: pass

## Execution posture

Merging this PR does not sync production. The manual full, non-pruning, unscoped Argo reconciliation will occur only after the new singleton writer has at least 30 minutes of stability and the newest two climate rows satisfy the exact recovery quorum/spread guard. This PR does not authorize or execute Gate R or Gate P.
