### PR TITLE
fix(experiment): grant readiness collector reads

### DIFF
--- a/db/migrations/240-experiment-v2-readiness-reader-grants.sql
+++ b/db/migrations/240-experiment-v2-readiness-reader-grants.sql
@@ -1,0 +1,53 @@
+-- 240-experiment-v2-readiness-reader-grants.sql
+--
+-- The attended proof-readiness collector connects with the ordinary ingestor
+-- login under default_transaction_read_only=on.  Migration 217 already gives
+-- that duty the live climate/band inputs used by the packet, but the recovery
+-- hook also needs four narrowly bounded read surfaces that were omitted from
+-- the runtime allowlist.  Grant only those reads; no experiment DML or
+-- actuation function is added.
+
+GRANT EXECUTE ON FUNCTION public.fn_experiment_v2_api_status(uuid)
+    TO verdify_ingestor_runtime;
+GRANT EXECUTE ON FUNCTION public.fn_experiment_v2_executor_runtime(uuid, text)
+    TO verdify_ingestor_runtime;
+GRANT SELECT ON TABLE public.experiment_v2_runtime_generations
+    TO verdify_ingestor_runtime;
+GRANT SELECT ON TABLE public.v_open_alerts
+    TO verdify_ingestor_runtime;
+
+DO $assertions$
+BEGIN
+    IF NOT has_function_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.fn_experiment_v2_api_status(uuid)',
+            'EXECUTE') OR
+       NOT has_function_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.fn_experiment_v2_executor_runtime(uuid,text)',
+            'EXECUTE') OR
+       NOT has_table_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.experiment_v2_runtime_generations',
+            'SELECT') OR
+       NOT has_table_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.v_open_alerts',
+            'SELECT') THEN
+        RAISE EXCEPTION
+            'experiment-v2 readiness collector read surface is incomplete';
+    END IF;
+
+    IF has_table_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.experiment_v2_runtime_generations',
+            'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') OR
+       has_table_privilege(
+            'verdify_ingestor_runtime_login',
+            'public.v_open_alerts',
+            'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER') THEN
+        RAISE EXCEPTION
+            'experiment-v2 readiness collector acquired a write privilege';
+    END IF;
+END
+$assertions$;

--- a/tests/test_experiment_schema_migration.py
+++ b/tests/test_experiment_schema_migration.py
@@ -266,6 +266,7 @@ def test_backfill_covers_repo_migrations_except_unapplied_with_correct_shas():
         "237-experiment-v2-direct-proof-recovery-range-rollover.sql",  # bind rollover to current recovery range
         "238-experiment-v2-separate-day1-authorization.sql",  # separate finalization from audited day-1 approval
         "239-experiment-v2-orphaned-preclaim-recovery.sql",  # seal retained noncausal recovery without proof credit
+        "240-experiment-v2-readiness-reader-grants.sql",  # bounded read surface for attended readiness
     }
     sql = BACKFILL_SQL.read_text()
     stamped = dict(

--- a/tests/test_experiment_v2_direct_proof_startup_rollover.py
+++ b/tests/test_experiment_v2_direct_proof_startup_rollover.py
@@ -37,7 +37,10 @@ def test_proof_seals_rollover_before_waiting_for_stable_successor() -> None:
     settle = script.index("writer-runtime-settle-wait")
     begin = script.index("aggressive_work_id = await connection.fetchval(", settle)
     assert resolve < settle < begin
-    assert "RUNTIME_REGISTRATION_SETTLE_SECONDS = 5 * 60" in script
+    # The successor-registration hardening in #724 raised this bounded wait to
+    # 30 minutes; keep the rollover ordering contract aligned with that live
+    # proof timeout instead of retaining the superseded five-minute value.
+    assert "RUNTIME_REGISTRATION_SETTLE_SECONDS = 30 * 60" in script
     assert 'activation_time("VERDIFY_DIRECT_PROOF_AUTHORIZED_TO")' in script
     assert 'required_activation_value("VERDIFY_DIRECT_PROOF_AUTHORIZATION_REF")' in script
 

--- a/tests/test_experiment_v2_readiness_reader_grants.py
+++ b/tests/test_experiment_v2_readiness_reader_grants.py
@@ -1,0 +1,42 @@
+"""Least-privilege contract for migration 240's readiness read surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/240-experiment-v2-readiness-reader-grants.sql"
+
+
+def _sql() -> str:
+    return MIGRATION.read_text()
+
+
+def test_readiness_grants_are_exactly_the_collector_reads() -> None:
+    sql = re.sub(r"--.*$", "", _sql(), flags=re.MULTILINE)
+    grants = re.findall(r"GRANT\s+(.+?)\s+TO\s+verdify_ingestor_runtime\s*;", sql, re.DOTALL | re.IGNORECASE)
+    normalized = {" ".join(grant.split()) for grant in grants}
+    assert normalized == {
+        "EXECUTE ON FUNCTION public.fn_experiment_v2_api_status(uuid)",
+        "EXECUTE ON FUNCTION public.fn_experiment_v2_executor_runtime(uuid, text)",
+        "SELECT ON TABLE public.experiment_v2_runtime_generations",
+        "SELECT ON TABLE public.v_open_alerts",
+    }
+
+
+def test_readiness_grants_add_no_role_or_write_capability() -> None:
+    sql = _sql().upper()
+    assert "CREATE ROLE" not in sql
+    assert "ALTER ROLE" not in sql
+    assert "SECURITY DEFINER" not in sql
+    for capability in ("INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"):
+        assert f"GRANT {capability}" not in sql
+    assert "ACQUIRED A WRITE PRIVILEGE" in sql
+
+
+def test_readiness_grants_attest_the_inherited_login_surface() -> None:
+    sql = _sql()
+    assert sql.count("verdify_ingestor_runtime_login") == 6
+    assert sql.count("has_function_privilege(") == 2
+    assert sql.count("has_table_privilege(") == 4


### PR DESCRIPTION
## Outcome
- add migration 240 granting the ordinary ingestor duty only the two read functions and two read relations required by the attended readiness collector
- assert the inherited login gains no write privilege
- align the stale startup-rollover test with the already-shipped 30-minute successor-registration bound

## Evidence
- 380 experiment-v2 tests pass
- focused readiness, proof-packet, ruff, and diff checks pass
- rollback-only live transaction exercised every collector query successfully; post-rollback privileges remain absent
- production readiness remains fail-closed and no experiment/device/database state was changed

Closes no issue; this unblocks the attended Gate R readiness retry.