### PR TITLE
fix(experiment): bind readiness to active Argo operation

### DIFF
--- a/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
+++ b/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
@@ -21,4 +21,4 @@ spec:
     spec:
       containers:
         - name: readiness
-          image: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:b6dd428c5c7d871c6f3f649e175f7cb9d28330832e249d1755f35fe243f5cbec
+          image: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:2cd02366cfa8ca492c4cdb92d160ece8a125666781f311b0f4aaecbc7a041460

--- a/scripts/experiment_v2_proof_packet.py
+++ b/scripts/experiment_v2_proof_packet.py
@@ -238,6 +238,32 @@ def _pod_container(pod: Mapping[str, Any], name: str) -> Mapping[str, Any]:
         raise CollectionError(f"running container status is absent: {name}") from exc
 
 
+def current_argo_revision(app: Mapping[str, Any]) -> str:
+    """Return the revision the attended operation is actually proving.
+
+    Argo can compare a manual-sync Application to a newer ``main`` commit while
+    an explicitly revision-pinned operation is still running.  In that case
+    ``status.sync.revision`` is the newer desired comparison, not the revision
+    executing the PostSync hook.  The top-level operation exists only while the
+    attended operation is active, so its exact revision is authoritative then;
+    outside an active operation the ordinary status revision remains the only
+    honest current revision.
+    """
+
+    active_operation = app.get("operation")
+    if isinstance(active_operation, Mapping):
+        active_sync = active_operation.get("sync")
+        revision = active_sync.get("revision") if isinstance(active_sync, Mapping) else None
+    else:
+        status = app.get("status")
+        sync_status = status.get("sync") if isinstance(status, Mapping) else None
+        revision = sync_status.get("revision") if isinstance(sync_status, Mapping) else None
+    value = str(revision or "")
+    if not SHA40.fullmatch(value):
+        raise CollectionError("Argo current operation revision is not an exact lowercase Git SHA")
+    return value
+
+
 def collect_kube(
     kube: KubeReader,
     *,
@@ -249,9 +275,7 @@ def collect_kube(
     now = datetime.now(UTC)
     observed_at = zulu(now)
     app = kube.json(f"/apis/argoproj.io/v1alpha1/namespaces/{ARGO_NAMESPACE}/applications/{ARGO_APPLICATION}")
-    argo_revision = str(app.get("status", {}).get("sync", {}).get("revision") or "")
-    if not SHA40.fullmatch(argo_revision):
-        raise CollectionError("Argo current revision is not an exact lowercase Git SHA")
+    argo_revision = current_argo_revision(app)
     if git_pin is not None and argo_revision != git_pin:
         raise CollectionError("Argo current revision differs from the expected Git pin")
 
@@ -395,7 +419,7 @@ def collect_kube(
         "attestation": attestation,
         "ingestor_env": ingestor_env,
         "argo": {
-            "revision": app_status["sync"]["revision"],
+            "revision": argo_revision,
             "source_path": app["spec"]["source"]["path"],
             "sync_status": app_status["sync"]["status"],
             "health_status": app_status["health"]["status"],

--- a/tests/test_experiment_v2_proof_packet.py
+++ b/tests/test_experiment_v2_proof_packet.py
@@ -287,3 +287,32 @@ def test_git_pin_is_either_exact_expected_or_derived_from_argo(tmp_path: Path) -
         collector.parser().parse_args(common)
     with pytest.raises(SystemExit):
         collector.parser().parse_args([*common, "--expected-git-pin", "a" * 40, "--derive-git-pin-from-argo"])
+
+
+def test_active_argo_operation_revision_wins_over_newer_desired_comparison() -> None:
+    active = "a" * 40
+    newer_main = "b" * 40
+    app = {
+        "operation": {"sync": {"revision": active}},
+        "status": {
+            "sync": {"revision": newer_main, "status": "OutOfSync"},
+            "operationState": {
+                "phase": "Running",
+                "operation": {"sync": {"revision": active}},
+                "syncResult": {"revision": active},
+            },
+        },
+    }
+    assert collector.current_argo_revision(app) == active
+
+    app.pop("operation")
+    assert collector.current_argo_revision(app) == newer_main
+
+
+def test_active_argo_operation_revision_must_be_exact() -> None:
+    app = {
+        "operation": {"sync": {"revision": "main"}},
+        "status": {"sync": {"revision": "c" * 40}},
+    }
+    with pytest.raises(collector.CollectionError, match="operation revision"):
+        collector.current_argo_revision(app)


### PR DESCRIPTION
## Summary
- derive the readiness packet Git pin from the active explicitly pinned Argo operation while its PostSync hook is running
- keep desired-status revision authoritative when no operation is active
- add the exact newer-main-vs-active-operation regression fixture
- reconcile the attended readiness hook image with the current canonical orchestrator pin

## Failure receipt
The first read-only readiness attempt failed closed as intended because Argo compared `main` at `4900d68d2f29ae100243791759846de93959e87c` while the full non-pruning operation ran exact revision `623f93f370ad0e674bc4f4cda85fa76baef28ab7`.

- Job UID: `1792f391-c5ae-4293-aa9d-c9f5e8a2e35b`
- Pod UID: `62583b2c-40af-4cac-8179-8a971f221582`
- output: `{"status":"failed-closed"}`
- DB remained draft / commissioning / emergency_hold / component off / lease 16 / zero exposure
- writer pod and Lease identity were unchanged

## Validation
- focused proof-packet/readiness/Gate R suite: 68 passed
- ruff: passed
- render contract: current attended image matches canonical prod pin
- local full harness reached DB-backed schema tests but the laptop default `docker exec verdify-timescaledb` backend is unavailable; authoritative in-cluster PR CI is required and will be the merge gate