### PR TITLE
Remove retired Lab stage overlay

### DIFF
--- a/deploy/k8s/overlays/lab-stage/kustomization.yaml
+++ b/deploy/k8s/overlays/lab-stage/kustomization.yaml
@@ -1,6 +1,0 @@
-# Temporary retirement tombstone. Sync this exact revision with prune=true so
-# ArgoCD removes every former Lab stage resource before the owning Application
-# and this empty overlay are deleted.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources: []

--- a/tests/test_lab_generator_standardization.py
+++ b/tests/test_lab_generator_standardization.py
@@ -28,11 +28,7 @@ def test_quartz_is_the_only_lab_generator_source_and_deployment_path():
     assert all(not (REPO_ROOT / path).exists() for path in retired)
     assert (REPO_ROOT / "site/quartz.config.ts").is_file()
     assert (REPO_ROOT / "site/quartz.layout.ts").is_file()
-    stage_overlay = REPO_ROOT / "deploy/k8s/overlays/lab-stage"
-    if stage_overlay.exists():
-        assert list(stage_overlay.iterdir()) == [stage_overlay / "kustomization.yaml"]
-        tombstone = yaml.safe_load((stage_overlay / "kustomization.yaml").read_text())
-        assert tombstone["resources"] == []
+    assert not (REPO_ROOT / "deploy/k8s/overlays/lab-stage").exists()
 
 
 def test_generated_ci_has_no_retired_lab_image_profile():


### PR DESCRIPTION
## Summary
- delete the empty Lab stage overlay after its Argo Application and resources were pruned
- make the single-generator contract require the stage path to remain absent

## Validation
- `.venv/bin/python -m pytest -q tests/test_lab_generator_standardization.py tests/test_lab_publish_k3s_guard.py` (51 tests)
- `kustomize build deploy/k8s/overlays/prod`
- `git diff --check`