### PR TITLE
test(ci): isolate Argo broker delivery qualification

### DIFF
--- a/deploy/k8s/ci-broker-qualification/configmap.yaml
+++ b/deploy/k8s/ci-broker-qualification/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verdify-ci-broker-qualification
+  namespace: verdify-platform
+  labels:
+    app.kubernetes.io/name: verdify-ci-broker-qualification
+    app.kubernetes.io/part-of: verdify-ci-delivery-test
+data:
+  purpose: repository-scoped Argo plan/apply/status qualification
+  payload-version: "1"

--- a/deploy/k8s/ci-broker-qualification/kustomization.yaml
+++ b/deploy/k8s/ci-broker-qualification/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml


### PR DESCRIPTION
Adds one isolated ConfigMap so the repository's existing Argo deployment broker can be tested through a real plan/apply/status cycle. The temporary control-plane Application points only at this directory and the immutable commit; it has no workload or hook.

Validation: kustomize renders exactly one ConfigMap in verdify-platform. This is a temporary qualification fixture; do not merge it into the production-triggering main pipeline. The fixture and Application will be retired after the durable result is recorded.
