### PR TITLE
ops(experiment): reconcile readiness image pin

### DIFF
--- a/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
+++ b/deploy/k8s/overlays/prod/experiment-v2-gate-r-readiness.patch.yaml
@@ -21,4 +21,4 @@ spec:
     spec:
       containers:
         - name: readiness
-          image: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:614c5d6392cbe68fc8f2e092fd8052d06e3d648a8fa9eac5d8e3b18cbe2afc89
+          image: registry.vallery.net/verdifyconsultancy/verdify-experiment-v2-orchestrator@sha256:66e0132ba39c86d80f6fd74b442b376be004675262fbb03e48fbb486986617e9


### PR DESCRIPTION
## Outcome
Reconcile the attended Gate R readiness Job image with the canonical orchestrator digest auto-pinned by `a9cb256b` after PR #760.

This is a one-line immutable digest correction. It changes no feature switch, writer/API/MCP/migrate image, authorization, or database state. Migration 240 from #761 remains pending for the normal migration hook.

## Validation
- focused readiness/proof/ledger tests pass
- production overlay renders and passes Kubernetes client dry-run
- diff check passes